### PR TITLE
Pass the right env value to the tool container while spawning

### DIFF
--- a/tools/structure/src/main.py
+++ b/tools/structure/src/main.py
@@ -96,11 +96,14 @@ class StructureTool(BaseTool):
             file_name = SettingsKeys.SUMMARIZE
         if self.workflow_filestorage:
             tool_data_dir = Path(self.get_env_or_die(ToolEnv.EXECUTION_DATA_DIR))
+            execution_run_data_folder = Path(
+                self.get_env_or_die(ToolEnv.EXECUTION_DATA_DIR)
+            )
         else:
             tool_data_dir = Path(self.get_env_or_die(SettingsKeys.TOOL_DATA_DIR))
-        execution_run_data_folder = Path(
-            self.get_env_or_die(SettingsKeys.EXECUTION_RUN_DATA_FOLDER)
-        )
+            execution_run_data_folder = Path(
+                self.get_env_or_die(SettingsKeys.EXECUTION_RUN_DATA_FOLDER)
+            )
 
         index = Index(
             tool=self,


### PR DESCRIPTION
## What

In case of highlighting/table extraction, while spawining the tool container, wrong path was being sent for EXECUTION_DATA_DIR while remote storage is ON.

## Why

The use of env variables was not handled correctly

## How

Pass the corrrect file path both in payload and indexing when remote storage is ON

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Highlighting / table extraction in Structure tool

## Database Migrations

-  NA

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
