### PR TITLE
fixes for user role change and Api key permission

### DIFF
--- a/backend/account_v2/authentication_controller.py
+++ b/backend/account_v2/authentication_controller.py
@@ -408,7 +408,7 @@ class AuthenticationController:
             )
             if current_roles:
                 self.save_organization_user_role(
-                    user_uid=user.user.user.id, role=current_roles[0]
+                    user_uid=user.user.id, role=current_roles[0]
                 )
             return current_roles[0]
         else:

--- a/backend/api_v2/api_key_views.py
+++ b/backend/api_v2/api_key_views.py
@@ -4,8 +4,8 @@ from api_v2.deployment_helper import DeploymentHelper
 from api_v2.exceptions import APINotFound, PathVariablesNotFound
 from api_v2.key_helper import KeyHelper
 from api_v2.models import APIKey
+from api_v2.permission import IsOwnerOrOrganizationMember
 from api_v2.serializers import APIKeyListSerializer, APIKeySerializer
-from permissions.permission import IsOwner
 from pipeline_v2.exceptions import PipelineNotFound
 from pipeline_v2.pipeline_processor import PipelineProcessor
 from rest_framework import serializers, viewsets
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 
 class APIKeyViewSet(viewsets.ModelViewSet):
     queryset = APIKey.objects.all()
-    permission_classes = [IsOwner]
+    permission_classes = [IsOwnerOrOrganizationMember]
 
     def get_serializer_class(self) -> serializers.Serializer:
         if self.action in ["api_keys"]:

--- a/backend/api_v2/permission.py
+++ b/backend/api_v2/permission.py
@@ -1,0 +1,28 @@
+from permissions.permission import IsOwner
+from utils.user_context import UserContext
+
+
+class IsOwnerOrOrganizationMember(IsOwner):
+    """Permission that grants access if the user is the owner or belongs to the
+    same organization."""
+
+    def has_object_permission(self, request, view, obj):
+        # Check if the user is the owner via base class logic
+        if super().has_object_permission(request, view, obj):
+            return True
+
+        # If the object has a 'created_by' field, but the user isn't the owner,
+        # deny access
+        if obj.created_by:
+            return False
+
+        # Support legacy API keys where 'created_by' is None by matching the
+        # organization ID. This allows organization members to access API keys as per
+        # the existing behavior.
+        user_organization = UserContext.get_organization()
+        # Check organization ID for associated `api` or `pipeline`
+        related_obj = getattr(obj, "api", None) or getattr(obj, "pipeline", None)
+        if related_obj and related_obj.organization_id == user_organization.id:
+            return True
+
+        return False


### PR DESCRIPTION
## What

### V2 changes
- Introduced an additional OR condition for existing API keys that lack a created_by field.
- Implemented a fix for user role changes.

## Why

- In multitenancy V2, we introduced enhanced permissions for API keys. This change ensures that existing API keys, which do not have a created_by field, are still accessible to users belonging to the same organization.

## How

- Created a new permission class to accommodate the updated access logic.
- Implemented fixes in the authentication controller to support the user role changes.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
