### PR TITLE
fix: Issue for gdrive with listing files

### DIFF
--- a/backend/workflow_manager/endpoint/source.py
+++ b/backend/workflow_manager/endpoint/source.py
@@ -170,6 +170,9 @@ class SourceConnector(BaseConnector):
         for input_directory in folders_to_process:
             # TODO: Move to connector class for better error handling
             try:
+                input_directory = source_fs.get_connector_root_dir(
+                    input_dir=input_directory, root_path=root_dir_path
+                )
                 is_directory = source_fs_fsspec.isdir(input_directory)
             except Exception as e:
                 raise InvalidInputDirectory(


### PR DESCRIPTION
## What

- Added `root` prefix for GDrive while listing files during workflow execution

## Why

- This was missed and caused an issue with file listing

## How

- The correct prefix gets added through the concrete class implementation

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Related Issues or PRs

- Regression from #603 

## Notes on Testing

- Tested locally, the error in case of incorrect directories does not get propagated correctly still. However this would allow happy path execution. Checked with @kirtimanmishrazipstack as well

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
