### PR TITLE
FIX - Removed usage of eval components in the FE

### DIFF
--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -48,22 +48,12 @@ import { useExceptionHandler } from "../../../hooks/useExceptionHandler";
 import { useSocketCustomToolStore } from "../../../store/socket-custom-tool";
 import { TokenCount } from "../token-count/TokenCount";
 
-let EvalBtn = null;
-let EvalMetrics = null;
-let EvalModal = null;
-let getEvalMetrics = (param1, param2) => {
+const EvalBtn = null;
+const EvalMetrics = null;
+const EvalModal = null;
+const getEvalMetrics = (param1, param2) => {
   return [];
 };
-try {
-  EvalBtn = require("../../../plugins/eval-btn/EvalBtn").EvalBtn;
-  EvalMetrics =
-    require("../../../plugins/eval-metrics/EvalMetrics").EvalMetrics;
-  EvalModal = require("../../../plugins/eval-modal/EvalModal").EvalModal;
-  getEvalMetrics =
-    require("../../../plugins/eval-helper/EvalHelper").getEvalMetrics;
-} catch {
-  // The components will remain null of it is not available
-}
 
 function PromptCard({
   promptDetails,

--- a/frontend/src/components/custom-tools/settings-modal/SettingsModal.jsx
+++ b/frontend/src/components/custom-tools/settings-modal/SettingsModal.jsx
@@ -18,13 +18,11 @@ import { PreAndPostAmbleModal } from "../pre-and-post-amble-modal/PreAndPostAmbl
 import "./SettingsModal.css";
 
 let SummarizeManager = null;
-let EvaluationManager = null;
+const EvaluationManager = null;
 let ChallengeManager = null;
 try {
   SummarizeManager =
     require("../../../plugins/summarize-manager/SummarizeManager").SummarizeManager;
-  EvaluationManager =
-    require("../../../plugins/evaluation-manager/EvaluationManager").EvaluationManager;
   ChallengeManager =
     require("../../../plugins/challenge-manager/ChallengeManager").ChallengeManager;
 } catch {
@@ -62,16 +60,12 @@ function SettingsModal({ open, setOpen, handleUpdateTool }) {
       ),
     };
 
-    if (SummarizeManager && EvaluationManager && ChallengeManager) {
-      // Add Summary Manager menu item to the existing list
+    let position = 1;
+    if (SummarizeManager) {
       items.splice(
-        1,
+        position,
         0,
-        ...[
-          getMenuItem("Summary Manager", 2, <FileTextOutlined />),
-          getMenuItem("Evaluation Manager", 3, <FileTextOutlined />),
-          getMenuItem("Challenge Manager", 4, <FileTextOutlined />),
-        ]
+        getMenuItem("Summary Manager", 2, <FileTextOutlined />)
       );
       listOfComponents[2] = (
         <SummarizeManager
@@ -79,8 +73,26 @@ function SettingsModal({ open, setOpen, handleUpdateTool }) {
           handleUpdateTool={handleUpdateTool}
         />
       );
+      position++;
+    }
+
+    if (EvaluationManager) {
+      items.splice(
+        position,
+        0,
+        getMenuItem("Evaluation Manager", 3, <FileTextOutlined />)
+      );
       listOfComponents[3] = (
         <EvaluationManager handleUpdateTool={handleUpdateTool} />
+      );
+      position++;
+    }
+
+    if (ChallengeManager) {
+      items.splice(
+        position,
+        0,
+        getMenuItem("Challenge Manager", 4, <FileTextOutlined />)
       );
       listOfComponents[4] = (
         <ChallengeManager handleUpdateTool={handleUpdateTool} />


### PR DESCRIPTION
## What
Removed the imports of the eval components from PromptCard.jsx and SettingsModal.jsx.

## Why
NA
-

## How
NA
-

## Database Migrations
NA
- 

## Env Config
NA
- 

## Relevant Docs
NA
-

## Related Issues or PRs
NA
-

## Dependencies Versions
NA
-

## Notes on Testing
Checked if the eval components are rendered anywhere in the UI.
-

## Screenshots
### Removed the Eval Chips from the prompt card:
![Screenshot from 2024-03-26 13-36-19](https://github.com/Zipstack/unstract/assets/89440263/42c23661-460c-40ed-8fa3-caae929cddb2)

### Removed Evaluation Manager from the settings modal:
![Screenshot from 2024-03-26 13-36-05](https://github.com/Zipstack/unstract/assets/89440263/a3854a01-aeec-4bbb-8df3-5a1a5d4a02c3)

## Checklist

I have read and understood the [Contribution Guidelines]().
