### PR TITLE
[FIX] Fixed issue where response is partial if it contains square or curly brackets

### DIFF
--- a/prompt-service/src/unstract/prompt_service/constants.py
+++ b/prompt-service/src/unstract/prompt_service/constants.py
@@ -66,6 +66,7 @@ class PromptServiceContants:
     CLEAN_CONTEXT = "clean-context"
     SUMMARIZE_AS_SOURCE = "summarize_as_source"
     VARIABLE_MAP = "variable_map"
+    TEXT = "text"
 
 
 class LogLevel(Enum):

--- a/prompt-service/src/unstract/prompt_service/helper.py
+++ b/prompt-service/src/unstract/prompt_service/helper.py
@@ -229,7 +229,7 @@ def construct_and_run_prompt(
         prompt=prompt,
         metadata=metadata,
         prompt_key=output[PSKeys.NAME],
-        prompt_type=output.get(PSKeys.TYPE, "Text"),
+        prompt_type=output.get(PSKeys.TYPE, PSKeys.TEXT),
     )
 
 

--- a/prompt-service/src/unstract/prompt_service/helper.py
+++ b/prompt-service/src/unstract/prompt_service/helper.py
@@ -229,6 +229,7 @@ def construct_and_run_prompt(
         prompt=prompt,
         metadata=metadata,
         prompt_key=output[PSKeys.NAME],
+        prompt_type=output.get(PSKeys.TYPE, "Text"),
     )
 
 
@@ -267,6 +268,7 @@ def run_completion(
     prompt: str,
     metadata: Optional[dict[str, str]] = None,
     prompt_key: Optional[str] = None,
+    prompt_type: Optional[str] = PSKeys.TEXT,
 ) -> str:
     logger: Logger = current_app.logger
     try:
@@ -279,6 +281,7 @@ def run_completion(
         completion = llm.complete(
             prompt=prompt,
             process_text=extract_epilogue,
+            extract_json=prompt_type.lower() != PSKeys.TEXT,
         )
         answer: str = completion[PSKeys.RESPONSE].text
         epilogue = completion.get(PSKeys.EPILOGUE)


### PR DESCRIPTION
## What

Fixed issue where response is partial if it contains square or curly brackets

## Why

-

## How

Make `extract_json` param as False if the type is `Text`

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

https://github.com/Zipstack/unstract-sdk/pull/98

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
