### PR TITLE
Added disabled view for disabled prompts

### DIFF
--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.css
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.css
@@ -218,10 +218,15 @@
 }
 
 .prompt-output-llm-bg {
-  background-color: #DDDDDD;
+  background-color: #dddddd;
   padding: 10px;
 }
 
 .prompt-output-title {
   font-size: 18px;
+}
+
+.card-disabled {
+  opacity: 0.7;
+  filter: grayscale(100%);
 }

--- a/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
@@ -164,7 +164,9 @@ function PromptCardItems({
   }, [llmProfiles, selectedLlmProfileId, enabledProfiles]);
 
   return (
-    <Card className="prompt-card">
+    <Card
+      className={`prompt-card ${!promptDetails?.active && "card-disabled"}`}
+    >
       <div className="prompt-card-div prompt-card-bg-col1 prompt-card-rad">
         <Space direction="vertical" className="width-100" ref={divRef}>
           <Header

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -123,7 +123,7 @@ function PromptOutput({
 
   if (
     (singlePassExtractMode || isSimplePromptStudio) &&
-    (promptDetails?.active || isSimplePromptStudio) &&
+    isSimplePromptStudio &&
     (firstResult?.output ||
       firstResult?.output === 0 ||
       spsLoading[selectedDoc?.document_id])


### PR DESCRIPTION
## What

- Added disabled view for disabled prompts
- Fixed prompt enable/disable state is not updated properly when multiple prompts are enabled/disabled

## Why

- In Prompt studio, When the prompt is disabled the particular prompt should in disabled view. But as of now there is no visual difference for that.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, This is minor UI improvement. It won't break any existing features

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/2c380e85-105d-400a-8175-811d9dc3477f)


## Checklist

I have read and understood the [Contribution Guidelines]().
