### PR TITLE
feat: Updated ADAPTER_LLMW_MAX_POLLS to 120 for 1 hour extraction

### DIFF
--- a/backend/sample.env
+++ b/backend/sample.env
@@ -120,8 +120,8 @@ SESSION_COOKIE_AGE=86400
 # Time in seconds to wait before polling LLMWhisperer's status API
 ADAPTER_LLMW_POLL_INTERVAL=30
 # Total number of times to poll the status API.
-# 500 mins to allow 1500 (max pages limit) * 20 (approx time in sec to process a page)
-ADAPTER_LLMW_MAX_POLLS=1000
+# ~60 mins (assuming it'll be enough to process 1500 pages with LLMW v2)
+ADAPTER_LLMW_MAX_POLLS=120
 # Number of times to retry the /whisper-status API before failing the extraction
 ADAPTER_LLMW_STATUS_RETRIES=5
 


### PR DESCRIPTION
## What

- Updated env to reduce extraction time from ~8.3 hours to ~1 hour

## Why

- After move to LLMW v2, multi page extractions of 1500 pages should be done in ~1 hour

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, reduced extraction time only for LLMW v2


## Env Config

```
# ~60 mins (assuming it'll be enough to process 1500 pages with LLMW v2)
ADAPTER_LLMW_MAX_POLLS=120
```

## Related Issues or PRs

-

## Notes on Testing

- No explicit testing / validation done - logic based on these envs work though

## Checklist

I have read and understood the [Contribution Guidelines]().
