### PR TITLE
fix: Logged errors unhandled by DRF but caught in django's exc handler

### DIFF
--- a/backend/middleware/exception.py
+++ b/backend/middleware/exception.py
@@ -68,13 +68,17 @@ class ExceptionLoggingMiddleware:
         # Handle only when running in production, for debug mode
         # Django takes care of displaying a detailed HTML page.
         if not settings.DEBUG and exception:
+            logger.error(f"Unhandled exception by DRF for {request}, logging error...")
+            ExceptionLoggingMiddleware.format_exc_and_log(
+                request=request, exception=exception
+            )
             detail = {"detail": "Error processing the request."}
             return HttpResponse(json.dumps(detail), status=500)
         return None
 
     @staticmethod
     def format_exc_and_log(
-        request: Request, response: Optional[Response], exception: Exception
+        request: Request, exception: Exception, response: Optional[Response] = None
     ) -> None:
         """Format the exception to be logged and logs it.
 


### PR DESCRIPTION
## What

- Logging exceptions (with or without traceback) for those errors which were not handled by DRF but caught and handled by django's exception logging middleware

## Why

- There exists scenarios where exceptions were not logged - this was due to cases where django handled the exception and not DRF

## How

- DRF's exception handler tries to handle errors first - this was already logged
- In some cases, it might not handle the error and instead let's django do it. In such scenarios - the error was not logged which lead to losing context on what actually went wrong

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, only additional log statement introduced

## Notes on Testing

- Tested by making code changes for this to kick in - however this wasn't tested on the actual scenario where this behaviour is observed.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
