### PR TITLE
fix: Make sure that images can be built on arm64

### DIFF
--- a/docker/dockerfiles/backend.Dockerfile
+++ b/docker/dockerfiles/backend.Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update; \
     apt-get --no-install-recommends install -y \
         # unstract sdk
         build-essential libmagic-dev pandoc pkg-config tesseract-ocr \
+        # pymssql
+        freetds-dev libssl-dev libkrb5-dev \
         # git url
         git; \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \

--- a/docker/dockerfiles/worker.Dockerfile
+++ b/docker/dockerfiles/worker.Dockerfile
@@ -13,7 +13,7 @@ ENV BUILD_PACKAGES_PATH unstract
 ENV PDM_VERSION 2.16.1
 
 RUN apt-get update \
-    && apt-get --no-install-recommends install -y docker \
+    && apt-get --no-install-recommends install -y docker build-essential pkg-config  freetds-dev libssl-dev libkrb5-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
     \
     && pip install --no-cache-dir -U pip pdm~=${PDM_VERSION}

--- a/docker/dockerfiles/x2text.Dockerfile
+++ b/docker/dockerfiles/x2text.Dockerfile
@@ -10,7 +10,10 @@ ENV PYTHONUNBUFFERED 1
 ENV BUILD_CONTEXT_PATH x2text-service
 ENV PDM_VERSION 2.16.1
 
-RUN pip install --no-cache-dir -U pip pdm~=${PDM_VERSION}; \
+RUN apt-get update; \
+    apt-get --no-install-recommends install -y \
+        build-essential pkg-config && \
+    pip install --no-cache-dir -U pip pdm~=${PDM_VERSION}; \
     \
     # Creates a non-root user with an explicit UID and adds permission to access the /app folder
     # For more info, please refer to https://aka.ms/vscode-docker-python-configure-containers


### PR DESCRIPTION
## What
Allow images to be built on arm64

## Why
If emulation is used, it is slow and a few errors happen making the backend not runnable


I have read and understood the [Contribution Guidelines](x).
