### PR TITLE
fix: Prompt studio tool export SPEC updated

### DIFF
--- a/unstract/tool-registry/src/unstract/tool_registry/dto.py
+++ b/unstract/tool-registry/src/unstract/tool_registry/dto.py
@@ -61,7 +61,7 @@ class Spec:
 
     title: str = ""
     description: str = ""
-    type: str = ""
+    type: str = "object"
     required: list[str] = field(default_factory=list)
     properties: dict[str, dict[str, Any]] = field(
         default_factory=dict[str, dict[str, Any]]
@@ -122,7 +122,7 @@ class Spec:
         return self.get_adapter_properties(AdapterTypes.X2TEXT)
 
     def get_ocr_adapter_properties(
-            self,
+        self,
     ) -> dict[str, dict[str, Any]]:
         return self.get_adapter_properties(AdapterTypes.OCR)
 
@@ -243,7 +243,6 @@ class Adapter:
     TEXT_EXTRACTORS_KEY = "textExtractors"
     OCRS_KEY = "ocrs"
 
-
     language_models: list[AdapterProperties] = field(
         default_factory=list[AdapterProperties]
     )
@@ -284,10 +283,7 @@ class Adapter:
             AdapterProperties.from_dict(text_extractor_dict)
             for text_extractor_dict in text_extractors_list
         ]
-        ocrs = [
-            AdapterProperties.from_dict(ocr_dict)
-            for ocr_dict in ocrs_list
-        ]
+        ocrs = [AdapterProperties.from_dict(ocr_dict) for ocr_dict in ocrs_list]
 
         return cls(
             language_models=language_models,


### PR DESCRIPTION
## What

- Fixed an issue where tools exported from prompt studio were not working
- Added a default to `type` in the Spec dataclass as `object`
- Exception handling condition to catch such `UnknownType` errors
- MINOR: Flake8 fixes

## Why

- This was missed previously and during JSON schema validation leaving it empty threw an error

## How

-

## Database Migrations

- This actually requires migrations to work seamlessly. However since it pertains to the exported tool - a simple re-export of existing tools will allow it to work as expected

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- [UN-1021](https://zipstack.atlassian.net/browse/UN-1021)

## Dependencies Versions

-

## Notes on Testing

- Tested by running the workflow locally

## Screenshots
- Results from the worker
![image](https://github.com/Zipstack/unstract/assets/117059509/a99b5a62-513e-4bcc-ad74-8b0b74a71eda)



## Checklist

I have read and understood the [Contribution Guidelines]().


[UN-1021]: https://zipstack.atlassian.net/browse/UN-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ