### PR TITLE
handled never ending etl issue in MRQ when highlight is not selected

### DIFF
--- a/backend/workflow_manager/endpoint/destination.py
+++ b/backend/workflow_manager/endpoint/destination.py
@@ -535,6 +535,8 @@ class DestinationConnector(BaseConnector):
             q_name = f"review_queue_{self.organization_id}_{workflow.id}"
             if meta_data:
                 whisper_hash = meta_data.get("whisper-hash")
+            else:
+                whisper_hash = None
             queue_result = QueueResult(
                 file=file_name,
                 status=QueueResultStatus.SUCCESS,

--- a/backend/workflow_manager/endpoint/destination.py
+++ b/backend/workflow_manager/endpoint/destination.py
@@ -528,17 +528,20 @@ class DestinationConnector(BaseConnector):
             settings=connector_settings, connector_id=connector.connector_id
         )
         with source_fs.open(input_file_path, "rb") as remote_file:
+            whisper_hash = None
             file_content = remote_file.read()
             # Convert file content to a base64 encoded string
             file_content_base64 = base64.b64encode(file_content).decode("utf-8")
             q_name = f"review_queue_{self.organization_id}_{workflow.id}"
+            if meta_data:
+                whisper_hash = meta_data.get("whisper-hash")
             queue_result = QueueResult(
                 file=file_name,
-                whisper_hash=meta_data["whisper-hash"],
                 status=QueueResultStatus.SUCCESS,
                 result=result,
                 workflow_id=str(self.workflow_id),
                 file_content=file_content_base64,
+                whisper_hash=whisper_hash,
             ).to_dict()
             # Convert the result dictionary to a JSON string
             queue_result_json = json.dumps(queue_result)

--- a/backend/workflow_manager/endpoint/queue_utils.py
+++ b/backend/workflow_manager/endpoint/queue_utils.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 from utils.constants import Common
 from workflow_manager.endpoint.exceptions import UnstractQueueException
@@ -34,11 +34,11 @@ class QueueUtils:
 @dataclass
 class QueueResult:
     file: str
-    whisper_hash: str
     status: QueueResultStatus
     result: Any
     workflow_id: str
     file_content: str
+    whisper_hash: Optional[str] = None
 
     def to_dict(self) -> Any:
         return {


### PR DESCRIPTION
## What

- When tool exported with highlight not enabled ETL was going into never ending state

## Why

- Was trying to get whisper_hash value and that was not handled properly

## How

- Checking for whisper_hash value present and if not present saving that values as none.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor fix

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
