### PR TITLE
[Fix] Document is not displaying in the output analyzer prompt studio

### DIFF
--- a/frontend/src/components/custom-tools/output-analyzer/OutputAnalyzerCard.jsx
+++ b/frontend/src/components/custom-tools/output-analyzer/OutputAnalyzerCard.jsx
@@ -55,7 +55,7 @@ function OutputAnalyzerCard({ doc, selectedPrompts, totalFields }) {
       setIsDocLoading(true);
       try {
         const res = await axiosPrivate.get(fileUrlEndpoint);
-        const base64String = res?.data?.data || "";
+        const base64String = res?.data?.data?.data || "";
         const blob = base64toBlob(base64String);
         setFileUrl(URL.createObjectURL(blob));
       } catch (err) {


### PR DESCRIPTION
## What

- Document is not displaying in the output analyzer prompt studio

## Why

- Regression due to addition of mimetype in response because of that content is added in 1 more nested level.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, its a minor fix.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/ad0e855e-14a6-433b-809c-dc8df5d767ad)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
