### PR TITLE
fix: Error handling fix for JSONDecodeError on adapters

### DIFF
--- a/backend/adapter_processor/adapter_processor.py
+++ b/backend/adapter_processor/adapter_processor.py
@@ -8,6 +8,7 @@ from adapter_processor.exceptions import (
     InternalServiceError,
     InValidAdapterId,
     TestAdapterError,
+    TestAdapterInputError,
 )
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -97,6 +98,12 @@ class AdapterProcessor:
             test_result: bool = adapter_instance.test_connection()
             logger.info(f"{adapter_id} test result: {test_result}")
             return test_result
+        # HACK: Remove after error is explicitly handled in VertexAI adapter
+        except json.JSONDecodeError:
+            raise TestAdapterInputError(
+                "Credentials is not a valid service account JSON, "
+                "please provide a valid JSON."
+            )
         except AdapterError as e:
             raise TestAdapterError(str(e))
 

--- a/backend/adapter_processor/exceptions.py
+++ b/backend/adapter_processor/exceptions.py
@@ -2,8 +2,6 @@ from typing import Optional
 
 from rest_framework.exceptions import APIException
 
-from backend.exceptions import UnstractBaseException
-
 
 class IdIsMandatory(APIException):
     status_code = 400
@@ -46,9 +44,14 @@ class UniqueConstraintViolation(APIException):
     default_detail = "Unique constraint violated"
 
 
-class TestAdapterError(UnstractBaseException):
+class TestAdapterError(APIException):
     status_code = 500
     default_detail = "Error while testing adapter"
+
+
+class TestAdapterInputError(APIException):
+    status_code = 400
+    default_detail = "Error while testing adapter, please check the configuration."
 
 
 class DeleteAdapterInUseError(APIException):

--- a/backend/adapter_processor/views.py
+++ b/backend/adapter_processor/views.py
@@ -115,17 +115,13 @@ class AdapterViewSet(GenericViewSet):
         adapter_metadata[AdapterKeys.ADAPTER_TYPE] = serializer.validated_data.get(
             AdapterKeys.ADAPTER_TYPE
         )
-        try:
-            test_result = AdapterProcessor.test_adapter(
-                adapter_id=adapter_id, adapter_metadata=adapter_metadata
-            )
-            return Response(
-                {AdapterKeys.IS_VALID: test_result},
-                status=status.HTTP_200_OK,
-            )
-        except Exception as e:
-            logger.error(f"Error testing adapter : {str(e)}")
-            raise e
+        test_result = AdapterProcessor.test_adapter(
+            adapter_id=adapter_id, adapter_metadata=adapter_metadata
+        )
+        return Response(
+            {AdapterKeys.IS_VALID: test_result},
+            status=status.HTTP_200_OK,
+        )
 
 
 class AdapterInstanceViewSet(ModelViewSet):

--- a/backend/connector_processor/connector_processor.py
+++ b/backend/connector_processor/connector_processor.py
@@ -8,7 +8,6 @@ from connector_auth.constants import ConnectorAuthKey
 from connector_auth.pipeline.common import ConnectorAuthHelper
 from connector_processor.constants import ConnectorKeys
 from connector_processor.exceptions import (
-    InternalServiceError,
     InValidConnectorId,
     InValidConnectorMode,
     OAuthTimeOut,
@@ -45,26 +44,27 @@ class ConnectorProcessor:
         updated_connectors = fetch_connectors_by_key_value(
             ConnectorKeys.ID, connector_id
         )
-        if len(updated_connectors) != 0:
-            connector = updated_connectors[0]
-            schema_details[ConnectorKeys.OAUTH] = connector.get(ConnectorKeys.OAUTH)
-            schema_details[ConnectorKeys.SOCIAL_AUTH_URL] = connector.get(
-                ConnectorKeys.SOCIAL_AUTH_URL
-            )
-            try:
-                schema_details[ConnectorKeys.JSON_SCHEMA] = json.loads(
-                    connector.get(ConnectorKeys.JSON_SCHEMA)
-                )
-            except Exception as exc:
-                logger.error(f"Error occurred while parsing JSON Schema: {exc}")
-                raise InternalServiceError()
-        else:
+        if len(updated_connectors) == 0:
             logger.error(
                 f"Invalid connector Id : {connector_id} "
                 f"while fetching "
                 f"JSON Schema"
             )
             raise InValidConnectorId()
+
+        connector = updated_connectors[0]
+        schema_details[ConnectorKeys.OAUTH] = connector.get(ConnectorKeys.OAUTH)
+        schema_details[ConnectorKeys.SOCIAL_AUTH_URL] = connector.get(
+            ConnectorKeys.SOCIAL_AUTH_URL
+        )
+        try:
+            schema_details[ConnectorKeys.JSON_SCHEMA] = json.loads(
+                connector.get(ConnectorKeys.JSON_SCHEMA)
+            )
+        except Exception as exc:
+            logger.error(f"Error occurred decoding JSON for {connector_id}: {exc}")
+            raise exc
+
         return schema_details
 
     @staticmethod


### PR DESCRIPTION
## What

- Error handling improvement for vertex AI adapter's test connection
- Minor code refactor in `connector_processor.py`

## Why

- Actual root cause was not properly displayed

## How

- Checked all usages of `json.loads()` within the adapters package and noticed that this will help handle it until the adapter / SDK changes are rolled out

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, error handling improvements only

## Notes on Testing

- Checked basic scenario of using an incorrect JSON for the credential

## Screenshots
![image](https://github.com/user-attachments/assets/7e05eecf-ba3a-4403-a1a4-5bcd6b6106ff)

## Checklist

I have read and understood the [Contribution Guidelines]().
