### PR TITLE
Un 1701 scaling of celery segregate by queue

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -65,7 +65,7 @@ To update the username or password after it's been set:
 Run the following command to start the worker:
 
 ```bash
-celery -A backend worker --loglevel=info -Q celery,celery_periodic_logs
+celery -A backend worker --loglevel=info -Q <queue_name>
 ```
 - The `celery` queue is used for default Celery tasks.
 - The `celery_periodic_logs` queue is utilized for logging history tasks.

--- a/backend/README.md
+++ b/backend/README.md
@@ -55,20 +55,28 @@ To update the username or password after it's been set:
 1. Login with the new credentials
 
 
-## Asynchronous execution/pipeline execution
+## Asynchronous Execution
 
- - Working with celery
- - Each pipeline or shared tasks will added to the queue (Redis), And the worker will consume from the queue
+This project uses Celery for handling asynchronous execution. Celery tasks are managed through various queues and consumed by workers.
+
+> ETL, TASK, and API Deployment are using these asynchronous workers. Log management also utilizes Celery.
+
+### Queues
+
+| Queue Name                 | Description                         |
+|----------------------------|-------------------------------------|
+| `celery`                   | Default queue for general Celery tasks. |
+| `celery_periodic_logs`     | Queue for logging history tasks.    |
+| `celery_log_task_queue`    | Queue for persisting logs.          |
+| `celery_api_deployments`   | Queue for API deployment tasks.     |
 
 ### Run Execution Worker
 
-Run the following command to start the worker:
+To start a Celery worker, use the following command:
 
 ```bash
 celery -A backend worker --loglevel=info -Q <queue_name>
-```
-- The `celery` queue is used for default Celery tasks.
-- The `celery_periodic_logs` queue is utilized for logging history tasks.
+
 
 ### Worker Dashboard
 

--- a/backend/api/deployment_helper.py
+++ b/backend/api/deployment_helper.py
@@ -20,6 +20,7 @@ from django.db import connection
 from rest_framework.request import Request
 from rest_framework.serializers import Serializer
 from rest_framework.utils.serializer_helpers import ReturnDict
+from utils.constants import CeleryQueue
 from workflow_manager.endpoint.destination import DestinationConnector
 from workflow_manager.endpoint.source import SourceConnector
 from workflow_manager.workflow.dto import ExecutionResponse
@@ -174,6 +175,7 @@ class DeploymentHelper(BaseAPIKeyValidator):
                 hash_values_of_files=hash_values_of_files,
                 timeout=timeout,
                 execution_id=execution_id,
+                queue=CeleryQueue.CELERY_API_DEPLOYMENTS,
             )
             result.status_api = DeploymentHelper.construct_status_endpoint(
                 api_endpoint=api.api_endpoint, execution_id=execution_id

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -91,10 +91,19 @@ backend.help = "Runs the Unstract backend"
 migrate_db.cmd = "python manage.py migrate"
 migrate_db.env_file = ".env"
 migrate_db.help = "Performs DB migrations for Unstract backend"
-# Commands for backend execution
-consumer.cmd = "celery -A backend worker --loglevel=info -Q celery,celery_periodic_logs,celery_log_task_queue --autoscale 8,1"
+# Commands for execution consumer
+consumer.cmd = "celery -A backend worker --loglevel=info -Q celery --autoscale 4,1"
 consumer.env_file = ".env"
 consumer.help = "Runs the Unstract consumer"
+# Commands for log-manager
+log-management-worker.cmd = "celery -A backend worker --loglevel=info -Q celery_periodic_logs,celery_llog-managere --autoscale 4,1"
+log-management-worker.env_file = ".env"
+log-management-worker.help = "Runs the Unstract log management worker."
+# Commands for api deployment executor
+api-deployment-worker.cmd = "celery -A backend worker --loglevel=info -Q celery_api_deployments --autoscale 4,1"
+api-deployment-worker.env_file = ".env"
+api-deployment-worker.help = "Runs the Unstract API deployment worker."
+
 # Celery Flower
 flower.cmd = "celery -A backend flower --port=5555"
 flower.env_file = ".env"

--- a/backend/utils/constants.py
+++ b/backend/utils/constants.py
@@ -42,6 +42,17 @@ class Pagination:
     MAX_PAGE_SIZE = 1000
 
 
+class CeleryQueue:
+    """Constants for Celery Queue.
+
+    Attributes:
+        CELERY_API_DEPLOYMENTS (str): The name of the Celery queue for API
+            deployments.
+    """
+
+    CELERY_API_DEPLOYMENTS = "celery_api_deployments"
+
+
 class ExecutionLogConstants:
     """Constants for ExecutionLog.
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -39,7 +39,48 @@ services:
     container_name: unstract-execution-consumer
     restart: unless-stopped
     entrypoint: .venv/bin/celery
-    command: "-A backend worker --loglevel=info -Q celery,celery_periodic_logs,celery_log_task_queue --autoscale=8,1"
+    command: "-A backend worker --loglevel=info -Q celery --autoscale=${EXECUTION_CONSUMER_AUTOSCALE}"
+    env_file:
+      - ../backend/.env
+    depends_on:
+      - redis
+    environment:
+      - ENVIRONMENT=development
+    labels:
+      - traefik.enable=false
+    volumes:
+      - ./workflow_data:/data
+      - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
+
+
+  # Celery worker for managing logs and periodic tasks
+  log-management-worker:
+    image: unstract/backend:${VERSION}
+    container_name: unstract-log-management-worker
+    restart: unless-stopped
+    entrypoint: .venv/bin/celery
+    command: "-A backend worker --loglevel=info -Q celery_periodic_logs,celery_log_task_queue --autoscale=${LOG_MANAGEMENT_WORKER_AUTOSCALE}"
+    env_file:
+      - ../backend/.env
+    depends_on:
+      - redis
+    environment:
+      - ENVIRONMENT=development
+    labels:
+      - traefik.enable=false
+    volumes:
+      - ./workflow_data:/data
+      - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
+
+
+  # Celery worker for handling API deployment tasks
+  api-deployment-worker:
+    image: unstract/backend:${VERSION}
+    container_name: unstract-api-deployment-worker
+    restart: unless-stopped
+    entrypoint: .venv/bin/celery
+    command: "-A backend worker --loglevel=info -Q celery_api_deployments --autoscale=${API_DEPLOYMENT_WORKER_AUTOSCALE}"
+
     env_file:
       - ../backend/.env
     depends_on:

--- a/docker/sample.env
+++ b/docker/sample.env
@@ -1,3 +1,10 @@
 # Path where public and private tools are registered
 # with a YAML and JSONs
 TOOL_REGISTRY_CONFIG_SRC_PATH="${PWD}/../unstract/tool-registry/tool_registry_config"
+
+# Celery Autoscaling Configuration
+# Specify the maximum and minimum number of concurrent workers for each Celery worker.
+# Format: <max_workers>,<min_workers>
+API_DEPLOYMENT_WORKER_AUTOSCALE=4,1
+LOG_MANAGEMENT_WORKER_AUTOSCALE=4,1
+EXECUTION_CONSUMER_AUTOSCALE=8,1


### PR DESCRIPTION
## What
- Imelemented a new queue for API Deployment process.
- Segregated Celery workers by assigning them specific queue names in the Docker Compose configuration.
- Enhanced the sample.env file to provide clear and simple autoscaling configurations for each worker.
- Refined the pyproject.toml scripts to reflect the new queue-based segregation, improving command clarity and consistency.

## Why

- To ensure that different tasks are handled by dedicated Celery workers, improving efficiency and organization.
- To make it easier to manage and scale individual worker processes based on their specific task queues.
- To standardize and simplify the configuration, making it more intuitive for the team to understand and maintain.

## How
- Imelemented a new queue for API Deployment and then executing the celery task with this queue name.
- Updated Docker Compose service names and comments to reflect the segregation of workers by queue names.
- Modified the sample.env file to include autoscaling settings for each worker based on its assigned queue.
- Adjusted pyproject.toml commands to align with the new worker segregation.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No new dependencies; updated autoscaling settings in the sample.env file of docker.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
