### PR TITLE
fix: UN-1025 Pinned qdrant server version to 1.7.4

### DIFF
--- a/docker/docker-compose-dev-essentials.yaml
+++ b/docker/docker-compose-dev-essentials.yaml
@@ -4,7 +4,7 @@ services:
   db:
     image: 'postgres:15.6'
     container_name: unstract-db
-    restart: always 
+    restart: always
     # set shared memory limit when using docker-compose
     shm_size: 128mb
     ports:
@@ -16,7 +16,7 @@ services:
       - ./essentials.env
     labels:
       - traefik.enable=false
-    
+
   redis:
     image: "redis:7.2.3"
     container_name: unstract-redis
@@ -110,7 +110,7 @@ services:
 
   qdrant:
     # Vector DB for doc indexer
-    image: 'qdrant/qdrant'
+    image: 'qdrant/qdrant:v1.7.4'
     container_name: unstract-vector-db
     restart: always
     ports:


### PR DESCRIPTION
## What

- Pinned qdrant server version to 1.7.4
- MINOR: Yaml file linting

## Why

- Faced an issue with local qdrant (1.7.0) - received validation errors while querying it against the qdrant server of v1.8.x
![image](https://github.com/Zipstack/unstract/assets/117059509/e6719092-28e3-4145-a108-8206db6a94f4)

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- [Qdrant Issue](https://github.com/qdrant/qdrant/issues/3828)

## Dependencies Versions

-

## Notes on Testing

- Updated the qdrant server version and ran a tool with local qdrant configured. It ran fine

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
