### PR TITLE
Change docker-compose to docker compose in workflows

### DIFF
--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./docker
         run: |
           DOCKER_VERSION_TAG=${{ github.event.release.tag_name  || github.event.inputs.tag}}
-          VERSION=$DOCKER_VERSION_TAG docker-compose -f docker-compose.build.yaml build --no-cache ${{ matrix.service_name }}
+          VERSION=$DOCKER_VERSION_TAG docker compose -f docker-compose.build.yaml build --no-cache ${{ matrix.service_name }}
           docker push unstract/${{ matrix.service_name }}:$DOCKER_VERSION_TAG
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "This workflow was triggered by a release event."


### PR DESCRIPTION
## What

Change "docker-compose" command to "docker compose" in github workflows

## Why

Docker builds have been failing recently with the following error 
https://github.com/Zipstack/unstract/actions/runs/10211001078/attempts/2

## How

- Change the commans

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

-  No

## Env Config

- NA

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
