### PR TITLE
[FIX] String being passed instead of boolean for FLIPT_SERVICE_AVAILABLE

### DIFF
--- a/unstract/flags/src/unstract/flags/client/flipt.py
+++ b/unstract/flags/src/unstract/flags/client/flipt.py
@@ -33,7 +33,9 @@ class FliptClient(BaseClient):
 
     def list_feature_flags(self, namespace_key: str) -> dict:
         try:
-            FLIPT_SERVICE_AVAILABLE = os.environ.get("FLIPT_SERVICE_AVAILABLE", False)
+            FLIPT_SERVICE_AVAILABLE = (
+                os.environ.get("FLIPT_SERVICE_AVAILABLE", "false").lower() == "true"
+            )
             if not FLIPT_SERVICE_AVAILABLE:
                 logger.warning("Flipt service is not available.")
                 return {}

--- a/unstract/flags/src/unstract/flags/feature_flag.py
+++ b/unstract/flags/src/unstract/flags/feature_flag.py
@@ -31,7 +31,9 @@ def check_feature_flag_status(
     """
 
     try:
-        FLIPT_SERVICE_AVAILABLE = os.environ.get("FLIPT_SERVICE_AVAILABLE", False)
+        FLIPT_SERVICE_AVAILABLE = (
+            os.environ.get("FLIPT_SERVICE_AVAILABLE", "false").lower() == "true"
+        )
         if not FLIPT_SERVICE_AVAILABLE:
             return False
 


### PR DESCRIPTION
## What

String being passed instead of boolean for FLIPT_SERVICE_AVAILABLE

## Why

String will always be considered as true.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
