### PR TITLE
Added condition to check adapter is shared to org

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
@@ -92,25 +92,29 @@ class PromptStudioHelper:
         profile_manager_owner = profile_manager.created_by
 
         is_llm_owned = (
-            profile_manager.llm.created_by == profile_manager_owner
+            profile_manager.llm.shared_to_org
+            or profile_manager.llm.created_by == profile_manager_owner
             or profile_manager.llm.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()
         )
         is_vector_store_owned = (
-            profile_manager.vector_store.created_by == profile_manager_owner
+            profile_manager.llm.shared_to_org
+            or profile_manager.vector_store.created_by == profile_manager_owner
             or profile_manager.vector_store.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()
         )
         is_embedding_model_owned = (
-            profile_manager.embedding_model.created_by == profile_manager_owner
+            profile_manager.llm.shared_to_org
+            or profile_manager.embedding_model.created_by == profile_manager_owner
             or profile_manager.embedding_model.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()
         )
         is_x2text_owned = (
-            profile_manager.x2text.created_by == profile_manager_owner
+            profile_manager.llm.shared_to_org
+            or profile_manager.x2text.created_by == profile_manager_owner
             or profile_manager.x2text.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()


### PR DESCRIPTION
## What

- Permission issue while the invited user tries to access the adapters at the org level.

## Why

- We were not checking the condition while using the adapters whether the adapter is shared across org.

## How

- Add conditing if it is shared to org , then allow access

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

-  NA

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested the org adapters with the invited users.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
