### PR TITLE
fixed notification closes automatically after few sec

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ function App() {
       message: alertDetails.title,
       description: alertDetails.content,
       type: alertDetails.type,
+      duration: 0,
     });
 
   return (


### PR DESCRIPTION
## What

- Notification component closed after few seconds

## Why

- After the duration time elapses, the notification closes automatically. If not specified, default value is 4.5 seconds. If you set the value to 0, the notification box will never close automatically.
## How

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-1195

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/Zipstack/unstract/assets/105187947/4642ce10-c3b8-4220-9606-d7525e107bb2)


## Checklist

I have read and understood the [Contribution Guidelines]().
