### PR TITLE
[Do not merge] When chunk_size=0, skip vector db

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/constants.py
+++ b/backend/prompt_studio/prompt_studio_core/constants.py
@@ -29,6 +29,7 @@ class ToolStudioPromptKeys:
     UNIQUE_FILE_ID = "unique_file_id"
     ID = "id"
     FILE_NAME = "file_name"
+    FILE_PATH = "file_path"
     FILE_HASH = "file_hash"
     TOOL_ID = "tool_id"
     NAME = "name"

--- a/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core/prompt_studio_helper.py
@@ -797,6 +797,7 @@ class PromptStudioHelper:
             TSPKeys.TOOL_ID: tool_id,
             TSPKeys.RUN_ID: run_id,
             TSPKeys.FILE_NAME: doc_name,
+            TSPKeys.FILE_PATH: os.path.split(doc_path)[0],
             TSPKeys.FILE_HASH: file_hash,
             Common.LOG_EVENTS_ID: StateStore.get(Common.LOG_EVENTS_ID),
         }

--- a/prompt-service/src/unstract/prompt_service/constants.py
+++ b/prompt-service/src/unstract/prompt_service/constants.py
@@ -8,6 +8,7 @@ class PromptServiceContants:
     TOOL_ID = "tool_id"
     RUN_ID = "run_id"
     FILE_NAME = "file_name"
+    FILE_PATH = "file_path"
     FILE_HASH = "file_hash"
     NAME = "name"
     ACTIVE = "active"

--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -245,7 +245,7 @@ def prompt_processor() -> Any:
                 RunLevel.RUN,
                 "Unable to obtain LLM / embedding / vectorDB",
             )
-            return APIError(message=msg)
+            raise APIError(message=msg)
 
         if output[PSKeys.TYPE] == PSKeys.TABLE:
             try:
@@ -323,7 +323,7 @@ def prompt_processor() -> Any:
                         RunLevel.RUN,
                         "Extracted file not present.",
                     )
-                    return APIError(message=msg)
+                    raise APIError(message=msg)
 
                 # TODO: Use vectorDB name when available
                 _publish_log(


### PR DESCRIPTION
## What

Current; implementation always uses the indexed nodes when fetching context for prompts. However, when chunk_size=0, since we have to send the entire context, we can directly send the extracted text instead of fetching the chunk from the vector db.

## Why

This will improve response time for prompts when chunk_size=0 as vector db need not be accessed

## How

When chunk_size=0, the context can be fetched from the extracted text present in the container file system

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

Maybe. Testing required around prompt studio for chunk sizes = 0 and > 0. Suggested to test with plugins also.

## Database Migrations

- None

## Env Config

- NA

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-1418

SDK PR
- https://github.com/Zipstack/unstract-sdk/pull/99

## Dependencies Versions

-

## Notes on Testing

- 

## Screenshots

Profile with Chunk_size=0
Manual indexing on a document. Here after indexing is completed, no nodes are added to the vector DB as shown
![image](https://github.com/user-attachments/assets/98b1e4fa-cfc8-4b8e-8fb7-fb2fa1cf335b)

Prompt run on top of manual indexing. Here after prompt run, still no records in the vector db. But still, prompt answers are right as the context gets picked up from the extracted text and works fine.
![image](https://github.com/user-attachments/assets/6ea9619c-2c68-431f-bc85-f564fe0748ca)


Running a prompt before manual indexing (dynamic indexing would kick in). 
![image](https://github.com/user-attachments/assets/4d6e05d7-4bf6-4b66-87a9-c4846e7fa355)


![image](https://github.com/user-attachments/assets/61faceb4-5d6e-4997-b727-a4747ab983c9)

Manually remove the extracted file after indexing. Run prompt. This gives an error saying the extracted file is missing
![image](https://github.com/user-attachments/assets/28673379-666a-4ee6-afff-9e079cdc22a6)

Now, do a manual re-indexing. Extracted file will be re-created. Then run prompt.

![image](https://github.com/user-attachments/assets/4392bbe6-ea42-485c-9253-645be22e3dba)

![image](https://github.com/user-attachments/assets/00f9a374-dd4e-43f6-bdb0-8991d67a4538)

![image](https://github.com/user-attachments/assets/88b3c4e2-c281-4dae-8cdf-ec973ca4f894)


Profile with chunk_size =1024

Manual indexing on a document. Here after indexing is completed, nodes are added to the vector DB as shown
![image](https://github.com/user-attachments/assets/30aabb48-8f72-4acf-8b26-74292dfaf820)

Prompt run on top of manual indexing. Prompt run works fine picking context from vector DB.
![image](https://github.com/user-attachments/assets/051e9fcd-a234-46ef-989d-62acd80e6df1)


Running a prompt before manual indexing (dynamic indexing would kick in) as there are no records in vector db.
![image](https://github.com/user-attachments/assets/f6473e9e-075f-433c-b572-39b69ffd87d3)

Dynamic indexing kicked in and prompt run worked fine

![image](https://github.com/user-attachments/assets/75922384-9ff4-4515-8b00-933170c36c64)

Manually remove the records from vector db
![image](https://github.com/user-attachments/assets/541c8259-7c2a-4cbb-bfd7-991325dd66cc)

On running prompt, we see an error
![image](https://github.com/user-attachments/assets/4f2aaa79-ada0-442f-8927-cf31e6bcadd1)


Manually re-index. Run prompt again and prompt should work fine. Nodes added to vector DB.
![image](https://github.com/user-attachments/assets/361b3fed-ac69-4ff4-a265-f61594c11b7d)

![image](https://github.com/user-attachments/assets/0ae6269a-6e2f-4f6a-98c7-6e9037cdb6f4)

 

## Checklist

I have read and understood the [Contribution Guidelines]().
