### PR TITLE
Fix/prompt studio basetool

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_ide_base_tool.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_ide_base_tool.py
@@ -5,6 +5,9 @@ from prompt_studio.prompt_studio_core_v2.constants import ToolStudioKeys
 from unstract.sdk.constants import LogLevel
 from unstract.sdk.tool.stream import StreamMixin
 
+from backend.constants import FeatureFlag
+from unstract.flags.feature_flag import check_feature_flag_status
+
 
 class PromptIdeBaseTool(StreamMixin):
     def __init__(self, log_level: LogLevel = LogLevel.INFO, org_id: str = "") -> None:
@@ -16,6 +19,13 @@ class PromptIdeBaseTool(StreamMixin):
         """
         self.log_level = log_level
         self.org_id = org_id
+        self.workflow_filestorage = None
+        if check_feature_flag_status(FeatureFlag.REMOTE_FILE_STORAGE):
+            from unstract.filesystem import FileStorageType, FileSystem
+
+            file_system = FileSystem(FileStorageType.WORKFLOW_EXECUTION)
+            self.workflow_filestorage = file_system.get_file_storage()
+
         super().__init__(log_level=log_level)
 
     def get_env_or_die(self, env_key: str) -> str:

--- a/unstract/filesystem/src/unstract/filesystem/file_storage_config.py
+++ b/unstract/filesystem/src/unstract/filesystem/file_storage_config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def get_provider(var_name: str, default: str = "minio") -> FileStorageProvider:
     """Retrieve the file storage provider based on an environment variable."""
-    provider_name = os.environ.get(var_name, default).capitalize()
+    provider_name = os.environ.get(var_name, default).upper()
     try:
         # Attempt to map the provider name to an enum value, case-insensitively
         return FileStorageProvider[provider_name]

--- a/unstract/workflow-execution/src/unstract/workflow_execution/execution_file_handler.py
+++ b/unstract/workflow-execution/src/unstract/workflow_execution/execution_file_handler.py
@@ -131,7 +131,7 @@ class ExecutionFileHandler:
         if check_feature_flag_status(FeatureFlag.REMOTE_FILE_STORAGE):
             file_system = FileSystem(FileStorageType.WORKFLOW_EXECUTION)
             file_storage = file_system.get_file_storage()
-            file_storage.json_dump(path=metadata_path, mode="w", data=content)
+            file_storage.json_dump(path=metadata_path, data=content)
         else:
             with fsspec.open(f"file://{metadata_path}", "w") as local_file:
                 json.dump(content, local_file)

--- a/unstract/workflow-execution/src/unstract/workflow_execution/execution_file_handler.py
+++ b/unstract/workflow-execution/src/unstract/workflow_execution/execution_file_handler.py
@@ -131,7 +131,7 @@ class ExecutionFileHandler:
         if check_feature_flag_status(FeatureFlag.REMOTE_FILE_STORAGE):
             file_system = FileSystem(FileStorageType.WORKFLOW_EXECUTION)
             file_storage = file_system.get_file_storage()
-            file_storage.write(path=metadata_path, mode="w", data=json.dumps(content))
+            file_storage.json_dump(path=metadata_path, mode="w", data=content)
         else:
             with fsspec.open(f"file://{metadata_path}", "w") as local_file:
                 json.dump(content, local_file)


### PR DESCRIPTION
## What

- Added workflow_filestorage to the Prompt Studio base tool to align with the SDK base tool property.
- Wrapped the feature under a feature flag (FeatureFlag.REMOTE_FILE_STORAGE) for controlled usage.
- The property may be refactored or removed later, based on its usage, once the feature flag is retired and the GA version of the SDK is adopted.

## Why

- The BaseTool class in the SDK includes this property, which is utilized in the x2text adapter.
- Ensuring the Prompt Studio base tool behaves consistently with the SDK BaseTool improves integration and maintainability.

## How

- Added the workflow_filestorage property to the Prompt Studio base tool.
- Integrated a check for the feature flag to conditionally initialize the property.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, under featureflag

## Database Migrations

- No

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
