### PR TITLE
docs: Added version compatibility unstract SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Unstract comes well documented. You can get introduced to the [basics of Unstrac
 
 ### Text Extractors
 
-|| Provider | Status | Version |
-|---|---|---|---|
-|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working | `>=v1.57.0` |
-|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Community | ✅ Working | |
-|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Enterprise | ✅ Working | |
-|<img src="docs/assets/3rd_party/llamaindex.png" width="32"/>| LlamaIndex Parse | ✅ Working | |
+|| Provider | Status |
+|---|---|---|
+|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working |
+|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Community | ✅ Working |
+|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Enterprise | ✅ Working |
+|<img src="docs/assets/3rd_party/llamaindex.png" width="32"/>| LlamaIndex Parse | ✅ Working |
 
 ### ETL Sources
 

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Unstract comes well documented. You can get introduced to the [basics of Unstrac
 
 ### Text Extractors
 
-|| Provider | Status |
-|---|---|---|
-|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working |
-|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Community | ✅ Working |
-|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Enterprise | ✅ Working |
-|<img src="docs/assets/3rd_party/llamaindex.png" width="32"/>| LlamaIndex Parse | ✅ Working |
+|| Provider | Status | Version Compatibility |
+|---|---|---|---|
+|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working | [v1](https://docs.unstract.com/llm_whisperer/apis/llm_whisperer_apis_intro), `v2` |
+|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Community | ✅ Working | [All](https://github.com/Unstructured-IO/unstructured/releases) |
+|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Enterprise | ✅ Working | All |
+|<img src="docs/assets/3rd_party/llamaindex.png" width="32"/>| LlamaIndex Parse | ✅ Working | [All](https://github.com/run-llama/llama_parse/releases) |
 
 ### ETL Sources
 
@@ -138,6 +138,12 @@ Unstract comes well documented. You can get introduced to the [basics of Unstrac
 |<img src="docs/assets/3rd_party/mysql.png" width="32"/>| MySQL | ✅ Working |
 |<img src="docs/assets/3rd_party/mariadb.png" width="32"/>| MariaDB | ✅ Working |
 |<img src="docs/assets/3rd_party/ms_sql.png" width="32"/>| Microsoft SQL Server | ✅ Working |
+
+### Unstract SDK
+
+| Component | Version Compatibility |
+|---|---|
+| `backend`, `prompt-service`, `tool-registry`, All tools | [0.52.0](https://github.com/Zipstack/unstract-sdk/releases/tag/v0.52.0) |
 
 ## 🙌 Contributing
 

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Unstract comes well documented. You can get introduced to the [basics of Unstrac
 
 ### Text Extractors
 
-|| Provider | Status | Version Compatibility |
+|| Provider | Status | Version |
 |---|---|---|---|
-|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working | [v1](https://docs.unstract.com/llm_whisperer/apis/llm_whisperer_apis_intro), `v2` |
-|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Community | ✅ Working | [All](https://github.com/Unstructured-IO/unstructured/releases) |
-|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Enterprise | ✅ Working | All |
-|<img src="docs/assets/3rd_party/llamaindex.png" width="32"/>| LlamaIndex Parse | ✅ Working | [All](https://github.com/run-llama/llama_parse/releases) |
+|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working | `>=v1.60.3` |
+|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Community | ✅ Working | |
+|<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Enterprise | ✅ Working | |
+|<img src="docs/assets/3rd_party/llamaindex.png" width="32"/>| LlamaIndex Parse | ✅ Working | |
 
 ### ETL Sources
 
@@ -139,11 +139,11 @@ Unstract comes well documented. You can get introduced to the [basics of Unstrac
 |<img src="docs/assets/3rd_party/mariadb.png" width="32"/>| MariaDB | ✅ Working |
 |<img src="docs/assets/3rd_party/ms_sql.png" width="32"/>| Microsoft SQL Server | ✅ Working |
 
-### Unstract SDK
+### [Unstract SDK](https://github.com/Zipstack/unstract-sdk)
 
-| Component | Version Compatibility |
+| Unstract Platform | Version |
 |---|---|
-| `backend`, `prompt-service`, `tool-registry`, All tools | [0.52.0](https://github.com/Zipstack/unstract-sdk/releases/tag/v0.52.0) |
+| `backend`, `prompt-service`, `tool-registry`, All tools | `>=0.52.0`|
 
 ## 🙌 Contributing
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Unstract comes well documented. You can get introduced to the [basics of Unstrac
 
 || Provider | Status | Version |
 |---|---|---|---|
-|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working | `>=v1.60.3` |
+|<img src="docs/assets/unstract_u_logo.png" width="32"/>| Unstract LLMWhisperer | ✅ Working | `>=v1.57.0` |
 |<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Community | ✅ Working | |
 |<img src="docs/assets/3rd_party/unstructured_io.png" width="32"/>| Unstructured.io Enterprise | ✅ Working | |
 |<img src="docs/assets/3rd_party/llamaindex.png" width="32"/>| LlamaIndex Parse | ✅ Working | |


### PR DESCRIPTION
## What

- Added version compatiblity for LLMW (column) and SDK (section)

NOTE: Will be adding a link to the v2 docs once its up

# How
- Min. LLMW version was obtained by checking the last updated SDK version with a change in the LLMW adapter (0.51.0) that was integrated in `v0.92.0`

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor doc PR

## Screenshots
![image](https://github.com/user-attachments/assets/3a4b5617-b1d0-4e91-9e94-9d2de74b4daf)
![image](https://github.com/user-attachments/assets/ddf9ec70-18a4-4c90-a275-34ea218d65b1)

## Checklist

I have read and understood the [Contribution Guidelines]().
