### PR TITLE
Added global error handler for prompt-service

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
@@ -782,7 +782,7 @@ class PromptStudioHelper:
         answer = responder.single_pass_extraction(payload)
         # TODO: Make use of dataclasses
         if answer["status"] == "ERROR":
-            error_message = answer.get("error", "")
+            error_message = answer.get("error", None)
             raise AnswerFetchError(error_message)
         output_response = json.loads(answer["structure_output"])
         return output_response

--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -1,10 +1,9 @@
-import json
 import logging
 from enum import Enum
 from typing import Any, Optional
 
 import peewee
-from flask import Flask, request
+from flask import Flask, json, request
 from llama_index import VectorStoreIndex
 from llama_index.llms import LLM
 from llama_index.vector_stores.types import ExactMatchFilter, MetadataFilters
@@ -23,6 +22,7 @@ from unstract.sdk.utils.service_context import (
     ServiceContext as UNServiceContext,
 )
 from unstract.sdk.vector_db import ToolVectorDB
+from werkzeug.exceptions import HTTPException
 
 from unstract.core.pubsub_helper import LogPublisher
 
@@ -768,6 +768,21 @@ def enable_single_pass_extraction() -> None:
 
 
 enable_single_pass_extraction()
+
+
+@app.errorhandler(HTTPException)
+def handle_exception(e):
+    """Return JSON instead of HTML for HTTP errors."""
+    response = e.get_response()
+    response.data = json.dumps(
+        {
+            "code": e.code,
+            "name": e.name,
+            "error": e.description,
+        }
+    )
+    response.content_type = "application/json"
+    return response
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Added global error handler for prompt-service

## Why

To display error response in `application/json` instead of `text/html`

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
