### PR TITLE
Fix folder path used in prompt service

### DIFF
--- a/prompt-service/sample.env
+++ b/prompt-service/sample.env
@@ -33,4 +33,4 @@ FLIPT_SERVICE_AVAILABLE=False
 #Remote storage related envs
 PERMANENT_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 TEMPORARY_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
-REMOTE_PROMPT_STUDIO_FILE_PATH="unstract/prompt_studio_data/"
+REMOTE_PROMPT_STUDIO_FILE_PATH="unstract/prompt-studio-data/"


### PR DESCRIPTION
## What

- Fix folder path used in prompt service

## Why

- Fix folder path used in prompt service

## How

- Fix folder path used in prompt service

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
