### PR TITLE
FIX: Hide Step Execution Buttons

### DIFF
--- a/frontend/src/components/agency/actions/Actions.jsx
+++ b/frontend/src/components/agency/actions/Actions.jsx
@@ -432,49 +432,51 @@ function Actions({ statusBarMsg, initializeWfComp, stepLoader }) {
             </Button>
           </Tooltip>
           <Divider type="vertical" />
-          <Tooltip title="Start step execution">
-            <Button
-              onClick={() =>
-                apiOpsPresent
-                  ? getInputFile(true, true, 0)
-                  : handleWfExecution(true, true, 0)
-              }
-              disabled={
-                disableAction() || handleDisable(0) || DISABLE_STEP_EXECUTION
-              }
-              loading={execType === "STEP"}
-            >
-              <StepIcon className="step-icon" />
-            </Button>
-          </Tooltip>
-          <Tooltip title="Next step">
-            <Button
-              onClick={() => handleWfExecution(false, true, 1)}
-              disabled={handleDisable(1) || DISABLE_STEP_EXECUTION}
-              loading={stepExecType === wfExecutionTypes[1]}
-            >
-              <StepForwardOutlined />
-            </Button>
-          </Tooltip>
-          <Tooltip title="Execute remaining steps">
-            <Button
-              onClick={() => handleWfExecution(false, true, 3)}
-              disabled={handleDisable(3) || DISABLE_STEP_EXECUTION}
-              loading={stepExecType === wfExecutionTypes[3]}
-            >
-              <FastForwardOutlined />
-            </Button>
-          </Tooltip>
-          <Tooltip title="Stop execution">
-            <Button
-              onClick={() => handleWfExecution(false, true, 2)}
-              disabled={handleDisable(2) || DISABLE_STEP_EXECUTION}
-              loading={stepExecType === wfExecutionTypes[2]}
-            >
-              <StopOutlined />
-            </Button>
-          </Tooltip>
-          <Divider type="vertical" />
+          {!DISABLE_STEP_EXECUTION && (
+            <>
+              <Tooltip title="Start step execution">
+                <Button
+                  onClick={() =>
+                    apiOpsPresent
+                      ? getInputFile(true, true, 0)
+                      : handleWfExecution(true, true, 0)
+                  }
+                  disabled={disableAction() || handleDisable(0)}
+                  loading={execType === "STEP"}
+                >
+                  <StepIcon className="step-icon" />
+                </Button>
+              </Tooltip>
+              <Tooltip title="Next step">
+                <Button
+                  onClick={() => handleWfExecution(false, true, 1)}
+                  disabled={handleDisable(1)}
+                  loading={stepExecType === wfExecutionTypes[1]}
+                >
+                  <StepForwardOutlined />
+                </Button>
+              </Tooltip>
+              <Tooltip title="Execute remaining steps">
+                <Button
+                  onClick={() => handleWfExecution(false, true, 3)}
+                  disabled={handleDisable(3)}
+                  loading={stepExecType === wfExecutionTypes[3]}
+                >
+                  <FastForwardOutlined />
+                </Button>
+              </Tooltip>
+              <Tooltip title="Stop execution">
+                <Button
+                  onClick={() => handleWfExecution(false, true, 2)}
+                  disabled={handleDisable(2)}
+                  loading={stepExecType === wfExecutionTypes[2]}
+                >
+                  <StopOutlined />
+                </Button>
+              </Tooltip>
+              <Divider type="vertical" />
+            </>
+          )}
           <Tooltip title="Clear Cache">
             <Button disabled={isLoading} onClick={handleClearCache}>
               <ClearOutlined />


### PR DESCRIPTION
## What

Hide the step execution buttons temporarily until the feature is fixed.

## Why

NA

## How

NA

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No, this PR will not break any existing features, as it is a simple UI fix to hide the step execution buttons.

## Database Migrations

NA

## Env Config

NA

## Relevant Docs

NA

## Related Issues or PRs

NA

## Dependencies Versions

NA

## Notes on Testing

NA

## Screenshots
### Workflow step execution buttons are hidden from the UI:
![Screenshot from 2024-08-09 00-09-51](https://github.com/user-attachments/assets/dab63753-bd10-4e04-bfb5-4c5b9aa5511d)


## Checklist

I have read and understood the [Contribution Guidelines]().
