### PR TITLE
fix: Error handling improvements: Unsaved classifier config and duplicate adapter name 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -643,7 +643,6 @@ backend/backend/settings/*
 !backend/backend/settings/test.py
 
 # Local Dependencies for docker testing
-unstract/unstract-adapters/
 unstract/unstract-sdk/
 
 # BE pluggable-apps

--- a/backend/adapter_processor/adapter_processor.py
+++ b/backend/adapter_processor/adapter_processor.py
@@ -33,13 +33,9 @@ class AdapterProcessor:
             AdapterKeys.ID, adapter_id
         )
         if len(updated_adapters) != 0:
-            try:
-                schema_details[AdapterKeys.JSON_SCHEMA] = json.loads(
-                    updated_adapters[0].get(AdapterKeys.JSON_SCHEMA)
-                )
-            except Exception as exc:
-                logger.error(f"Error occured while parsing JSON Schema : {exc}")
-                raise InternalServiceError()
+            schema_details[AdapterKeys.JSON_SCHEMA] = json.loads(
+                updated_adapters[0].get(AdapterKeys.JSON_SCHEMA)
+            )
         else:
             logger.error(
                 f"Invalid adapter Id : {adapter_id} while fetching JSON Schema"
@@ -257,8 +253,5 @@ class AdapterProcessor:
         except ObjectDoesNotExist as e:
             logger.error(f"No default adapters found: {e}")
             raise InternalServiceError(
-                "No default adapters found, " "configure them through Platform Settings"
+                "No default adapters found, configure them through Platform Settings"
             )
-        except Exception as e:
-            logger.error(f"Error occurred while fetching default adapters: {e}")
-            raise InternalServiceError("Error fetching default adapters")

--- a/backend/adapter_processor/constants.py
+++ b/backend/adapter_processor/constants.py
@@ -24,5 +24,6 @@ class AdapterKeys:
         "Configuration with this name already exists within your organisation. "
         "Please try with a different name."
     )
+    ADAPTER_NAME = "adapter_name"
     ADAPTER_CREATED_BY = "created_by_email"
     ADAPTER_CONTEXT_WINDOW_SIZE = "context_window_size"

--- a/backend/adapter_processor/exceptions.py
+++ b/backend/adapter_processor/exceptions.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from adapter_processor.constants import AdapterKeys
 from rest_framework.exceptions import APIException
 
 
@@ -39,9 +40,19 @@ class CannotDeleteDefaultAdapter(APIException):
     )
 
 
-class UniqueConstraintViolation(APIException):
+class DuplicateAdapterNameError(APIException):
     status_code = 400
-    default_detail = "Unique constraint violated"
+    default_detail: str = AdapterKeys.ADAPTER_NAME_EXISTS
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        detail: Optional[str] = None,
+        code: Optional[str] = None,
+    ) -> None:
+        if name:
+            detail = self.default_detail.replace("this name", f"name '{name}'")
+        super().__init__(detail, code)
 
 
 class TestAdapterError(APIException):
@@ -64,6 +75,8 @@ class DeleteAdapterInUseError(APIException):
         adapter_name: str = "adapter",
     ):
         if detail is None:
+            if adapter_name != "adapter":
+                adapter_name = f"'{adapter_name}'"
             detail = (
                 f"Cannot delete {adapter_name}. "
                 "It is used in a workflow or a prompt studio project"

--- a/backend/tool_instance/tool_instance_helper.py
+++ b/backend/tool_instance/tool_instance_helper.py
@@ -360,6 +360,18 @@ class ToolInstanceHelper:
                     required_prop = e.schema.get("properties").get(validator_val)
                     required_display_name = required_prop.get("title")
                     err_msg = err_msg.replace(validator_val, required_display_name)
+            elif e.validator == "minItems":
+                validated_entity_display_name = e.schema.get("title")
+                err_msg = (
+                    f"'{validated_entity_display_name}' requires atleast"
+                    f" {e.validator_value} values."
+                )
+            elif e.validator == "maxItems":
+                validated_entity_display_name = e.schema.get("title")
+                err_msg = (
+                    f"'{validated_entity_display_name}' requires atmost"
+                    f" {e.validator_value} values."
+                )
             else:
                 logger.warning(f"Unformatted exception sent to user: {err_msg}")
             raise ToolSettingValidationError(


### PR DESCRIPTION
## What

- Handle error when classifier config is not saved during WF run
- Handle duplicate adapter name errors better
- Removed some unnecessary catch-all errors which would re-raise a different exception

## Why

- Unsaved config during a WF run raised an obscure error message

## How

- Handled few extra cases for JSON schema validation

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor error handling concerns only


## Notes on Testing

- Tested locally by reproducing these cases

## Screenshots

![image](https://github.com/user-attachments/assets/ed765c37-2136-40ef-8702-08f27083b0b5)
![image](https://github.com/user-attachments/assets/13dfe3a9-9df5-4656-aaa4-1a331d5150f6)

## Checklist

I have read and understood the [Contribution Guidelines]().
