### PR TITLE
fix: Avoid pipeline status update for API deployments

### DIFF
--- a/backend/pdm.lock
+++ b/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "deploy", "test"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:65995bec9035d980c5dbfa609f531964e573eb0bb13fa53c207a4ae006c253b0"
+content_hash = "sha256:5924a0dcf9f3a5a94264fa1ed7a3d8bd5a2c7db3b565a2ba887c93e06dbb0e09"
 
 [[package]]
 name = "adlfs"

--- a/backend/workflow_manager/workflow/models/execution.py
+++ b/backend/workflow_manager/workflow/models/execution.py
@@ -64,3 +64,13 @@ class WorkflowExecution(BaseModel):
     execution_time = models.FloatField(
         default=0, db_comment="execution time in seconds"
     )
+
+    def __str__(self) -> str:
+        return (
+            f"Workflow execution: {self.id} ("
+            f"pipeline ID: {self.pipeline_id}, "
+            f"workflow iD: {self.workflow_id}, "
+            f"execution method: {self.execution_method}, "
+            f"status: {self.status}, "
+            f"error message: {self.error_message})"
+        )

--- a/backend/workflow_manager/workflow/workflow_helper.py
+++ b/backend/workflow_manager/workflow/workflow_helper.py
@@ -306,13 +306,14 @@ class WorkflowHelper:
                     PipelineProcessor.update_pipeline(
                         pipeline_id, Pipeline.PipelineStatus.FAILURE
                     )
+        # Expected exception since API deployments are not tracked in Pipeline
+        except Pipeline.DoesNotExist:
+            pass
         except Exception as e:
-            # Expected exception since API deployments are not tracked in Pipeline
-            if not isinstance(e, Pipeline.DoesNotExist):
-                logger.warning(
-                    f"Error updating pipeline {pipeline_id} status: {e} ",
-                    f"with workflow execution: {workflow_execution}",
-                )
+            logger.warning(
+                f"Error updating pipeline {pipeline_id} status: {e} "
+                f"with workflow execution: {workflow_execution}"
+            )
 
     @staticmethod
     def get_status_of_async_task(

--- a/backend/workflow_manager/workflow/workflow_helper.py
+++ b/backend/workflow_manager/workflow/workflow_helper.py
@@ -311,7 +311,7 @@ class WorkflowHelper:
             pass
         except Exception as e:
             logger.warning(
-                f"Error updating pipeline {pipeline_id} status: {e} "
+                f"Error updating pipeline {pipeline_id} status: {e}, "
                 f"with workflow execution: {workflow_execution}"
             )
 

--- a/backend/workflow_manager/workflow/workflow_helper.py
+++ b/backend/workflow_manager/workflow/workflow_helper.py
@@ -307,10 +307,12 @@ class WorkflowHelper:
                         pipeline_id, Pipeline.PipelineStatus.FAILURE
                     )
         except Exception as e:
-            logger.warning(
-                f"Error updating pipeline {pipeline_id} status: {e}",
-                f", workflow execution: {workflow_execution}",
-            )
+            # Expected exception since API deployments are not tracked in Pipeline
+            if "Pipeline matching query does not exist" not in str(e):
+                logger.warning(
+                    f"Error updating pipeline {pipeline_id} status: {e} ",
+                    f"with workflow execution: {workflow_execution}",
+                )
 
     @staticmethod
     def get_status_of_async_task(

--- a/backend/workflow_manager/workflow/workflow_helper.py
+++ b/backend/workflow_manager/workflow/workflow_helper.py
@@ -308,7 +308,7 @@ class WorkflowHelper:
                     )
         except Exception as e:
             # Expected exception since API deployments are not tracked in Pipeline
-            if "Pipeline matching query does not exist" not in str(e):
+            if not isinstance(e, Pipeline.DoesNotExist):
                 logger.warning(
                     f"Error updating pipeline {pipeline_id} status: {e} ",
                     f"with workflow execution: {workflow_execution}",

--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -837,7 +837,7 @@ def log_exceptions(e: HTTPException):
     """
     code = 500
     if hasattr(e, "code"):
-        code = e.code
+        code = e.code or code
 
     if code >= 500:
         message = "{method} {url} {status}\n\n{error}\n\n````{tb}````".format(


### PR DESCRIPTION
## What

- Suppress exceptions that occur when pipeline status is updated
- MINOR: Fixed error handling logic in prompt service  

## Why

- API dpeloyments don't maintain the last run status hence any updates here causes an issue since there's no entry for it in `Pipeline`

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No


## Related Issues or PRs

- #381 


## Notes on Testing

- Able to obtain response for prev deployed APIs and new ones too

## Screenshots
![image](https://github.com/Zipstack/unstract/assets/117059509/f0ec6ab6-1c3c-4321-81ac-b33f4b2f3b6e)


## Checklist

I have read and understood the [Contribution Guidelines]().
