### PR TITLE
validate user exist on remove organization user method

### DIFF
--- a/backend/account_v2/authentication_helper.py
+++ b/backend/account_v2/authentication_helper.py
@@ -109,13 +109,25 @@ class AuthenticationHelper:
         Parameters:
             user_id (str): The user_id of the users to remove.
         """
+
+        organization_user = OrganizationMemberService.get_user_by_user_id(user_id)
+        if not organization_user:
+            logger.warning(
+                f"User removal skipped: User '{user_id}' not found in "
+                f"organization '{organization_id}'."
+            )
+            return
+
         # removing user from organization
         OrganizationMemberService.remove_user_by_user_id(user_id)
+
         # removing user m2m relations , while removing user
         User.objects.get(user_id=user_id).prompt_registries.clear()
         User.objects.get(user_id=user_id).shared_custom_tools.clear()
         User.objects.get(user_id=user_id).shared_adapters_instance.clear()
+
         # removing user from organization cache
         OrganizationMemberService.remove_user_membership_in_organization_cache(
             user_id=user_id, organization_id=organization_id
         )
+        logger.info(f"User '{user_id}' removed from organization '{organization_id}'")


### PR DESCRIPTION
## What

- Added validation to the user removal method to ensure the user exists in the organization before attempting deletion.

## Why

- Prevents unnecessary operations or errors by verifying the user's association with the organization prior to removal.

## How

- Introduced a check in the user removal method to confirm the user's presence in the organization. If the user does not exist, the method logs a warning and exits gracefully.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- UN-1922

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines]().
