### PR TITLE
[DON'T MERGE] FIX: Commented out React Strict Mode and added developer instructions for re-enabling it

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { StrictMode } from "react"; // eslint-disable-line no-unused-vars
 import ReactDOM from "react-dom/client";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
@@ -24,15 +24,16 @@ if (enablePosthog !== "false") {
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
-    <PostHogProvider client={posthog}>
-      <SocketProvider>
-        <LazyLoader
-          loader={<GenericLoader />}
-          component={() => import("./App.jsx")}
-          componentName="App"
-        />
-      </SocketProvider>
-    </PostHogProvider>
-  </React.StrictMode>
+  // Uncomment the following <StrictMode> tags to enable React Strict Mode for additional development checks
+  // <StrictMode>
+  <PostHogProvider client={posthog}>
+    <SocketProvider>
+      <LazyLoader
+        loader={<GenericLoader />}
+        component={() => import("./App.jsx")}
+        componentName="App"
+      />
+    </SocketProvider>
+  </PostHogProvider>
+  // </StrictMode>
 );

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,6 @@
-import { StrictMode } from "react"; // eslint-disable-line no-unused-vars
+// Uncomment the line below to enable the import for React Strict Mode
+// import { StrictMode } from "react";
+
 import ReactDOM from "react-dom/client";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";


### PR DESCRIPTION
## What

1. Commented out the React Strict Mode in the application’s entry point to prevent issues caused by its additional checks during local development.
2. Added comments with instructions for developers on how to re-enable React Strict Mode if they wish to use it for additional development checks.

## Why

1. React Strict Mode performs extra checks in development, such as double-invoking lifecycle methods like `useEffect`. While these checks are useful for identifying potential issues, they can cause confusion and unexpected behavior during local development that won’t occur in production.
2. Disabling Strict Mode can make the development process smoother by avoiding these checks. However, developers should still have the option to enable it when needed for debugging or identifying issues.

## How

1. Both the `<StrictMode>` component in the render method and the `StrictMode` import statement have been commented out.
2. Clear instructions are provided as comments in the code, informing developers how to re-enable Strict Mode by uncommenting both the import and the component.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. Only the React Strict Mode has been disabled in this PR, and this change should not affect any existing features.

## Database Migrations

NA

## Env Config

NA

## Relevant Docs

NA

## Related Issues or PRs

NA

## Dependencies Versions

NA

## Notes on Testing

NA

## Screenshots
NA

## Checklist

I have read and understood the [Contribution Guidelines]().
