### PR TITLE
[Fix] Removed tooltip message for highlight not supported

### DIFF
--- a/frontend/src/components/custom-tools/document-manager/DocumentManager.jsx
+++ b/frontend/src/components/custom-tools/document-manager/DocumentManager.jsx
@@ -380,7 +380,7 @@ function DocumentManager({ generateIndex, handleUpdateTool, handleDocChange }) {
               ) : null}
             </div>
             <div>
-              <Tooltip title="Manage Documents">
+              <Tooltip title="Manage Document Variants">
                 <Button
                   className="doc-manager-btn"
                   onClick={() => setOpenManageDocsModal(true)}

--- a/frontend/src/components/custom-tools/manage-docs-modal/ManageDocsModal.jsx
+++ b/frontend/src/components/custom-tools/manage-docs-modal/ManageDocsModal.jsx
@@ -307,7 +307,7 @@ function ManageDocsModal({
 
   const columns = [
     {
-      title: "Document",
+      title: "Document Variants",
       dataIndex: "document",
       key: "document",
     },
@@ -663,7 +663,7 @@ function ManageDocsModal({
           <SpaceWrapper>
             <Space>
               <Typography.Text className="add-cus-tool-header">
-                Manage Documents
+                Manage Document Variants
               </Typography.Text>
             </Space>
             <div>

--- a/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
+++ b/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
@@ -300,7 +300,7 @@ function OutputForDocModal({
 
   const columns = [
     {
-      title: "Document",
+      title: "Document Variants",
       dataIndex: "document",
       key: "document",
     },

--- a/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
@@ -8,6 +8,7 @@ import {
   Row,
   Select,
   Space,
+  Tag,
   Typography,
 } from "antd";
 import { useEffect, useRef, useState } from "react";
@@ -250,6 +251,22 @@ function PromptCardItems({
                           </Typography.Link>
                         </Space>
                       </Button>
+                    </Space>
+                    <Space>
+                      {details?.enable_highlight &&
+                        ["json", "table", "record"].includes(enforceType) && (
+                          <Tag
+                            color="red"
+                            style={{
+                              whiteSpace: "normal",
+                              wordWrap: "break-word",
+                              minWidth: "200px",
+                            }}
+                          >
+                            Highlighting is not supported when enforce type is{" "}
+                            {enforceType}
+                          </Tag>
+                        )}
                     </Space>
                     <Space>
                       {(enforceType === TABLE_ENFORCE_TYPE ||

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -84,6 +84,9 @@ function PromptOutput({
   const { generatePromptOutputKey } = usePromptOutput();
   const isTableExtraction =
     enforceType === TABLE_ENFORCE_TYPE || enforceType === RECORD_ENFORCE_TYPE;
+  const noHighlightEnforceType = !["json", "table", "record"].includes(
+    enforceType
+  );
   const tooltipContent = (adapterConf) => (
     <div>
       {Object.entries(adapterConf)?.map(([key, value]) => (
@@ -204,7 +207,7 @@ function PromptOutput({
               transition={{ duration: 0.5, ease: "linear" }}
               className={`prompt-card-llm ${
                 details?.enable_highlight &&
-                enforceType !== "json" &&
+                noHighlightEnforceType &&
                 selectedHighlight?.highlightedPrompt === promptId &&
                 selectedHighlight?.highlightedProfile === profileId &&
                 "highlighted-prompt-cell"
@@ -212,9 +215,9 @@ function PromptOutput({
             >
               <Tooltip
                 title={
-                  details?.enable_highlight && enforceType !== "json"
-                    ? "Click to highlight"
-                    : "Highlighting is not supported when enforce type is JSON"
+                  details?.enable_highlight &&
+                  noHighlightEnforceType &&
+                  "Click to highlight"
                 }
               >
                 <Col


### PR DESCRIPTION
## What

- Removed tooltip showing “Highlight is not supported” to a static message

## Why

- For better UI/UX

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor improvement in UI/UX

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/33afae99-2d5d-46f2-bdb0-717a42eb6bb6)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
