### PR TITLE
fix on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,10 @@
 default_language_version:
   python: python3.9
 default_stages:
-  - commit
+  - pre-commit
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         exclude_types:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,10 +84,10 @@ repos:
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]
-  - repo: https://github.com/pycqa/docformatter
-    rev: v1.7.5
-    hooks:
-      - id: docformatter
+  # - repo: https://github.com/pycqa/docformatter
+  #   rev: v1.7.5
+  #   hooks:
+  #     - id: docformatter
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.16.0
     hooks:


### PR DESCRIPTION
## What

- fix on pre-commit failure and update in version. commented outdated docformatter pre-commit hooks

## Why

- docformatter Official release still broken with pre-commit [docformatter](https://github.com/PyCQA/docformatter)
## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

- Issue references: https://github.com/PyCQA/docformatter/issues/293
- https://github.com/PyCQA/docformatter/issues/294
## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
