### PR TITLE
FIX: Removed the usage of escape-html library

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,6 @@
         "cronstrue": "^2.48.0",
         "emoji-picker-react": "^4.8.0",
         "emoji-regex": "^10.3.0",
-        "escape-html": "^1.0.3",
         "handlebars": "^4.7.8",
         "http-proxy-middleware": "^2.0.6",
         "js-cookie": "^3.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "cronstrue": "^2.48.0",
     "emoji-picker-react": "^4.8.0",
     "emoji-regex": "^10.3.0",
-    "escape-html": "^1.0.3",
     "handlebars": "^4.7.8",
     "http-proxy-middleware": "^2.0.6",
     "js-cookie": "^3.0.5",

--- a/frontend/src/components/custom-tools/text-viewer-pre/TextViewerPre.jsx
+++ b/frontend/src/components/custom-tools/text-viewer-pre/TextViewerPre.jsx
@@ -1,10 +1,9 @@
 import PropTypes from "prop-types";
-import escapeHTML from "escape-html";
 
 function TextViewerPre({ text }) {
   return (
     <div className="text-viewer-layout">
-      <pre style={{ fontSize: "12px" }}>{escapeHTML(text)}</pre>
+      <pre style={{ fontSize: "12px" }}>{text}</pre>
     </div>
   );
 }


### PR DESCRIPTION
## What

The [escape-html](https://www.npmjs.com/package/escape-html) library is not needed as react by default escapes HTML.

**Resources**:
1. https://www.stackhawk.com/blog/react-xss-guide-examples-and-prevention/
2. https://legacy.reactjs.org/docs/introducing-jsx.html#jsx-prevents-injection-attacks

-

## Why

Removed the escape-html library because that work in handle by react by default.

-

## How

Removed the usage from the `/src/components/custom-tools/text-viewer-pre/TextViewerPre.jsx` component and did `npm uninstall` to remove the package.

-

## Can this PR break any existing features. If yes please list of possible items. If no please exaplin why. (PS: Admins do not merge the PR without this section filled)

No, this PR will not break any existing features. It is a UI change where we render the raw text.

-

## Database Migrations
NA
- 

## Env Config
NA
- 

## Relevant Docs
NA
-

## Related Issues or PRs
NA
-

## Dependencies Versions
NA
-

## Notes on Testing
NA
-

## Screenshots

![image](https://github.com/Zipstack/unstract/assets/89440263/bfe080d4-0a9c-4ca4-94fc-94f9883613b0)

## Checklist

I have read and understood the [Contribution Guidelines]().
