### PR TITLE
Removing the feature flag check

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -17,8 +17,7 @@ Including another URLconf
 from django.conf.urls import *  # noqa: F401, F403
 from django.urls import include, path
 
-from backend.constants import FeatureFlag, UrlPathConstants
-from unstract.flags.feature_flag import check_feature_flag_status
+from backend.constants import UrlPathConstants
 
 urlpatterns = [
     path("", include("tenant_account.urls")),
@@ -63,25 +62,24 @@ urlpatterns = [
 ]
 
 
-if check_feature_flag_status(FeatureFlag.APP_DEPLOYMENT):
-    # APP deployment urls
-    try:
-        import pluggable_apps.apps.app_deployment.urls  # noqa # pylint: disable=unused-import
-        import pluggable_apps.apps.canned_question.urls  # noqa # pylint: disable=unused-import
-        import pluggable_apps.apps.chat_history.urls  # noqa # pylint: disable=unused-import
-        import pluggable_apps.apps.chat_transcript.urls  # noqa # pylint: disable=unused-import
+# APP deployment urls
+try:
+    import pluggable_apps.apps.app_deployment.urls  # noqa # pylint: disable=unused-import
+    import pluggable_apps.apps.canned_question.urls  # noqa # pylint: disable=unused-import
+    import pluggable_apps.apps.chat_history.urls  # noqa # pylint: disable=unused-import
+    import pluggable_apps.apps.chat_transcript.urls  # noqa # pylint: disable=unused-import
 
-        urlpatterns += [
-            path(
-                "canned_question/",
-                include("pluggable_apps.apps.canned_question.urls"),
-            ),
-            path("app/", include("pluggable_apps.apps.app_deployment.urls")),
-            path("chat_history/", include("pluggable_apps.apps.chat_history.urls")),
-            path("chat/", include("pluggable_apps.apps.chat_transcript.urls")),
-        ]
-    except ImportError:
-        pass
+    urlpatterns += [
+        path(
+            "canned_question/",
+            include("pluggable_apps.apps.canned_question.urls"),
+        ),
+        path("app/", include("pluggable_apps.apps.app_deployment.urls")),
+        path("chat_history/", include("pluggable_apps.apps.chat_history.urls")),
+        path("chat/", include("pluggable_apps.apps.chat_transcript.urls")),
+    ]
+except ImportError:
+    pass
 
 # Subscription urls
 try:


### PR DESCRIPTION
## What

- Adding a feature flag in `urls.py` file can be in effect only during server start up

## Why

-  Will lose the flexibility of  enabling/disabling the feature on the go.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
