### PR TITLE
Added adapter type in adapter listing response

### DIFF
--- a/backend/adapter_processor/serializers.py
+++ b/backend/adapter_processor/serializers.py
@@ -78,7 +78,12 @@ class AdapterListSerializer(BaseAdapterSerializer):
 
     class Meta(BaseAdapterSerializer.Meta):
         model = AdapterInstance
-        fields = ("id", "adapter_id", "adapter_name")  # type: ignore
+        fields = (
+            "id",
+            "adapter_id",
+            "adapter_name",
+            "adapter_type",
+        )  # type: ignore
 
     def to_representation(self, instance: AdapterInstance) -> dict[str, str]:
         rep: dict[str, str] = super().to_representation(instance)


### PR DESCRIPTION
## What

Added adapter_type in serializer


## Why

The adapter type filed is used in the onboarding page.  With the previous change, we were not sending the adapter type in the adapter listing response. 

## How

Added the required filed in serializer

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
