### PR TITLE
fix: Prompt studio regression with default profile error

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
@@ -222,8 +222,6 @@ class PromptStudioHelper:
             )
             file_path = str(Path(file_path) / file_name)
 
-        if not default_profile:
-            raise DefaultProfileError()
         if not tool:
             logger.error(f"No tool instance found for the ID {tool_id}")
             raise ToolNotValid()

--- a/backend/prompt_studio/prompt_studio_core/serializers.py
+++ b/backend/prompt_studio/prompt_studio_core/serializers.py
@@ -6,6 +6,7 @@ from prompt_studio.prompt_profile_manager.models import ProfileManager
 from prompt_studio.prompt_studio.models import ToolStudioPrompt
 from prompt_studio.prompt_studio.serializers import ToolStudioPromptSerializer
 from prompt_studio.prompt_studio_core.constants import ToolStudioKeys as TSKeys
+from prompt_studio.prompt_studio_core.exceptions import DefaultProfileError
 from rest_framework import serializers
 
 from backend.serializers import AuditSerializer
@@ -35,7 +36,7 @@ class CustomToolSerializer(AuditSerializer):
         try:
             profile_manager = ProfileManager.get_default_llm_profile(instance)
             data[TSKeys.DEFAULT_PROFILE] = profile_manager.profile_id
-        except ObjectDoesNotExist:
+        except DefaultProfileError:
             logger.info(
                 "Default LLM profile doesnt exist for prompt tool %s",
                 str(instance.tool_id),


### PR DESCRIPTION
## What

- Caught and suppressed the `DefaultProfileError` that arises while querying for the default profile of a `CustomTool`

## Why

- This is a regression related to [this PR](https://github.com/Zipstack/unstract/pull/151)

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tried creating a prompt studio tool

## Screenshots

![image](https://github.com/Zipstack/unstract/assets/117059509/b767bf82-f7dd-437c-a269-7f618b3071da)


## Checklist

I have read and understood the [Contribution Guidelines]().
