### PR TITLE
Default prompt service gunicorn workers to gthread

### DIFF
--- a/prompt-service/entrypoint.sh
+++ b/prompt-service/entrypoint.sh
@@ -5,7 +5,6 @@
     --bind 0.0.0.0:3003 \
     --workers 2 \
     --threads 2 \
-    --worker-class gevent\
     --log-level debug \
     --timeout 900 \
     --access-logfile - \


### PR DESCRIPTION
## What

Default prompt service gunicorn workers to gthread and keep it aligned with backend

## Why

gevent seems to have some incompatibility with grpc calls being made by vector db connectors. Hence the service is in a deadlock state until the worker times out.

## How

Remove the explicit setting

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- May be

## Database Migrations

- NA

## Env Config

-  NA

## Relevant Docs

- https://medium.com/@crueda/gunicorn-flask-with-a-side-of-grpc-98a74c9285a7

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested Milvus connection andd seems to work fine

## Screenshots

![image](https://github.com/Zipstack/unstract/assets/142381512/2ed37827-7a4e-4ec6-ba97-e32c84e5fd36)


## Checklist

I have read and understood the [Contribution Guidelines]().
