### PR TITLE
fix: Classifier fix to get extracted text, bumped version to 0.0.24

### DIFF
--- a/tools/classifier/src/config/properties.json
+++ b/tools/classifier/src/config/properties.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.0.1",
   "displayName": "File Classifier",
   "functionName": "classify",
-  "toolVersion": "0.0.23",
+  "toolVersion": "0.0.24",
   "description": "Classifies a file into a bin based on its contents",
   "input": {
     "description": "File to be classified"

--- a/tools/classifier/src/helper.py
+++ b/tools/classifier/src/helper.py
@@ -5,7 +5,7 @@ from unstract.sdk.constants import ToolEnv
 from unstract.sdk.llm import LLM
 from unstract.sdk.tool.base import BaseTool
 from unstract.sdk.utils import ToolUtils
-from unstract.sdk.x2txt import X2Text
+from unstract.sdk.x2txt import TextExtractionResult, X2Text
 
 
 class ClassifierHelper:
@@ -48,7 +48,10 @@ class ClassifierHelper:
         self.tool.stream_log("Adapter created")
 
         try:
-            extracted_text: str = x2text.process(input_file_path=file)
+            extraction_result: TextExtractionResult = x2text.process(
+                input_file_path=file
+            )
+            extracted_text: str = extraction_result.extracted_text
             return extracted_text
         except Exception as e:
             self.tool.stream_log(f"Adapter error: {e}")


### PR DESCRIPTION
## What

- Obtained extracted text from `TextExtractionResult`
- Bumped classifier tool to 0.0.24

## Why

- Was missed in classifier tool during a recent change in [this PR](https://github.com/Zipstack/unstract-adapters/pull/53)


## Related Issues or PRs

- https://github.com/Zipstack/unstract-adapters/pull/53

## Notes on Testing

- No explicit testing done, simple change of retrieval from a dict

## Checklist

I have read and understood the [Contribution Guidelines]().
