### PR TITLE
Making sure the response dispatched even in case of unhandled error

### DIFF
--- a/backend/account/authentication_controller.py
+++ b/backend/account/authentication_controller.py
@@ -115,17 +115,22 @@ class AuthenticationController:
         except Exception as ex:
             #
             self.user_logout(request)
+
+            response = Response(
+                status=status.HTTP_412_PRECONDITION_FAILED,
+            )
             if hasattr(ex, "code") and ex.code in {
                 AuthorizationErrorCode.USF,
                 AuthorizationErrorCode.USR,
                 AuthorizationErrorCode.INE001,
                 AuthorizationErrorCode.INE002,
             }:  # type: ignore
-                response = Response(
-                    status=status.HTTP_412_PRECONDITION_FAILED,
-                    data={"domain": ex.data.get("domain"), "code": ex.code},
-                )
+                response.data = ({"domain": ex.data.get("domain"), "code": ex.code},)
                 return response
+            # Return in case even if missed unknown exception in
+            # self.auth_service.user_organizations(request)
+            return response
+
         user: User = request.user
         org_ids = {org.id for org in organizations}
 


### PR DESCRIPTION
## What

- Add Generic exception to handle logout for unhandled auth0 excpetions.

## Why

- It need to be logout when auth0 have any exception while trying to get or create organization

## How

- Handled by adding new generic error code

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- It Added an error code in the exception handler  for the unknown exceptions, So There is no chance to break existing feature.

## Database Migrations

-  No migrations

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
