### PR TITLE
Fix/confidence data to prompt service

### DIFF
--- a/prompt-service/src/unstract/prompt_service/constants.py
+++ b/prompt-service/src/unstract/prompt_service/constants.py
@@ -71,6 +71,7 @@ class PromptServiceContants:
     ENABLE_HIGHLIGHT = "enable_highlight"
     FILE_PATH = "file_path"
     HIGHLIGHT_DATA = "highlight_data"
+    CONFIDENCE_DATA = "confidence_data"
 
 
 class RunLevel(Enum):

--- a/prompt-service/src/unstract/prompt_service/helper.py
+++ b/prompt-service/src/unstract/prompt_service/helper.py
@@ -296,8 +296,19 @@ def run_completion(
         )
         answer: str = completion[PSKeys.RESPONSE].text
         highlight_data = completion.get(PSKeys.HIGHLIGHT_DATA)
-        if all([metadata, highlight_data, prompt_key]):
-            metadata.setdefault(PSKeys.HIGHLIGHT_DATA, {})[prompt_key] = highlight_data
+        confidence_data = completion.get(PSKeys.CONFIDENCE_DATA)
+
+        if metadata is not None and prompt_key:
+            if highlight_data:
+                metadata.setdefault(PSKeys.HIGHLIGHT_DATA, {})[
+                    prompt_key
+                ] = highlight_data
+
+            if confidence_data:
+                metadata.setdefault(PSKeys.CONFIDENCE_DATA, {})[
+                    prompt_key
+                ] = confidence_data
+
         return answer
     # TODO: Catch and handle specific exception here
     except SdkRateLimitError as e:

--- a/tools/structure/src/main.py
+++ b/tools/structure/src/main.py
@@ -236,21 +236,6 @@ class StructureTool(BaseTool):
 
         if not summarize_as_source:
             metadata = structured_output_dict[SettingsKeys.METADATA]
-            epilogue = metadata.pop(SettingsKeys.EPILOGUE, None)
-            if epilogue:
-                try:
-                    from helper import (  # type: ignore [attr-defined]
-                        get_confidence_data,
-                    )
-
-                    metadata[SettingsKeys.CONFIDENCE_DATA] = get_confidence_data(
-                        epilogue, tool_data_dir
-                    )
-                except ImportError:
-                    self.stream_log(
-                        f"Confidence data is not added. {PAID_FEATURE_MSG}",
-                        level=LogLevel.WARN,
-                    )
             # Update the dictionary with modified metadata
             structured_output_dict[SettingsKeys.METADATA] = metadata
             structured_output = json.dumps(structured_output_dict)


### PR DESCRIPTION
## Note: IMPORTANT

- Need to take structure tool build Once PR got merged

## What

- Added confidence metadata logic in prompt service
- Removed confidence logic and unused highlight code from structure tool

## Why

- Due to Architectural change in highlight data logic

## How

- Moved confidence meta data logic to prompt service

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
