### PR TITLE
feat: Tool container name validation for length < 63

### DIFF
--- a/unstract/core/src/unstract/core/utilities.py
+++ b/unstract/core/src/unstract/core/utilities.py
@@ -1,5 +1,8 @@
+import logging
 import os
 from typing import Optional
+
+logger = logging.getLogger()
 
 
 class UnstractUtils:
@@ -28,4 +31,12 @@ class UnstractUtils:
     def build_tool_container_name(
         tool_image: str, tool_version: str, run_id: str
     ) -> str:
-        return f"{tool_image.split('/')[-1]}-{tool_version}-{run_id}"
+        container_name = f"{tool_image.split('/')[-1]}-{tool_version}-{run_id}"
+
+        # To support limits of container clients like K8s
+        if len(container_name) > 63:
+            logger.warning(
+                f"Container name exceeds 63 char limit for '{container_name}', "
+                "truncating to 63 chars. There might be collisions in container names"
+            )
+        return container_name[:63]


### PR DESCRIPTION
**NOTE: v2 change not required**
## What

- Validating tool container name length to ensure its < 63 chars

## Why

- Addressing ask related to #666 
- In case of runner clients like K8s it'll be an issue


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor log change and string slicing involved

## Related Issues or PRs

- #666 



## Notes on Testing

- No explicit testing done to ensure this warning is raised

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
