### PR TITLE
Replace incorrect package with the correct one

### DIFF
--- a/backend/account_v2/subscription_loader.py
+++ b/backend/account_v2/subscription_loader.py
@@ -1,10 +1,10 @@
 import logging
 import os
-from datetime import timezone
 from importlib import import_module
 from typing import Any
 
 from django.apps import apps
+from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## What

- Replaced the incorrect package import from `datetime` (`from datetime import timezone`) with the correct import from Django (`from django.utils import timezone`).

## Why

- The timezone package was not imported from the correct location, resulting in an error: `'datetime.timezone' has no attribute 'now'`. This change resolves the issue by ensuring the correct timezone functionality is available.

## How

- Updated the import statement to use the appropriate Django utility for timezone management.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
