### PR TITLE
Separtion of URL's based on pluggable apps

### DIFF
--- a/backend/backend/constants.py
+++ b/backend/backend/constants.py
@@ -34,3 +34,4 @@ class FeatureFlag:
     """Temporary feature flags."""
 
     MULTI_TENANCY_V2 = "multi_tenancy_v2"
+    APP_DEPLOYMENT = "app_deployment"


### PR DESCRIPTION
## What

- Separating pluggable apps's URL
- Added URLs include behind feature flag

## Why

- even if import fails of unrelated apps, it will cause a 404 issue the existing apps

## How

- Separated out app-deployment apps and added it behind feature flag.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
