### PR TITLE
feat: Minor index error handling enhancement

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/exceptions.py
+++ b/backend/prompt_studio/prompt_studio_core/exceptions.py
@@ -19,7 +19,7 @@ class PromptNotValid(APIException):
 
 
 class IndexingAPIError(APIException):
-    status_code = 400
+    status_code = 500
     default_detail = "Error while indexing file"
 
 

--- a/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
@@ -661,13 +661,14 @@ class PromptStudioHelper:
             )
             return doc_id
         except IndexingError as e:
+            doc_name = os.path.split(file_path)[1]
             PromptStudioHelper._publish_log(
-                {"tool_id": tool_id, "doc_name": os.path.split(file_path)[1]},
+                {"tool_id": tool_id, "doc_name": doc_name},
                 LogLevels.ERROR,
                 LogLevels.RUN,
-                "Indexing failed",
+                f"Indexing failed : {e}",
             )
-            raise IndexingAPIError(str(e)) from e
+            raise IndexingAPIError(f"Error while indexing {doc_name}. {str(e)}") from e
 
     @staticmethod
     def _fetch_single_pass_response(

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -123,8 +123,10 @@ SYSTEM_ADMIN_EMAIL="admin@abc.com"
 # Set Django Session Expiry Time (in seconds)
 SESSION_COOKIE_AGE=86400
 
+
 # Control async extraction of LLM Whisperer
 # Time in seconds to wait before polling LLMWhisperer's status API
 ADAPTER_LLMW_POLL_INTERVAL=30
 # Total number of times to poll the status API.
-ADAPTER_LLMW_MAX_POLLS=30
+# 500 mins to allow 1500 (max pages limit) * 20 (approx time in sec to process a page)
+ADAPTER_LLMW_MAX_POLLS=1000


### PR DESCRIPTION
## What

- Updated `IndexingAPIError` to return 500
- Added `doc_name` to logs sent to FE
- Updated `ADAPTER_LLMW_MAX_POLLS=1000` (corresponds to 1500 max limit of LLM whisperer x 20s approx to process a page)



## Can this PR break any existing features. If yes please list of possible items. If no please exaplin why. (PS: Admins do not merge the PR without this section filled)

- No, minor index error enhancements




## Screenshots
![image](https://github.com/Zipstack/unstract/assets/117059509/595bbaf7-ec33-4f3a-a5c0-d2794882fb7d)

## Checklist

I have read and understood the [Contribution Guidelines]().
