### PR TITLE
Changed service name for document in docker compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -141,7 +141,7 @@ services:
     labels:
       - traefik.enable=false
 
-  document:
+  document-service:
     image: unstract/document-service:${VERSION}
     container_name: unstract-document-service
     ports:


### PR DESCRIPTION
## What

- Changed service name for document in docker compose
 
## Why

- So that the name matches with the one used in `docker-compse.build.yaml` and also with the existing convention we follow

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
