### PR TITLE
fix: Added ownership privileges for non-root user in prompt service Dockerfile

### DIFF
--- a/docker/dockerfiles/prompt.Dockerfile
+++ b/docker/dockerfiles/prompt.Dockerfile
@@ -43,9 +43,8 @@ RUN pdm venv create -w virtualenv --with-pip && \
         opentelemetry-exporter-otlp && \
     opentelemetry-bootstrap -a install
 
-# Read and execute access to non-root user to avoid security hotspot
-# Write access to specific sub-directory need to be explicitly provided if required
-COPY --chmod=755 ${BUILD_CONTEXT_PATH} /app/
+# TODO: Security issue but ignoring it for nuitka based builds
+COPY --chown=unstract ${BUILD_CONTEXT_PATH} /app/
 # Copy local dependencies
 COPY --chown=unstract ${BUILD_PACKAGES_PATH}/core /unstract/core
 COPY --chown=unstract ${BUILD_PACKAGES_PATH}/flags /unstract/flags


### PR DESCRIPTION

## What

- Added ownership privilege for non root user to prompt service Dockerfile

## Why

- Nuitka based build issues observed, temporarily making this change


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, however it has a known security hotspot

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- No explicit testing done

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
