### PR TITLE
FIX: Tooltip Text Fixed for Collapse/Expand Button in Prompt Card

### DIFF
--- a/frontend/src/components/custom-tools/prompt-card/ExpandCardBtn.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/ExpandCardBtn.jsx
@@ -10,10 +10,10 @@ function ExpandCardBtn({ expandCard, setExpandCard }) {
   useEffect(() => {
     if (expandCard) {
       setIcon(<FullscreenExitOutlined className="prompt-card-actions-head" />);
-      setTooltip("Expand");
+      setTooltip("Collapse");
     } else {
       setIcon(<FullscreenOutlined className="prompt-card-actions-head" />);
-      setTooltip("Collapse");
+      setTooltip("Expand");
     }
   }, [expandCard]);
 


### PR DESCRIPTION
## What

Fixed the tooltip text for the collapse/expand button in the prompt card.

-

## Why
NA
-

## How
NA
-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. This PR will not break any existing features.
-

## Database Migrations
NA
- 

## Env Config
NA
- 

## Relevant Docs
NA
-

## Related Issues or PRs
NA
-

## Dependencies Versions
NA
-

## Notes on Testing
NA
-

## Screenshots

**Collapse Button:**
![Screenshot from 2024-06-10 23-13-28](https://github.com/Zipstack/unstract/assets/89440263/dff641bc-d8d4-4ec5-bb64-2fd683148e3a)

**Expand Button:**
![Screenshot from 2024-06-10 23-13-35](https://github.com/Zipstack/unstract/assets/89440263/26840f64-2a70-4e60-9c40-b336f3410d23)


## Checklist

I have read and understood the [Contribution Guidelines]().
