### PR TITLE
fix/Prompt-Tool-delete-fix

### DIFF
--- a/backend/prompt_studio/prompt_studio_index_manager/models.py
+++ b/backend/prompt_studio/prompt_studio_index_manager/models.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import uuid
-from django.core.exceptions import ObjectDoesNotExist
 
 from account.models import User
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection, models
-from django.db.models.signals import post_delete, pre_delete
+from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from prompt_studio.prompt_profile_manager.models import ProfileManager
 from prompt_studio.prompt_studio_core.prompt_ide_base_tool import PromptIdeBaseTool
@@ -90,6 +90,7 @@ class IndexManager(BaseModel):
             ),
         ]
 
+
 def delete_from_vector_db(index_ids_history, vector_db_instance_id):
     org_schema = connection.tenant.schema_name
     util = PromptIdeBaseTool(log_level=LogLevel.INFO, org_id=org_schema)
@@ -120,7 +121,9 @@ def perform_vector_db_cleanup(sender, instance, **kwargs):
     except SdkError as e:
         logger.error(f"Error while performing vector db cleanup: {e}")
     except ObjectDoesNotExist:
-        logger.error(f"No ProfileManager found for tool_id {instance.document_manager.tool_id}")
+        logger.error(
+            f"No ProfileManager found for tool_id {instance.document_manager.tool_id}"
+        )
     except AttributeError:
         logger.error("ProfileManager or vector_store is None")
     except Exception as e:

--- a/backend/prompt_studio/prompt_studio_index_manager/models.py
+++ b/backend/prompt_studio/prompt_studio_index_manager/models.py
@@ -118,13 +118,11 @@ def perform_vector_db_cleanup(sender, instance, **kwargs):
         index_ids_history = json.loads(instance.index_ids_history)
         vector_db_instance_id = str(instance.profile_manager.vector_store.id)
         delete_from_vector_db(index_ids_history, vector_db_instance_id)
-    except SdkError as e:
-        logger.error(f"Error while performing vector db cleanup: {e}")
-    except ObjectDoesNotExist:
-        logger.error(
-            f"No ProfileManager found for tool_id {instance.document_manager.tool_id}"
-        )
-    except AttributeError:
-        logger.error("ProfileManager or vector_store is None")
     except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
+        logger.warning(
+            "Error during vector DB cleanup for deleted document "
+            "in prompt studio tool %s: %s",
+            instance.document_manager.tool_id,
+            e,
+            exc_info=True # For additional stack trace
+        )

--- a/backend/prompt_studio/prompt_studio_index_manager/models.py
+++ b/backend/prompt_studio/prompt_studio_index_manager/models.py
@@ -3,7 +3,6 @@ import logging
 import uuid
 
 from account.models import User
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection, models
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -11,7 +10,6 @@ from prompt_studio.prompt_profile_manager.models import ProfileManager
 from prompt_studio.prompt_studio_core.prompt_ide_base_tool import PromptIdeBaseTool
 from prompt_studio.prompt_studio_document_manager.models import DocumentManager
 from unstract.sdk.constants import LogLevel
-from unstract.sdk.exceptions import SdkError
 from unstract.sdk.vector_db import VectorDB
 from utils.models.base_model import BaseModel
 
@@ -124,5 +122,5 @@ def perform_vector_db_cleanup(sender, instance, **kwargs):
             "in prompt studio tool %s: %s",
             instance.document_manager.tool_id,
             e,
-            exc_info=True # For additional stack trace
+            exc_info=True,  # For additional stack trace
         )


### PR DESCRIPTION
## What

- Regression fix for prompt studio tool delete.
- Added some additional refactoring for better readability.

## How

- The earlier used post delete signal is now modified to `pre_delete`. The issue was caused when the cascade delete method removing profile entry before this deletion happens.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- NO

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
