### PR TITLE
FIX: Alert message appears when the app is loaded initially

### DIFF
--- a/frontend/src/hooks/useSessionValid.js
+++ b/frontend/src/hooks/useSessionValid.js
@@ -38,6 +38,12 @@ function useSessionValid() {
   return async () => {
     try {
       const userSessionData = await userSession();
+
+      // Return if the user is not authenticated
+      if (!userSessionData) {
+        return;
+      }
+
       const signedInOrgId = userSessionData?.organization_id;
 
       // API to get the list of organizations


### PR DESCRIPTION
## What

An alert displaying "Something went wrong" is shown when the app is loaded without authentication.

## Why

An API call to retrieve the list of organizations is still being made when the user is not authenticated. This call is unnecessary and should be avoided if the user isn't authenticated.

## How

Added a return statement for cases where the user is not authenticated, preventing the subsequent API call to retrieve the list of organizations.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
### The unnecessary alert message is not longer displayed:
![image](https://github.com/user-attachments/assets/835336da-5e56-4b3a-b779-387019609bd1)

### The subsequent API call to get the list of organizations is not made if the session API fails:
![image](https://github.com/user-attachments/assets/33da95ed-542a-46df-bf62-12b2194a7a4c)



## Checklist

I have read and understood the [Contribution Guidelines]().
