### PR TITLE
fix: Quick fix on missing env required by feature behind flag

### DIFF
--- a/backend/backend/public_urls.py
+++ b/backend/backend/public_urls.py
@@ -70,8 +70,9 @@ except ImportError:
     pass
 
 try:
-    mr_path_prefix = settings.MANUAL_REVEIEW_QUEUE_PATH_PREFIX
     import pluggable_apps.manual_review.public_urls  # noqa # pylint: disable=unused-import
+
+    mr_path_prefix = settings.MANUAL_REVEIEW_QUEUE_PATH_PREFIX
 
     urlpatterns += [
         path(f"{mr_path_prefix}/", include("pluggable_apps.manual_review.public_urls")),


### PR DESCRIPTION
## What

- Moved the error causing line after an import of a feature that should run with a feature flag
- This is a temporary fix to avoid the OSS from crashing

## Why

- The missing setting threw an error

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No



## Notes on Testing

- Able to run backend on OSS fine


## Checklist

I have read and understood the [Contribution Guidelines]().
