### PR TITLE
fixed redirect to new prompt project after created

### DIFF
--- a/frontend/src/components/custom-tools/add-custom-tool-form-modal/AddCustomToolFormModal.jsx
+++ b/frontend/src/components/custom-tools/add-custom-tool-form-modal/AddCustomToolFormModal.jsx
@@ -7,6 +7,7 @@ import { getBackendErrorDetail } from "../../../helpers/GetStaticData";
 import { useAlertStore } from "../../../store/alert-store";
 import "./AddCustomToolFormModal.css";
 import { useExceptionHandler } from "../../../hooks/useExceptionHandler";
+import { useNavigate } from "react-router-dom";
 const defaultFromDetails = {
   tool_name: "",
   author: "",
@@ -31,6 +32,7 @@ function AddCustomToolFormModal({
   );
   const [icon, setIcon] = useState(isEdit ? formDetails.icon : "");
   const [backendErrors, setBackendErrors] = useState(null);
+  const navigate = useNavigate();
 
   const updateIcon = (emoji) => {
     setIcon(emoji);
@@ -71,6 +73,7 @@ function AddCustomToolFormModal({
         });
         setOpen(false);
         clearFormDetails();
+        navigate(success?.tool_id);
       })
       .catch((err) => {
         handleException(err, "", setBackendErrors);

--- a/frontend/src/components/custom-tools/list-of-tools/ListOfTools.jsx
+++ b/frontend/src/components/custom-tools/list-of-tools/ListOfTools.jsx
@@ -88,7 +88,7 @@ function ListOfTools() {
           const tool = res?.data;
           updateList(isEdit, tool);
           setOpenAddTool(false);
-          resolve(true);
+          resolve(res?.data);
         })
         .catch((err) => {
           reject(err);


### PR DESCRIPTION
## What

- Fixed redirect to new prompt project after created

## Why

- When new instance of prompt studio is created, page is not redirecting to created instance instead list of prompt studio is displayed. For better user experience, we are redirecting to newly created project.

## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-1095

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

![image](https://github.com/Zipstack/unstract/assets/105187947/39856477-86f6-4055-a60b-d625cb030459)


## Checklist

I have read and understood the [Contribution Guidelines]().
