### PR TITLE
Re-indexing issue fix

### DIFF
--- a/backend/prompt_studio/prompt_studio_index_manager/prompt_studio_index_helper.py
+++ b/backend/prompt_studio/prompt_studio_index_manager/prompt_studio_index_helper.py
@@ -27,7 +27,6 @@ class PromptStudioIndexHelper:
         args: dict[str, str] = dict()
         args["document_manager"] = document
         args["profile_manager"] = profile_manager
-        args[index_id] = doc_id
 
         try:
             # Create or get the existing record for this document and
@@ -50,6 +49,7 @@ class PromptStudioIndexHelper:
             if doc_id not in index_ids:
                 index_ids_list.append(doc_id)
 
+            args[index_id] = doc_id
             args["index_ids_history"] = json.dumps(index_ids_list)
 
             # Update the record with the index id


### PR DESCRIPTION
## What

- Re-indexing failing on the following cases
   - Multi-prompt and Summary enabled
   - Profile manager profile is updated and then re-indexing

## Why

- get_or_create needs to be called only with the composite key. In this case, that was not done and hence wrong results were returned

## How

- Make sure to call get() only using the primary/composite keys

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- NA

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-1262

## Dependencies Versions

-

## Notes on Testing

- Tested Summarisation with Multi-prompt
- Edit profile manager and then perform manual re-index

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
