### PR TITLE
github action runner moved into public one

### DIFF
--- a/.github/workflows/ci-container-build.yaml
+++ b/.github/workflows/ci-container-build.yaml
@@ -35,7 +35,7 @@ on:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    runs-on: custom-k8s-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/docker-build-push-dev.yaml
+++ b/.github/workflows/docker-build-push-dev.yaml
@@ -26,7 +26,7 @@ run-name: "[${{ inputs.service_name }}] Docker Image Build and Push (Development
 
 jobs:
   build-and-push:
-    runs-on: custom-k8s-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"

--- a/.github/workflows/docker-tools-build-push.yaml
+++ b/.github/workflows/docker-tools-build-push.yaml
@@ -21,7 +21,7 @@ run-name: "[${{ inputs.service_name }}] Docker Image Build and Push (Development
 
 jobs:
     build-and-push:
-      runs-on: custom-k8s-runner
+      runs-on: ubuntu-latest
       steps:
         - name: Output Inputs
           run: echo "${{ toJSON(github.event.inputs) }}"

--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -9,7 +9,7 @@ run-name: "[${{ github.event.release.tag_name }}] Docker Image Build and Push (P
 
 jobs:
   build-and-push:
-    runs-on: custom-k8s-runner
+    runs-on: ubuntu-latest
     strategy:
       matrix:          
         service_name: [backend, frontend, document-service, platform-service, prompt-service, worker, x2text-service]


### PR DESCRIPTION
## What

github action runner moved into public one

## Why

-

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
