### PR TITLE
Indexing/Summarization fails with Pinecone inconsistently

### DIFF
--- a/backend/prompt_studio/prompt_studio_output_manager/output_manager_helper.py
+++ b/backend/prompt_studio/prompt_studio_output_manager/output_manager_helper.py
@@ -81,7 +81,9 @@ class OutputManagerHelper:
 
                 args: dict[str, str] = dict()
                 args["run_id"] = run_id
-                # Update the record with the run id
+                args["output"] = output
+                args["eval_metrics"] = eval_metrics
+                # Update the record with the run id and other params
                 PromptStudioOutputManager.objects.filter(
                     document_manager=document_manager,
                     tool_id=tool,

--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -303,7 +303,9 @@ def prompt_processor() -> Any:
                 # query with doc_id fails even though indexing just happened.
                 # This causes the following retrieve to return no text.
                 # To rule out any lag on the Pinecone vector DB write,
-                # the following sleep is added
+                # the following sleep is added.
+                # Note: This will not fix the issue. Since this issue is inconsistent
+                # and not reproducible easily, this is just a safety net.
                 time.sleep(2)
                 context: Optional[str] = tool_index.get_text_from_index(
                     embedding_instance_id=output[PSKeys.EMBEDDING],
@@ -701,6 +703,8 @@ def run_retrieval(  # type:ignore
         # This causes the following retrieve to return no text.
         # To rule out any lag on the Pinecone vector DB write,
         # the following sleep is added
+        # Note: This will not fix the issue. Since this issue is inconsistent
+        # and not reproducible easily, this is just a safety net.
         time.sleep(2)
         context = _retrieve_context(output, doc_id, vector_index, prompt)
 


### PR DESCRIPTION
## What

1)  Seeing an inconsistent issue where Pinecone database does not seem to reflect the documents inserted after indexing. In such cases, when summarization follows and tries to retrieve the node(s)  that just got indexed as part of indexing,  the retrieval returns an empty list. This shows up as an error "Couldn't fetch context from vector db" especially in cases when chunk_size=0. This is not an easily reproducible issue.


2)  Prompt edit is not displaying the right prompt results after running the edited prompt

## Why

1) Suspecting delay on db writes on the Pinecone side.
2) The updated answer after prompt edit is not getting stored in the prompt_outputs table and hence it always shows the old answer

## How

1)  Added a small sleep to try retrieval one more time again. 

Note: This will not fix the issue. Since this issue is inconsistent  and not reproducible easily, this is just a safety net.

2) Fixed the update query to store the updated results



## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

1)  This should only be invoked when the just indexed documents do not show up on retrieval. Not expecting others flows to break.

2) Only affects prompt outputs flow

## Database Migrations

- NA

## Env Config

- NA

## Relevant Docs

-

## Related Issues or PRs

1) https://zipstack.atlassian.net/browse/UN-1288
2)  https://zipstack.atlassian.net/browse/UN-1294 

## Dependencies Versions

-

## Notes on Testing

1) Very difficult to reproduce. Manually intervened and tested. Documented in JIRA UN-1288

2) Add a prompt. Makse sure to run and see the answer. Edit the prompt question and re-run prompt and  make sure to see a new relevant answer. Checked prompt_output_manager table to see if the new answer is updated.

## Screenshots

Prompt 1

![image](https://github.com/Zipstack/unstract/assets/142381512/9c76f506-f2ea-4963-80eb-19f25b04eb84)

DB values 

![image](https://github.com/Zipstack/unstract/assets/142381512/19ac19b1-8e9b-4aca-a379-f6c0fa7defa5)


Edit and run a new prompt

![image](https://github.com/Zipstack/unstract/assets/142381512/61c5ba5c-57a8-48bb-8ec0-3fa9ef031855)


DB values

![image](https://github.com/Zipstack/unstract/assets/142381512/7670b490-9593-43ff-9b03-410cad839721)


## Checklist

I have read and understood the [Contribution Guidelines]().
