### PR TITLE
Fixed Enforce Type Issues for Boolean and JSON

### DIFF
--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -464,6 +464,15 @@ def prompt_processor() -> Any:
             if assertion_failed or answer.lower() == "na":
                 structured_output[output[PSKeys.NAME]] = None
             else:
+                prompt = f'Extract yes/no from the following text:\n{answer}\n\n\
+                    Output in single word.\
+                    If the context is trying to convey that the answer is true, \
+                    then return "yes", else return "no".'
+                answer, usage = run_completion(
+                    llm_helper,
+                    llm_li,
+                    prompt,
+                )
                 if answer.lower() == "yes":
                     structured_output[output[PSKeys.NAME]] = True
                 else:
@@ -472,6 +481,14 @@ def prompt_processor() -> Any:
             if assertion_failed or answer.lower() == "[]" or answer.lower() == "na":
                 structured_output[output[PSKeys.NAME]] = None
             else:
+                prompt = (
+                    f"Convert the following text:\n{answer} into valid JSON format."
+                )
+                answer, usage = run_completion(
+                    llm_helper,
+                    llm_li,
+                    prompt,
+                )
                 # Remove any markdown code blocks
                 lines = answer.split("\n")
                 answer = ""


### PR DESCRIPTION
## What
Fixed the following issues:
1. The prompt result for Boolean enforce type was always false.
2. Only when we specify in the prompt that we want the result in JSON format, it was working. Just selecting JSON from the enforce type was returning an empty object.
-

## Why
NA
-

## How
NA
-

## Database Migrations
NA
- 

## Env Config
NA
- 

## Relevant Docs
NA
-

## Related Issues or PRs
NA
-

## Dependencies Versions
NA
-

## Notes on Testing
NA
-

## Screenshots
### Prompt Card 1 contains the example for boolean enforce type
### Prompt Card 2 contains the example for JSON enforce type
![image](https://github.com/Zipstack/unstract/assets/89440263/1d4ad981-778e-41b4-93bb-2608ed95f5b0)

## Checklist

I have read and understood the [Contribution Guidelines]().
