### PR TITLE
fix: Minor fix in exc middleware, removed extra pyupgrade hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,13 +132,6 @@ repos:
     rev: v1.1.2
     hooks:
       - id: htmlhint
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
-    hooks:
-      - id: pyupgrade
-        entry: pyupgrade --py38-plus --keep-runtime-typing
-        types:
-          - python
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.39.0
     hooks:

--- a/backend/account/authentication_controller.py
+++ b/backend/account/authentication_controller.py
@@ -159,7 +159,7 @@ class AuthenticationController:
         except Exception as ex:
             #
             self.user_logout(request)
-            if ex.code == AuthorizationErrorCode.USF:  # type: ignore
+            if hasattr(ex, "code") and ex.code == AuthorizationErrorCode.USF:  # type: ignore
                 response = Response(
                     status=status.HTTP_412_PRECONDITION_FAILED,
                     data={"domain": ex.data.get("domain")},  # type: ignore

--- a/backend/middleware/exception.py
+++ b/backend/middleware/exception.py
@@ -81,7 +81,7 @@ class ExceptionLoggingMiddleware:
             request (HttpRequest): Request to get API endpoint hit
             exception (Exception): Exception that was raised to be logged
         """
-        if response.status_code >= 500:
+        if hasattr(response, "status_code") and response.status_code >= 500:
             message = (
                 "{method} {url} {status}\n\n{error}\n\n````{tb}````".format(
                     method=request.method,


### PR DESCRIPTION
## What

- Minor fix in exception middleware - added an extra check
- Similar check in auth_controller (if explicit exception is caught, this might not be required)
- Removed extra pyupgrade hook

## Why

- Faced the below issue from exception middleware
![image](https://github.com/Zipstack/unstract/assets/117059509/4e17cdfb-98e7-4327-8063-4d944bf79124)
- Faced a similar error with the auth controller as well, however didn't save a screenshot for it, if an explicit exception is caught, that check might not be necessary
- [Pyupgrade hook removal](https://github.com/Zipstack/unstract/pull/220#discussion_r1554949247)


## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/220 : Observed extra pyupgrade hook


## Notes on Testing

- Observed that those error logs were fixed later, forgot to capture screenshots for it - but since these are non breaking fixes, it should be okay

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
