### PR TITLE
fix: Removed unnecessary kwarg db_instance in platform-service

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -16,5 +16,4 @@ fi
     --log-level debug \
     --timeout 600 \
     --access-logfile - \
-    --reload \
     backend.wsgi:application

--- a/platform-service/src/unstract/platform_service/controller/platform.py
+++ b/platform-service/src/unstract/platform_service/controller/platform.py
@@ -499,7 +499,6 @@ def custom_tool_instance() -> Any:
 
         try:
             data_dict = PromptStudioRequestHelper.get_prompt_instance_from_db(
-                db_instance=db,
                 organization_id=organization_id,
                 prompt_registry_id=prompt_registry_id,
             )

--- a/prompt-service/entrypoint.sh
+++ b/prompt-service/entrypoint.sh
@@ -8,5 +8,4 @@
     --log-level debug \
     --timeout 900 \
     --access-logfile - \
-    --reload \
     unstract.prompt_service.main:app


### PR DESCRIPTION
## What
- Removed `db_instance` kwarg in `platform-service`
- Removed reload on change option for `prompt-service and `backend` entrypoint 

## Why

```
[2024-09-27 08:06:33 +0000] ERROR in platform-service (platform): Error while getting db adapter settings for: 8714603a-0a63-4b7a-8eec-b7967fe71270 Error: get_prompt_instance_from_db() got an unexpected keyword argument 'db_instance'
```


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No


## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/742



## Notes on Testing

- Exported a tool locally and ran it in a workflow

## Screenshots
![image](https://github.com/user-attachments/assets/a967f511-387f-4be2-ae4e-862a317882d1)

## Checklist

I have read and understood the [Contribution Guidelines]().
