### PR TITLE
[FIX] Line item extraction file read fix

### DIFF
--- a/prompt-service/src/unstract/prompt_service/helper.py
+++ b/prompt-service/src/unstract/prompt_service/helper.py
@@ -427,7 +427,7 @@ def extract_line_item(
         raise FileNotFoundError(
             f"The file at path '{extract_file_path}' does not exist."
         )
-    context = fs_instance.read(path=extract_file_path, encoding="utf-8", mode="rb")
+    context = fs_instance.read(path=extract_file_path, encoding="utf-8", mode="r")
 
     prompt = construct_prompt(
         preamble=tool_settings.get(PSKeys.PREAMBLE, ""),


### PR DESCRIPTION
## What

- File was read in "rb" instead of "r"

## Why

- Error occurs due to reading of bytes

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
