### PR TITLE
fix: Fixed index key generation in prompt service

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
@@ -333,7 +333,7 @@ class PromptStudioHelper:
 
             logger.info(f"[{tool_id}] Executing single prompt {id}")
             PromptStudioHelper._publish_log(
-                {"tool_id": tool_id, "prompt_id": id},
+                {"tool_id": tool_id, "prompt_id": id, "doc_name": file_name},
                 LogLevels.INFO,
                 LogLevels.RUN,
                 "Executing single prompt",
@@ -353,7 +353,7 @@ class PromptStudioHelper:
 
             logger.info(f"[{tool.tool_id}] Invoking prompt service for prompt {id}")
             PromptStudioHelper._publish_log(
-                {"tool_id": tool_id, "prompt_id": id},
+                {"tool_id": tool_id, "prompt_id": id, "doc_name": file_name},
                 LogLevels.DEBUG,
                 LogLevels.RUN,
                 "Invoking prompt service",
@@ -651,6 +651,7 @@ class PromptStudioHelper:
             util = PromptIdeBaseTool(log_level=LogLevel.INFO, org_id=org_id)
             tool_index = ToolIndex(tool=util)
         except Exception as e:
+            # TODO: Review use of this
             PromptStudioHelper._publish_log(
                 {"tool_id": tool_id, "doc_name": os.path.split(file_path)[1]},
                 LogLevels.ERROR,

--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -226,8 +226,8 @@ def prompt_processor() -> Any:
             vector_db=output[PSKeys.VECTOR_DB],
             embedding=output[PSKeys.EMBEDDING],
             x2text=output[PSKeys.X2TEXT_ADAPTER],
-            chunk_size=output[PSKeys.CHUNK_SIZE],
-            chunk_overlap=output[PSKeys.CHUNK_OVERLAP],
+            chunk_size=str(output[PSKeys.CHUNK_SIZE]),
+            chunk_overlap=str(output[PSKeys.CHUNK_OVERLAP]),
         )
         _publish_log(
             log_events_id,
@@ -302,11 +302,27 @@ def prompt_processor() -> Any:
         context = ""
         if output[PSKeys.CHUNK_SIZE] == 0:
             # We can do this only for chunkless indexes
-            context = tool_index.get_text_from_index(
+            context: Optional[str] = tool_index.get_text_from_index(
                 embedding_type=output[PSKeys.EMBEDDING],
                 vector_db=output[PSKeys.VECTOR_DB],
                 doc_id=doc_id,
             )
+            if context is None:
+                msg = (
+                    "Couldn't fetch context from"
+                    f" vector DB {output[PSKeys.VECTOR_DB]}"
+                )
+                app.logger.error(msg)
+                result["error"] = msg
+                # TODO: Try to fill doc_name also here
+                _publish_log(
+                    log_events_id,
+                    {"tool_id": tool_id},
+                    LogLevel.ERROR,
+                    RunLevel.RUN,
+                    "Couldn't fetch context from vector DB",
+                )
+                return result, 500
 
         assertion_failed = False
         answer = "yes"


### PR DESCRIPTION
## What

- Typed chunk size and chunk overlap as str - to remain consistent with how its indexed

## Why

- Inconsistency in types result in different hashes, raising an SDK PR to handle this uniformly
![image](https://github.com/Zipstack/unstract/assets/117059509/7d16d414-6fc9-4ff3-a043-c574ab3b5175)

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, it only has minor log updates and an update for indexing correctly

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tried indexing and executing a prompt

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
