### PR TITLE
Load file util  function fix

### DIFF
--- a/backend/workflow_manager/endpoint/source.py
+++ b/backend/workflow_manager/endpoint/source.py
@@ -395,7 +395,7 @@ class SourceConnector(BaseConnector):
             file_content = remote_file.read()
             file_stream = BytesIO(file_content)
 
-        return remote_file.key, file_stream
+        return os.path.basename(input_file_path), file_stream
 
     @classmethod
     def add_input_file_to_api_storage(

--- a/backend/workflow_manager/endpoint/source.py
+++ b/backend/workflow_manager/endpoint/source.py
@@ -386,6 +386,17 @@ class SourceConnector(BaseConnector):
             results.append({"file": file_name, "result": result})
 
     def load_file(self, input_file_path: str) -> tuple[str, BytesIO]:
+        """Load file contnt and file name based on the file path.
+
+        Args:
+            input_file_path (str): source file
+
+        Raises:
+            InvalidSource: _description_
+
+        Returns:
+            tuple[str, BytesIO]: file_name , file content
+        """
         connector: ConnectorInstance = self.endpoint.connector_instance
         connector_settings: dict[str, Any] = connector.connector_metadata
         source_fs: fsspec.AbstractFileSystem = self.get_fsspec(


### PR DESCRIPTION
## What

- Utill function for loading the file content and file name from file path. 

## Why

- Earlier used `remote.key` to extract the file name which was working for minio as source. But if we  are using Gdrive `remote ` doesn't have value `key`.

## How

- Used a generic function that works across all source systems to retrieve the name.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
