### PR TITLE
added a custom DB engine for V2 to add search path

### DIFF
--- a/backend/backend/custom_db/base.py
+++ b/backend/backend/custom_db/base.py
@@ -1,0 +1,52 @@
+import logging
+
+from django.conf import settings
+from django.db.backends.postgresql.base import (
+    DatabaseWrapper as PostgresDatabaseWrapper,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseWrapper(PostgresDatabaseWrapper):
+    """Custom DatabaseWrapper to manage PostgreSQL connections and set the
+    search path."""
+
+    def get_new_connection(self, conn_params):
+        """Establish a new database connection or reuse an existing one, and
+        set the search path.
+
+        Args:
+            conn_params: Parameters for the new database connection.
+
+        Returns:
+            connection: The database connection
+        """
+        connection = super().get_new_connection(conn_params)
+        logger.info(f"DB connection (ID: {id(connection)}) is established or reused.")
+        self.set_search_path(connection)
+        return connection
+
+    def set_search_path(self, connection):
+        """Set the search path for the given database connection.
+
+        This ensures that the database queries will look in the specified schema.
+
+        Args:
+            connection: The database connection for which to set the search path.
+        """
+        conn_id = id(connection)
+        original_autocommit = connection.autocommit
+        try:
+            connection.autocommit = True
+            logger.debug(
+                f"Setting search_path to {settings.DB_SCHEMA} for DB connection ID "
+                f"{conn_id}."
+            )
+            with connection.cursor() as cursor:
+                cursor.execute(f"SET search_path TO {settings.DB_SCHEMA}")
+            logger.debug(
+                f"Successfully set search_path for DB connection ID {conn_id}."
+            )
+        finally:
+            connection.autocommit = original_autocommit

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -375,7 +375,7 @@ if check_feature_flag_status(FeatureFlag.MULTI_TENANCY_V2):
     ROOT_URLCONF = "backend.base_urls"
 
     # DB Configuration
-    DB_ENGINE = "django.db.backends.postgresql"
+    DB_ENGINE = "backend.custom_db"
 
     # Models
     AUTH_USER_MODEL = "account_v2.User"
@@ -396,10 +396,6 @@ if check_feature_flag_status(FeatureFlag.MULTI_TENANCY_V2):
             "PASSWORD": f"{DB_PASSWORD}",
             "PORT": f"{DB_PORT}",
             "ATOMIC_REQUESTS": ATOMIC_REQUESTS,
-            "OPTIONS": {
-                "options": f"-c search_path={DB_SCHEMA}",
-                "application_name": os.environ.get("APPLICATION_NAME", ""),
-            },
         }
     }
 else:


### PR DESCRIPTION
## What

- Implemented a custom Django database engine.
- Integrated support for setting the search_path for multi-tenant V2 (which may operate in a schema other than the default public schema).

## Why

- This change ensures compatibility between Django and connection poolers like PgBouncer by setting the appropriate schema search_path for each connection.

## How

- Developed a custom database engine that sets the search_path automatically for each new or reused connection.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- No

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
