### PR TITLE
fix: Added task ID in WF execution model in API deployment POST call

### DIFF
--- a/backend/workflow_manager/workflow_v2/execution.py
+++ b/backend/workflow_manager/workflow_v2/execution.py
@@ -415,7 +415,11 @@ class WorkflowExecutionServiceHelper(WorkflowExecutionService):
     @staticmethod
     def update_execution_task(execution_id: str, task_id: str) -> None:
         try:
+            assert (
+                task_id is not None
+            ), f"task_id is NULL for execution_id: {execution_id}"
             execution = WorkflowExecution.objects.get(pk=execution_id)
+            # TODO: Review if status should be updated to EXECUTING
             execution.task_id = task_id
             execution.save()
         except WorkflowExecution.DoesNotExist:


### PR DESCRIPTION
## What

- Added minor logs 
- Added task ID to WF execution model in the POST call itself

## Why

- To not wait until the celery based execution itself to update this value
- Allows for retrieving the status after an API deployment right away

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Possible, if celery's task ID can change at any point - I doubt if that's the case


## Notes on Testing

- Minor testing locally due to the constraint of time

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
