### PR TITLE
fix: Deprecated django tenant schema function replaced

### DIFF
--- a/backend/api/deployment_helper.py
+++ b/backend/api/deployment_helper.py
@@ -88,7 +88,7 @@ class DeploymentHelper(BaseAPIKeyValidator):
         Returns:
         - str: The complete API endpoint URL.
         """
-        org_schema = connection.get_tenant().schema_name
+        org_schema = connection.tenant.schema_name
         return f"{ApiExecution.PATH}/{org_schema}/{api_name}/"
 
     @staticmethod

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -87,12 +87,12 @@ class APIDeployment(BaseModel):
             try:
                 original = APIDeployment.objects.get(pk=self.pk)
                 if original.api_name != self.api_name:
-                    org_schema = connection.get_tenant().schema_name
+                    org_schema = connection.tenant.schema_name
                     self.api_endpoint = (
                         f"{ApiExecution.PATH}/{org_schema}/{self.api_name}/"
                     )
             except APIDeployment.DoesNotExist:
-                org_schema = connection.get_tenant().schema_name
+                org_schema = connection.tenant.schema_name
 
                 self.api_endpoint = f"{ApiExecution.PATH}/{org_schema}/{self.api_name}/"
         super().save(*args, **kwargs)

--- a/backend/api_v2/deployment_helper.py
+++ b/backend/api_v2/deployment_helper.py
@@ -134,7 +134,7 @@ class DeploymentHelper:
         Returns:
         - str: The complete API endpoint URL.
         """
-        org_schema = connection.get_tenant().schema_name
+        org_schema = connection.tenant.schema_name
         return f"{ApiExecution.PATH}/{org_schema}/{api_name}/"
 
     @staticmethod

--- a/backend/pipeline/models.py
+++ b/backend/pipeline/models.py
@@ -91,7 +91,7 @@ class Pipeline(BaseModel):
 
     @property
     def api_endpoint(self):
-        org_schema = connection.get_tenant().schema_name
+        org_schema = connection.tenant.schema_name
         deployment_endpoint = settings.API_DEPLOYMENT_PATH_PREFIX + "/pipeline/api"
         api_endpoint = f"{deployment_endpoint}/{org_schema}/{self.id}/"
         return api_endpoint

--- a/backend/platform_settings/platform_auth_service.py
+++ b/backend/platform_settings/platform_auth_service.py
@@ -155,7 +155,7 @@ class PlatformAuthenticationService:
             error: IntegrityError
         """
         try:
-            organization = connection.get_tenant()
+            organization = connection.tenant
             platform_key.modified_by = user
             if action == PlatformServiceConstants.ACTIVATE:
                 active_keys: list[PlatformKey] = PlatformKey.objects.filter(
@@ -193,7 +193,7 @@ class PlatformAuthenticationService:
             Any: List of platform keys.
         """
         try:
-            organization_id = connection.get_tenant().id
+            organization_id = connection.tenant.id
             platform_keys: list[PlatformKey] = PlatformKey.objects.filter(
                 organization=organization_id
             )

--- a/backend/platform_settings/views.py
+++ b/backend/platform_settings/views.py
@@ -109,7 +109,7 @@ class PlatformKeyViewSet(viewsets.ModelViewSet):
         is_active = request.data.get(PlatformServiceConstants.IS_ACTIVE)
         key_name = request.data.get(PlatformServiceConstants.KEY_NAME)
 
-        organization: Organization = connection.get_tenant()
+        organization: Organization = connection.tenant
 
         PlatformAuthHelper.validate_token_count(organization=organization)
 


### PR DESCRIPTION
## What

- Replaced `connection.get_tenant()` with `connection.tenant`

## Why

- To address deprecation warning
![image](https://github.com/user-attachments/assets/25f6ced2-1119-44bd-9ce8-ae94900d8718)


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, updated to method suggested by the library


## Notes on Testing

- No explicit testing done, able to run workflows / pipelines.

## Checklist

I have read and understood the [Contribution Guidelines]().
