### PR TITLE
Permission fix for adding shared llm adapter in profile manager

### DIFF
--- a/backend/adapter_processor/models.py
+++ b/backend/adapter_processor/models.py
@@ -111,9 +111,7 @@ class AdapterInstance(BaseModel):
 
         adapter_metadata = self.get_adapter_meta_data()
         # Get the adapter_instance
-        adapter_class = Adapterkit().get_adapter_class_by_adapter_id(
-            self.adapter_id
-        )
+        adapter_class = Adapterkit().get_adapter_class_by_adapter_id(self.adapter_id)
         adapter_instance = adapter_class(adapter_metadata)
         if isinstance(adapter_instance, LLMAdapter):
             return adapter_instance.get_context_window_size()

--- a/backend/adapter_processor/models.py
+++ b/backend/adapter_processor/models.py
@@ -111,13 +111,12 @@ class AdapterInstance(BaseModel):
 
         adapter_metadata = self.get_adapter_meta_data()
         # Get the adapter_instance
-        adapter_class = Adapterkit().get_adapter_class_by_adapter_id(self.adapter_id)
+        adapter_class = Adapterkit().get_adapter_class_by_adapter_id(
+            self.adapter_id
+        )
         adapter_instance = adapter_class(adapter_metadata)
-
         if isinstance(adapter_instance, LLMAdapter):
-
             return adapter_instance.get_context_window_size()
-
         return 0
 
 

--- a/backend/adapter_processor/models.py
+++ b/backend/adapter_processor/models.py
@@ -111,9 +111,7 @@ class AdapterInstance(BaseModel):
 
         adapter_metadata = self.get_adapter_meta_data()
         # Get the adapter_instance
-        adapter_class = Adapterkit().get_adapter_class_by_adapter_id(
-            self.adapter_id
-        )
+        adapter_class = Adapterkit().get_adapter_class_by_adapter_id(self.adapter_id)
         adapter_instance = adapter_class(adapter_metadata)
 
         if isinstance(adapter_instance, LLMAdapter):

--- a/backend/adapter_processor/serializers.py
+++ b/backend/adapter_processor/serializers.py
@@ -94,7 +94,7 @@ class AdapterInstanceSerializer(BaseAdapterSerializer):
         return rep
 
 
-class AdapterInfoSerilazier(BaseAdapterSerializer):
+class AdapterInfoSerializer(BaseAdapterSerializer):
 
     context_window_size = serializers.SerializerMethodField()
 
@@ -117,12 +117,12 @@ class AdapterInfoSerilazier(BaseAdapterSerializer):
         adapter_metadata = json.loads(
             f.decrypt(bytes(obj.adapter_metadata_b).decode("utf-8"))
         )
+        # Get the adapter_instance
         adapter_class = Adapterkit().get_adapter_class_by_adapter_id(
             obj.adapter_id
         )
         adapter_instance = adapter_class(adapter_metadata)
-        # If adapter_instance is a LLM send
-        # additional parameter of context_window
+
         if isinstance(adapter_instance, LLMAdapter):
 
             return adapter_instance.get_context_window_size()

--- a/backend/adapter_processor/urls.py
+++ b/backend/adapter_processor/urls.py
@@ -23,6 +23,7 @@ adapter_detail = AdapterInstanceViewSet.as_view(
 )
 
 adapter_users = AdapterInstanceViewSet.as_view({"get": "list_of_shared_users"})
+adapter_info = AdapterInstanceViewSet.as_view({"get": "adapter_info"})
 urlpatterns = format_suffix_patterns(
     [
         path("adapter_schema/", adapter_schema, name="get_adapter_schema"),
@@ -30,6 +31,7 @@ urlpatterns = format_suffix_patterns(
         path("adapter/", adapter_list, name="adapter-list"),
         path("adapter/default_triad/", default_triad, name="default_triad"),
         path("adapter/<uuid:pk>/", adapter_detail, name="adapter_detail"),
+        path("adapter/info/<uuid:pk>/", adapter_info, name="adapter_info"),
         path("test_adapters/", adapter_test, name="adapter-test"),
         path(
             "adapter/users/<uuid:pk>/",

--- a/backend/adapter_processor/views.py
+++ b/backend/adapter_processor/views.py
@@ -12,7 +12,7 @@ from adapter_processor.exceptions import (
     UniqueConstraintViolation,
 )
 from adapter_processor.serializers import (
-    AdapterInfoSerilazier,
+    AdapterInfoSerializer,
     AdapterInstanceSerializer,
     AdapterListSerializer,
     DefaultAdapterSerializer,
@@ -310,6 +310,6 @@ class AdapterInstanceViewSet(ModelViewSet):
             self.get_object()
         )  # Assuming you have a get_object method in your viewset
 
-        serialized_instances = AdapterInfoSerilazier(adapter).data
+        serialized_instances = AdapterInfoSerializer(adapter).data
 
         return Response(serialized_instances)

--- a/backend/adapter_processor/views.py
+++ b/backend/adapter_processor/views.py
@@ -295,9 +295,7 @@ class AdapterInstanceViewSet(ModelViewSet):
         self, request: HttpRequest, pk: Any = None
     ) -> Response:
         self.permission_classes = [IsOwnerOrSharedUser]
-        adapter = (
-            self.get_object()
-        )  # Assuming you have a get_object method in your viewset
+        adapter = self.get_object()
 
         serialized_instances = SharedUserListSerializer(adapter).data
 
@@ -306,9 +304,7 @@ class AdapterInstanceViewSet(ModelViewSet):
     @action(detail=True, methods=["get"])
     def adapter_info(self, request: HttpRequest, pk: uuid) -> Response:
         self.permission_classes = [IsOwnerOrSharedUser]
-        adapter = (
-            self.get_object()
-        )  # Assuming you have a get_object method in your viewset
+        adapter = self.get_object()
 
         serialized_instances = AdapterInfoSerializer(adapter).data
 

--- a/backend/adapter_processor/views.py
+++ b/backend/adapter_processor/views.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from typing import Any, Optional
 
 from adapter_processor.adapter_processor import AdapterProcessor
@@ -11,6 +12,7 @@ from adapter_processor.exceptions import (
     UniqueConstraintViolation,
 )
 from adapter_processor.serializers import (
+    AdapterInfoSerilazier,
     AdapterInstanceSerializer,
     AdapterListSerializer,
     DefaultAdapterSerializer,
@@ -298,5 +300,16 @@ class AdapterInstanceViewSet(ModelViewSet):
         )  # Assuming you have a get_object method in your viewset
 
         serialized_instances = SharedUserListSerializer(adapter).data
+
+        return Response(serialized_instances)
+
+    @action(detail=True, methods=["get"])
+    def adapter_info(self, request: HttpRequest, pk: uuid) -> Response:
+        self.permission_classes = [IsOwnerOrSharedUser]
+        adapter = (
+            self.get_object()
+        )  # Assuming you have a get_object method in your viewset
+
+        serialized_instances = AdapterInfoSerilazier(adapter).data
 
         return Response(serialized_instances)

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
@@ -356,7 +356,7 @@ function AddLlmProfile({
     }
     const requestOptions = {
       method: "GET",
-      url: `/api/v1/unstract/${sessionDetails?.orgId}/adapter/${value}/`,
+      url: `/api/v1/unstract/${sessionDetails?.orgId}/adapter/info/${value}/`,
       headers: {
         "X-CSRFToken": sessionDetails?.csrfToken,
       },
@@ -365,7 +365,7 @@ function AddLlmProfile({
     axiosPrivate(requestOptions)
       .then((res) => {
         const data = res?.data;
-        const contextWindowSize = data.adapter_metadata.context_window_size;
+        const contextWindowSize = data.context_window_size;
         const chunkSize = form.getFieldValue("chunk_size");
         setTokenSize(chunkSize > 0 ? calcTokenSize(chunkSize) : 0);
         setMaxTokenSize(contextWindowSize);


### PR DESCRIPTION
## What

- When user try to create the new LLM Profile for shared prompt studio project and try to choose the shared LLM in profile, getting permisson issue.


## Why

- User can only use the shared adapter in their profile manager, they can’t get metadata ( including credentials and other configurations of the adapter)

## How

- Introduced API which gives out insensitive  info such as context window size, enabled permission to shared users as well

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

![image](https://github.com/Zipstack/unstract/assets/116638720/086cb031-f3e0-40af-bfd4-1900ee6db90e)
![image](https://github.com/Zipstack/unstract/assets/116638720/b02d74f9-e3c9-4831-8c5f-ae7a2de6cb76)


## Checklist

I have read and understood the [Contribution Guidelines]().
