### PR TITLE
fix: Avoid tool setting validation for API deployment

### DIFF
--- a/backend/tool_instance/tool_instance_helper.py
+++ b/backend/tool_instance/tool_instance_helper.py
@@ -346,7 +346,12 @@ class ToolInstanceHelper:
             else tool_uid
         )
         # Getting user from local_context store
-        user: User = StateStore.get(Common.USER_ID)
+        user: Optional[User] = StateStore.get(Common.USER_ID)
+        # FIXME: Skipping tool setting validation if user is not set.
+        # This occurs during API deployment since the API endpoint is
+        # whitelisted and `user` is not set in StateStore by the middleware.
+        if not user:
+            return True, ""
         schema_json: dict[str, Any] = ToolProcessor.get_json_schema_for_tool(
             tool_uid=tool_uid, user=user
         )


### PR DESCRIPTION
## What

- Avoids tool setting validation for API deployment

## Why

- During tool setting validation we try to access `user` from the StateStore which will not be set by the middleware since API deployment is a whitelisted call.

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested locally by deploying an API

## Screenshots


![image](https://github.com/Zipstack/unstract/assets/117059509/9e26bb59-e45f-48a2-aeaf-7b04a3f13009)
![image](https://github.com/Zipstack/unstract/assets/117059509/9c019064-8cf8-4e12-9314-224f4d44b71d)

## Checklist

I have read and understood the [Contribution Guidelines]().
