### PR TITLE
file validation in serailizer with number of file

### DIFF
--- a/backend/api_v2/api_deployment_views.py
+++ b/backend/api_v2/api_deployment_views.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from api_v2.constants import ApiExecution
 from api_v2.deployment_helper import DeploymentHelper
-from api_v2.exceptions import InvalidAPIRequest, NoActiveAPIKeyError
+from api_v2.exceptions import NoActiveAPIKeyError
 from api_v2.models import APIDeployment
 from api_v2.postman_collection.dto import PostmanCollection
 from api_v2.serializers import (
@@ -47,16 +47,14 @@ class DeploymentExecution(views.APIView):
     def post(
         self, request: Request, org_name: str, api_name: str, api: APIDeployment
     ) -> Response:
-        file_objs = request.FILES.getlist(ApiExecution.FILES_FORM_DATA)
         serializer = ExecutionRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        file_objs = serializer.validated_data.get(ApiExecution.FILES_FORM_DATA)
         timeout = serializer.validated_data.get(ApiExecution.TIMEOUT_FORM_DATA)
         include_metadata = serializer.validated_data.get(ApiExecution.INCLUDE_METADATA)
         include_metrics = serializer.validated_data.get(ApiExecution.INCLUDE_METRICS)
         use_file_history = serializer.validated_data.get(ApiExecution.USE_FILE_HISTORY)
         tag_names = serializer.validated_data.get(ApiExecution.TAGS)
-        if not file_objs or len(file_objs) == 0:
-            raise InvalidAPIRequest("File shouldn't be empty")
         response = DeploymentHelper.execute_workflow(
             organization_name=org_name,
             api=api,


### PR DESCRIPTION
## What

- Moved file validation logic to the serializer for better modularity.
- Introduced a limit on the number of files that can be uploaded (maximum of 32).

## Why

- To ensure resource stability by restricting the input size and preventing excessive uploads.
- To provide clear and user-friendly error messages for invalid inputs.

## How

- Added a files field to the serializer and implemented custom validation for file count.
- Moved file validation logic into the serializer's validate method to centralize validation and keep the API logic cleaner.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this change only affects the file validation logic in the API deployment flow. The updates are backward-compatible and do not modify any existing behaviors outside this scope.

## Database Migrations

-  No

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
