### PR TITLE
Added condition to check adapter is shared to org in static tools

### DIFF
--- a/backend/tool_instance/tool_instance_helper.py
+++ b/backend/tool_instance/tool_instance_helper.py
@@ -416,7 +416,8 @@ class ToolInstanceHelper:
                 raise PermissionDenied(error_msg)
 
             if not (
-                adapter_instance.created_by == user
+                adapter_instance.shared_to_org
+                or adapter_instance.created_by == user
                 or adapter_instance.shared_users.filter(pk=user.pk).exists()
             ):
                 logger.error(


### PR DESCRIPTION
## What

- Getting permission denied error while using org adapter with static tools

## Why

- Missed check the adapter sharted to org condition

## How

- Added the missing condition to allow org level adapters to be used with static tools

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- NO

## Database Migrations

- NA

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested org level adapter with static tools

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
