### PR TITLE
Make the Cron Scheduler an Optional Field.

### DIFF
--- a/frontend/src/components/pipelines-or-deployments/etl-task-deploy/EtlTaskDeploy.jsx
+++ b/frontend/src/components/pipelines-or-deployments/etl-task-deploy/EtlTaskDeploy.jsx
@@ -300,12 +300,6 @@ const EtlTaskDeploy = ({
           <Form.Item
             label="Cron Schedule"
             name="cron_string"
-            rules={[
-              {
-                required: true,
-                message: "Please add cron schedule",
-              },
-            ]}
             validateStatus={
               getBackendErrorDetail("cron_string", backendErrors) ? "error" : ""
             }
@@ -314,7 +308,6 @@ const EtlTaskDeploy = ({
             <div className="cron-string-div">
               <Input
                 readOnly={true}
-                disabled={true}
                 value={formDetails?.cron_string}
                 className="cron-string-input"
               />

--- a/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
+++ b/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
@@ -467,7 +467,7 @@ function Pipelines({ type }) {
       render: (_, record) => (
         <div>
           <Typography.Text className="p-or-d-typography" strong>
-            {cronstrue.toString(record?.cron_string)}
+            {record?.cron_string && cronstrue.toString(record?.cron_string)}
           </Typography.Text>
         </div>
       ),


### PR DESCRIPTION
## What

The cron scheduler input field in the create ETL/TASK pipeline form no longer needs to be a required field.

## Why

NA

## How

NA

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

This PR contains minor UI changes, so the chances of it breaking any existing features are unlikely.

## Database Migrations

NA

## Env Config

NA

## Relevant Docs

NA

## Related Issues or PRs

https://github.com/Zipstack/unstract/pull/545

## Dependencies Versions

NA

## Notes on Testing

NA

## Screenshots
Optional Field for Cron Scheduler:
![Screenshot from 2024-08-07 00-30-50](https://github.com/user-attachments/assets/8d5ad238-0350-4d82-b48d-fa974e5fbde9)

Table view of the Cron String is not available:
![Screenshot from 2024-08-07 00-30-56](https://github.com/user-attachments/assets/2c98fabe-44b0-47bc-aa3f-c7c00b461c48)


## Checklist

I have read and understood the [Contribution Guidelines]().
