### PR TITLE
FIX: Removed the logic that conditionally hides the `mark_horizontal_lines` field

### DIFF
--- a/frontend/src/layouts/rjsf-form-layout/CustomFieldTemplate.jsx
+++ b/frontend/src/layouts/rjsf-form-layout/CustomFieldTemplate.jsx
@@ -1,3 +1,4 @@
+import { Typography } from "antd";
 import PropTypes from "prop-types";
 
 const CustomFieldTemplate = (props) => {
@@ -5,7 +6,7 @@ const CustomFieldTemplate = (props) => {
   return (
     <div className={classNames}>
       {children}
-      {errors}
+      <Typography.Text type="danger">{errors}</Typography.Text>
       {help}
     </div>
   );

--- a/frontend/src/layouts/rjsf-form-layout/RjsfFormLayout.jsx
+++ b/frontend/src/layouts/rjsf-form-layout/RjsfFormLayout.jsx
@@ -78,9 +78,6 @@ function RjsfFormLayout({
   const uiSchema = useMemo(
     () => ({
       "ui:classNames": "my-rjsf-form",
-      mark_horizontal_lines: {
-        "ui:widget": !formData?.mark_vertical_lines ? "hidden" : undefined,
-      },
     }),
     [formData]
   );


### PR DESCRIPTION
## What

1. Removed the logic that conditionally hides the `mark_horizontal_lines` field when `mark_vertical_lines` is `false`.
2. Enhanced styling for RJSF fields to display error messages using Typography with the danger type.

## Why

The previous logic caused a UX issue where users couldn't uncheck the `mark_horizontal_lines` field after it was hidden, despite its value remaining `true`. This led to unexpected errors, as the value was still being passed to the backend.

## How

1. Eliminated the conditional rendering logic for the `mark_horizontal_lines` field.
2. Updated error message styling in RJSF to use Typography with `danger` type for better visibility and clarity.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. The changes in this PR are very minimal and the chances of this breaking any existing features is very low.

## Database Migrations

NA

## Env Config

NA

## Relevant Docs

NA

## Related Issues or PRs

NA

## Dependencies Versions

NA

## Notes on Testing

NA

## Screenshots
![Screenshot from 2025-01-17 16-53-21](https://github.com/user-attachments/assets/576a1f92-2dd3-4371-9b38-8cfd0fcdb568)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
