### PR TITLE
Support remote storage for OSS users

### DIFF
--- a/backend/sample.env
+++ b/backend/sample.env
@@ -149,14 +149,14 @@ API_EXECUTION_DIR_PREFIX="unstract/api"
 
 # Storage Provider for Workflow Execution
 # Valid options: MINIO, S3, etc..
-WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS='{"provider":"minio","credentials": {"endpoint_url":"http://unstract-minio:9000","key":"XXX","secret":"XXX"}}'
+WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 
 # Storage Provider for API Execution
-API_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "XXX", "secret": "XXX"}}'
+API_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 
 #Remote storage related envs
-PERMANENT_REMOTE_STORAGE={"provider":"gcs","credentials":<credentials>}
-REMOTE_PROMPT_STUDIO_FILE_PATH="<bucket_name>/prompt_studio_data/"
+PERMANENT_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
+REMOTE_PROMPT_STUDIO_FILE_PATH="unstract/prompt-studio-data"
 
 # Storage Provider for Tool registry
 TOOL_REGISTRY_STORAGE_CREDENTIALS='{"provider":"local"}'

--- a/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
+++ b/backend/utils/file_storage/helpers/prompt_studio_file_helper.py
@@ -115,7 +115,7 @@ class PromptStudioFileHelper:
         )
         # TODO : Handle this with proper fix
         # Temporary Hack for frictionless onboarding as the user id will be empty
-        if not fs_instance.exists(file_system_path):
+        if not user_id and not fs_instance.exists(file_system_path):
             file_system_path = (
                 PromptStudioFileHelper.get_or_create_prompt_studio_subdirectory(
                     org_id=org_id,
@@ -126,7 +126,9 @@ class PromptStudioFileHelper:
             )
         file_path = str(Path(file_system_path) / file_name)
         legacy_file_path = str(Path(legacy_file_system_path) / file_name)
-        file_content_type = fs_instance.mime_type(file_path)
+        file_content_type = fs_instance.mime_type(
+            path=file_path, legacy_storage_path=legacy_file_path
+        )
         if file_content_type == "application/pdf":
             # Read contents of PDF file into a string
             text_content_bytes: bytes = fs_instance.read(

--- a/docker/docker-compose-dev-essentials.yaml
+++ b/docker/docker-compose-dev-essentials.yaml
@@ -46,6 +46,18 @@ services:
       - traefik.http.routers.minio.rule=Host(`minio.unstract.localhost`)
       - traefik.http.services.minio.loadbalancer.server.port=9001
 
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      mc alias set minio http://unstract-minio:9000 minio minio123;
+      mc mb minio/unstract;
+      exit 0;
+      "
+
   reverse-proxy:
     # The official v2 Traefik docker image
     image: traefik:v2.10

--- a/docker/docker-compose-dev-essentials.yaml
+++ b/docker/docker-compose-dev-essentials.yaml
@@ -55,8 +55,11 @@ services:
       sleep 5;
       mc alias set minio http://unstract-minio:9000 minio minio123;
       mc mb minio/unstract;
+      mc mirror /app/prompt-studio-data minio/unstract/prompt-studio-data;
       exit 0;
       "
+    volumes:
+      - prompt_studio_data:/app/prompt-studio-data
 
   reverse-proxy:
     # The official v2 Traefik docker image

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       - redis
       - reverse-proxy
       - minio
+      - createbuckets
       - platform-service
       - prompt-service
       - x2text-service
@@ -171,6 +172,8 @@ services:
     restart: unless-stopped
     depends_on:
       - db
+      - minio
+      - createbuckets
     ports:
       - "3003:3003"
     env_file:
@@ -208,6 +211,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - redis
+      - minio
+      - createbuckets
     labels:
       - traefik.enable=false
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -211,8 +211,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - redis
-      - minio
-      - createbuckets
     labels:
       - traefik.enable=false
 

--- a/platform-service/sample.env
+++ b/platform-service/sample.env
@@ -34,6 +34,7 @@ MODEL_PRICES_TTL_IN_DAYS=7
 MODEL_PRICES_FILE_PATH="<bucket-name>/cost/model_prices.json"
 
 #Remote storage config
-FILE_STORAGE_CREDENTIALS='{"provider":"gcs","credentials": {"token": {token-value-json}}'
+FILE_STORAGE_CREDENTIALS='{"provider":"local"}'
+REMOTE_MODEL_PRICES_FILE_PATH="unstract/cost/model_prices.json"
 
 LOG_LEVEL=INFO

--- a/prompt-service/sample.env
+++ b/prompt-service/sample.env
@@ -30,7 +30,7 @@ PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 # Flipt Service
 FLIPT_SERVICE_AVAILABLE=False
 
-
 #Remote storage related envs
-PERMANENT_REMOTE_STORAGE={"provider":"gcs","credentials":<credentials>}
-REMOTE_PROMPT_STUDIO_FILE_PATH="<bucket_name>/prompt_studio_data/"
+PERMANENT_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
+TEMPORARY_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
+REMOTE_PROMPT_STUDIO_FILE_PATH="unstract/prompt_studio_data/"

--- a/runner/sample.env
+++ b/runner/sample.env
@@ -26,7 +26,7 @@ PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 
 # File System Configuration for Workflow and API Execution
 # Directory Prefixes for storing execution files
-WORKFLOW_EXECUTION_DIR_PREFIX="/unstract/execution"
+WORKFLOW_EXECUTION_DIR_PREFIX="unstract/execution"
 # Storage Provider for Workflow Execution
 # Valid options: MINIO, S3, etc..
-WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS='{"provider":"minio","credentials": {"endpoint_url":"http://unstract-minio:9000","key":"XXX","secret":"XXX"}}'
+WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'


### PR DESCRIPTION
## What

- Support remote storage for OSS users with docker setup

## Why

- Supporting remote storage for OSS users using docker setup is required to keep Unstract working for the community

## How

- Configure minio as remote storage instead of local container storage
- Use local storage only for costing in Platform service and tool registry in backend

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- New user signup to be tested.

## Database Migrations

- NA

## Env Config

- run-platform.sh will take care of necessary env setup

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract-sdk/pull/157

## Dependencies Versions

- 

## Notes on Testing

- Testing was carried out by enabling remote storage feature flag and with this PR specific changes on the mainstream branch

## Screenshots

Tool run
![image](https://github.com/user-attachments/assets/671debe4-f9c6-467f-ac7f-d90913b9cc91)
 
Prompt studio
![image](https://github.com/user-attachments/assets/eabbfe85-3221-47d7-8e08-1246f4f20388)

createbuckets - mirror command - transferring data
![image](https://github.com/user-attachments/assets/1e72efa1-8480-4023-b2d1-76856e3c2f12)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
