### PR TITLE
Added queue name in celery docker-compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
     container_name: unstract-execution-consumer
     restart: unless-stopped
     entrypoint: .venv/bin/celery
-    command: "-A backend worker --loglevel=info --autoscale=8,1"
+    command: "-A backend worker --loglevel=info -Q celery,celery_periodic_logs --autoscale=8,1"
     env_file:
       - ../backend/.env
     depends_on:


### PR DESCRIPTION
## What

- Added queue name in celery docker-compose

## Why

- We created a new queue for logs , So the consumer commands should includes all required queue names.

## How

- Added the queue names in celery run command

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. We have to confirm the celry consumer is working

## Database Migrations

-  No
## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
