### PR TITLE
fix: Exception handling middleware traceback and worker log fix

### DIFF
--- a/worker/src/unstract/worker/worker.py
+++ b/worker/src/unstract/worker/worker.py
@@ -46,13 +46,13 @@ class UnstractWorker:
                     registry=private_registry_url,
                 )
             except FileNotFoundError as file_err:
-                logger.error(
+                self.logger.error(
                     f"Service account key file is not mounted "
                     f"in {private_registry_credential_path}: {file_err}"
                     "Logging to private registry might fail, if private tool is used."
                 )
             except APIError as api_err:
-                logger.error(
+                self.logger.error(
                     f"Exception occured while invoking docker client : {api_err}."
                     f"Authentication to artifact registry failed."
                 )


### PR DESCRIPTION
## What

- Updated `response` to be `Optional` and added a default status code of 500
- Updated usage of logger in `worker`

## Why

- Exception handling middleware raised such tracebacks
![image](https://github.com/Zipstack/unstract/assets/117059509/bcd21202-3f36-4feb-a99a-9f62f03f77f4)

- Minor conflict when PRs were merged in `worker`


## Can this PR break any existing features. If yes please list of possible items. If no please exaplin why. (PS: Admins do not merge the PR without this section filled)

- No, no migrations involved and we safely assume a default of 500 for errors

## Notes on Testing

- Checked logs to observe the incorrect log removed


## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
