### PR TITLE
replacing cached queryset with dynamic queryset

### DIFF
--- a/backend/file_management/views.py
+++ b/backend/file_management/views.py
@@ -44,7 +44,9 @@ class FileManagementViewSet(viewsets.ModelViewSet):
     """
 
     versioning_class = URLPathVersioning
-    queryset = ConnectorInstance.objects.all()
+
+    def get_queryset(self):
+        return ConnectorInstance.objects.all()
 
     def get_serializer_class(self) -> serializers.Serializer:
         if self.action == "upload":

--- a/backend/platform_settings_v2/views.py
+++ b/backend/platform_settings_v2/views.py
@@ -21,8 +21,10 @@ logger = logging.getLogger(__name__)
 
 
 class PlatformKeyViewSet(viewsets.ModelViewSet):
-    queryset = PlatformKey.objects.all()
     serializer_class = PlatformKeySerializer
+
+    def get_queryset(self):
+        return PlatformKey.objects.all()
 
     def validate_user_role(func: Any) -> Any:
         def wrapper(

--- a/backend/prompt_studio/prompt_studio_document_manager_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_document_manager_v2/views.py
@@ -16,7 +16,6 @@ from .models import DocumentManager
 
 class PromptStudioDocumentManagerView(viewsets.ModelViewSet):
     versioning_class = URLPathVersioning
-    queryset = DocumentManager.objects.all()
     serializer_class = PromptStudioDocumentManagerSerializer
 
     def get_queryset(self) -> Optional[QuerySet]:

--- a/backend/prompt_studio/prompt_studio_index_manager_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_index_manager_v2/views.py
@@ -14,7 +14,6 @@ from .models import IndexManager
 
 class IndexManagerView(viewsets.ModelViewSet):
     versioning_class = URLPathVersioning
-    queryset = IndexManager.objects.all()
     serializer_class = IndexManagerSerializer
 
     def get_queryset(self) -> Optional[QuerySet]:

--- a/backend/prompt_studio/prompt_studio_output_manager_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_output_manager_v2/views.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 class PromptStudioOutputView(viewsets.ModelViewSet):
     versioning_class = URLPathVersioning
-    queryset = PromptStudioOutputManager.objects.all()
     serializer_class = PromptStudioOutputSerializer
 
     def get_queryset(self) -> Optional[QuerySet]:
@@ -56,6 +55,8 @@ class PromptStudioOutputView(viewsets.ModelViewSet):
 
         if filter_args:
             queryset = PromptStudioOutputManager.objects.filter(**filter_args)
+        else:
+            queryset = PromptStudioOutputManager.objects.all()
 
         return queryset
 

--- a/backend/prompt_studio/prompt_studio_registry_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/views.py
@@ -20,7 +20,6 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
     tool hub."""
 
     versioning_class = URLPathVersioning
-    queryset = PromptStudioRegistry.objects.all()
     serializer_class = PromptStudioRegistrySerializer
 
     def get_queryset(self) -> Optional[QuerySet]:

--- a/backend/tool_instance_v2/views.py
+++ b/backend/tool_instance_v2/views.py
@@ -63,7 +63,6 @@ def get_tool_list(request: Request) -> Response:
 
 class ToolInstanceViewSet(viewsets.ModelViewSet):
     versioning_class = URLPathVersioning
-    queryset = ToolInstance.objects.all()
     serializer_class = ToolInstanceSerializer
 
     def get_queryset(self) -> QuerySet:

--- a/backend/workflow_manager/endpoint_v2/views.py
+++ b/backend/workflow_manager/endpoint_v2/views.py
@@ -11,7 +11,6 @@ from workflow_manager.workflow_v2.serializers import WorkflowEndpointSerializer
 
 
 class WorkflowEndpointViewSet(viewsets.ModelViewSet):
-    queryset = WorkflowEndpoint.objects.all()
     serializer_class = WorkflowEndpointSerializer
 
     def get_queryset(self) -> QuerySet:

--- a/backend/workflow_manager/workflow_v2/views.py
+++ b/backend/workflow_manager/workflow_v2/views.py
@@ -52,7 +52,6 @@ def make_execution_response(response: ExecutionResponse) -> Any:
 class WorkflowViewSet(viewsets.ModelViewSet):
     versioning_class = URLPathVersioning
     permission_classes = [IsOwner]
-    queryset = Workflow.objects.all()
 
     def get_queryset(self) -> QuerySet:
         filter_args = FilterHelper.build_filter_args(


### PR DESCRIPTION
## What

-  Added get_query_set methods in ViewSet

## Why

- Getting cached result . Noticed in V2
-  https://github.com/encode/django-rest-framework/blob/cdb8a3c3c86bbb74f17f8880c52000602b015ed4/rest_framework/generics.py#L51C1-L63C66

## How

-  Added method `get_queryset` in viewset

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
