### PR TITLE
fix: Prompt-service issue for 0 chunk size

### DIFF
--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -486,10 +486,9 @@ def prompt_processor() -> Any:
         if output[PSKeys.CHUNK_SIZE] == 0:
             # We can do this only for chunkless indexes
             context = tool_index.get_text_from_index(
-                project_id=tool_id,
+                embedding_type=output[PSKeys.EMBEDDING],
                 vector_db=output[PSKeys.VECTOR_DB],
                 doc_id=doc_id,
-                embedding_dimension=embedding_dimension,
             )
 
         assertion_failed = False


### PR DESCRIPTION
## What
- Updated prompt-service's usage of `ToolIndex.get_text_from_index()` from the SDK

## Why
- The function was not updated after some breaking changes were made in the SDK
- This caused an issue when chunk size was 0

## How

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing
- Tried to generate responses from LLM when chunk size was 0

## Screenshots
![image](https://github.com/Zipstack/unstract/assets/117059509/b5a15e0a-e318-4435-9853-a4ac8f48ef67)


## Checklist

I have read and understood the [Contribution Guidelines]().
