### PR TITLE
Added env setting for django atomic requests

### DIFF
--- a/backend/account/authentication_controller.py
+++ b/backend/account/authentication_controller.py
@@ -168,7 +168,7 @@ class AuthenticationController:
             )
 
             # Django tenant migration will happen in the below code block
-            with transaction.atomic():
+            with transaction.atomic(durable=True):
                 if not organization:
                     try:
                         organization_data: OrganizationData = (

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -361,7 +361,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "backend.wsgi.application"
 
-ATOMIC_REQUESTS = os.environ.get("ATOMIC_REQUESTS", False)
+ATOMIC_REQUESTS = os.environ.get("DJANGO_ATOMIC_REQUESTS", False)
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -360,7 +360,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "backend.wsgi.application"
 
-
+ATOMIC_REQUESTS = os.environ.get("ATOMIC_REQUESTS", False)
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
@@ -372,7 +372,7 @@ DATABASES = {
         "HOST": f"{DB_HOST}",
         "PASSWORD": f"{DB_PASSWORD}",
         "PORT": f"{DB_PORT}",
-        "ATOMIC_REQUESTS": True,
+        "ATOMIC_REQUESTS": ATOMIC_REQUESTS,
     }
 }
 

--- a/backend/prompt_studio/prompt_studio_core/urls.py
+++ b/backend/prompt_studio/prompt_studio_core/urls.py
@@ -1,6 +1,4 @@
-from django.db import transaction
 from django.urls import path
-from django.utils.decorators import method_decorator
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from .views import PromptStudioCoreView
@@ -79,9 +77,7 @@ urlpatterns = format_suffix_patterns(
         ),
         path(
             "prompt-studio/index-document/<uuid:pk>",
-            method_decorator(transaction.non_atomic_requests)(
-                prompt_studio_prompt_index
-            ),
+            prompt_studio_prompt_index,
             name="prompt-studio-prompt-index",
         ),
         path(


### PR DESCRIPTION
## What

- Moved ATOMIC Request setting at Django framework level to env
- Added Django tenant migrations  and organization creation to a single transaction block

## Why

- 

## How

- https://docs.djangoproject.com/en/5.1/topics/db/transactions/#tying-transactions-to-http-requests

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Need to check the impact of the ignoring transaction boundaries

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
