### PR TITLE
Updated Actions which uses a deprecated Node.js version 

### DIFF
--- a/.github/workflows/ci-container-build.yaml
+++ b/.github/workflows/ci-container-build.yaml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 
     - name: Cache tox environments
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .tox/
         key: ${{ runner.os }}-tox-${{ hashFiles('**/pyproject.toml', '**/tox.ini') }}

--- a/.github/workflows/docker-tools-build-push.yaml
+++ b/.github/workflows/docker-tools-build-push.yaml
@@ -27,10 +27,10 @@ jobs:
           run: echo "${{ toJSON(github.event.inputs) }}"
 
         - name: Checkout code
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
 
         - name: Login to Docker Hub
-          uses: docker/login-action@v1
+          uses: docker/login-action@v3
           with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/pdm-lock-automation.yaml
+++ b/.github/workflows/pdm-lock-automation.yaml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 

--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -23,18 +23,18 @@ jobs:
     steps:
       - name: Checkout code for release
         if: github.event_name == 'release'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
 
 
       - name: Checkout code for branch
         if: github.event_name != 'release'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION


## What

Updated deprecated Github action version 

## Why

The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, docker/login-action@v1

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
