### PR TITLE
updated migration with datamigation from empty string to null

### DIFF
--- a/backend/usage_v2/migrations/0002_alter_usage_run_id.py
+++ b/backend/usage_v2/migrations/0002_alter_usage_run_id.py
@@ -3,6 +3,11 @@
 from django.db import migrations, models
 
 
+def convert_empty_to_null(apps, schema_editor):
+    usage = apps.get_model("usage_v2", "Usage")
+    usage.objects.filter(run_id="").update(run_id=None)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -10,6 +15,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(
+            convert_empty_to_null, reverse_code=migrations.RunPython.noop
+        ),
         migrations.AlterField(
             model_name="usage",
             name="run_id",

--- a/platform-service/src/unstract/platform_service/controller/platform.py
+++ b/platform-service/src/unstract/platform_service/controller/platform.py
@@ -198,7 +198,7 @@ def usage() -> Any:
     workflow_id = payload.get("workflow_id")
     execution_id = payload.get("execution_id", "")
     adapter_instance_id = payload.get("adapter_instance_id", "")
-    run_id = payload.get("run_id", "")
+    run_id = payload.get("run_id")
     usage_type = payload.get("usage_type", "")
     llm_usage_reason = payload.get("llm_usage_reason", "")
     model_name = payload.get("model_name", "")


### PR DESCRIPTION
## What

-  Fix for the  Error django.db.utils.DataError: invalid input syntax for type uuid: ""
- Added: Datamigration to migrate Empty string  to Nnull
- Updated platform service to insert null value for run_id instead of emtpy string

## Why

-  Error django.db.utils.DataError: invalid input syntax for type uuid: ""

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
