### PR TITLE
[FIX] Extrracting Public Share URL in separate block

### DIFF
--- a/backend/backend/public_urls.py
+++ b/backend/backend/public_urls.py
@@ -48,12 +48,19 @@ urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 try:
     import pluggable_apps.platform_admin.urls  # noqa # pylint: disable=unused-import
-    import pluggable_apps.public_shares_share_controller.urls  # noqa # pylint: disable=unused-import
+
+    urlpatterns += [
+        path(f"{path_prefix}/", include("pluggable_apps.platform_admin.urls")),
+    ]
+except ImportError:
+    pass
+
+try:
+    import pluggable_apps.public_shares.share_controller.urls  # noqa # pylint: disable=unused-import
 
     share_path_prefix = settings.PUBLIC_PATH_PREFIX
 
     urlpatterns += [
-        path(f"{path_prefix}/", include("pluggable_apps.platform_admin.urls")),
         # Public Sharing
         path(
             f"{share_path_prefix}/",


### PR DESCRIPTION
## What
PR extracts the public share URLs to a separate block.
...

## Why
This is done to keep apps mutually exclusive and even if any one app fails, it doesn't impact the other.
...

## How
Adding the imports to new block.
...

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
No, it involves adding the new apps URLs to a seperate independant block. 
...

## Database Migrations
Not applicable.
...

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
