### PR TITLE
fix: Defined enable_challenge in prompt-service for error handling

### DIFF
--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -101,6 +101,7 @@ def prompt_processor() -> Any:
     if not payload:
         raise NoPayloadError
     tool_settings = payload.get(PSKeys.TOOL_SETTINGS, {})
+    enable_challenge = tool_settings.get(PSKeys.ENABLE_CHALLENGE, False)
     # TODO: Rename "outputs" to "prompts" in payload
     prompts = payload.get(PSKeys.OUTPUTS, [])
     tool_id: str = payload.get(PSKeys.TOOL_ID, "")
@@ -277,7 +278,6 @@ def prompt_processor() -> Any:
                     metadata=metadata,
                     execution_source=execution_source,
                 )
-                # TODO: Handle metrics for line-item extraction
                 continue
             except APIError as e:
                 app.logger.error(
@@ -512,7 +512,6 @@ def prompt_processor() -> Any:
                     output[PSKeys.NAME]
                 ].rstrip("\n")
 
-            enable_challenge = tool_settings.get(PSKeys.ENABLE_CHALLENGE)
             # Challenge condition
             if enable_challenge:
                 challenge_plugin: dict[str, Any] = plugins.get(PSKeys.CHALLENGE, {})

--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -494,12 +494,24 @@ def prompt_processor() -> Any:
                             )
                             structured_output[output[PSKeys.NAME]] = json.loads(answer)
                         except JSONDecodeError as e:
-                            app.logger.info(
-                                f"JSON format error : {answer}", LogLevel.ERROR
+                            err_msg = (
+                                f"Error parsing response (to json): {e}\n"
+                                f"Candidate JSON: {answer}"
                             )
-                            app.logger.info(
-                                f"Error parsing response (to json): {e}",
-                                LogLevel.ERROR,
+                            app.logger.info(err_msg, LogLevel.ERROR)
+                            # TODO: Format log message after unifying these types
+                            publish_log(
+                                log_events_id,
+                                {
+                                    "tool_id": tool_id,
+                                    "prompt_key": prompt_name,
+                                    "doc_name": doc_name,
+                                },
+                                LogLevel.INFO,
+                                RunLevel.RUN,
+                                "Unable to parse JSON response from LLM, try using our"
+                                " cloud / enterprise feature of 'line-item', "
+                                "'record' or 'table' type",
                             )
                             structured_output[output[PSKeys.NAME]] = {}
 

--- a/unstract/core/src/unstract/core/utilities.py
+++ b/unstract/core/src/unstract/core/utilities.py
@@ -41,6 +41,7 @@ class UnstractUtils:
         if len(container_name) > 63:
             logger.warning(
                 f"Container name exceeds 63 char limit for '{container_name}', "
-                "truncating to 63 chars. There might be collisions in container names"
+                "truncating to 63 chars. There might be collisions in container names."
+                f"Truncated container name: {container_name[:63]}"
             )
         return container_name[:63]


### PR DESCRIPTION
## What

- Defined `enable_challenge` before referencing it
- Logged message to the user in case of JSON parsing errors
- MINOR: Logged truncated container name

## Why

- Caused an issue with propagating errors from prompt-service

## How

- Referenced it before using it in `finally`

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor changes for error handling


## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/900

## Notes on Testing

- Didn't test this exception explicitly locally, but nothing breaks in prompt-service while running it

## Screenshots
![image](https://github.com/user-attachments/assets/a7438bfa-5463-4676-927e-4b69e816b470)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
