### PR TITLE
Prompt studio cutom tool filter by user

### DIFF
--- a/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
+++ b/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Optional
 
+from account.models import User
 from django.conf import settings
 from django.db import IntegrityError
 from prompt_studio.prompt_studio.models import ToolStudioPrompt
@@ -113,10 +114,10 @@ class PromptStudioRegistryHelper:
                 PromptStudioRegistryHelper.frame_properties(tool=custom_tool)
             )
             spec: Spec = PromptStudioRegistryHelper.frame_spec(tool=custom_tool)
-            prompts: list[
-                ToolStudioPrompt
-            ] = PromptStudioHelper.fetch_prompt_from_tool(
-                tool_id=custom_tool.tool_id
+            prompts: list[ToolStudioPrompt] = (
+                PromptStudioHelper.fetch_prompt_from_tool(
+                    tool_id=custom_tool.tool_id
+                )
             )
             metadata = PromptStudioRegistryHelper.frame_export_json(
                 tool=custom_tool, prompts=prompts
@@ -126,6 +127,8 @@ class PromptStudioRegistryHelper:
             created: bool
             obj, created = PromptStudioRegistry.objects.update_or_create(
                 custom_tool=custom_tool,
+                created_by=custom_tool.created_by,
+                modified_by=custom_tool.modified_by,
                 defaults={
                     "name": custom_tool.tool_name,
                     "tool_property": properties.to_dict(),
@@ -190,9 +193,9 @@ class PromptStudioRegistryHelper:
             adapter_id = str(prompt.profile_manager.embedding_model.adapter_id)
             embedding_suffix = adapter_id.split("|")[0]
 
-            output[
-                JsonSchemaKey.ASSERTION_FAILURE_PROMPT
-            ] = prompt.assertion_failure_prompt
+            output[JsonSchemaKey.ASSERTION_FAILURE_PROMPT] = (
+                prompt.assertion_failure_prompt
+            )
             output[JsonSchemaKey.ASSERT_PROMPT] = prompt.assert_prompt
             output[JsonSchemaKey.IS_ASSERT] = prompt.is_assert
             output[JsonSchemaKey.PROMPT] = prompt.prompt
@@ -201,21 +204,21 @@ class PromptStudioRegistryHelper:
             output[JsonSchemaKey.VECTOR_DB] = vector_db
             output[JsonSchemaKey.EMBEDDING] = embedding_model
             output[JsonSchemaKey.X2TEXT_ADAPTER] = x2text
-            output[
-                JsonSchemaKey.CHUNK_OVERLAP
-            ] = prompt.profile_manager.chunk_overlap
+            output[JsonSchemaKey.CHUNK_OVERLAP] = (
+                prompt.profile_manager.chunk_overlap
+            )
             output[JsonSchemaKey.LLM] = llm
             output[JsonSchemaKey.PREAMBLE] = tool.preamble
             output[JsonSchemaKey.POSTAMBLE] = tool.postamble
             output[JsonSchemaKey.GRAMMAR] = grammar_list
             output[JsonSchemaKey.TYPE] = prompt.enforce_type
             output[JsonSchemaKey.NAME] = prompt.prompt_key
-            output[
-                JsonSchemaKey.RETRIEVAL_STRATEGY
-            ] = prompt.profile_manager.retrieval_strategy
-            output[
-                JsonSchemaKey.SIMILARITY_TOP_K
-            ] = prompt.profile_manager.similarity_top_k
+            output[JsonSchemaKey.RETRIEVAL_STRATEGY] = (
+                prompt.profile_manager.retrieval_strategy
+            )
+            output[JsonSchemaKey.SIMILARITY_TOP_K] = (
+                prompt.profile_manager.similarity_top_k
+            )
             output[JsonSchemaKey.SECTION] = prompt.profile_manager.section
             output[JsonSchemaKey.REINDEX] = prompt.profile_manager.reindex
             output[JsonSchemaKey.EMBEDDING_SUFFIX] = embedding_suffix
@@ -231,9 +234,11 @@ class PromptStudioRegistryHelper:
         return export_metadata
 
     @staticmethod
-    def fetch_json_for_registry() -> list[dict[str, Any]]:
+    def fetch_json_for_registry(user: User) -> list[dict[str, Any]]:
         try:
-            prompt_studio_tools = PromptStudioRegistry.objects.all()
+            prompt_studio_tools = PromptStudioRegistry.objects.filter(
+                created_by=user
+            )
             pi_serializer = PromptStudioRegistrySerializer(
                 instance=prompt_studio_tools, many=True
             )

--- a/backend/tool_instance/tool_processor.py
+++ b/backend/tool_instance/tool_processor.py
@@ -131,12 +131,12 @@ class ToolProcessor:
                 schema.properties[key]["enum"] = list(adapter_names)
 
     @staticmethod
-    def get_tool_list() -> list[dict[str, Any]]:
+    def get_tool_list(user: User) -> list[dict[str, Any]]:
         """Function to get a list of tools."""
         tool_registry = ToolRegistry()
         prompt_studio_tools: list[
             dict[str, Any]
-        ] = PromptStudioRegistryHelper.fetch_json_for_registry()
+        ] = PromptStudioRegistryHelper.fetch_json_for_registry(user)
         tool_list: list[
             dict[str, Any]
         ] = tool_registry.fetch_tools_descriptions()

--- a/backend/tool_instance/views.py
+++ b/backend/tool_instance/views.py
@@ -51,7 +51,7 @@ def get_tool_list(request: Request) -> Response:
         try:
             logger.info("Fetching tools from the tool registry...")
             return Response(
-                data=ToolProcessor.get_tool_list(), status=status.HTTP_200_OK
+                data=ToolProcessor.get_tool_list(request.user), status=status.HTTP_200_OK
             )
         except Exception as exc:
             logger.error(f"Failed to fetch tools: {exc}")


### PR DESCRIPTION
## What

Exported tools should be available only to the user who has created the prompt studio tool.

## Why

The created and modified user details were not getting saved.

## How

Added filter based on `created_by`.

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
