### PR TITLE
Shared tool export fix

### DIFF
--- a/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
+++ b/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
@@ -176,7 +176,6 @@ class PromptStudioRegistryHelper:
             obj, created = PromptStudioRegistry.objects.update_or_create(
                 custom_tool=custom_tool,
                 created_by=custom_tool.created_by,
-                modified_by=custom_tool.modified_by,
                 defaults={
                     "name": custom_tool.tool_name,
                     "tool_property": properties.to_dict(),
@@ -190,7 +189,7 @@ class PromptStudioRegistryHelper:
                 logger.info(f"PSR {obj.prompt_registry_id} was created")
             else:
                 logger.info(f"PSR {obj.prompt_registry_id} was updated")
-
+            obj.modified_by = custom_tool.modified_by
             obj.shared_to_org = shared_with_org
             if not shared_with_org:
                 obj.shared_users.clear()


### PR DESCRIPTION
## What

- https://zipstack.atlassian.net/jira/software/c/projects/UN/issues/UN-1449?

## Why

- Failing with integrity exception. Prompt registry with Custom Tool is one-to-one related.
- So while trying to save the prompt registry with different modified by record its string insert a new promo registry entry with an existing custom tool which breaks the one-to-one relation.

## How

- Worked around with the database interaction.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

-  None

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tried tool export with the owner as well as the shared user.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
