### PR TITLE
FEAT: Allow Disabling Posthog via ENV Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ Contributions are welcome! Please read [CONTRIBUTE.md](CONTRIBUTE.md) for furthe
 
 ## 📊 A note on analytics
 
-In full disclosure, Unstract integrates Posthog to track usage analytics. As you can inspect the relevant code here, we collect the minimum possible metrics.
+In full disclosure, Unstract integrates Posthog to track usage analytics. As you can inspect the relevant code here, we collect the minimum possible metrics. Posthog can be disabled if desired by setting `REACT_APP_ENABLE_POSTHOG` to `false` in the frontend's .env file.

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -8,13 +8,19 @@ import { LazyLoader } from "./components/widgets/lazy-loader/LazyLoader.jsx";
 import { SocketProvider } from "./helpers/SocketContext.js";
 import "./index.css";
 
-const API_KEY = "phc_PTafesyRuRB5hceRILaNPeyu2IDuzPshyjIPYGvgoBd"; // gitleaks:allow
-const API_HOST = "https://eu.i.posthog.com/";
-posthog.init(API_KEY, {
-  api_host: API_HOST,
-  capture_pageview: false,
-  autocapture: false,
-});
+const enablePosthog = process.env.REACT_APP_ENABLE_POSTHOG;
+if (enablePosthog !== "false") {
+  // Define the PostHog API key and host URL
+  const API_KEY = "phc_PTafesyRuRB5hceRILaNPeyu2IDuzPshyjIPYGvgoBd"; // gitleaks:allow
+  const API_HOST = "https://eu.i.posthog.com/";
+
+  // Initialize PostHog with the specified API key and host
+  posthog.init(API_KEY, {
+    api_host: API_HOST,
+    capture_pageview: false,
+    autocapture: false,
+  });
+}
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(


### PR DESCRIPTION
## What

Posthog can be disabled by setting the environment variable `REACT_APP_ENABLE_POSTHOG` to `false`.

## Why

NA

## How

NA

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No, this PR will not break any existing features. This is an independent block of code that doesn't affect other items in any way.

## Database Migrations

- NA

## Env Config

A new env variable called `REACT_APP_ENABLE_POSTHOG` has been introduced in the **frontend** in this PR. It is an **optional** variable that defaults to `true`.

## Relevant Docs

NA

## Related Issues or PRs

NA

## Dependencies Versions

NA

## Notes on Testing

NA

## Screenshots
Screenshots are not applicable for this PR since the changes will be reflected in the Posthog dashboard.

## Checklist

I have read and understood the [Contribution Guidelines]().
