### PR TITLE
FIX: Replace 'markdown-to-jsx' with 'remarkable' for Better Large Markdown String Support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,6 +52,7 @@
         "react-scripts": "5.0.1",
         "react-social-login-buttons": "^3.9.1",
         "remark-gfm": "^3.0.1",
+        "remarkable": "^2.0.1",
         "socket.io-client": "^4.7.2",
         "uuid": "^9.0.1",
         "zustand": "^4.3.8"
@@ -5860,6 +5861,14 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/autolinker": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
+      "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -17537,6 +17546,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remarkable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+      "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "autolinker": "^3.11.0"
+      },
+      "bin": {
+        "remarkable": "bin/remarkable.js"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/remarkable/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -24763,6 +24795,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
+    "autolinker": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
+      "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
     },
     "autoprefixer": {
       "version": "10.4.14",
@@ -33083,6 +33123,25 @@
         "mdast-util-gfm": "^2.0.0",
         "micromark-extension-gfm": "^2.0.0",
         "unified": "^10.0.0"
+      }
+    },
+    "remarkable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+      "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "^3.11.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        }
       }
     },
     "renderkid": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,6 @@
         "js-cookie": "^3.0.5",
         "js-yaml": "^4.1.0",
         "json-2-csv": "^5.5.1",
-        "markdown-to-jsx": "^7.2.1",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.45",
         "pdfjs-dist": "^3.4.120",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,6 @@
     "js-cookie": "^3.0.5",
     "js-yaml": "^4.1.0",
     "json-2-csv": "^5.5.1",
-    "markdown-to-jsx": "^7.2.1",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.45",
     "pdfjs-dist": "^3.4.120",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "react-scripts": "5.0.1",
     "react-social-login-buttons": "^3.9.1",
     "remark-gfm": "^3.0.1",
+    "remarkable": "^2.0.1",
     "socket.io-client": "^4.7.2",
     "uuid": "^9.0.1",
     "zustand": "^4.3.8"

--- a/frontend/src/components/agency/markdown-renderer/MarkdownRenderer.jsx
+++ b/frontend/src/components/agency/markdown-renderer/MarkdownRenderer.jsx
@@ -1,32 +1,22 @@
 import PropTypes from "prop-types";
-import ReactMarkdown from "markdown-to-jsx";
+import { memo, useMemo } from "react";
+import { Remarkable } from "remarkable";
 
-function MarkdownRenderer({ markdownText }) {
-  return (
-    <ReactMarkdown
-      options={{
-        overrides: {
-          pre: {
-            component: MyParagraph,
-          },
-        },
-      }}
-    >
-      {markdownText}
-    </ReactMarkdown>
-  );
-}
+const md = new Remarkable();
+
+const MarkdownRenderer = memo(({ markdownText }) => {
+  const htmlContent = useMemo(() => {
+    if (!markdownText) return "";
+    return md.render(markdownText);
+  }, [markdownText]);
+
+  return <div dangerouslySetInnerHTML={{ __html: htmlContent }} />;
+});
+
+MarkdownRenderer.displayName = "MarkdownRenderer";
 
 MarkdownRenderer.propTypes = {
   markdownText: PropTypes.string,
-};
-
-const MyParagraph = ({ children, ...props }) => (
-  <div {...props}>{children}</div>
-);
-
-MyParagraph.propTypes = {
-  children: PropTypes.any,
 };
 
 export { MarkdownRenderer };


### PR DESCRIPTION
## What

This PR replaces the markdown-to-jsx library with the remarkable library for rendering Markdown content in the application.

## Why

- The `markdown-to-jsx` library struggles with very large Markdown strings, leading to performance issues and even crashes in some cases.
- The `remarkable` library is chosen as a replacement because:
  1. It handles large Markdown strings efficiently.
  2. It aligns better with the application's requirement for rendering large content without performance degradation.

## How

Replaced `markdown-to-jsx` with `remarkable` in the MarkdownRenderer component.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. The changes are limited to the **MarkdownRenderer** component, which is used in only one place — inside the workflow. So, the chances of this PR breaking any existing features is very low.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
### Large markdown text is rendered without any issues:
![image](https://github.com/user-attachments/assets/4c32927f-ebce-4e30-822d-ad58abd08408)

## Checklist

I have read and understood the [Contribution Guidelines]().
