### PR TITLE
Fix  usage tracking

### DIFF
--- a/tools/classifier/src/config/properties.json
+++ b/tools/classifier/src/config/properties.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.0.1",
   "displayName": "File Classifier",
   "functionName": "classify",
-  "toolVersion": "0.0.15",
+  "toolVersion": "0.0.16",
   "description": "Classifies a file into a bin based on its contents",
   "input": {
     "description": "File to be classified"

--- a/tools/classifier/src/main.py
+++ b/tools/classifier/src/main.py
@@ -88,6 +88,7 @@ class UnstractClassifier(BaseTool):
             llm=llm,
             workflow_id=self.workflow_id,
             execution_id=self.execution_id,
+            adapter_instance_id=llm_adapter_instance_id,
         )
         max_tokens = tool_llm.get_max_tokens(reserved_for_output=50 + 1000)
         max_bytes = int(max_tokens * 1.3)


### PR DESCRIPTION
## What

Pass `adapter_instance_id` to callback_manager

## Why

To track llm token usage

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. We are just passing `adapter_instance_id` to callback_manager

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
