### PR TITLE
fix: Renamed runner back to worker to resolve build issues

### DIFF
--- a/docker/docker-compose.build.yaml
+++ b/docker/docker-compose.build.yaml
@@ -9,7 +9,7 @@ services:
     build:
       dockerfile: docker/dockerfiles/backend.Dockerfile
       context: ..
-  runner:
+  worker:
     image: unstract/worker:${VERSION}
     build:
       dockerfile: docker/dockerfiles/worker.Dockerfile


### PR DESCRIPTION
## What

- Renamed `runner` back to `worker` to resolve build issues

## Why

- https://github.com/Zipstack/unstract/actions/runs/10881772003/job/30191421596


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this reverts a change which was made earlier

## Notes on Testing

- No explicit testing done

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
