### PR TITLE
Adapter search results fix

### DIFF
--- a/frontend/src/components/input-output/list-of-sources/ListOfSources.jsx
+++ b/frontend/src/components/input-output/list-of-sources/ListOfSources.jsx
@@ -1,8 +1,7 @@
 import { SearchOutlined } from "@ant-design/icons";
 import { Input, List } from "antd";
-import debounce from "lodash/debounce";
 import PropTypes from "prop-types";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { sourceTypes } from "../../../helpers/GetStaticData";
 import { useAxiosPrivate } from "../../../hooks/useAxiosPrivate";
@@ -40,13 +39,14 @@ function ListOfSources({ setSelectedSourceId, type }) {
   useEffect(() => {
     if (searchText?.length === 0) {
       setFilteredSourcesList(sourcesList);
+    } else {
+      const filteredList = [...sourcesList].filter((source) => {
+        const name = source?.name?.toUpperCase();
+        const searchUpperCase = searchText.toUpperCase();
+        return name.includes(searchUpperCase);
+      });
+      setFilteredSourcesList(filteredList);
     }
-    const filteredList = [...sourcesList].filter((source) => {
-      const name = source?.name?.toUpperCase();
-      const searchUpperCase = searchText.toUpperCase();
-      return name.includes(searchUpperCase);
-    });
-    setFilteredSourcesList(filteredList);
   }, [sourcesList, searchText]);
 
   useEffect(() => {
@@ -91,12 +91,10 @@ function ListOfSources({ setSelectedSourceId, type }) {
       });
   };
 
-  const onSearchDebounce = useCallback(
-    debounce(({ target: { value } }) => {
-      setSearchText(value);
-    }, 600),
-    []
-  );
+  const onSearch = (event) => {
+    const { value } = event.target;
+    setSearchText(value);
+  };
 
   if (isLoading) {
     return <SpinnerLoader />;
@@ -108,7 +106,7 @@ function ListOfSources({ setSelectedSourceId, type }) {
         <Input
           placeholder="Search"
           prefix={<SearchOutlined className="search-outlined" />}
-          onChange={onSearchDebounce}
+          onChange={onSearch}
           value={searchText}
         />
       </div>


### PR DESCRIPTION
## What

- Fix for adapters search results for LLM, Embedding and VectorDB to be displayed in modal.

## Why

- Was facing issues earlier with initial entered value not changing and results not reflecting accordingly.

## How

- Removed debounce method to change will during change in text field. Use-effect can handle this directly.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
