### PR TITLE
Update docker-build-push-dev.yaml

### DIFF
--- a/.github/workflows/docker-build-push-dev.yaml
+++ b/.github/workflows/docker-build-push-dev.yaml
@@ -57,7 +57,8 @@ jobs:
           # Push all built images
           docker push unstract/backend:${{ github.event.inputs.tag }}
           docker push unstract/frontend:${{ github.event.inputs.tag }}
-          docker push unstract/document-service:${{ github.event.inputs.tag }}
+          # document-service is an optional. so it is commented out
+          # docker push unstract/document-service:${{ github.event.inputs.tag }}
           docker push unstract/platform-service:${{ github.event.inputs.tag }}
           docker push unstract/worker:${{ github.event.inputs.tag }}
           docker push unstract/prompt-service:${{ github.event.inputs.tag }}


### PR DESCRIPTION

## What

-  document-service is an optional. so removed from manual docker image build/push action

## Why

- it is failing github action on build

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
