### PR TITLE
[FIX] Disabling Setting buttons for Public share

### DIFF
--- a/frontend/src/components/custom-tools/highlight-metadata/HighLightMetaData.jsx
+++ b/frontend/src/components/custom-tools/highlight-metadata/HighLightMetaData.jsx
@@ -13,7 +13,7 @@ function HighLightMetaData({ handleUpdateTool }) {
   const [enableHighlighting, setEnableHighlighting] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const { details, updateCustomTool } = useCustomToolStore();
+  const { details, updateCustomTool, isPublicSource } = useCustomToolStore();
 
   const { setAlertDetails } = useAlertStore();
   const handleException = useExceptionHandler();
@@ -62,6 +62,7 @@ function HighLightMetaData({ handleUpdateTool }) {
             <Checkbox
               checked={enableHighlighting}
               onChange={(e) => setEnableHighlighting(e.target.checked)}
+              disabled={isPublicSource}
             />
             <Typography.Text>Enable Highlighting</Typography.Text>
           </Space>
@@ -90,7 +91,12 @@ function HighLightMetaData({ handleUpdateTool }) {
           </Space>
         </Form.Item>
         <Form.Item className="display-flex-right">
-          <CustomButton type="primary" htmlType="submit" loading={isLoading}>
+          <CustomButton
+            type="primary"
+            htmlType="submit"
+            loading={isLoading}
+            disabled={isPublicSource}
+          >
             Save
           </CustomButton>
         </Form.Item>

--- a/frontend/src/components/custom-tools/manage-llm-profiles/ManageLlmProfiles.jsx
+++ b/frontend/src/components/custom-tools/manage-llm-profiles/ManageLlmProfiles.jsx
@@ -251,7 +251,7 @@ function ManageLlmProfiles() {
           <CustomButton
             type="primary"
             onClick={handleAddNewLlmProfileBtnClick}
-            disabled={isMaxProfile}
+            disabled={isMaxProfile || isPublicSource}
           >
             Add New LLM Profile
           </CustomButton>

--- a/frontend/src/components/custom-tools/pre-and-post-amble-modal/PreAndPostAmbleModal.jsx
+++ b/frontend/src/components/custom-tools/pre-and-post-amble-modal/PreAndPostAmbleModal.jsx
@@ -8,6 +8,7 @@ import { useCustomToolStore } from "../../../store/custom-tool-store";
 import { CustomButton } from "../../widgets/custom-button/CustomButton";
 import { useExceptionHandler } from "../../../hooks/useExceptionHandler";
 import SpaceWrapper from "../../widgets/space-wrapper/SpaceWrapper";
+
 import DefaultPrompts from "./DefaultPrompts.json";
 
 const fieldNames = {

--- a/frontend/src/components/custom-tools/pre-and-post-amble-modal/PreAndPostAmbleModal.jsx
+++ b/frontend/src/components/custom-tools/pre-and-post-amble-modal/PreAndPostAmbleModal.jsx
@@ -92,6 +92,7 @@ function PreAndPostAmbleModal({ type, handleUpdateTool }) {
             rows={4}
             value={text}
             onChange={(e) => setText(e.target.value)}
+            disabled={isPublicSource}
           />
           <Button
             size="small"


### PR DESCRIPTION
## What
PR disables the following buttons and text areas. 
Settings > Manage highlighting
Settings > Add LLM Profile  
...

## Why
Disabled to prevent the unauthenticated user from accessing the feature. 
...

## How
Adding it to the param for disabling.
...

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
No, it only has param addition with `isPublicSource` value.
...

## Database Migrations
Not applicable.
...

## Env Config
Not applicable.
...
 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions
Not applicable.
...

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
