### PR TITLE
Remove internal docker compose pull policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ Automate critical business processes that involve complex documents with a human
 
 ## 🚀 Getting started
 
+### System Requirements
+
+- 8GB RAM (recommended)
+
 ### Prerequisites
 
 - Linux or MacOS (Intel or M-series)
 - Docker
 - Docker Compose (if you need to install it separately)
+- Git
 
 Next, either download a release or clone this repo and do the following:
 

--- a/run-platform.sh
+++ b/run-platform.sh
@@ -136,7 +136,7 @@ do_git_pull() {
   fi
 
   echo -e "Performing git switch to ""$blue_text""main branch""$default_text".
-  # git switch main
+  git switch main
 
   echo -e "Performing ""$blue_text""git pull""$default_text"" on main branch."
   git pull
@@ -152,6 +152,7 @@ setup_env() {
     env_path="$script_dir/$service/.env"
 
     if [ -e "$sample_env_path" ] && [ ! -e "$env_path" ]; then
+      first_setup=true
       cp "$sample_env_path" "$env_path"
       # Add encryption secret for backend and platform-service.
       if [[ "$service" == "backend" || "$service" == "platform-service" ]]; then
@@ -174,7 +175,7 @@ setup_env() {
         fi
       fi
       echo -e "Created env for ""$blue_text""$service""$default_text" at ""$blue_text""$env_path""$default_text"."
-    else
+    elif [ "$opt_upgrade" = true ]; then
       python3 $script_dir/docker/scripts/merge_env.py $sample_env_path $env_path
       if [ $? -ne 0 ]; then
         exit 1
@@ -186,7 +187,7 @@ setup_env() {
   if [ ! -e "$script_dir/docker/essentials.env" ]; then
     cp "$script_dir/docker/sample.essentials.env" "$script_dir/docker/essentials.env"
     echo -e "Created env for ""$blue_text""essential services""$default_text"" at ""$blue_text""$script_dir/docker/essentials.env""$default_text""."
-  else
+  elif [ "$opt_upgrade" = true ]; then
     python3 $script_dir/docker/scripts/merge_env.py "$script_dir/docker/sample.essentials.env" "$script_dir/docker/essentials.env"
     if [ $? -ne 0 ]; then
       exit 1
@@ -194,6 +195,7 @@ setup_env() {
     echo -e "Merged env for ""$blue_text""essential services""$default_text"" at ""$blue_text""$script_dir/docker/essentials.env""$default_text""."
   fi
 
+  # Not part of an upgrade.
   if [ ! -e "$script_dir/docker/proxy_overrides.yaml" ]; then
     echo -e "NOTE: Proxy behaviour can be overridden via ""$blue_text""$script_dir/docker/proxy_overrides.yaml""$default_text""."
   else
@@ -214,7 +216,7 @@ build_services() {
       echo -e "$red_text""Failed to build docker images.""$default_text"
       exit 1
     }
-  else
+  elif [ "$first_setup" = true ] || [ "$opt_upgrade" = true ]; then
     echo -e "$blue_text""Pulling""$default_text"" docker images tag ""$blue_text""$opt_version""$default_text""."
     VERSION=$opt_version $docker_compose_cmd -f $script_dir/docker/docker-compose.yaml pull || {
       echo -e "$red_text""Failed to pull docker images.""$default_text"
@@ -261,6 +263,7 @@ opt_verbose=false
 opt_version="latest"
 
 script_dir=$(dirname "$(readlink -f "$BASH_SOURCE")")
+first_setup=false
 # Extract service names from docker compose file.
 services=($(VERSION=$opt_version $docker_compose_cmd -f $script_dir/docker/docker-compose.build.yaml config --services))
 

--- a/run-platform.sh
+++ b/run-platform.sh
@@ -216,15 +216,10 @@ build_services() {
     }
   else
     echo -e "$blue_text""Pulling""$default_text"" docker images tag ""$blue_text""$opt_version""$default_text""."
-
-    pull_policy="missing"
-    if [ "$opt_upgrade" = true ] && [ "$opt_version" = "latest" ]; then
-      pull_policy="always"
-    fi
-
-    VERSION=$opt_version $docker_compose_cmd -f $script_dir/docker/docker-compose.yaml pull --policy $pull_policy || {
-      echo -e "$red_text""Failed to pull docker images. Check the version.""$default_text"
-      echo -e "$red_text""Also make sure docker is running and try again.""$default_text"
+    VERSION=$opt_version $docker_compose_cmd -f $script_dir/docker/docker-compose.yaml pull || {
+      echo -e "$red_text""Failed to pull docker images.""$default_text"
+      echo -e "$red_text""Either version not found or docker is not running.""$default_text"
+      echo -e "$red_text""Please check and try again.""$default_text"
       exit 1
     }
   fi


### PR DESCRIPTION
## What

- Remove setting docker compose pull policy internally in run script
- Do images pull only on first setup or upgrade
- Update system requirements
- Update prerequisites

## Why

- Observed issue:
```
Pulling docker images tag latest.
unknown flag: --policy
Failed to pull docker images. Check the version.
Also make sure docker is running and try again.
```
- Either we need to explicitly check for `docker compose` version compatibility for this option (available only with `docker compose > = v2.22.0`) or remove its usage altogether. It is ok to remove as even without this option `docker compose pull` will always check if there is any changes in the image tag contents and only if any found, will do the actual pull.
- Upgrade should always be an explicit action.

## Notes on Testing

- [DONE] Creates env when running the script for first time
- [DONE] Does not git pull, merge env or pull images on subsequent runs
- [DONE] Does git pull, merges env and pulls images on subsequent runs if upgrade option is true

## Checklist

I have read and understood the [Contribution Guidelines]().
