### PR TITLE
fix: Fixed attribute error on plugin absence during indexing

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/views.py
+++ b/backend/prompt_studio/prompt_studio_core/views.py
@@ -241,14 +241,15 @@ class PromptStudioCoreView(viewsets.ModelViewSet):
             name="summarizer",
             plugins=self.processor_plugins,
         )
-        cls.process(
-            tool_id=str(tool.tool_id),
-            file_name=file_name,
-            org_id=UserSessionUtils.get_organization_id(request),
-            user_id=tool.created_by.user_id,
-            document_id=document_id,
-            usage_kwargs=usage_kwargs.copy(),
-        )
+        if cls:
+            cls.process(
+                tool_id=str(tool.tool_id),
+                file_name=file_name,
+                org_id=UserSessionUtils.get_organization_id(request),
+                user_id=tool.created_by.user_id,
+                document_id=document_id,
+                usage_kwargs=usage_kwargs.copy(),
+            )
 
         if unique_id:
             return Response(


### PR DESCRIPTION
## What

- Added a check to ensure plugin exists before calling its method

## Why

- Resulted in an attribute error when plugin is absent


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Notes on Testing

- Tried indexing without the plugin

## Screenshots
![image](https://github.com/user-attachments/assets/a09950b4-5aaf-4ff3-a746-83c4ca46793d)


## Checklist

I have read and understood the [Contribution Guidelines]().
