### PR TITLE
[Fix] Prompt studio: Removed highlight support for enforce type JSON

### DIFF
--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -171,7 +171,10 @@ const PromptCard = memo(
       highlightedPrompt,
       highlightedProfile
     ) => {
-      if (details?.enable_highlight) {
+      if (
+        details?.enable_highlight &&
+        promptDetailsState?.enforce_type !== "json"
+      ) {
         updateCustomTool({
           selectedHighlight: {
             highlight: highlightData,

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -214,7 +214,7 @@ function PromptOutput({
                 title={
                   details?.enable_highlight && enforceType !== "json"
                     ? "Click to highlight"
-                    : "Highlight not supported for enforce type JSON"
+                    : "Highlighting is not supported when enforce type is JSON"
                 }
               >
                 <Col

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -84,7 +84,6 @@ function PromptOutput({
   const { generatePromptOutputKey } = usePromptOutput();
   const isTableExtraction =
     enforceType === TABLE_ENFORCE_TYPE || enforceType === RECORD_ENFORCE_TYPE;
-
   const tooltipContent = (adapterConf) => (
     <div>
       {Object.entries(adapterConf)?.map(([key, value]) => (
@@ -205,13 +204,18 @@ function PromptOutput({
               transition={{ duration: 0.5, ease: "linear" }}
               className={`prompt-card-llm ${
                 details?.enable_highlight &&
+                enforceType !== "json" &&
                 selectedHighlight?.highlightedPrompt === promptId &&
                 selectedHighlight?.highlightedProfile === profileId &&
                 "highlighted-prompt-cell"
               }`}
             >
               <Tooltip
-                title={details?.enable_highlight && "Click to highlight"}
+                title={
+                  details?.enable_highlight && enforceType !== "json"
+                    ? "Click to highlight"
+                    : "Highlight not supported for enforce type JSON"
+                }
               >
                 <Col
                   key={profileId}


### PR DESCRIPTION
## What

- Removed highlight support for enforce type JSON

## Why

- Highlight for json need to be handled same as MRQ.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Yes, Might break highlight.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/ee5b09dc-4e01-44c5-82ec-872590053b03)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
