### PR TITLE
fix: Added schema to page usage query in platform-service, refactored defa…

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -101,7 +101,7 @@ DB_USER = os.environ.get("DB_USER", "unstract_dev")
 DB_HOST = os.environ.get("DB_HOST", "backend-db-1")
 DB_PASSWORD = os.environ.get("DB_PASSWORD", "unstract_pass")
 DB_PORT = os.environ.get("DB_PORT", 5432)
-DB_SCHEMA = os.environ.get("DB_SCHEMA", "unstract_v2")
+DB_SCHEMA = os.environ.get("DB_SCHEMA", "unstract")
 
 DEFAULT_ORGANIZATION = "default_org"
 FLIPT_BASE_URL = os.environ.get("FLIPT_BASE_URL", "http://localhost:9005")

--- a/platform-service/src/unstract/platform_service/constants.py
+++ b/platform-service/src/unstract/platform_service/constants.py
@@ -7,17 +7,12 @@ class FeatureFlag:
 class DBTable:
     """Database tables."""
 
-    PAGE_USAGE = "page_usage"
-
-
-class DBTableV2:
-    """Database tables."""
-
     ORGANIZATION = "organization"
     ADAPTER_INSTANCE = "adapter_instance"
     PROMPT_STUDIO_REGISTRY = "prompt_studio_registry"
     PLATFORM_KEY = "platform_key"
     TOKEN_USAGE = "usage"
+    PAGE_USAGE = "page_usage"
 
 
 class LogLevel:

--- a/platform-service/src/unstract/platform_service/env.py
+++ b/platform-service/src/unstract/platform_service/env.py
@@ -26,7 +26,7 @@ class Env:
     APPLICATION_NAME = EnvManager.get_required_setting(
         "APPLICATION_NAME", "unstract-platform-service"
     )
-    DB_SCHEMA = EnvManager.get_required_setting("DB_SCHEMA", "unstract_v2")
+    DB_SCHEMA = EnvManager.get_required_setting("DB_SCHEMA")
     LOG_LEVEL = EnvManager.get_required_setting("LOG_LEVEL", LogLevel.INFO)
 
 

--- a/platform-service/src/unstract/platform_service/helper/adapter_instance.py
+++ b/platform-service/src/unstract/platform_service/helper/adapter_instance.py
@@ -1,11 +1,11 @@
 from typing import Any, Optional
 
-from unstract.platform_service.constants import DBTableV2
+from unstract.platform_service.constants import DBTable
 from unstract.platform_service.exceptions import APIError
 from unstract.platform_service.extensions import db
 from unstract.platform_service.utils import EnvManager
 
-DB_SCHEMA = EnvManager.get_required_setting("DB_SCHEMA", "unstract_v2")
+DB_SCHEMA = EnvManager.get_required_setting("DB_SCHEMA", "unstract")
 
 
 class AdapterInstanceRequestHelper:
@@ -26,7 +26,7 @@ class AdapterInstanceRequestHelper:
         """
         query = (
             "SELECT id, adapter_id, adapter_name, adapter_type, adapter_metadata_b"
-            f' FROM "{DB_SCHEMA}".{DBTableV2.ADAPTER_INSTANCE} x '
+            f' FROM "{DB_SCHEMA}".{DBTable.ADAPTER_INSTANCE} x '
             f"WHERE id='{adapter_instance_id}' and "
             f"organization_id='{organization_uid}'"
         )

--- a/platform-service/src/unstract/platform_service/helper/prompt_studio.py
+++ b/platform-service/src/unstract/platform_service/helper/prompt_studio.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-from unstract.platform_service.constants import DBTableV2
+from unstract.platform_service.constants import DBTable
 from unstract.platform_service.exceptions import APIError
 from unstract.platform_service.extensions import db
 from unstract.platform_service.utils import EnvManager
 
-DB_SCHEMA = EnvManager.get_required_setting("DB_SCHEMA", "unstract_v2")
+DB_SCHEMA = EnvManager.get_required_setting("DB_SCHEMA", "unstract")
 
 
 class PromptStudioRequestHelper:
@@ -26,7 +26,7 @@ class PromptStudioRequestHelper:
         query = (
             "SELECT prompt_registry_id, tool_spec, "
             "tool_metadata, tool_property FROM "
-            f'"{DB_SCHEMA}".{DBTableV2.PROMPT_STUDIO_REGISTRY} x '
+            f'"{DB_SCHEMA}".{DBTable.PROMPT_STUDIO_REGISTRY} x '
             f"WHERE prompt_registry_id='{prompt_registry_id}'"
         )
         cursor = db.execute_sql(query)

--- a/prompt-service/src/unstract/prompt_service/authentication_middleware.py
+++ b/prompt-service/src/unstract/prompt_service/authentication_middleware.py
@@ -6,7 +6,7 @@ from unstract.prompt_service.constants import DBTableV2
 from unstract.prompt_service.db_utils import DBUtils
 from unstract.prompt_service.env_manager import EnvLoader
 
-DB_SCHEMA = EnvLoader.get_env_or_die("DB_SCHEMA", "unstract_v2")
+DB_SCHEMA = EnvLoader.get_env_or_die("DB_SCHEMA", "unstract")
 
 
 class AuthenticationMiddleware:

--- a/prompt-service/src/unstract/prompt_service/db_utils.py
+++ b/prompt-service/src/unstract/prompt_service/db_utils.py
@@ -4,7 +4,7 @@ from unstract.prompt_service.config import db
 from unstract.prompt_service.constants import DBTableV2
 from unstract.prompt_service.env_manager import EnvLoader
 
-DB_SCHEMA = EnvLoader.get_env_or_die("DB_SCHEMA", "unstract_v2")
+DB_SCHEMA = EnvLoader.get_env_or_die("DB_SCHEMA", "unstract")
 
 
 class DBUtils:

--- a/prompt-service/src/unstract/prompt_service/helper.py
+++ b/prompt-service/src/unstract/prompt_service/helper.py
@@ -114,7 +114,7 @@ def initialize_plugin_endpoints(app: Flask) -> None:
 
 
 def query_usage_metadata(token: str, metadata: dict[str, Any]) -> dict[str, Any]:
-    DB_SCHEMA = EnvLoader.get_env_or_die("DB_SCHEMA", "unstract_v2")
+    DB_SCHEMA = EnvLoader.get_env_or_die("DB_SCHEMA", "unstract")
     organization_uid, org_id = DBUtils.get_organization_from_bearer_token(token)
     run_id: str = metadata["run_id"]
     query: str = f"""


### PR DESCRIPTION
## What

- Added schema to page usage query in platform-service
![image](https://github.com/user-attachments/assets/0adf896f-a222-4e68-89c3-b182dc5dfe97)

- Refactored default env set for DB_SCHEMA to `unstract`

## Why

- Refer [this](https://unstract.slack.com/archives/C06RL7J6JDS/p1731735335883719?thread_ts=1731593538.827089&cid=C06RL7J6JDS)
- Schema was missed for this `page_usage` insert query in `platform-service`

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, only default value updated as per `sample.env` and required fix added


## Notes on Testing

- No explicit testing done since issue was not immediately reproducible locally. Logical change that should resolve user's issue

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
