### PR TITLE
Replaced to notification component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { ConfigProvider, message, theme } from "antd";
+import { ConfigProvider, notification, theme } from "antd";
 import { BrowserRouter } from "react-router-dom";
 
 import { THEME } from "./helpers/GetStaticData.js";
@@ -8,12 +8,17 @@ import { useSessionStore } from "./store/session-store.js";
 import PostHogPageviewTracker from "./PostHogPageviewTracker.js";
 
 function App() {
-  const [messageApi, contextHolder] = message.useMessage();
+  const [notificationAPI, contextHolder] = notification.useNotification();
   const { defaultAlgorithm, darkAlgorithm } = theme;
   const { sessionDetails } = useSessionStore();
   const { AlertDetails } = useAlertStore();
 
-  AlertDetails.content && messageApi.open(AlertDetails);
+  AlertDetails.content &&
+    notificationAPI.open({
+      message: AlertDetails.title || "Success",
+      description: AlertDetails.content,
+      type: AlertDetails.type,
+    });
 
   return (
     <ConfigProvider

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,13 +11,13 @@ function App() {
   const [notificationAPI, contextHolder] = notification.useNotification();
   const { defaultAlgorithm, darkAlgorithm } = theme;
   const { sessionDetails } = useSessionStore();
-  const { AlertDetails } = useAlertStore();
+  const { alertDetails } = useAlertStore();
 
-  AlertDetails.content &&
+  alertDetails.content &&
     notificationAPI.open({
-      message: AlertDetails.title || "Success",
-      description: AlertDetails.content,
-      type: AlertDetails.type,
+      message: alertDetails.title,
+      description: alertDetails.content,
+      type: alertDetails.type,
     });
 
   return (

--- a/frontend/src/components/input-output/add-source-modal/AddSourceModal.jsx
+++ b/frontend/src/components/input-output/add-source-modal/AddSourceModal.jsx
@@ -98,6 +98,7 @@ function AddSourceModal({
       .catch((err) => {
         setAlertDetails(handleException(err));
         setOpen(false);
+        setEditItemId(null);
       });
   };
 

--- a/frontend/src/hooks/useExceptionHandler.jsx
+++ b/frontend/src/hooks/useExceptionHandler.jsx
@@ -6,12 +6,14 @@ const useExceptionHandler = () => {
   const handleException = (
     err,
     errMessage = "Something went wrong",
-    setBackendErrors = undefined
+    setBackendErrors = undefined,
+    title = "Failed"
   ) => {
     if (!err) {
       return {
         type: "error",
         content: errMessage,
+        title: title,
       };
     }
 
@@ -27,6 +29,7 @@ const useExceptionHandler = () => {
         case "subscription_error":
           navigate("/trial-expired");
           return {
+            title: title,
             type: "error",
             content:
               errors && errors[0]?.detail ? errors[0].detail : errMessage,
@@ -34,18 +37,21 @@ const useExceptionHandler = () => {
         case "client_error":
         case "server_error":
           return {
+            title: title,
             type: "error",
             content:
               errors && errors[0]?.detail ? errors[0].detail : errMessage,
           };
         default:
           return {
+            title: title,
             type: "error",
             content: errMessage,
           };
       }
     } else {
       return {
+        title: title,
         type: "error",
         content: errMessage,
       };

--- a/frontend/src/store/alert-store.js
+++ b/frontend/src/store/alert-store.js
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 const STORE_VARIABLES = {
-  AlertDetails: {
+  alertDetails: {
     type: "",
     content: "",
     title: "",
@@ -11,15 +11,10 @@ const useAlertStore = create((setState) => ({
   ...STORE_VARIABLES,
   setAlertDetails: (details) => {
     setState(() => {
-      let title = details.title;
-      if (!title) {
-        if (details.type === "error") {
-          title = "Failed";
-        } else {
-          title = "Success";
-        }
-      }
-      return { AlertDetails: { ...details, title } };
+      const title = details.title;
+      const notificationTitle =
+        title || (details.type === "error" ? "Failed" : "Success");
+      return { alertDetails: { ...details, title: notificationTitle } };
     });
   },
 }));

--- a/frontend/src/store/alert-store.js
+++ b/frontend/src/store/alert-store.js
@@ -4,13 +4,22 @@ const STORE_VARIABLES = {
   AlertDetails: {
     type: "",
     content: "",
+    title: "",
   },
 };
 const useAlertStore = create((setState) => ({
   ...STORE_VARIABLES,
   setAlertDetails: (details) => {
     setState(() => {
-      return { AlertDetails: { ...details, duration: 5 } };
+      let title = details.title;
+      if (!title) {
+        if (details.type === "error") {
+          title = "Failed";
+        } else {
+          title = "Success";
+        }
+      }
+      return { AlertDetails: { ...details, title } };
     });
   },
 }));


### PR DESCRIPTION
## What

- Replaced message component to notification component

## Why

- Currently, we are using the [Message](https://ant.design/components/message) component to display popup error messages. This popup message is dismissed automatically, but we want to change this behavior. We want users to be able to close the popup message manually. Therefore, replacing this with the [Notification](https://ant.design/components/notification) component is a good approach, as it remains on the screen until the user manually closes it, providing several other useful customization options as well.

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/Zipstack/unstract/assets/105187947/5fbdc64d-6db0-4195-b15e-a7acb23dd86e)
![image](https://github.com/Zipstack/unstract/assets/105187947/a7edf486-8cf3-4f31-ab21-76d4f4fc95f8)


## Checklist

I have read and understood the [Contribution Guidelines]().
