### PR TITLE
fix/show_error_on_wf_execution

### DIFF
--- a/backend/workflow_manager/workflow/views.py
+++ b/backend/workflow_manager/workflow/views.py
@@ -23,6 +23,7 @@ from workflow_manager.workflow.constants import WorkflowKey
 from workflow_manager.workflow.dto import ExecutionResponse
 from workflow_manager.workflow.enums import SchemaEntity, SchemaType
 from workflow_manager.workflow.exceptions import (
+    InternalException,
     WorkflowDoesNotExistError,
     WorkflowGenerationError,
     WorkflowRegenerationError,
@@ -192,6 +193,12 @@ class WorkflowViewSet(viewsets.ModelViewSet):
                 hash_values_of_files=hashes_of_files,
                 include_metadata=include_metadata,
             )
+            if (
+                execution_response.execution_status == "ERROR"
+                and execution_response.result
+                and execution_response.result[0].get("error")
+            ):
+                raise InternalException(execution_response.result[0].get("error"))
             return Response(
                 make_execution_response(execution_response),
                 status=status.HTTP_200_OK,


### PR DESCRIPTION
## What

- Errors alerts in workflow executions were not showing while running the workflow from the Workflow execution screen.

## Why

- The response of executiohn was 200 , hence it was not going into error block in FE

## How

-  Raised exception-based workflow execution status

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- None

## Database Migrations

-  None

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested locally with tool error.

## Screenshots
![image](https://github.com/user-attachments/assets/b9964ded-940e-4f21-a968-3c1673c35267)


## Checklist

I have read and understood the [Contribution Guidelines]().
