### PR TITLE
update data migration with missed tables

### DIFF
--- a/backend/migrating/v2/query.py
+++ b/backend/migrating/v2/query.py
@@ -302,6 +302,19 @@ class MigrationQuery:
                 "dest_table": "adapter_instance",
             },
             {
+                "name": f"migration_{schema}_adapter_instance_shared_users",
+                "src_query": f"""
+                    SELECT adapterinstance_id, user_id
+                    FROM "{schema}".adapter_adapterinstance_shared_users;
+                """,
+                "dest_query": f"""
+                    INSERT INTO "{self.v2_schema}".adapter_instance_shared_users (
+                        adapterinstance_id, user_id
+                    ) VALUES (%s, %s);
+                """,
+                "dest_table": "adapter_instance_shared_users",
+            },
+            {
                 "name": f"migration_{schema}_003_workflow",
                 "src_query": f"""
                     SELECT id, prompt_name, description, workflow_name, prompt_text,
@@ -341,6 +354,28 @@ class MigrationQuery:
                     {organization_id});
                 """,
                 "dest_table": "connector_instance",
+            },
+            {
+                "name": f"migration_{schema}_tool_instance",
+                "src_query": f"""
+                    SELECT id, tool_id, workflow_id, input, output, version, metadata,
+                        step, status, created_by_id, modified_by_id,
+                        input_file_connector_id, output_file_connector_id,
+                        input_db_connector_id, output_db_connector_id,
+                        created_at, modified_at
+                    FROM "{schema}".tool_instance_toolinstance;
+                """,
+                "dest_query": f"""
+                    INSERT INTO "{self.v2_schema}".tool_instance (
+                        id, tool_id, workflow_id, input, output, version, metadata,
+                        step, status, created_by_id, modified_by_id,
+                        input_file_connector_id, output_file_connector_id,
+                        input_db_connector_id, output_db_connector_id,
+                        created_at, modified_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s, %s, %s);
+                """,
+                "dest_table": "tool_instance",
             },
             {
                 "name": f"migration_{schema}_workflow_endpoint",


### PR DESCRIPTION
## What
 ### V2 
- Added data migrations for   tool_instance and  adapter_instance_shared_users

## Why

- It was missed in erlier version

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
