### PR TITLE
FIX: Handle Public/Protected Routes

### DIFF
--- a/frontend/src/routes/Router.jsx
+++ b/frontend/src/routes/Router.jsx
@@ -113,19 +113,19 @@ function Router() {
 
         {/* protected routes */}
         <Route path="setOrg" element={<SetOrgPage />} />
+        {SelectProduct && (
+          <Route path="selectProduct" element={<SelectProduct />} />
+        )}
+        {TrialRoutes && (
+          <Route path="/trial-expired" element={<TrialRoutes />} />
+        )}
+        {PaymentSuccessful && (
+          <Route path="/payment/success" element={<PaymentSuccessful />} />
+        )}
         <Route path="" element={<RequireAuth />}>
           <Route path="">{MainAppRoute}</Route>
           {llmWhispererRouter && (
             <Route path="llm-whisperer">{llmWhispererRouter()}</Route>
-          )}
-          {TrialRoutes && (
-            <Route path="/trial-expired" element={<TrialRoutes />} />
-          )}
-          {SelectProduct && (
-            <Route path="selectProduct" element={<SelectProduct />} />
-          )}
-          {PaymentSuccessful && (
-            <Route path="/payment/success" element={<PaymentSuccessful />} />
           )}
         </Route>
       </Route>


### PR DESCRIPTION
## What

Made the `/selectedProduct` route public to allow access before full authentication is completed.

## Why

The` /selectedProduct` route was previously private (issue created in this [PR](https://github.com/Zipstack/unstract/pull/836)), causing redirection to `/landing` before the user could select a product. Making it public resolves this issue.

## How

Moved the necessary routes outside the protected routes wrapper.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. This PR is a targeted bug fix with minimal changes, so the risk of impacting existing features is low.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/747b14af-c58c-4ae5-8dcb-ee6b1b3f6f74)


## Checklist

I have read and understood the [Contribution Guidelines]().
