### PR TITLE
Removed with atomic block for django tenant

### DIFF
--- a/backend/account/authentication_controller.py
+++ b/backend/account/authentication_controller.py
@@ -35,7 +35,6 @@ from account.serializer import (
 from account.user import UserService
 from django.conf import settings
 from django.contrib.auth import logout as django_logout
-from django.db import transaction
 from django.db.utils import IntegrityError
 from django.middleware import csrf
 from django.shortcuts import redirect
@@ -166,33 +165,28 @@ class AuthenticationController:
             organization = OrganizationService.get_organization_by_org_id(
                 organization_id
             )
-
-            # Django tenant migration will happen in the below code block
-            with transaction.atomic(durable=True):
-                if not organization:
-                    try:
-                        organization_data: OrganizationData = (
-                            self.auth_service.get_organization_by_org_id(
-                                organization_id
-                            )
-                        )
-                    except ValueError:
-                        raise OrganizationNotExist()
-                    try:
-                        organization = OrganizationService.create_organization(
-                            organization_data.name,
-                            organization_data.display_name,
-                            organization_data.id,
-                        )
-                        new_organization = True
-                    except IntegrityError:
-                        raise DuplicateData(
-                            f"{ErrorMessage.ORGANIZATION_EXIST}, \
-                                {ErrorMessage.DUPLICATE_API}"
-                        )
-                organization_member = self.create_tenant_user(
-                    organization=organization, user=user
-                )
+            if not organization:
+                try:
+                    organization_data: OrganizationData = (
+                        self.auth_service.get_organization_by_org_id(organization_id)
+                    )
+                except ValueError:
+                    raise OrganizationNotExist()
+                try:
+                    organization = OrganizationService.create_organization(
+                        organization_data.name,
+                        organization_data.display_name,
+                        organization_data.id,
+                    )
+                    new_organization = True
+                except IntegrityError:
+                    raise DuplicateData(
+                        f"{ErrorMessage.ORGANIZATION_EXIST}, \
+                            {ErrorMessage.DUPLICATE_API}"
+                    )
+            organization_member = self.create_tenant_user(
+                organization=organization, user=user
+            )
 
             if new_organization:
                 try:


### PR DESCRIPTION
## What

- A durable atomic block cannot be nested within another atomic block

## Why

- Once we enable django_atomic requests to true, with transaction block inside views shouldn't be with option durable

## How

- we are going ahead with atomic_request true. hence ignoring the inner block.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/24dd8a94-ae36-4d4d-82be-84105899d6b0)

## Checklist

I have read and understood the [Contribution Guidelines]().
