### PR TITLE
Fix for issue in displaying the backend validation errors

### DIFF
--- a/frontend/src/hooks/useExceptionHandler.jsx
+++ b/frontend/src/hooks/useExceptionHandler.jsx
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 
 const useExceptionHandler = () => {
   const navigate = useNavigate();
-  const handleException = (err, errMessage = "Something went wrong") => {
+  const handleException = (
+    err,
+    errMessage = "Something went wrong",
+    setBackendErrors = undefined
+  ) => {
     if (!err) {
       return {
         type: "error",
@@ -16,6 +20,9 @@ const useExceptionHandler = () => {
       switch (type) {
         case "validation_error":
           // Handle validation errors
+          if (setBackendErrors) {
+            setBackendErrors(err?.response?.data);
+          }
           break;
         case "subscription_error":
           navigate("/trial-expired");


### PR DESCRIPTION
## What

- Fix for the issue in showing the backend validation error messages

## Why

- This is a regression issue where we neglected to invoke the `setBackendErrors` method when encountering backend validation errors.

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

![image](https://github.com/Zipstack/unstract/assets/113336661/2093154f-7b56-4065-b2e3-076a2632a170)

## Checklist

I have read and understood the [Contribution Guidelines]().
