### PR TITLE
Pipline flow changed from asyncrounous execution function

### DIFF
--- a/backend/scheduler/helper.py
+++ b/backend/scheduler/helper.py
@@ -63,7 +63,8 @@ class SchedulerHelper:
                 str(workflow_id),
                 organization_id,
                 execution_action or "",
-                "",  # TODO: execution_id parameter cannot be removed without a migration.
+                # TODO: execution_id parameter cannot be removed without a migration.
+                "",
                 str(pipeline.pk),
                 # Added to remain backward compatible - remove after data migration
                 # which removes unused args in execute_pipeline_task

--- a/backend/scheduler/helper.py
+++ b/backend/scheduler/helper.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from typing import Any
 
 from django.db import connection
@@ -20,11 +19,11 @@ from unstract.flags.feature_flag import check_feature_flag_status
 if check_feature_flag_status(FeatureFlag.MULTI_TENANCY_V2):
     from pipeline_v2.models import Pipeline
     from utils.user_context import UserContext
-    from workflow_manager.workflow_v2.constants import WorkflowExecutionKey, WorkflowKey
+    from workflow_manager.workflow_v2.constants import WorkflowKey
     from workflow_manager.workflow_v2.serializers import ExecuteWorkflowSerializer
 else:
     from pipeline.models import Pipeline
-    from workflow_manager.workflow.constants import WorkflowExecutionKey, WorkflowKey
+    from workflow_manager.workflow.constants import WorkflowKey
     from workflow_manager.workflow.serializers import ExecuteWorkflowSerializer
 logger = logging.getLogger(__name__)
 
@@ -46,8 +45,6 @@ class SchedulerHelper:
         task_data = job_kwargs.get("data", {})
 
         task_data[WorkflowKey.WF_ID] = pipeline.workflow.id
-        execution_id = str(uuid.uuid4())
-        task_data[WorkflowExecutionKey.EXECUTION_ID] = execution_id
         serializer = ExecuteWorkflowSerializer(data=task_data)
         serializer.is_valid(raise_exception=True)
         workflow_id = serializer.get_workflow_id(serializer.validated_data)
@@ -66,7 +63,7 @@ class SchedulerHelper:
                 str(workflow_id),
                 organization_id,
                 execution_action or "",
-                execution_id,
+                "",  # TODO: This parameter cannot be removed without a migration.
                 str(pipeline.pk),
                 # Added to remain backward compatible - remove after data migration
                 # which removes unused args in execute_pipeline_task

--- a/backend/scheduler/helper.py
+++ b/backend/scheduler/helper.py
@@ -63,7 +63,7 @@ class SchedulerHelper:
                 str(workflow_id),
                 organization_id,
                 execution_action or "",
-                "",  # TODO: This parameter cannot be removed without a migration.
+                "",  # TODO: execution_id parameter cannot be removed without a migration.
                 str(pipeline.pk),
                 # Added to remain backward compatible - remove after data migration
                 # which removes unused args in execute_pipeline_task

--- a/backend/scheduler/tasks.py
+++ b/backend/scheduler/tasks.py
@@ -80,7 +80,6 @@ def execute_pipeline_task(
         execute_pipeline_task_v2(
             workflow_id=workflow_id,
             organization_id=org_schema,
-            execution_id=execution_id,
             pipeline_id=pipepline_id,
             pipeline_name=name,
         )
@@ -120,7 +119,7 @@ def execute_pipeline_task(
                 pipepline_id, Pipeline.PipelineStatus.INPROGRESS
             )
             execution_response = WorkflowHelper.complete_execution(
-                workflow, execution_id, pipepline_id
+                workflow=workflow, pipeline_id=pipepline_id
             )
             execution_response.remove_result_metadata_keys()
             logger.info(f"Execution response: {execution_response}")
@@ -132,7 +131,6 @@ def execute_pipeline_task(
 def execute_pipeline_task_v2(
     workflow_id: Any,
     organization_id: Any,
-    execution_id: Any,
     pipeline_id: Any,
     pipeline_name: Any,
 ) -> None:
@@ -141,7 +139,6 @@ def execute_pipeline_task_v2(
     Args:
         workflow_id (Any): UID of workflow entity
         org_schema (Any): Organization Identifier
-        execution_id (Any): UID of execution entity
         pipeline_id (Any): UID of pipeline entity
         name (Any): pipeline name
     """
@@ -170,7 +167,7 @@ def execute_pipeline_task_v2(
             pipeline_id, Pipeline.PipelineStatus.INPROGRESS
         )
         execution_response = WorkflowHelper.complete_execution(
-            workflow, execution_id, pipeline_id
+            workflow=workflow, pipeline_id=pipeline_id
         )
         execution_response.remove_result_metadata_keys()
         logger.info(

--- a/backend/workflow_manager/workflow/execution.py
+++ b/backend/workflow_manager/workflow/execution.py
@@ -103,8 +103,9 @@ class WorkflowExecutionServiceHelper(WorkflowExecutionService):
 
         self.compilation_result = self.compile_workflow(execution_id=self.execution_id)
 
-    @staticmethod
+    @classmethod
     def create_workflow_execution(
+        cls,
         workflow_id: str,
         pipeline_id: Optional[str] = None,
         single_step: bool = False,
@@ -113,6 +114,11 @@ class WorkflowExecutionServiceHelper(WorkflowExecutionService):
         execution_id: Optional[str] = None,
         mode: tuple[str, str] = WorkflowExecution.Mode.INSTANT,
     ) -> WorkflowExecution:
+        # Validating with existing execution
+        existing_execution = cls.get_execution_instance_by_id(execution_id)
+        if existing_execution:
+            return existing_execution
+
         execution_method: tuple[str, str] = (
             WorkflowExecution.Method.SCHEDULED
             if scheduled
@@ -167,6 +173,26 @@ class WorkflowExecutionServiceHelper(WorkflowExecutionService):
             pk=self.execution_id
         )
         return execution
+
+    @classmethod
+    def get_execution_instance_by_id(
+        cls, execution_id: str
+    ) -> Optional[WorkflowExecution]:
+        """Get execution by execution ID.
+
+        Args:
+            execution_id (str): UID of execution entity
+
+        Returns:
+            Optional[WorkflowExecution]: WorkflowExecution Entity
+        """
+        try:
+            execution: WorkflowExecution = WorkflowExecution.objects.get(
+                pk=execution_id
+            )
+            return execution
+        except WorkflowExecution.DoesNotExist:
+            return None
 
     def build(self) -> None:
         if self.compilation_result["success"] is True:

--- a/backend/workflow_manager/workflow/views.py
+++ b/backend/workflow_manager/workflow/views.py
@@ -30,6 +30,7 @@ from workflow_manager.workflow.exceptions import (
     WorkflowRegenerationError,
 )
 from workflow_manager.workflow.generator import WorkflowGenerator
+from workflow_manager.workflow.models.execution import WorkflowExecution
 from workflow_manager.workflow.models.workflow import Workflow
 from workflow_manager.workflow.serializers import (
     ExecuteWorkflowResponseSerializer,
@@ -233,12 +234,14 @@ class WorkflowViewSet(viewsets.ModelViewSet):
                 workflow=workflow,
                 execution_id=execution_id,
                 pipeline_id=pipeline_guid,
+                execution_mode=WorkflowExecution.Mode.INSTANT,
                 hash_values_of_files=hash_values_of_files,
             )
         else:
             execution_response = WorkflowHelper.complete_execution(
                 workflow=workflow,
                 execution_id=execution_id,
+                execution_mode=WorkflowExecution.Mode.INSTANT,
                 hash_values_of_files=hash_values_of_files,
             )
         return execution_response


### PR DESCRIPTION
## What

- Making execution ID for each pipeline execution to uniquely identify each run.
- Ensuring a new WorkflowExecution entity for every pipeline execution, ensuring each run is tracked separately.
- Updated the pipeline execution flow by calling execute_bin function directly
- Pipline Execution flow changed from existing asyncrounous execution  to reduce multiple Celery calls.

## Why

- Errors were occurring when an execution ID was sent by the pipeline without the execution being created first. By creating a new WorkflowExecution entity and execution ID for each pipeline run, this issue is resolved, ensuring proper tracking and identification.

## How

- Implemented the generation of a unique execution ID and creation of a new WorkflowExecution entity for every pipeline execution.
- Replaced the some function calls with a direct call to the execute_bin function to streamline the process and avoid redundant Celery calls.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-Might be. Had fixed pipline execution flow,

## Database Migrations

-  NO

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
