### PR TITLE
refactor: FE dockerfile optimized for better caching

### DIFF
--- a/docker/dockerfiles/frontend.Dockerfile
+++ b/docker/dockerfiles/frontend.Dockerfile
@@ -1,29 +1,37 @@
-FROM node:16 AS builder
+# Use a smaller base image for the builder stage
+FROM node:16-alpine AS builder
 
 # Build-time environment variables
-ENV BUILD_CONTEXT_PATH frontend
-ENV REACT_APP_BACKEND_URL ""
+ENV BUILD_CONTEXT_PATH=frontend
+ENV REACT_APP_BACKEND_URL=""
 
 # Set the working directory inside the container
 WORKDIR /app
 
+# Copy only the files needed for installing dependencies
+COPY ${BUILD_CONTEXT_PATH}/package.json ${BUILD_CONTEXT_PATH}/package-lock.json ./
+
+# Install dependencies (this layer will be cached unless package.json or package-lock.json changes)
+RUN npm install --ignore-scripts
+
+# Copy the rest of the application files
 COPY ${BUILD_CONTEXT_PATH}/ .
 
-RUN set -e; \
-    # Install app dependencies
-    npm install --ignore-scripts; \
-    # Build the React app
-    npm run build;
+# Build the React app
+RUN npm run build
 
-
-FROM nginx:1.25
+# Use a smaller base image for the final stage
+FROM nginx:1.25-alpine
 
 LABEL maintainer="Zipstack Inc."
 
-# Remove the default NGINX configuration
+# Remove the default NGINX configuration (if needed)
 # RUN rm /etc/nginx/conf.d/default.conf
 
+# Copy built assets from the builder stage
 COPY --from=builder /app/build /usr/share/nginx/html
+
+# Copy custom NGINX configuration
 COPY --from=builder /app/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80


### PR DESCRIPTION
## What

- Refactored FE dockerfile
  - Used a smaller base image
  - Copied package.json first to help install and cache for FE dependent libraries first, then copied code

## Why

- To reduce FE build time (**22.28% faster**)

## How

- Used a smaller base image
- Restructured some instructions to make better use of docker's caching

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, tested it locally with a smaller base image

## Related Issues or PRs

- #1126 - Similar optimization

## Notes on Testing

- Built FE docker without these changes and with these changes to compare time taken
- Made small changes to FE to simulate code changes and rebuilds - able to use the platform afterwards

## Screenshots
1. Before making changes - `140s` to rebuild image after code changes (did a git pull here for the code changes)
![image](https://github.com/user-attachments/assets/5895f36d-5c44-4b81-8fa2-fdd87be35531)

1. After making changes - `108.8s` to rebuild image after code changes
![image](https://github.com/user-attachments/assets/13a5b0ce-ca68-4252-8f16-b8cf8fa2e8e8)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
