### PR TITLE
HOTFIX: Trigger logout when mandatory API fails.

### DIFF
--- a/frontend/src/hooks/useExceptionHandler.jsx
+++ b/frontend/src/hooks/useExceptionHandler.jsx
@@ -1,8 +1,6 @@
-import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 
 const useExceptionHandler = () => {
-  const navigate = useNavigate();
   const handleException = (
     err,
     errMessage = "Something went wrong",
@@ -36,7 +34,6 @@ const useExceptionHandler = () => {
           }
           break;
         case "subscription_error":
-          navigate("/trial-expired");
           return {
             title: title,
             type: "error",

--- a/frontend/src/hooks/useExceptionHandler.jsx
+++ b/frontend/src/hooks/useExceptionHandler.jsx
@@ -1,6 +1,8 @@
+import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 
 const useExceptionHandler = () => {
+  const navigate = useNavigate();
   const handleException = (
     err,
     errMessage = "Something went wrong",
@@ -34,6 +36,7 @@ const useExceptionHandler = () => {
           }
           break;
         case "subscription_error":
+          navigate("/trial-expired");
           return {
             title: title,
             type: "error",

--- a/frontend/src/hooks/useLogout.js
+++ b/frontend/src/hooks/useLogout.js
@@ -1,3 +1,4 @@
+import Cookies from "js-cookie";
 import { usePostHog } from "posthog-js/react";
 import { getSessionData } from "../helpers/GetSessionData";
 import { getBaseUrl } from "../helpers/GetStaticData";
@@ -7,9 +8,15 @@ function useLogout() {
   const setSessionDetails = useSessionStore((state) => state.setSessionDetails);
   const posthog = usePostHog();
 
+  const clearSessionCookies = () => {
+    Cookies.remove("sessionid");
+    Cookies.remove("csrftoken");
+  };
+
   return () => {
     setSessionDetails(getSessionData(null));
     posthog.reset();
+    clearSessionCookies();
     const baseUrl = getBaseUrl();
     const newURL = baseUrl + "/api/v1/logout";
     window.location.href = newURL;

--- a/frontend/src/hooks/useSessionValid.js
+++ b/frontend/src/hooks/useSessionValid.js
@@ -36,10 +36,10 @@ function useSessionValid() {
   const navigate = useNavigate();
   const userSession = useUserSession();
   const logout = useLogout();
-  const timestamp = new Date().getTime();
 
   return async () => {
     try {
+      const timestamp = new Date().getTime();
       const userSessionData = await userSession();
 
       // Return if the user is not authenticated

--- a/frontend/src/hooks/useSessionValid.js
+++ b/frontend/src/hooks/useSessionValid.js
@@ -38,6 +38,12 @@ function useSessionValid() {
   return async () => {
     try {
       const userSessionData = await userSession();
+
+      // Return if the user is not authenticated
+      if (!userSessionData) {
+        return;
+      }
+
       const signedInOrgId = userSessionData?.organization_id;
 
       // API to get the list of organizations

--- a/frontend/src/hooks/useSessionValid.js
+++ b/frontend/src/hooks/useSessionValid.js
@@ -156,7 +156,7 @@ function useSessionValid() {
     } catch (err) {
       setAlertDetails(handleException(err));
       if (err.response?.status === 402) {
-        navigate("/trial-expired");
+        handleException(err);
         return;
       }
 

--- a/frontend/src/hooks/useSessionValid.js
+++ b/frontend/src/hooks/useSessionValid.js
@@ -67,6 +67,10 @@ function useSessionValid() {
       const orgId = signedInOrgId || orgs[0].id;
       const csrfToken = Cookies.get("csrftoken");
 
+      if (!orgId || !csrfToken) {
+        throw Error("Required fields are missing.");
+      }
+
       // API to set the organization and get the user details
       requestOptions["method"] = "POST";
       requestOptions[

--- a/frontend/src/hooks/useUserSession.js
+++ b/frontend/src/hooks/useUserSession.js
@@ -8,12 +8,13 @@ const useUserSession = () => {
   const handleException = useExceptionHandler();
   const { setAlertDetails } = useAlertStore();
   const fallbackErrorMessage = "Error while getting session";
+  const timestamp = new Date().getTime();
 
   return async () => {
     try {
       const requestOptions = {
         method: "GET",
-        url: "/api/v1/session",
+        url: `/api/v1/session?q=${timestamp}`,
       };
       const res = await axios(requestOptions);
       return res.data;

--- a/frontend/src/hooks/useUserSession.js
+++ b/frontend/src/hooks/useUserSession.js
@@ -8,10 +8,10 @@ const useUserSession = () => {
   const handleException = useExceptionHandler();
   const { setAlertDetails } = useAlertStore();
   const fallbackErrorMessage = "Error while getting session";
-  const timestamp = new Date().getTime();
 
   return async () => {
     try {
+      const timestamp = new Date().getTime();
       const requestOptions = {
         method: "GET",
         url: `/api/v1/session?q=${timestamp}`,


### PR DESCRIPTION
## What

1. Log the user out if any one of the mandatory APIs fails.
2. Passed a timestamp in the query param for the mandatory APIs.

## Why

The session cookies were not being cleared earlier when one of the mandatory session APIs failed.

## How

The session cookies are now cleared by triggering the logout function when any of the mandatory session APIs fail.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

Yes, the major changes in this PR are in the `useSessionValid` hook, which is responsible for allowing the user to access authenticated pages.

## Database Migrations

NA

## Env Config

NA

## Relevant Docs

NA

## Related Issues or PRs

NA

## Dependencies Versions

NA

## Notes on Testing

NA

## Screenshots

NA

## Checklist

I have read and understood the [Contribution Guidelines]().
