### PR TITLE
Fix: Added force export to prompt studio tool export

### DIFF
--- a/backend/prompt_studio/prompt_studio_core/views.py
+++ b/backend/prompt_studio/prompt_studio_core/views.py
@@ -530,10 +530,12 @@ class PromptStudioCoreView(viewsets.ModelViewSet):
         is_shared_with_org: bool = serializer.validated_data.get("is_shared_with_org")
         user_ids = set(serializer.validated_data.get("user_id"))
 
+        force_export = serializer.validated_data.get("force_export")
         PromptStudioRegistryHelper.update_or_create_psr_tool(
             custom_tool=custom_tool,
             shared_with_org=is_shared_with_org,
             user_ids=user_ids,
+            force_export=force_export,
         )
         return Response(
             {"message": "Custom tool exported sucessfully."},

--- a/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
+++ b/backend/prompt_studio/prompt_studio_registry/prompt_studio_registry_helper.py
@@ -134,7 +134,10 @@ class PromptStudioRegistryHelper:
 
     @staticmethod
     def update_or_create_psr_tool(
-        custom_tool: CustomTool, shared_with_org: bool, user_ids: set[int]
+        custom_tool: CustomTool,
+        shared_with_org: bool,
+        user_ids: set[int],
+        force_export: bool,
     ) -> PromptStudioRegistry:
         """Updates or creates the PromptStudioRegistry record.
 
@@ -142,7 +145,13 @@ class PromptStudioRegistryHelper:
         1:1 with the `CustomTool`.
 
         Args:
-            tool_id (str): ID of the custom tool.
+            custom_tool (CustomTool): The instance of the custom tool to be updated
+                or created.
+            shared_with_org (bool): Flag indicating whether the tool is shared with
+                the organization.
+            user_ids (set[int]): A set of user IDs to whom the tool is shared.
+            force_export (bool): Indicates if the export is being forced.
+
 
         Raises:
             ToolSaveError
@@ -160,7 +169,7 @@ class PromptStudioRegistryHelper:
                 tool_id=custom_tool.tool_id
             )
             metadata = PromptStudioRegistryHelper.frame_export_json(
-                tool=custom_tool, prompts=prompts
+                tool=custom_tool, prompts=prompts, force_export=force_export
             )
 
             obj: PromptStudioRegistry
@@ -206,7 +215,9 @@ class PromptStudioRegistryHelper:
 
     @staticmethod
     def frame_export_json(
-        tool: CustomTool, prompts: list[ToolStudioPrompt]
+        tool: CustomTool,
+        prompts: list[ToolStudioPrompt],
+        force_export: bool,
     ) -> dict[str, Any]:
         export_metadata = {}
 
@@ -281,15 +292,15 @@ class PromptStudioRegistryHelper:
                 invalidated_prompts.append(prompt.prompt_key)
                 continue
 
-            prompt_output = PromptStudioOutputManager.objects.filter(
-                tool_id=tool.tool_id,
-                prompt_id=prompt.prompt_id,
-                profile_manager=prompt.profile_manager,
-            ).all()
-
-            if not prompt_output:
-                invalidated_outputs.append(prompt.prompt_key)
-                continue
+            if not force_export:
+                prompt_output = PromptStudioOutputManager.objects.filter(
+                    tool_id=tool.tool_id,
+                    prompt_id=prompt.prompt_id,
+                    profile_manager=prompt.profile_manager,
+                ).all()
+                if not prompt_output:
+                    invalidated_outputs.append(prompt.prompt_key)
+                    continue
 
             if not prompt.profile_manager:
                 prompt.profile_manager = default_llm_profile
@@ -352,10 +363,12 @@ class PromptStudioRegistryHelper:
                 f"Cannot export tool. Prompt(s): {', '.join(invalidated_prompts)} "
                 "are empty. Please enter a valid prompt."
             )
-        if invalidated_outputs:
+        if not force_export and invalidated_outputs:
             raise InValidCustomToolError(
-                f"Cannot export tool. Prompt(s): {', '.join(invalidated_outputs)} "
-                "were not run. Please run them before exporting."
+                detail="Cannot export tool. Prompt(s):"
+                f" {', '.join(invalidated_outputs)}"
+                " were not run. Please run them before exporting.",
+                code="warning",
             )
         export_metadata[JsonSchemaKey.TOOL_SETTINGS] = tool_settings
         export_metadata[JsonSchemaKey.OUTPUTS] = outputs

--- a/backend/prompt_studio/prompt_studio_registry/serializers.py
+++ b/backend/prompt_studio/prompt_studio_registry/serializers.py
@@ -36,3 +36,4 @@ class PromptStudioRegistryInfoSerializer(AuditSerializer):
 class ExportToolRequestSerializer(serializers.Serializer):
     is_shared_with_org = serializers.BooleanField(default=False)
     user_id = serializers.ListField(child=serializers.IntegerField(), required=False)
+    force_export = serializers.BooleanField(default=False)

--- a/frontend/src/components/custom-tools/header/Header.jsx
+++ b/frontend/src/components/custom-tools/header/Header.jsx
@@ -62,11 +62,6 @@ function Header({
     isSharedWithEveryone,
     forcedExport = false
   ) => {
-    setLastExportParams({
-      selectedUsers,
-      toolDetail,
-      isSharedWithEveryone,
-    });
     const body = {
       is_shared_with_org: isSharedWithEveryone,
       user_id: isSharedWithEveryone ? [] : selectedUsers,
@@ -91,6 +86,11 @@ function Header({
       })
       .catch((err) => {
         if (err?.response?.data?.errors[0]?.code === "warning") {
+          setLastExportParams({
+            selectedUsers,
+            toolDetail,
+            isSharedWithEveryone,
+          });
           setConfirmModalVisible(true); // Show the confirmation modal
           return; // Exit early to prevent any further execution
         }
@@ -227,21 +227,18 @@ function Header({
           toolDetails={toolDetails}
         />
       </div>
-
-      {confirmModalVisible && (
-        <Modal
-          onOk={handleConfirmForceExport} // Pass the confirm action
-          onCancel={() => setConfirmModalVisible(false)} // Close the modal on cancel
-          open={confirmModalVisible}
-          title="Are you sure"
-          okText="Force Export"
-          centered
-        >
-          Unable to export tool. Some Prompt(s) were not run. Please run them
-          before exporting.{" "}
-          <strong>Would you like to force export anyway?</strong>
-        </Modal>
-      )}
+      <Modal
+        onOk={handleConfirmForceExport} // Pass the confirm action
+        onCancel={() => setConfirmModalVisible(false)} // Close the modal on cancel
+        open={confirmModalVisible}
+        title="Are you sure"
+        okText="Force Export"
+        centered
+      >
+        Unable to export tool. Some prompt(s) were not run. Please run them
+        before exporting.{" "}
+        <strong>Would you like to force export anyway?</strong>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/components/custom-tools/header/Header.jsx
+++ b/frontend/src/components/custom-tools/header/Header.jsx
@@ -103,13 +103,10 @@ function Header({
   };
 
   const handleConfirmForceExport = useCallback(() => {
-    if (lastExportParams) {
-      const { selectedUsers, toolDetail, isSharedWithEveryone } =
-        lastExportParams;
+    const { selectedUsers, toolDetail, isSharedWithEveryone } =
+      lastExportParams;
 
-      handleExport(selectedUsers, toolDetail, isSharedWithEveryone, true);
-    }
-
+    handleExport(selectedUsers, toolDetail, isSharedWithEveryone, true);
     setConfirmModalVisible(false);
   }, [lastExportParams]);
 

--- a/frontend/src/components/custom-tools/header/Header.jsx
+++ b/frontend/src/components/custom-tools/header/Header.jsx
@@ -238,8 +238,8 @@ function Header({
           centered
         >
           Unable to export tool. Some Prompt(s) were not run. Please run them
-          before exporting.
-          <strong> Would you like to force export anyway?</strong>
+          before exporting.{" "}
+          <strong>Would you like to force export anyway?</strong>
         </Modal>
       )}
     </div>

--- a/frontend/src/components/custom-tools/prompt-card/DisplayPromptResult.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/DisplayPromptResult.jsx
@@ -6,7 +6,7 @@ import { displayPromptResult } from "../../../helpers/GetStaticData";
 import "./PromptCard.css";
 
 function DisplayPromptResult({ output }) {
-  if (!output) {
+  if (output === undefined) {
     return (
       <Typography.Text className="prompt-not-ran">
         <span>


### PR DESCRIPTION
## What

- Added force export to prompt studio tool export
- Fixed Yet to run displayed while prompt output is null

## Why

- We internally set up the default profile during export if the profile is not selected for a prompt, but the user may not have known this or may not have executed the prompt in the default profile. Thus, even if the prompt is not executed, we still permit users to export by force export. 

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Yes. Changes made on existing feature might cause issue in export.

## Database Migrations

- N/A

## Env Config

- N/A

## Relevant Docs

- N/A

## Related Issues or PRs

- N/A

## Dependencies Versions

- N/A

## Notes on Testing

- N/A

## Screenshots
![image](https://github.com/user-attachments/assets/8ef976e6-6f8a-4022-92a4-1a0a178a23b0)
![image](https://github.com/user-attachments/assets/e76ec6ef-8336-487e-a848-95bff77c214d)



## Checklist

I have read and understood the [Contribution Guidelines]().
