### PR TITLE
Corrected the permission issue in profile manager side

### DIFF
--- a/backend/adapter_processor/views.py
+++ b/backend/adapter_processor/views.py
@@ -28,7 +28,7 @@ from permissions.permission import (
     IsFrictionLessAdapter,
     IsFrictionLessAdapterDelete,
     IsOwner,
-    IsOwnerOrSharedUserOrOrg,
+    IsOwnerOrSharedUserOrSharedToOrg,
 )
 from rest_framework import status
 from rest_framework.decorators import action
@@ -141,7 +141,7 @@ class AdapterInstanceViewSet(ModelViewSet):
             return [IsFrictionLessAdapterDelete()]
 
         elif self.action in ["list_of_shared_users", "adapter_info"]:
-            return [IsOwnerOrSharedUserOrOrg()]
+            return [IsOwnerOrSharedUserOrSharedToOrg()]
 
         # Hack for friction-less onboarding
         # User cant view/update metadata but can delete/share etc

--- a/backend/adapter_processor/views.py
+++ b/backend/adapter_processor/views.py
@@ -28,7 +28,7 @@ from permissions.permission import (
     IsFrictionLessAdapter,
     IsFrictionLessAdapterDelete,
     IsOwner,
-    IsOwnerOrSharedUser,
+    IsOwnerOrSharedUserOrOrg,
 )
 from rest_framework import status
 from rest_framework.decorators import action
@@ -139,6 +139,9 @@ class AdapterInstanceViewSet(ModelViewSet):
 
         elif self.action == "destroy":
             return [IsFrictionLessAdapterDelete()]
+
+        elif self.action in ["list_of_shared_users", "adapter_info"]:
+            return [IsOwnerOrSharedUserOrOrg()]
 
         # Hack for friction-less onboarding
         # User cant view/update metadata but can delete/share etc
@@ -295,7 +298,7 @@ class AdapterInstanceViewSet(ModelViewSet):
 
     @action(detail=True, methods=["get"])
     def list_of_shared_users(self, request: HttpRequest, pk: Any = None) -> Response:
-        self.permission_classes = [IsOwnerOrSharedUser]
+
         adapter = self.get_object()
 
         serialized_instances = SharedUserListSerializer(adapter).data
@@ -304,7 +307,7 @@ class AdapterInstanceViewSet(ModelViewSet):
 
     @action(detail=True, methods=["get"])
     def adapter_info(self, request: HttpRequest, pk: uuid) -> Response:
-        self.permission_classes = [IsOwnerOrSharedUser]
+
         adapter = self.get_object()
 
         serialized_instances = AdapterInfoSerializer(adapter).data

--- a/backend/permissions/permission.py
+++ b/backend/permissions/permission.py
@@ -18,11 +18,29 @@ class IsOwnerOrSharedUser(permissions.BasePermission):
     """Custom permission to only allow owners and shared users of an object."""
 
     def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+
         return (
             True
             if (
                 obj.created_by == request.user
                 or obj.shared_users.filter(pk=request.user.pk).exists()
+            )
+            else False
+        )
+
+
+class IsOwnerOrSharedUserOrOrg(permissions.BasePermission):
+    """Custom permission to only allow owners and shared users of an object or
+    if it is shared to org."""
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+
+        return (
+            True
+            if (
+                obj.created_by == request.user
+                or obj.shared_users.filter(pk=request.user.pk).exists()
+                or obj.shared_to_org
             )
             else False
         )

--- a/backend/permissions/permission.py
+++ b/backend/permissions/permission.py
@@ -29,7 +29,7 @@ class IsOwnerOrSharedUser(permissions.BasePermission):
         )
 
 
-class IsOwnerOrSharedUserOrOrg(permissions.BasePermission):
+class IsOwnerOrSharedUserOrSharedToOrg(permissions.BasePermission):
     """Custom permission to only allow owners and shared users of an object or
     if it is shared to org."""
 


### PR DESCRIPTION
## What

-  When the shared LLM is selected in the profile manager, permission error thrown,

## Why

-  There is precedence order for determining permissions in a ViewSet . 
- Irrespective of attaching permission in method level, It was getting overridden from the `get_permissions` method

## How

- Added conditons to `get_permissions` method to include the actions


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Added new permmision class for this check, which validates the org level check as well

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
Shared LLM
![image](https://github.com/Zipstack/unstract/assets/116638720/ce2a3da4-29ea-4efd-91db-f0221607674d)

When shared LLM is selected
![image](https://github.com/Zipstack/unstract/assets/116638720/28c18857-24f8-493a-8b7d-a0e7ec6a0d77)

When org level LLM is selected

![image](https://github.com/Zipstack/unstract/assets/116638720/c0fa0140-cef7-42b6-a32b-205d29ec703e)




## Checklist

I have read and understood the [Contribution Guidelines]().
