### PR TITLE
feat: Enhanced tool-structure logs, show file name in tool-structure metadata

### DIFF
--- a/tools/structure/src/config/properties.json
+++ b/tools/structure/src/config/properties.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.0.1",
   "displayName": "Structure Tool",
   "functionName": "structure_tool",
-  "toolVersion": "0.0.46",
+  "toolVersion": "0.0.48",
   "description": "This is a template tool which can answer set of input prompts designed in the Prompt Studio",
   "input": {
     "description": "File that needs to be indexed and parsed for answers"

--- a/tools/structure/src/config/properties.json
+++ b/tools/structure/src/config/properties.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.0.1",
   "displayName": "Structure Tool",
   "functionName": "structure_tool",
-  "toolVersion": "0.0.48",
+  "toolVersion": "0.0.49",
   "description": "This is a template tool which can answer set of input prompts designed in the Prompt Studio",
   "input": {
     "description": "File that needs to be indexed and parsed for answers"

--- a/tools/structure/src/utils.py
+++ b/tools/structure/src/utils.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+
+def json_to_markdown(data: Any, level: int = 0, parent_key: str = "") -> str:
+    markdown = ""
+    indent = "  " * level  # Increase indentation by 2 for nested levels
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if isinstance(value, (dict, list)):
+                # If value is a dict or list, make it expandable
+                markdown += f"{indent}- **{key}**:\n"
+                markdown += json_to_markdown(value, level + 1, key)
+            else:
+                markdown += f"{indent}- **{key}**: {value}\n"
+    elif isinstance(data, list):
+        for index, item in enumerate(data, 1):
+            # Use parent key for list item naming
+            # Fall back to "Item" if parent_key is empty
+            # TODO: Determine child key using parent key for all plural combinations
+            item_label = (
+                f"{parent_key[:-1] if parent_key.endswith('s') else parent_key} {index}"
+                if parent_key
+                else f"Item {index}"
+            )
+            markdown += f"{indent}- **{item_label}**\n"
+            markdown += json_to_markdown(item, level + 1, parent_key)
+    else:
+        markdown += f"{indent}- {data}\n"
+
+    return markdown


### PR DESCRIPTION
## What

- Improved structure tool logs in workflow
- Removed some verbose / redundant logs
- Bumped structure tool version to `0.0.48`
- Show actual file name in the result's metadata instead of `INFILE`
- Minor refactoring in the tool code

## Why

- Structure tool's logs was previously dumping the entire `tool_metadata` which was not readable and usually ignored
- This PR aims to improve readability and provide useful logs

## How

- Added a util function to convert json to markdown

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, predominantly log related changes

## Notes on Testing

- Tried running the tool standalone and ran it with the platform in a workflow

## Screenshots
![image](https://github.com/user-attachments/assets/689a1082-052b-4b5b-bd5a-8af92363dae0)
![image](https://github.com/user-attachments/assets/385b8fae-59b8-4893-b38a-ddeac313ebe2)

## Checklist

I have read and understood the [Contribution Guidelines]().
