### PR TITLE
fix: Minor prompt service log enhancement, minor refactor

### DIFF
--- a/backend/prompt_studio/prompt_studio/models.py
+++ b/backend/prompt_studio/prompt_studio/models.py
@@ -64,6 +64,7 @@ class ToolStudioPrompt(BaseModel):
         blank=True,
     )
     output = models.TextField(blank=True)
+    # TODO: Remove below 3 fields related to assertion
     assert_prompt = models.TextField(
         blank=True,
         null=True,

--- a/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
+++ b/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
@@ -233,6 +233,7 @@ class PromptStudioRegistryHelper:
             adapter_id = str(prompt.profile_manager.embedding_model.adapter_id)
             embedding_suffix = adapter_id.split("|")[0]
 
+            # TODO: Remove these fields related to assertion
             output[JsonSchemaKey.ASSERTION_FAILURE_PROMPT] = (
                 prompt.assertion_failure_prompt
             )

--- a/tools/structure/src/main.py
+++ b/tools/structure/src/main.py
@@ -67,7 +67,7 @@ class StructureTool(BaseTool):
             self.stream_error_and_exit(f"Error fetching data and indexing: {e}")
 
         _, file_name = os.path.split(input_file)
-        # TODO : Check if reindex. If Yes, reindex, else continue.
+        # TODO : Resolve and pass log events ID
         payload = {
             "outputs": outputs,
             "tool_id": tool_id,


### PR DESCRIPTION
## What

- Enhanced prompt service logs to include the prompt / document which caused the issue
- Minor TODO comments added in code
- Refactored `_fetch_response()` to run with a single prompt instance instead of a list

## Why

- Prompt studio errors don't have enough context while running multiple docs / prompts
![image](https://github.com/Zipstack/unstract/assets/117059509/f9d805b1-da4d-4672-8b12-5231d798a4ee)

- Existing function to fetch response unnecessarily accepts a list - this refactor was needed to specify the prompt that causes an error

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, no DB migrations involved and the main changes are on log messages. Other code changes is just refactor on an existing function


## Notes on Testing

- Simulated an error from prompt service to check locally

## Screenshots
![image](https://github.com/Zipstack/unstract/assets/117059509/edda72ca-ab95-403e-8ce9-d9df31521cf2)

## Checklist

I have read and understood the [Contribution Guidelines]().
