### PR TITLE
feat: Backend - prompt service plumbing for error handling

### DIFF
--- a/backend/prompt_studio/prompt_studio/exceptions.py
+++ b/backend/prompt_studio/prompt_studio/exceptions.py
@@ -6,11 +6,6 @@ class IndexingError(APIException):
     default_detail = "Error while indexing file"
 
 
-class FilenameMissingError(APIException):
-    status_code = 400
-    default_detail = "No file selected to parse."
-
-
 class AnswerFetchError(APIException):
     status_code = 400
     default_detail = "Error occured while fetching response for the prompt"

--- a/backend/prompt_studio/prompt_studio_core/constants.py
+++ b/backend/prompt_studio/prompt_studio_core/constants.py
@@ -29,7 +29,6 @@ class ToolStudioPromptKeys:
     ID = "id"
     FILE_NAME = "file_name"
     FILE_HASH = "file_hash"
-    UNDEFINED = "undefined"
     TOOL_ID = "tool_id"
     NAME = "name"
     ACTIVE = "active"

--- a/backend/prompt_studio/prompt_studio_core/views.py
+++ b/backend/prompt_studio/prompt_studio_core/views.py
@@ -14,7 +14,6 @@ from prompt_studio.prompt_profile_manager.constants import ProfileManagerErrors
 from prompt_studio.prompt_profile_manager.models import ProfileManager
 from prompt_studio.prompt_profile_manager.serializers import ProfileManagerSerializer
 from prompt_studio.prompt_studio.constants import ToolStudioPromptErrors
-from prompt_studio.prompt_studio.exceptions import FilenameMissingError
 from prompt_studio.prompt_studio.serializers import ToolStudioPromptSerializer
 from prompt_studio.prompt_studio_core.constants import (
     FileViewTypes,
@@ -249,17 +248,11 @@ class PromptStudioCoreView(viewsets.ModelViewSet):
         custom_tool = self.get_object()
         tool_id: str = str(custom_tool.tool_id)
         document_id: str = request.data.get(ToolStudioPromptKeys.DOCUMENT_ID)
-        document: DocumentManager = DocumentManager.objects.get(pk=document_id)
-        file_name: str = document.document_name
         id: str = request.data.get(ToolStudioPromptKeys.ID)
 
-        if not file_name or file_name == ToolStudioPromptKeys.UNDEFINED:
-            logger.error("Mandatory field file_name is missing")
-            raise FilenameMissingError()
         response: dict[str, Any] = PromptStudioHelper.prompt_responder(
             id=id,
             tool_id=tool_id,
-            file_name=file_name,
             org_id=UserSessionUtils.get_organization_id(request),
             user_id=custom_tool.created_by.user_id,
             document_id=document_id,
@@ -274,9 +267,6 @@ class PromptStudioCoreView(viewsets.ModelViewSet):
             request (HttpRequest): _description_
             pk (Any): Primary key of the CustomTool
 
-        Raises:
-            FilenameMissingError: _description_
-
         Returns:
             Response
         """
@@ -285,15 +275,9 @@ class PromptStudioCoreView(viewsets.ModelViewSet):
         custom_tool = self.get_object()
         tool_id: str = str(custom_tool.tool_id)
         document_id: str = request.data.get(ToolStudioPromptKeys.DOCUMENT_ID)
-        document: DocumentManager = DocumentManager.objects.get(pk=document_id)
-        file_name: str = document.document_name
 
-        if not file_name or file_name == ToolStudioPromptKeys.UNDEFINED:
-            logger.error("Mandatory field file_name is missing")
-            raise FilenameMissingError()
         response: dict[str, Any] = PromptStudioHelper.prompt_responder(
             tool_id=tool_id,
-            file_name=file_name,
             org_id=UserSessionUtils.get_organization_id(request),
             user_id=custom_tool.created_by.user_id,
             document_id=document_id,

--- a/prompt-service/src/unstract/prompt_service/exceptions.py
+++ b/prompt-service/src/unstract/prompt_service/exceptions.py
@@ -1,0 +1,44 @@
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+from werkzeug.exceptions import HTTPException
+
+DEFAULT_ERR_MESSAGE = "Something went wrong"
+
+
+@dataclass
+class ErrorResponse:
+    """Represents error response from prompt service."""
+
+    error: str = DEFAULT_ERR_MESSAGE
+    name: str = "PromptServiceError"
+    code: int = 500
+    payload: Optional[Any] = None
+
+
+class APIError(HTTPException):
+    code = 500
+
+    def __init__(
+        self,
+        message: str = DEFAULT_ERR_MESSAGE,
+        code: Optional[int] = None,
+        payload: Any = None,
+    ):
+        super().__init__(description=message)
+        self.message = message
+        if code is not None:
+            self.code = code
+        self.payload = payload
+
+    def to_dict(self):
+        err = ErrorResponse(
+            error=self.message,
+            code=self.code,
+            payload=self.payload,
+            name=self.__class__.__name__,
+        )
+        return asdict(err)
+
+    def __str__(self):
+        return str(self.message)

--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -1,20 +1,23 @@
 import logging
+import traceback
 from enum import Enum
 from json import JSONDecodeError
 from typing import Any, Optional
 
 import peewee
-from flask import Flask, json, request
+from flask import Flask, json, jsonify, request
 from llama_index.core import VectorStoreIndex
 from llama_index.core.llms import LLM
 from llama_index.core.vector_stores import ExactMatchFilter, MetadataFilters
 from unstract.prompt_service.authentication_middleware import AuthenticationMiddleware
 from unstract.prompt_service.constants import PromptServiceContants as PSKeys
 from unstract.prompt_service.constants import RunLevel
+from unstract.prompt_service.exceptions import APIError, ErrorResponse
 from unstract.prompt_service.helper import EnvLoader, plugin_loader
 from unstract.prompt_service.prompt_ide_base_tool import PromptServiceBaseTool
 from unstract.sdk.constants import LogLevel
 from unstract.sdk.embedding import ToolEmbedding
+from unstract.sdk.exceptions import SdkError
 from unstract.sdk.index import ToolIndex
 from unstract.sdk.llm import ToolLLM
 from unstract.sdk.utils.callback_manager import CallbackManager as UNCallbackManager
@@ -170,13 +173,14 @@ def prompt_processor() -> Any:
     outputs = payload.get(PSKeys.OUTPUTS)
     tool_id: str = payload.get(PSKeys.TOOL_ID, "")
     file_hash = payload.get(PSKeys.FILE_HASH)
+    doc_name = str(payload.get(PSKeys.FILE_NAME, ""))
     log_events_id: str = payload.get(PSKeys.LOG_EVENTS_ID, "")
 
     structured_output: dict[str, Any] = {}
     variable_names: list[str] = []
     _publish_log(
         log_events_id,
-        {"tool_id": tool_id},
+        {"tool_id": tool_id, "doc_name": doc_name},
         LogLevel.DEBUG,
         RunLevel.RUN,
         "Preparing to execute all prompts",
@@ -186,7 +190,7 @@ def prompt_processor() -> Any:
         variable_names.append(output[PSKeys.NAME])
     for output in outputs:  # type:ignore
         active = output[PSKeys.ACTIVE]
-        name = output[PSKeys.NAME]
+        prompt_name = output[PSKeys.NAME]
         promptx = output[PSKeys.PROMPT]
         chunk_size = output[PSKeys.CHUNK_SIZE]
         util = PromptServiceBaseTool(log_level=LogLevel.INFO, platform_key=platform_key)
@@ -194,20 +198,20 @@ def prompt_processor() -> Any:
         adapter_instance_id = output[PSKeys.LLM]
 
         if active is False:
-            app.logger.info(f"[{tool_id}] Skipping inactive prompt: {name}")
+            app.logger.info(f"[{tool_id}] Skipping inactive prompt: {prompt_name}")
             _publish_log(
                 log_events_id,
-                {"tool_id": tool_id, "prompt_key": name},
+                {"tool_id": tool_id, "prompt_key": prompt_name, "doc_name": doc_name},
                 LogLevel.INFO,
                 RunLevel.RUN,
                 "Skipping inactive prompt",
             )
             continue
 
-        app.logger.info(f"[{tool_id}] Executing prompt: {name}")
+        app.logger.info(f"[{tool_id}] Executing prompt: {prompt_name}")
         _publish_log(
             log_events_id,
-            {"tool_id": tool_id, "prompt_key": name},
+            {"tool_id": tool_id, "prompt_key": prompt_name, "doc_name": doc_name},
             LogLevel.DEBUG,
             RunLevel.RUN,
             "Executing prompt",
@@ -231,65 +235,40 @@ def prompt_processor() -> Any:
         )
         _publish_log(
             log_events_id,
-            {"tool_id": tool_id, "prompt_key": name},
+            {"tool_id": tool_id, "prompt_key": prompt_name, "doc_name": doc_name},
             LogLevel.DEBUG,
             RunLevel.RUN,
             "Retrieved document ID",
         )
 
-        llm_helper = ToolLLM(tool=util)
-        llm_li: Optional[LLM] = llm_helper.get_llm(
-            adapter_instance_id=adapter_instance_id
-        )
-        if llm_li is None:
-            msg = f"Couldn't fetch LLM {adapter_instance_id}"
-            app.logger.error(msg)
-            _publish_log(
-                log_events_id,
-                {"tool_id": tool_id, "prompt_key": name},
-                LogLevel.ERROR,
-                RunLevel.RUN,
-                "Failed due to LLM error",
+        try:
+            llm_helper = ToolLLM(tool=util)
+            llm_li: LLM = llm_helper.get_llm(adapter_instance_id=adapter_instance_id)
+            embedd_helper = ToolEmbedding(tool=util)
+            embedding_li = embedd_helper.get_embedding(
+                adapter_instance_id=output[PSKeys.EMBEDDING]
             )
-            result["error"] = msg
-            return result, 500
-        embedd_helper = ToolEmbedding(tool=util)
-        embedding_li = embedd_helper.get_embedding(
-            adapter_instance_id=output[PSKeys.EMBEDDING]
-        )
-        if embedding_li is None:
-            msg = f"Couldn't fetch embedding {output[PSKeys.EMBEDDING]}"
-            app.logger.error(msg)
-            _publish_log(
-                log_events_id,
-                {"tool_id": tool_id, "prompt_key": name},
-                LogLevel.ERROR,
-                RunLevel.RUN,
-                "Failed due to embedding error",
-            )
-            result["error"] = msg
-            return result, 500
-        embedding_dimension = embedd_helper.get_embedding_length(embedding_li)
+            embedding_dimension = embedd_helper.get_embedding_length(embedding_li)
 
-        vdb_helper = ToolVectorDB(
-            tool=util,
-        )
-        vector_db_li = vdb_helper.get_vector_db(
-            adapter_instance_id=output[PSKeys.VECTOR_DB],
-            embedding_dimension=embedding_dimension,
-        )
-        if vector_db_li is None:
-            msg = f"Couldn't fetch vector DB {output[PSKeys.VECTOR_DB]}"
+            vdb_helper = ToolVectorDB(
+                tool=util,
+            )
+            vector_db_li = vdb_helper.get_vector_db(
+                adapter_instance_id=output[PSKeys.VECTOR_DB],
+                embedding_dimension=embedding_dimension,
+            )
+        except SdkError as e:
+            msg = f"Couldn't fetch adapter. {e}"
             app.logger.error(msg)
-            result["error"] = msg
             _publish_log(
                 log_events_id,
-                {"tool_id": tool_id, "prompt_key": name},
+                {"tool_id": tool_id, "prompt_key": prompt_name, "doc_name": doc_name},
                 LogLevel.ERROR,
                 RunLevel.RUN,
-                "Failed due to vector db error",
+                "Unable to obtain LLM / embedding / vectorDB",
             )
-            return result, 500
+            return APIError(message=msg)
+
         # Set up llm, embedding and callback manager to collect usage stats
         # for this context
         UNCallbackManager.set_callback_manager(
@@ -308,27 +287,27 @@ def prompt_processor() -> Any:
                 doc_id=doc_id,
             )
             if context is None:
-                msg = (
-                    "Couldn't fetch context from"
-                    f" vector DB {output[PSKeys.VECTOR_DB]}"
-                )
-                app.logger.error(msg)
-                result["error"] = msg
-                # TODO: Try to fill doc_name also here
+                # TODO: Obtain user set name for vector DB
+                msg = "Couldn't fetch context from vector DB"
+                app.logger.error(msg + f" {output[PSKeys.VECTOR_DB]}")
                 _publish_log(
                     log_events_id,
-                    {"tool_id": tool_id},
+                    {
+                        "tool_id": tool_id,
+                        "prompt_key": prompt_name,
+                        "doc_name": doc_name,
+                    },
                     LogLevel.ERROR,
                     RunLevel.RUN,
-                    "Couldn't fetch context from vector DB",
+                    msg,
                 )
-                return result, 500
+                raise APIError(message=msg)
 
         assertion_failed = False
         answer = "yes"
         _publish_log(
             log_events_id,
-            {"tool_id": tool_id, "prompt_key": name},
+            {"tool_id": tool_id, "prompt_key": prompt_name, "doc_name": doc_name},
             LogLevel.DEBUG,
             RunLevel.RUN,
             "Verifying assertion prompt",
@@ -349,7 +328,7 @@ def prompt_processor() -> Any:
             app.logger.info("Assert failed.")
             _publish_log(
                 log_events_id,
-                {"tool_id": tool_id, "prompt_key": name},
+                {"tool_id": tool_id, "prompt_key": prompt_name, "doc_name": doc_name},
                 LogLevel.DEBUG,
                 RunLevel.RUN,
                 "Assertion failed",
@@ -385,7 +364,11 @@ def prompt_processor() -> Any:
                 answer = "NA"
                 _publish_log(
                     log_events_id,
-                    {"tool_id": tool_id, "prompt_key": name},
+                    {
+                        "tool_id": tool_id,
+                        "prompt_key": prompt_name,
+                        "doc_name": doc_name,
+                    },
                     LogLevel.INFO,
                     RunLevel.RUN,
                     "Retrieving context from adapter",
@@ -407,7 +390,11 @@ def prompt_processor() -> Any:
 
                 _publish_log(
                     log_events_id,
-                    {"tool_id": tool_id, "prompt_key": name},
+                    {
+                        "tool_id": tool_id,
+                        "prompt_key": prompt_name,
+                        "doc_name": doc_name,
+                    },
                     LogLevel.DEBUG,
                     RunLevel.RUN,
                     "Retrieved context from adapter",
@@ -415,7 +402,7 @@ def prompt_processor() -> Any:
 
         _publish_log(
             log_events_id,
-            {"tool_id": tool_id, "prompt_key": name},
+            {"tool_id": tool_id, "prompt_key": prompt_name, "doc_name": doc_name},
             LogLevel.INFO,
             RunLevel.RUN,
             f"Processing prompt type: {output[PSKeys.TYPE]}",
@@ -574,7 +561,11 @@ def prompt_processor() -> Any:
             if eval_plugin:
                 _publish_log(
                     log_events_id,
-                    {"tool_id": tool_id, "prompt_key": name},
+                    {
+                        "tool_id": tool_id,
+                        "prompt_key": prompt_name,
+                        "doc_name": doc_name,
+                    },
                     LogLevel.INFO,
                     RunLevel.EVAL,
                     "Evaluating response",
@@ -598,7 +589,11 @@ def prompt_processor() -> Any:
                     )
                     _publish_log(
                         log_events_id,
-                        {"tool_id": tool_id, "prompt_key": name},
+                        {
+                            "tool_id": tool_id,
+                            "prompt_key": prompt_name,
+                            "doc_name": doc_name,
+                        },
                         LogLevel.ERROR,
                         RunLevel.EVAL,
                         "Error while evaluation",
@@ -606,7 +601,11 @@ def prompt_processor() -> Any:
                 else:
                     _publish_log(
                         log_events_id,
-                        {"tool_id": tool_id, "prompt_key": name},
+                        {
+                            "tool_id": tool_id,
+                            "prompt_key": prompt_name,
+                            "doc_name": doc_name,
+                        },
                         LogLevel.DEBUG,
                         RunLevel.EVAL,
                         "Evaluation completed",
@@ -618,7 +617,7 @@ def prompt_processor() -> Any:
 
     _publish_log(
         log_events_id,
-        {"tool_id": tool_id},
+        {"tool_id": tool_id, "doc_name": doc_name},
         LogLevel.INFO,
         RunLevel.RUN,
         "Sanitizing null values",
@@ -641,7 +640,7 @@ def prompt_processor() -> Any:
 
     _publish_log(
         log_events_id,
-        {"tool_id": tool_id},
+        {"tool_id": tool_id, "doc_name": doc_name},
         LogLevel.INFO,
         RunLevel.RUN,
         "Execution complete",
@@ -743,9 +742,11 @@ def run_completion(
 
         answer: str = completion[PSKeys.RESPONSE].text
         return answer
+    # TODO: Catch and handle specific exception here
     except Exception as e:
-        app.logger.info(f"Error completing prompt: {e}.")
-        raise e
+        app.logger.info(f"Error fetching response for prompt: {e}.")
+        # TODO: Publish this error as a FE update
+        raise APIError(str(e)) from e
 
 
 def extract_variable(
@@ -785,19 +786,62 @@ def enable_single_pass_extraction() -> None:
 enable_single_pass_extraction()
 
 
+def log_exceptions(e: HTTPException):
+    """Helper method to log exceptions.
+
+    Args:
+        e (HTTPException): Exception to log
+    """
+    code = 500
+    if hasattr(e, "code"):
+        code = e.code
+
+    if code >= 500:
+        message = "{method} {url} {status}\n\n{error}\n\n````{tb}````".format(
+            method=request.method,
+            url=request.url,
+            status=code,
+            error=str(e),
+            tb=traceback.format_exc(),
+        )
+    else:
+        message = "{method} {url} {status} {error}".format(
+            method=request.method,
+            url=request.url,
+            status=code,
+            error=str(e),
+        )
+    app.logger.error(message)
+
+
 @app.errorhandler(HTTPException)
-def handle_exception(e):
+def handle_http_exception(e: HTTPException):
     """Return JSON instead of HTML for HTTP errors."""
-    response = e.get_response()
-    response.data = json.dumps(
-        {
-            "code": e.code,
-            "name": e.name,
-            "error": e.description,
-        }
-    )
-    response.content_type = "application/json"
-    return response
+    log_exceptions(e)
+    if isinstance(e, APIError):
+        return jsonify(e.to_dict()), e.code
+    else:
+        response = e.get_response()
+        response.data = json.dumps(
+            ErrorResponse(error=e.description, name=e.name, code=e.code)
+        )
+        response.content_type = "application/json"
+        return response
+
+
+@app.errorhandler(Exception)
+def handle_uncaught_exception(e):
+    """Handler for uncaught exceptions.
+
+    Args:
+        e (Exception): Any uncaught exception
+    """
+    # pass through HTTP errors
+    if isinstance(e, HTTPException):
+        return handle_http_exception(e)
+
+    log_exceptions(e)
+    return handle_http_exception(APIError())
 
 
 if __name__ == "__main__":

--- a/unstract/workflow-execution/src/unstract/workflow_execution/workflow_execution.py
+++ b/unstract/workflow-execution/src/unstract/workflow_execution/workflow_execution.py
@@ -204,7 +204,8 @@ class WorkflowExecutionService:
             )
             if not self.validate_execution_result(step + 1):
                 raise ToolOutputNotFoundException(
-                    f"Tool exception raised for tool {tool_uid}"
+                    f"Tool exception raised for tool {tool_uid}, "
+                    "check logs for more information"
                 )
             log_message = f"Step {actual_step} executed successfully"
             self.publish_update_log(


### PR DESCRIPTION
## What

- Added support in `prompt-service` to log exceptions similar to `backend` and wrap with a valid response format
      ```
      {
          "code": 500
          "name": "PromptServiceError"
          "description": "Some user-friendly message
      }
      ```
- Update `prompt-service` FE status updates to include the `doc_name`
- Added support in `backend` to parse and report this as an error, avoided suppressing errors
- MINOR: Removed some unused code in the `backend`

## Why

- Previously there was no exception handling around prompt service calls back to the backend

## How

- Passed the error message back to the `backend` and also pushed some updates to the FE

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, no DB migrations. It doesn't introduce breaking changes to any APIs and all function definition changes were updated in places of use


## Relevant Docs

- https://flask.palletsprojects.com/en/2.3.x/errorhandling/


## Notes on Testing

- Tried reproducing some prompt studio errors locally and observed the error. The error handling isn't 100% yet - we include JSONs in the error message at times and we would have to beautify the response a bit more wherever possible
- Subsequent improvements require changes in the SDK and adapters which can follow in a future PR

## Screenshots
![image](https://github.com/Zipstack/unstract/assets/117059509/29b93538-4844-4336-8cb9-a5d6a1c14365)
![image](https://github.com/Zipstack/unstract/assets/117059509/2cfe34f7-8a7d-48a5-bcb2-5553f6f191f3)
![image](https://github.com/Zipstack/unstract/assets/117059509/117d7cdd-0e66-4883-b9b6-1e75e91d5abc)

## Checklist

I have read and understood the [Contribution Guidelines]().
