### PR TITLE
fix: Allow pipeline enable / disable done through PATCH calls

### DIFF
--- a/backend/pipeline/serializers/crud.py
+++ b/backend/pipeline/serializers/crud.py
@@ -89,10 +89,11 @@ class PipelineSerializer(AuditSerializer):
         return super().create(validated_data)
 
     def save(self, **kwargs: Any) -> Pipeline:
-        if self.validated_data[PK.CRON_STRING]:
-            self.validated_data[PK.SCHEDULED] = True
-        else:
-            self.validated_data[PK.SCHEDULED] = False
+        if PK.CRON_STRING in self.validated_data:
+            if self.validated_data[PK.CRON_STRING]:
+                self.validated_data[PK.SCHEDULED] = True
+            else:
+                self.validated_data[PK.SCHEDULED] = False
         pipeline: Pipeline = super().save(**kwargs)
         if pipeline.cron_string is None:
             SchedulerHelper.remove_job(pipeline_id=str(pipeline.id))


### PR DESCRIPTION
## What

- Pipeline attribute `is_scheduled` updated only if `cron_string` is present in the request

## Why

- In case of PATCH calls (done when pipeline is enabled / disabled) the `cron_string` might not be present and it resulted in a KeyError
![image](https://github.com/user-attachments/assets/76676a36-db33-4951-971a-0c1d033cda82)


## How

- Check presence of key `cron_string` before

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this aims to fix the issue by checking for the presence of the key beforehand

## Related Issues or PRs

- Regression introduced by #627 

## Notes on Testing

- Tested it locally - tried creating / editing and enabling new / existing pipelines

## Screenshots
![image](https://github.com/user-attachments/assets/0b948789-d28d-44cb-ab6d-e42482d14948)


## Checklist

I have read and understood the [Contribution Guidelines]().
