### PR TITLE
Update frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,15 +54,11 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
+## React Strict Mode
 
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+*React Strict Mode* is enabled by default, which will **mount all components twice** during local development.
 
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+This helps in verifying the integrity of the React components, and is in alignment with all the frontend use cases known and envisioned currently.
 
 ## Learn More
 


### PR DESCRIPTION
## What

* Add notice for react strict mode
* Remove default doc for npm eject

## Why

* For reasons mentioned [here](https://github.com/Zipstack/unstract/pull/807#issuecomment-2464426640) we will keep React Strict Mode enabled by default for now, in which case it is better to add a notice otherwise it might confuse unwary frontend contributors
* We are almost never going to do a destructive operation like `npm eject`, hence removed the doc regarding the same.

## How

- Updated frontend README
- Updated public docs [here](https://docs.unstract.com/unstract/contributing/unstract/contribute-frontend/#react-strict-mode)

## Checklist

I have read and understood the [Contribution Guidelines]().
