### PR TITLE
FIX: Ensure User Details Are Set Even if Session Validity Check Fails

### DIFF
--- a/frontend/src/hooks/useSessionValid.js
+++ b/frontend/src/hooks/useSessionValid.js
@@ -59,6 +59,7 @@ function useSessionValid() {
     return false;
   };
   return async () => {
+    let userAndOrgDetails = null;
     try {
       const userSessionData = await userSession();
 
@@ -92,7 +93,6 @@ function useSessionValid() {
         navigate("/setOrg", { state: orgs });
         return;
       }
-      let userAndOrgDetails = null;
       const orgId = signedInOrgId || orgs[0].id;
       const csrfToken = Cookies.get("csrftoken");
 
@@ -161,8 +161,6 @@ function useSessionValid() {
         userAndOrgDetails["isPlatformAdmin"] = await isPlatformAdmin();
       }
       userAndOrgDetails["role"] = userSessionData.role;
-      // Set the session details
-      setSessionDetails(getSessionData(userAndOrgDetails));
     } catch (err) {
       // TODO: Throw popup error message
       // REVIEW: Add condition to check for trial period status
@@ -178,6 +176,9 @@ function useSessionValid() {
         // May be need a logout button there or auto logout
       }
       setAlertDetails(handleException(err));
+    } finally {
+      // Set the session details
+      setSessionDetails(getSessionData(userAndOrgDetails));
     }
   };
 }


### PR DESCRIPTION
## What

If any of the session validity check APIs fail, the flow moves to the `catch` block, causing us to miss setting the user details extracted from the successful session validity checks.

## Why

This was causing issues because certain pages required basic user details, even if some session validity check APIs failed.

## How

The logic for setting user details has been moved from the try block to the finally block. This ensures that any user details extracted from the session validity APIs are stored in the global state, even if some of the APIs fail.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

Yes. This is a small change that's been made. But since this is a very high level component that gets executed when the app loads, there are chances of this breaking any existing features.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
### The subscription expired page is loading the admin message as expected
![Screenshot from 2025-02-08 12-13-50](https://github.com/user-attachments/assets/6c489e04-6def-490b-b395-661c9b887b22)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
