### PR TITLE
Removed edit button on ETL pipeline

### DIFF
--- a/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
+++ b/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
@@ -1,7 +1,6 @@
 import {
   ClearOutlined,
   DeleteOutlined,
-  EditOutlined,
   EllipsisOutlined,
   SyncOutlined,
   HighlightOutlined,

--- a/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
+++ b/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
@@ -225,23 +225,6 @@ function Pipelines({ type }) {
         <Space
           direction="horizontal"
           className="action-items"
-          onClick={() => openAddModal(true)}
-        >
-          <div>
-            <EditOutlined />
-          </div>
-          <div>
-            <Typography.Text>Edit</Typography.Text>
-          </div>
-        </Space>
-      ),
-    },
-    {
-      key: "2",
-      label: (
-        <Space
-          direction="horizontal"
-          className="action-items"
           onClick={() => setOpenDeleteModal(true)}
         >
           <div>
@@ -254,7 +237,7 @@ function Pipelines({ type }) {
       ),
     },
     {
-      key: "3",
+      key: "2",
       label: (
         <Space
           direction="horizontal"
@@ -271,7 +254,7 @@ function Pipelines({ type }) {
       ),
     },
     {
-      key: "4",
+      key: "3",
       label: (
         <Space
           direction="horizontal"
@@ -288,7 +271,7 @@ function Pipelines({ type }) {
       ),
     },
     {
-      key: "5",
+      key: "4",
       label: (
         <Space
           direction="horizontal"


### PR DESCRIPTION
## What

- Removed edit button from ETL pipeline

## Why

- The implementation needs to be revised.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, Button removed from option this wont break any existing features

## Database Migrations

-  NA

## Env Config

- NA

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-1235

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

![image](https://github.com/Zipstack/unstract/assets/105187947/57605dec-8b7d-4960-a847-edc46c5840d6)


## Checklist

I have read and understood the [Contribution Guidelines]().
