### PR TITLE
FIX: Issue with displaying the prompt output in the coverage modal

### DIFF
--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -325,7 +325,7 @@ function PromptCard({
     handleDocOutputs(docId, true, null);
     handleRunApiRequest(docId)
       .then((res) => {
-        const data = res?.data;
+        const data = res?.data?.output;
         const value = data[promptDetails?.prompt_key];
         if (value || value === 0) {
           setCoverage((prev) => prev + 1);
@@ -390,7 +390,7 @@ function PromptCard({
       handleDocOutputs(docId, true, null);
       handleRunApiRequest(docId)
         .then((res) => {
-          const data = res?.data;
+          const data = res?.data?.output;
           const outputValue = data[promptDetails?.prompt_key];
           if (outputValue || outputValue === 0) {
             setCoverage((prev) => prev + 1);


### PR DESCRIPTION
## What

Fixed the issue with displaying the prompt output in the coverage modal after the prompt run.

-

## Why

The response of the `/prompt-studio/fetch_response/{tool_id}` API was modified, but the corresponding updates in the FE were inadvertently missed.

-

## How

Updated the FE to correctly handle the new structure of the API response from `/prompt-studio/fetch_response/{tool_id}`.

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No, this PR will not affect any existing features. It is a minor UI fix that will only impact the coverage modal.

-

## Database Migrations
NA
- 

## Env Config
NA
- 

## Relevant Docs
NA
-

## Related Issues or PRs
https://zipstack.atlassian.net/browse/UN-1290
-

## Dependencies Versions
NA
-

## Notes on Testing
NA
-

## Screenshots
![Screenshot from 2024-05-28 00-04-55](https://github.com/Zipstack/unstract/assets/89440263/465e8157-9b59-4d19-91d2-bf8870ce0298)


## Checklist

I have read and understood the [Contribution Guidelines]().
