### PR TITLE
fix: Fix issue with checking tool access for static tools

### DIFF
--- a/backend/tool_instance/tool_instance_helper.py
+++ b/backend/tool_instance/tool_instance_helper.py
@@ -9,7 +9,9 @@ from adapter_processor.adapter_processor import AdapterProcessor
 from adapter_processor.models import AdapterInstance
 from connector.connector_instance_helper import ConnectorInstanceHelper
 from django.core.exceptions import PermissionDenied
-from jsonschema.exceptions import UnknownType, ValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
+from jsonschema.exceptions import UnknownType
+from jsonschema.exceptions import ValidationError as JSONValidationError
 from prompt_studio.prompt_studio_registry.models import PromptStudioRegistry
 from tool_instance.constants import JsonSchemaKey
 from tool_instance.models import ToolInstance
@@ -360,7 +362,7 @@ class ToolInstanceHelper:
             return True, ""
         except JSONDecodeError as e:
             return False, str(e)
-        except ValidationError as e:
+        except JSONValidationError as e:
             logger.error(e)
             return False, str(tool_name + ": " + e.schema["description"])
         except UnknownType as e:
@@ -442,11 +444,17 @@ class ToolInstanceHelper:
         user: User,
         tool_uid: str,
     ) -> None:
-        prompt_regitry_tool = PromptStudioRegistry.objects.get(pk=tool_uid)
+        # HACK: Assume tool_uid is a prompt studio exported tool and query it.
+        # We suppress ValidationError when tool_uid is of a static tool.
+        try:
+            prompt_registry_tool = PromptStudioRegistry.objects.get(pk=tool_uid)
+        except DjangoValidationError:
+            logger.info(f"Not validating tool access for tool: {tool_uid}")
+            return
 
         if (
-            prompt_regitry_tool.shared_to_org
-            or prompt_regitry_tool.shared_users.filter(pk=user.pk).exists()
+            prompt_registry_tool.shared_to_org
+            or prompt_registry_tool.shared_users.filter(pk=user.pk).exists()
         ):
             return
         else:


### PR DESCRIPTION
## What

- HACK: Suppresses `ValidationError` thrown when checking access for static tools
- The actual fix might involve reviewing the handling of static tools and dynamic tools (prompt studio exported tools)
- Minor: Typo fix for a variable `prompt_registry_tool`

## Why

- During workflow execution, prompt studio exported tools need to be checked for access
- `tool_uid` can represent a static tool (its a string like `classifier` in that case) or a UUID in cases of exported tools from prompt studio.
- `ValidationError` is thrown when querying `PromptStudioRegistry` for `tool_uid`'s of static tools like `classifier`

Parts of the traceback
![image](https://github.com/Zipstack/unstract/assets/117059509/6cd12ad9-cf62-438e-ab19-9692163d6162)


## Notes on Testing

- Was able to reproduce the error locally, and the error was not raised after the fix was applied

## Screenshots
![image](https://github.com/Zipstack/unstract/assets/117059509/2942588d-e8fd-460b-8194-74a1dcd60ef0)


## Checklist

I have read and understood the [Contribution Guidelines]().
