### PR TITLE
Removed unknown args from the function

### DIFF
--- a/platform-service/src/unstract/platform_service/main.py
+++ b/platform-service/src/unstract/platform_service/main.py
@@ -472,7 +472,7 @@ def custom_tool_instance() -> Any:
     http://localhost:3001/db/custom_tool_instance/prompt_registry_id=id1
     """
     bearer_token = get_token_from_auth_header(request)
-    organization_uid, organization_id = get_organization_from_bearer_token(bearer_token)
+    _, organization_id = get_organization_from_bearer_token(bearer_token)
     if not organization_id:
         return INVALID_ORGANIZATOIN, 403
 
@@ -484,7 +484,6 @@ def custom_tool_instance() -> Any:
                 db_instance=be_db,
                 organization_id=organization_id,
                 prompt_registry_id=prompt_registry_id,
-                organization_uid=organization_uid,
             )
             return jsonify(data_dict)
         except Exception as e:


### PR DESCRIPTION
## What

- Removed unknown args from the function organization_uid

## Why

- The function shoudn't need an parameter like organization_uid
- It's mistakenly added , So raised error while workflow execution with a prompt exported tool.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![workflow_with_exported_tool](https://github.com/Zipstack/unstract/assets/117142933/2781377a-315e-48eb-984d-605bd578176b)


## Checklist

I have read and understood the [Contribution Guidelines]().
