### PR TITLE
FIX: Optimize Timer Handling for Prompt Run API Calls

### DIFF
--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -22,11 +22,7 @@ import {
 import { motion, AnimatePresence } from "framer-motion";
 import CheckableTag from "antd/es/tag/CheckableTag";
 
-import {
-  displayPromptResult,
-  formatNumberWithCommas,
-  getFormattedTotalCost,
-} from "../../../helpers/GetStaticData";
+import { displayPromptResult } from "../../../helpers/GetStaticData";
 import { SpinnerLoader } from "../../widgets/spinner-loader/SpinnerLoader";
 import { TokenUsage } from "../token-usage/TokenUsage";
 import { useWindowDimensions } from "../../../hooks/useWindowDimensions";
@@ -37,6 +33,8 @@ import { useAlertStore } from "../../../store/alert-store";
 import { PromptOutputExpandBtn } from "./PromptOutputExpandBtn";
 import { DisplayPromptResult } from "./DisplayPromptResult";
 import usePromptOutput from "../../../hooks/usePromptOutput";
+import { PromptRunTimer } from "./PromptRunTimer";
+import { PromptRunCost } from "./PromptRunCost";
 
 let TableOutput;
 try {
@@ -237,14 +235,24 @@ function PromptOutput({
                       )}
                     </Typography.Text>
                     <Typography.Text className="prompt-cost-item">
-                      Time:
-                      {timers[tokenUsageId] || 0}s
+                      <PromptRunTimer
+                        timer={timers[profileId]}
+                        isLoading={
+                          isRunLoading[
+                            `${selectedDoc?.document_id}_${profileId}`
+                          ]
+                        }
+                      />
                     </Typography.Text>
                     <Typography.Text className="prompt-cost-item">
-                      Cost: $
-                      {formatNumberWithCommas(
-                        getFormattedTotalCost(promptOutputData?.tokenUsage)
-                      )}
+                      <PromptRunCost
+                        tokenUsage={promptOutputData?.tokenUsage}
+                        isLoading={
+                          isRunLoading[
+                            `${selectedDoc?.document_id}_${profileId}`
+                          ]
+                        }
+                      />
                     </Typography.Text>
                   </div>
                   <div className="prompt-info">

--- a/frontend/src/components/custom-tools/prompt-card/PromptRunCost.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptRunCost.jsx
@@ -1,0 +1,23 @@
+import { memo } from "react";
+import PropTypes from "prop-types";
+import {
+  formatNumberWithCommas,
+  getFormattedTotalCost,
+} from "../../../helpers/GetStaticData";
+
+const PromptRunCost = memo(({ tokenUsage, isLoading }) => {
+  if (!tokenUsage || isLoading) {
+    return "Cost: NA";
+  }
+
+  return `Cost: $${formatNumberWithCommas(getFormattedTotalCost(tokenUsage))}`;
+});
+
+PromptRunCost.displayName = "PromptRunCost";
+
+PromptRunCost.propTypes = {
+  tokenUsage: PropTypes.number,
+  isLoading: PropTypes.bool.isRequired,
+};
+
+export { PromptRunCost };

--- a/frontend/src/components/custom-tools/prompt-card/PromptRunTimer.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptRunTimer.jsx
@@ -1,0 +1,19 @@
+import { memo } from "react";
+import PropTypes from "prop-types";
+
+const PromptRunTimer = memo(({ timer, isLoading }) => {
+  if (!timer?.startTime || !timer?.endTime || isLoading) {
+    return "Time: 0s";
+  }
+
+  return `Time: ${Math.floor((timer?.endTime - timer?.startTime) / 1000)}s`;
+});
+
+PromptRunTimer.displayName = "PromptRunTimer";
+
+PromptRunTimer.propTypes = {
+  timer: PropTypes.object,
+  isLoading: PropTypes.bool.isRequired,
+};
+
+export { PromptRunTimer };


### PR DESCRIPTION
## What

This PR introduces optimizations to how timers are handled in PromptCard component when the prompt run API call is triggered

## Why

Previously, each `PromptCard` initiated a `setInterval` to update the timer every second during the API call. Multiple `setInterval` instances created concurrently caused excessive component re-renders and increased CPU load when several prompt runs were triggered simultaneously.

## How

The `setInterval` logic has been replaced with a more efficient timestamp-based approach. When the API call is triggered, a `startTime` timestamp is captured. Upon API completion, an `endTime` timestamp is captured. The difference between `startTime` and `endTime` is calculated, converted into seconds, and displayed in the card. This eliminates the need for frequent re-renders during the `setInterval` logic.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

Yes, this PR includes changes to how the time taken for a prompt run is handled. These modifications may impact other features within the `PromptCard` component.

## Database Migrations

NA

## Env Config

NA

## Relevant Docs

NA

## Related Issues or PRs

NA

## Dependencies Versions

NA

## Notes on Testing

NA

## Screenshots
### Time taken to run each prompt is displayed in the below screenshot:
![Screenshot from 2024-09-17 15-52-28](https://github.com/user-attachments/assets/ad50b171-e797-4872-b360-9f88480c5245)


## Checklist

I have read and understood the [Contribution Guidelines]().
