### PR TITLE
feat: Added celery config: visibility_timeout for broker

### DIFF
--- a/backend/backend/celery_config.py
+++ b/backend/backend/celery_config.py
@@ -40,6 +40,7 @@ class CeleryConfig:
 
     beat_scheduler = "django_celery_beat.schedulers:DatabaseScheduler"
 
+    task_acks_late = True
     # Large timeout avoids worker to pick up same unacknowledged task again
     broker_transport_options = {
         "visibility_timeout": float(

--- a/backend/backend/celery_config.py
+++ b/backend/backend/celery_config.py
@@ -1,0 +1,40 @@
+from urllib.parse import quote_plus
+
+from django.conf import settings
+
+from unstract.core.utilities import UnstractUtils
+
+
+class CeleryConfig:
+    """Specifies celery configuration
+
+    Refer https://docs.celeryq.dev/en/stable/userguide/configuration.html
+    """
+
+    # Result backend configuration
+    result_backend = (
+        f"db+postgresql://{settings.DB_USER}:{quote_plus(settings.DB_PASSWORD)}"
+        f"@{settings.DB_HOST}:{settings.DB_PORT}/{settings.DB_NAME}"
+    )
+
+    # Broker URL configuration
+    broker_url = UnstractUtils.get_env(
+        "CELERY_BROKER_URL",
+        f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}",
+        raise_err=True,
+    )
+
+    # Task serialization and content settings
+    accept_content = ["json"]
+    task_serializer = "json"
+    result_serializer = "json"
+    result_extended = True
+
+    # Timezone and logger settings
+    timezone = "UTC"
+    worker_hijack_root_logger = False
+
+    beat_scheduler = "django_celery_beat.schedulers:DatabaseScheduler"
+
+    # Large timeout avoids worker to pick up same unacknowledged task again
+    broker_transport_options = {"visibility_timeout": 7200}  # 2 hours

--- a/backend/backend/celery_config.py
+++ b/backend/backend/celery_config.py
@@ -11,6 +11,10 @@ class CeleryConfig:
     Refer https://docs.celeryq.dev/en/stable/userguide/configuration.html
     """
 
+    # Envs defined for configuration with Unstract
+    CELERY_BROKER_URL = "CELERY_BROKER_URL"
+    CELERY_BROKER_VISIBILITY_TIMEOUT = "CELERY_BROKER_VISIBILITY_TIMEOUT"
+
     # Result backend configuration
     result_backend = (
         f"db+postgresql://{settings.DB_USER}:{quote_plus(settings.DB_PASSWORD)}"
@@ -19,7 +23,7 @@ class CeleryConfig:
 
     # Broker URL configuration
     broker_url = UnstractUtils.get_env(
-        "CELERY_BROKER_URL",
+        CELERY_BROKER_URL,
         f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}",
         raise_err=True,
     )
@@ -37,4 +41,8 @@ class CeleryConfig:
     beat_scheduler = "django_celery_beat.schedulers:DatabaseScheduler"
 
     # Large timeout avoids worker to pick up same unacknowledged task again
-    broker_transport_options = {"visibility_timeout": 7200}  # 2 hours
+    broker_transport_options = {
+        "visibility_timeout": UnstractUtils.get_env(
+            CELERY_BROKER_VISIBILITY_TIMEOUT, "7200"
+        )
+    }

--- a/backend/backend/celery_config.py
+++ b/backend/backend/celery_config.py
@@ -42,7 +42,7 @@ class CeleryConfig:
 
     # Large timeout avoids worker to pick up same unacknowledged task again
     broker_transport_options = {
-        "visibility_timeout": UnstractUtils.get_env(
-            CELERY_BROKER_VISIBILITY_TIMEOUT, "7200"
+        "visibility_timeout": float(
+            UnstractUtils.get_env(CELERY_BROKER_VISIBILITY_TIMEOUT, 3600)
         )
     }

--- a/backend/backend/celery_config.py
+++ b/backend/backend/celery_config.py
@@ -44,6 +44,6 @@ class CeleryConfig:
     # Large timeout avoids worker to pick up same unacknowledged task again
     broker_transport_options = {
         "visibility_timeout": float(
-            UnstractUtils.get_env(CELERY_BROKER_VISIBILITY_TIMEOUT, 3600)
+            UnstractUtils.get_env(CELERY_BROKER_VISIBILITY_TIMEOUT, 7200)
         )
     }

--- a/backend/backend/celery_service.py
+++ b/backend/backend/celery_service.py
@@ -32,7 +32,7 @@ app.config_from_object("backend.celery_config.CeleryConfig")
 app.autodiscover_tasks()
 
 logger.debug(
-    f"Celery Configuration:\n" f"{pformat(app.conf.table(with_defaults=False))}"
+    f"Celery Configuration:\n" f"{pformat(app.conf.table(with_defaults=True))}"
 )
 
 # Define the queues to purge when the Celery broker is restarted.

--- a/backend/backend/celery_service.py
+++ b/backend/backend/celery_service.py
@@ -31,8 +31,8 @@ TaskRegistry()
 app.config_from_object("backend.celery_config.CeleryConfig")
 app.autodiscover_tasks()
 
-logger.info(
-    f"\nCelery Configuration:\n" f"{pformat(app.conf.table(with_defaults=True))}"
+logger.debug(
+    f"Celery Configuration:\n" f"{pformat(app.conf.table(with_defaults=False))}"
 )
 
 # Define the queues to purge when the Celery broker is restarted.

--- a/backend/backend/celery_service.py
+++ b/backend/backend/celery_service.py
@@ -1,12 +1,16 @@
 """This module contains the Celery configuration for the backend project."""
 
+import logging
 import os
+from pprint import pformat
 
+import django
 from celery import Celery
-from django.conf import settings
 from utils.constants import ExecutionLogConstants
 
 from backend.celery_task import TaskRegistry
+
+logger = logging.getLogger(__name__)
 
 # Set the default Django settings module for the 'celery' program.
 os.environ.setdefault(
@@ -14,30 +18,26 @@ os.environ.setdefault(
     os.environ.get("DJANGO_SETTINGS_MODULE", "backend.settings.dev"),
 )
 
+# Helps configure Django's logger for celery workers
+django.setup()
+
 # Create a Celery instance. Default time zone is UTC.
 app = Celery("backend")
 
-# To register the custom tasks.
+# Register custom tasks
 TaskRegistry()
 
-# Use Redis as the message broker.
-app.conf.broker_url = settings.CELERY_BROKER_URL
-app.conf.result_backend = settings.CELERY_RESULT_BACKEND
-
-
 # Load task modules from all registered Django app configs.
-app.config_from_object("django.conf:settings", namespace="CELERY")
-
-# Autodiscover tasks in all installed apps.
+app.config_from_object("backend.celery_config.CeleryConfig")
 app.autodiscover_tasks()
+
+logger.info(
+    f"\nCelery Configuration:\n" f"{pformat(app.conf.table(with_defaults=True))}"
+)
 
 # Define the queues to purge when the Celery broker is restarted.
 queues_to_purge = [ExecutionLogConstants.CELERY_QUEUE_NAME]
 with app.connection() as connection:
     channel = connection.channel()
-
     for queue_name in queues_to_purge:
         channel.queue_purge(queue_name)
-
-# Use the Django-Celery-Beat scheduler.
-app.conf.beat_scheduler = "django_celery_beat.schedulers:DatabaseScheduler"

--- a/backend/backend/celery_service.py
+++ b/backend/backend/celery_service.py
@@ -1,14 +1,15 @@
 """This module contains the Celery configuration for the backend project."""
 
 import logging
+import logging.config
 import os
 from pprint import pformat
 
-import django
 from celery import Celery
 from utils.constants import ExecutionLogConstants
 
 from backend.celery_task import TaskRegistry
+from backend.settings.base import LOGGING
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +19,8 @@ os.environ.setdefault(
     os.environ.get("DJANGO_SETTINGS_MODULE", "backend.settings.dev"),
 )
 
-# Helps configure Django's logger for celery workers
-django.setup()
+# Configure logging for celery worker using same config as Django
+logging.config.dictConfig(LOGGING)
 
 # Create a Celery instance. Default time zone is UTC.
 app = Celery("backend")

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import os
 from pathlib import Path
 from typing import Optional
-from urllib.parse import quote_plus
 
 from dotenv import find_dotenv, load_dotenv
 from utils.common_utils import CommonUtils
@@ -130,9 +129,6 @@ LOG_HISTORY_CONSUMER_INTERVAL = int(
     get_required_setting("LOG_HISTORY_CONSUMER_INTERVAL", "60")
 )
 LOGS_BATCH_LIMIT = int(get_required_setting("LOGS_BATCH_LIMIT", "30"))
-CELERY_BROKER_URL = get_required_setting(
-    "CELERY_BROKER_URL", f"redis://{REDIS_HOST}:{REDIS_PORT}"
-)
 
 INDEXING_FLAG_TTL = int(get_required_setting("INDEXING_FLAG_TTL"))
 NOTIFICATION_TIMEOUT = int(get_required_setting("NOTIFICATION_TIMEOUT", "5"))
@@ -366,20 +362,6 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 RQ_QUEUES = {
     "default": {"USE_REDIS_CACHE": "default"},
 }
-
-
-# CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/1"
-# Postgres as result backend
-CELERY_RESULT_BACKEND = (
-    f"db+postgresql://{DB_USER}:{quote_plus(DB_PASSWORD)}"
-    f"@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-)
-CELERY_ACCEPT_CONTENT = ["json"]
-CELERY_TASK_SERIALIZER = "json"
-CELERY_RESULT_SERIALIZER = "json"
-CELERY_TIMEZONE = "UTC"
-CELERY_TASK_MAX_RETRIES = 3
-CELERY_TASK_RETRY_BACKOFF = 60  # Time in seconds before retrying the task
 
 # Feature Flag
 FEATURE_FLAG_SERVICE_URL = {"evaluate": f"{FLIPT_BASE_URL}/api/v1/flags/evaluate/"}

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -129,6 +129,9 @@ LOG_HISTORY_CONSUMER_INTERVAL = int(
     get_required_setting("LOG_HISTORY_CONSUMER_INTERVAL", "60")
 )
 LOGS_BATCH_LIMIT = int(get_required_setting("LOGS_BATCH_LIMIT", "30"))
+LOGS_EXPIRATION_TIME_IN_SECOND = int(
+    get_required_setting("LOGS_EXPIRATION_TIME_IN_SECOND")
+)
 
 INDEXING_FLAG_TTL = int(get_required_setting("INDEXING_FLAG_TTL"))
 NOTIFICATION_TIMEOUT = int(get_required_setting("NOTIFICATION_TIMEOUT", "5"))

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -126,8 +126,9 @@ LOG_HISTORY_CONSUMER_INTERVAL=30
 LOGS_BATCH_LIMIT=30
 
 # Celery Configuration
+# Used by celery and to connect to queue to push logs
 CELERY_BROKER_URL = "redis://unstract-redis:6379"
-CELERY_BROKER_VISIBILITY_TIMEOUT = "3600"  # 1 hour
+CELERY_BROKER_VISIBILITY_TIMEOUT = "86400"  # 1 day
 
 # Indexing flag to prevent re-index
 INDEXING_FLAG_TTL=1800

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -127,7 +127,7 @@ LOGS_BATCH_LIMIT=30
 
 # Celery Configuration
 CELERY_BROKER_URL = "redis://unstract-redis:6379"
-CELERY_BROKER_VISIBILITY_TIMEOUT = "7200"  # 2 hours
+CELERY_BROKER_VISIBILITY_TIMEOUT = "3600"  # 1 hour
 
 # Indexing flag to prevent re-index
 INDEXING_FLAG_TTL=1800

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -127,6 +127,7 @@ LOGS_BATCH_LIMIT=30
 
 # Celery Configuration
 CELERY_BROKER_URL = "redis://unstract-redis:6379"
+CELERY_BROKER_VISIBILITY_TIMEOUT = "7200"  # 2 hours
 
 # Indexing flag to prevent re-index
 INDEXING_FLAG_TTL=1800

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -576,7 +576,7 @@ class WorkflowHelper:
     @shared_task(
         name="async_execute_bin",
         autoretry_for=(Exception,),
-        max_retries=1,
+        max_retries=0,
         retry_backoff=True,
         retry_backoff_max=500,
         retry_jitter=True,

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -575,7 +575,6 @@ class WorkflowHelper:
     @staticmethod
     @shared_task(
         name="async_execute_bin",
-        acks_late=True,
         autoretry_for=(Exception,),
         max_retries=1,
         retry_backoff=True,


### PR DESCRIPTION
## What

- Added celery config for redis broker: `visibility_timeout` to 1 day (defaults to 2 hours)
- Added `acks_late=True` 
- Refactored how we read celery config
- Set `max_retries=0` for task `async_execute_bin`

## Why

- `async_execute_bin` runs with `acks_late` which also causes this issue
- Default timeout of 1 hour causes the task to be re-executed for long running tasks (> 1 hour). Increasing this default timeout by assuming that 2 hours is enough time for our current tasks to complete
- Simulated with a low `visibility_timeout=10` and a sleep in the task
```
->  celery@pop-os: OK
    * {'id': 'd728ca97-3780-412a-a973-be2f213c7406', 'name': 'async_execute_bin', 'args': ['mock_org', UUID('995b7a87-148c-4a35-9a3d-8b81b34cf27f'), UUID('a53f289f-8fdb-418d-9830-4ccc460bfaab'), {'apple_10K_2022.pdf': {'file_path': 'unstract/api/mock_org/995b7a87-148c-4a35-9a3d-8b81b34cf27f/a53f289f-8fdb-418d-9830-4ccc460bfaab/apple_10K_2022.pdf', 'file_hash': '40f4a5169ac49f1c3011b8287afe28364138cd4f3e4db36c8d75c9da0f6b2a93', 'file_name': 'apple_10K_2022.pdf', 'source_connection_type': 'API', 'file_destination': None, 'is_executed': False, 'file_size': 729516, 'mime_type': 'application/pdf'}}], 'kwargs': {'scheduled': False, 'execution_mode': None, 'pipeline_id': UUID('48e6a6e2-b312-4516-a809-dca17778d66c'), 'log_events_id': None, 'use_file_history': False}, 'type': 'async_execute_bin', 'hostname': 'celery@pop-os', 'time_start': 1740375422.779477, 'acknowledged': False, 'delivery_info': {'exchange': '', 'routing_key': 'celery_api_deployments', 'priority': 0, 'redelivered': True}, 'worker_pid': 1727862}
    * {'id': 'd728ca97-3780-412a-a973-be2f213c7406', 'name': 'async_execute_bin', 'args': ['mock_org', UUID('995b7a87-148c-4a35-9a3d-8b81b34cf27f'), UUID('a53f289f-8fdb-418d-9830-4ccc460bfaab'), {'apple_10K_2022.pdf': {'file_path': 'unstract/api/mock_org/995b7a87-148c-4a35-9a3d-8b81b34cf27f/a53f289f-8fdb-418d-9830-4ccc460bfaab/apple_10K_2022.pdf', 'file_hash': '40f4a5169ac49f1c3011b8287afe28364138cd4f3e4db36c8d75c9da0f6b2a93', 'file_name': 'apple_10K_2022.pdf', 'source_connection_type': 'API', 'file_destination': None, 'is_executed': False, 'file_size': 729516, 'mime_type': 'application/pdf'}}], 'kwargs': {'scheduled': False, 'execution_mode': None, 'pipeline_id': UUID('48e6a6e2-b312-4516-a809-dca17778d66c'), 'log_events_id': None, 'use_file_history': False}, 'type': 'async_execute_bin', 'hostname': 'celery@pop-os', 'time_start': 1740375347.206673, 'acknowledged': False, 'delivery_info': {'exchange': '', 'routing_key': 'celery_api_deployments', 'priority': 0, 'redelivered': False}, 'worker_pid': 1726596}
    * {'id': 'd728ca97-3780-412a-a973-be2f213c7406', 'name': 'async_execute_bin', 'args': ['mock_org', UUID('995b7a87-148c-4a35-9a3d-8b81b34cf27f'), UUID('a53f289f-8fdb-418d-9830-4ccc460bfaab'), {'apple_10K_2022.pdf': {'file_path': 'unstract/api/mock_org/995b7a87-148c-4a35-9a3d-8b81b34cf27f/a53f289f-8fdb-418d-9830-4ccc460bfaab/apple_10K_2022.pdf', 'file_hash': '40f4a5169ac49f1c3011b8287afe28364138cd4f3e4db36c8d75c9da0f6b2a93', 'file_name': 'apple_10K_2022.pdf', 'source_connection_type': 'API', 'file_destination': None, 'is_executed': False, 'file_size': 729516, 'mime_type': 'application/pdf'}}], 'kwargs': {'scheduled': False, 'execution_mode': None, 'pipeline_id': UUID('48e6a6e2-b312-4516-a809-dca17778d66c'), 'log_events_id': None, 'use_file_history': False}, 'type': 'async_execute_bin', 'hostname': 'celery@pop-os', 'time_start': 1740375389.326329, 'acknowledged': False, 'delivery_info': {'exchange': '', 'routing_key': 'celery_api_deployments', 'priority': 0, 'redelivered': True}, 'worker_pid': 1727408}
```

## How

- This PR is only a workaround to make this behaviour less likely and to allow 2 hours before re-executing the same task again

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, only increased the default timeout
- However in cases where the worker is abruptly killed - its possible that the tasks will be made visible only after this 2 hour limit now instead of the default 1 hour
  - [This gist](https://gist.github.com/mlavin/6671079) might have a way to make it immediate

## Relevant Docs

- [Visibility timeout](https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#redis-visibility-timeout)
- [task_acks_late](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-acks-late)
- [Celery config](https://docs.celeryq.dev/en/stable/userguide/configuration.html#new-lowercase-settings)

## Notes on Testing

- Tested celery behaviour locally - checked for its corrected logging and its ability to run tasks
- Unable to avoid the issue of multiple executions in case of long-running jobs still - this PR is only a work around

## Screenshots
1. Example celery config with altered visibility timeout
![image](https://github.com/user-attachments/assets/105da3e4-ff94-408e-87e2-c68f120d5aea)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
