### PR TITLE
[FIX] Remote-storage - Multi-doc upload

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/views.py
@@ -513,7 +513,8 @@ class PromptStudioCoreView(viewsets.ModelViewSet):
                     org_id=UserSessionUtils.get_organization_id(request),
                     user_id=custom_tool.created_by.user_id,
                     tool_id=str(custom_tool.tool_id),
-                    uploaded_file=file_data,
+                    file_name=file_name,
+                    file_data=file_data,
                 )
 
             # Create a record in the db for the file

--- a/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
+++ b/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
@@ -77,7 +77,7 @@ class PromptStudioFileHelper:
         fs_instance.write(
             path=file_path,
             mode="wb",
-            data=file_data if isinstance(file_data, bytes) else file_data.read()
+            data=file_data if isinstance(file_data, bytes) else file_data.read(),
         )
 
     @staticmethod

--- a/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
+++ b/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
@@ -73,12 +73,12 @@ class PromptStudioFileHelper:
             )
         )
 
-        if isinstance(file_data, bytes):
-            file_path = str(Path(file_system_path) / file_name)
-            fs_instance.write(path=file_path, mode="wb", data=file_data)
-        else:
-            file_path = str(Path(file_system_path) / file_name)
-            fs_instance.write(path=file_path, mode="wb", data=file_data.read())
+        file_path = str(Path(file_system_path) / file_name)
+        fs_instance.write(
+            path=file_path,
+            mode="wb",
+            data=file_data if isinstance(file_data, bytes) else file_data.read()
+        )
 
     @staticmethod
     def fetch_file_contents(

--- a/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
+++ b/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
@@ -49,7 +49,7 @@ class PromptStudioFileHelper:
 
     @staticmethod
     def upload_for_ide(
-        org_id: str, user_id: str, tool_id: str, uploaded_file: Any
+        org_id: str, user_id: str, tool_id: str, file_data: Any, file_name: str
     ) -> None:
         """Uploads the file to a remote storage
 
@@ -57,7 +57,8 @@ class PromptStudioFileHelper:
             org_id (str): Organization ID
             user_id (str): User ID
             tool_id (str): ID of the prompt studio tool
-            uploaded_file : File to upload to remote
+            file_data (Any) : File data
+            file_name (str) : Name of the file to be uploaded
         """
         fs_instance = EnvHelper.get_storage(
             storage_type=StorageType.PERMANENT,
@@ -71,8 +72,13 @@ class PromptStudioFileHelper:
                 tool_id=str(tool_id),
             )
         )
-        file_path = str(Path(file_system_path) / uploaded_file.name)
-        fs_instance.write(path=file_path, mode="wb", data=uploaded_file.read())
+
+        if isinstance(file_data, bytes):
+            file_path = str(Path(file_system_path) / file_name)
+            fs_instance.write(path=file_path, mode="wb", data=file_data)
+        else:
+            file_path = str(Path(file_system_path) / file_name)
+            fs_instance.write(path=file_path, mode="wb", data=file_data.read())
 
     @staticmethod
     def fetch_file_contents(


### PR DESCRIPTION
## What

Fix for multi-doc uploads for remote storage

## Why

Files other than pdf were failing to get uploaded in prompt-studio

## How

Files other than pdf had a conversion logic which changes the file name and file data. These need to be taken into account while processing files for file storage. That was missed in code and the same is added as a fix in this PR.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Prompt studion multi-doc upload

## Database Migrations

- NA

## Env Config

- NA

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Upload doc, docx, xlsx, pdf

## Screenshots


![image](https://github.com/user-attachments/assets/83c334a2-8861-4acc-aada-5216e3a6e243)


![image](https://github.com/user-attachments/assets/0b2e55b4-0691-4e84-90df-2751fc22b0eb)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
