### PR TITLE
Set server_tokens to off in the nginx configuration

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -24,7 +24,7 @@ http {
 
     sendfile        on;
     #tcp_nopush     on;
-
+    server_tokens   off;
     keepalive_timeout  65;
 
     gzip  on;


### PR DESCRIPTION
## What

Set server_tokens to off in the nginx configuration

## Why

Disable emitting nginx version in the `Server` response header field

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
