### PR TITLE
feat: UN-2166 Passed optional container name from backend to runner

### DIFF
--- a/backend/workflow_manager/workflow_v2/execution.py
+++ b/backend/workflow_manager/workflow_v2/execution.py
@@ -231,9 +231,7 @@ class WorkflowExecutionServiceHelper(WorkflowExecutionService):
             )
             raise WorkflowExecutionError(self.compilation_result["problems"][0])
 
-    def execute(
-        self, file_execution_id: str, file_name: str, single_step: bool = False
-    ) -> None:
+    def execute(self, file_execution_id: str, single_step: bool = False) -> None:
         execution_type = ExecutionType.COMPLETE
         if single_step:
             execution_type = ExecutionType.STEP
@@ -256,7 +254,6 @@ class WorkflowExecutionServiceHelper(WorkflowExecutionService):
         try:
             self.execute_workflow(
                 file_execution_id=file_execution_id,
-                file_name=file_name,
                 execution_type=execution_type,
             )
             end_time = time.time()
@@ -356,7 +353,13 @@ class WorkflowExecutionServiceHelper(WorkflowExecutionService):
         )
         workflow_file_execution.update_status(ExecutionStatus.EXECUTING)
 
-        self.execute(file_execution_id, file_name, single_step)
+        logger.info(
+            f"Running execution: '{self.execution_id}',  "
+            f"file_execution_id: '{file_execution_id}', "
+            f"file '{file_name}'"
+        )
+
+        self.execute(file_execution_id, single_step)
         self.publish_log(f"Tool executed successfully for '{file_name}'")
         self._handle_execution_type(execution_type)
 

--- a/docker/scripts/pdm-lock-gen/pdm-lock.sh
+++ b/docker/scripts/pdm-lock-gen/pdm-lock.sh
@@ -79,7 +79,6 @@ directories=(
     "platform-service"
     "x2text-service"
     "unstract/connectors"
-    "unstract/tool-sandbox"
 )
 
 # If directories are passed as arguments, override the default

--- a/runner/src/unstract/runner/clients/docker.py
+++ b/runner/src/unstract/runner/clients/docker.py
@@ -158,17 +158,24 @@ class Client(ContainerClientInterface):
     def get_container_run_config(
         self,
         command: list[str],
-        run_id: str,
+        file_execution_id: str,
+        container_name: Optional[str] = None,
         envs: Optional[dict[str, Any]] = None,
         auto_remove: bool = False,
     ) -> dict[str, Any]:
         if envs is None:
             envs = {}
         mounts = []
+
+        if not container_name:
+            container_name = UnstractUtils.build_tool_container_name(
+                tool_image=self.image_name,
+                tool_version=self.image_tag,
+                file_execution_id=file_execution_id,
+            )
+
         return {
-            "name": UnstractUtils.build_tool_container_name(
-                tool_image=self.image_name, tool_version=self.image_tag, run_id=run_id
-            ),
+            "name": container_name,
             "image": self.get_image(),
             "command": command,
             "detach": True,

--- a/runner/src/unstract/runner/clients/interface.py
+++ b/runner/src/unstract/runner/clients/interface.py
@@ -62,7 +62,8 @@ class ContainerClientInterface(ABC):
     def get_container_run_config(
         self,
         command: list[str],
-        run_id: str,
+        file_execution_id: str,
+        container_name: Optional[str] = None,
         envs: Optional[dict[str, Any]] = None,
         auto_remove: bool = False,
     ) -> dict[str, Any]:

--- a/runner/src/unstract/runner/clients/test_docker.py
+++ b/runner/src/unstract/runner/clients/test_docker.py
@@ -109,7 +109,7 @@ def test_get_image(docker_client, mocker):
 def test_get_container_run_config(docker_client, mocker):
     """Test the get_container_run_config method."""
     command = ["echo", "hello"]
-    run_id = "run123"
+    file_execution_id = "run123"
 
     mocker.patch.object(docker_client, "_Client__image_exists", return_value=True)
     mocker_normalize = mocker.patch(
@@ -117,11 +117,13 @@ def test_get_container_run_config(docker_client, mocker):
         return_value="test-image",
     )
     config = docker_client.get_container_run_config(
-        command, run_id, envs={"KEY": "VALUE"}, auto_remove=True
+        command, file_execution_id, envs={"KEY": "VALUE"}, auto_remove=True
     )
 
     mocker_normalize.assert_called_once_with(
-        tool_image="test-image", tool_version="latest", run_id=run_id
+        tool_image="test-image",
+        tool_version="latest",
+        file_execution_id=file_execution_id,
     )
     assert config["name"] == "test-image"
     assert config["image"] == "test-image:latest"
@@ -134,17 +136,21 @@ def test_get_container_run_config_without_mount(docker_client, mocker):
     """Test the get_container_run_config method."""
     os.environ[Env.EXECUTION_DATA_DIR] = "/source"
     command = ["echo", "hello"]
-    run_id = "run123"
+    file_execution_id = "run123"
 
     mocker.patch.object(docker_client, "_Client__image_exists", return_value=True)
     mocker_normalize = mocker.patch(
         "unstract.core.utilities.UnstractUtils.build_tool_container_name",
         return_value="test-image",
     )
-    config = docker_client.get_container_run_config(command, run_id, auto_remove=True)
+    config = docker_client.get_container_run_config(
+        command, file_execution_id, auto_remove=True
+    )
 
     mocker_normalize.assert_called_once_with(
-        tool_image="test-image", tool_version="latest", run_id=run_id
+        tool_image="test-image",
+        tool_version="latest",
+        file_execution_id=file_execution_id,
     )
     assert config["name"] == "test-image"
     assert config["image"] == "test-image:latest"

--- a/runner/src/unstract/runner/main.py
+++ b/runner/src/unstract/runner/main.py
@@ -28,17 +28,19 @@ def run_container() -> Optional[Any]:
     organization_id = data["organization_id"]
     workflow_id = data["workflow_id"]
     execution_id = data["execution_id"]
-    run_id = data["run_id"]
+    file_execution_id = data["file_execution_id"]
+    container_name = data["container_name"]
     settings = data["settings"]
     envs = data["envs"]
     messaging_channel = data["messaging_channel"]
 
     runner = UnstractRunner(image_name, image_tag, app)
     result = runner.run_container(
+        container_name=container_name,
         organization_id=organization_id,
         workflow_id=workflow_id,
         execution_id=execution_id,
-        run_id=run_id,
+        file_execution_id=file_execution_id,
         settings=settings,
         envs=envs,
         messaging_channel=messaging_channel,

--- a/unstract/core/src/unstract/core/utilities.py
+++ b/unstract/core/src/unstract/core/utilities.py
@@ -30,12 +30,16 @@ class UnstractUtils:
 
     @staticmethod
     def build_tool_container_name(
-        tool_image: str, tool_version: str, run_id: str
+        tool_image: str,
+        tool_version: str,
+        file_execution_id: str,
+        retry_count: Optional[int] = None,
     ) -> str:
         tool_name = tool_image.split("/")[-1]
-        # TODO: Add execution attempt to better track instead of uuid
-        short_uuid = uuid.uuid4().hex[:6]  # To avoid duplicate name collision
-        container_name = f"{tool_name}-{tool_version}-{short_uuid}-{run_id}"
+        # To avoid duplicate name collision
+        if not retry_count:
+            retry_count = uuid.uuid4().hex[:6]
+        container_name = f"{tool_name}-{tool_version}-{retry_count}-{file_execution_id}"
 
         # To support limits of container clients like K8s
         if len(container_name) > 63:

--- a/unstract/core/src/unstract/core/utilities.py
+++ b/unstract/core/src/unstract/core/utilities.py
@@ -37,9 +37,14 @@ class UnstractUtils:
     ) -> str:
         tool_name = tool_image.split("/")[-1]
         # To avoid duplicate name collision
-        if not retry_count:
-            retry_count = uuid.uuid4().hex[:6]
-        container_name = f"{tool_name}-{tool_version}-{retry_count}-{file_execution_id}"
+        if retry_count:
+            unique_suffix = retry_count
+        else:
+            unique_suffix = uuid.uuid4().hex[:6]
+
+        container_name = (
+            f"{tool_name}-{tool_version}-{unique_suffix}-{file_execution_id}"
+        )
 
         # To support limits of container clients like K8s
         if len(container_name) > 63:

--- a/unstract/tool-sandbox/pyproject.toml
+++ b/unstract/tool-sandbox/pyproject.toml
@@ -10,7 +10,18 @@ authors = [
     {name = "Zipstack Inc.", email = "devsupport@zipstack.com"},
 ]
 dependencies = [
-    "requests==2.31.0"
+    "requests==2.31.0",
+    # ! IMPORTANT!
+    # Local dependencies usually need to be added as:
+    # https://pdm-project.org/latest/usage/dependency/#local-dependencies
+    #
+    # However, local dependencies which are not direct depedency of main project
+    # appear as absolute paths in pdm.lock of main project, making it impossible
+    # to check in the lock file.
+    #
+    # Hence instead, add the dependencies without version constraints where the
+    # assumption is they are added as direct dependencies in main project itself.
+    "unstract-core",
 ]
 requires-python = ">=3.9"
 readme = "README.md"

--- a/unstract/tool-sandbox/src/unstract/tool_sandbox/tool_sandbox.py
+++ b/unstract/tool-sandbox/src/unstract/tool_sandbox/tool_sandbox.py
@@ -93,10 +93,13 @@ class ToolSandbox:
         )
         return result
 
-    def run_tool(self, run_id: str) -> Optional[dict[str, Any]]:
+    def run_tool(
+        self, file_execution_id: str, retry_count: Optional[int] = None
+    ) -> Optional[dict[str, Any]]:
         return self.helper.call_tool_handler(  # type: ignore
-            run_id,
+            file_execution_id,
             self.image_name,
             self.image_tag,
             self.settings,
+            retry_count,
         )

--- a/unstract/workflow-execution/src/unstract/workflow_execution/tools_utils.py
+++ b/unstract/workflow-execution/src/unstract/workflow_execution/tools_utils.py
@@ -174,21 +174,21 @@ class ToolsUtils:
 
     def run_tool(
         self,
-        run_id: str,
+        file_execution_id: str,
         tool_sandbox: ToolSandbox,
     ) -> Any:
-        return self.run_tool_with_retry(run_id, tool_sandbox)
+        return self.run_tool_with_retry(file_execution_id, tool_sandbox)
 
     def run_tool_with_retry(
         self,
-        run_id: str,
+        file_execution_id: str,
         tool_sandbox: ToolSandbox,
         max_retries: int = ToolExecution.MAXIMUM_RETRY,
     ) -> Any:
         error: Optional[dict[str, Any]] = None
         for retry_count in range(max_retries):
             try:
-                response = tool_sandbox.run_tool(run_id)
+                response = tool_sandbox.run_tool(file_execution_id, retry_count)
                 if response:
                     return response
                 logger.warning(

--- a/unstract/workflow-execution/src/unstract/workflow_execution/workflow_execution.py
+++ b/unstract/workflow-execution/src/unstract/workflow_execution/workflow_execution.py
@@ -24,7 +24,6 @@ from unstract.workflow_execution.execution_file_handler import ExecutionFileHand
 from unstract.workflow_execution.tools_utils import ToolsUtils
 
 from unstract.core.pubsub_helper import LogPublisher
-from unstract.core.utilities import UnstractUtils
 
 logger = logging.getLogger(__name__)
 
@@ -140,14 +139,13 @@ class WorkflowExecutionService:
         logger.info(f"Execution {self.execution_id}: Build completed")
 
     def execute_workflow(
-        self, file_execution_id: str, file_name: str, execution_type: ExecutionType
+        self, file_execution_id: str, execution_type: ExecutionType
     ) -> None:
         """Executes the complete workflow by running each tools one by one.
         Returns the result from final tool in a dictionary.
 
         Args:
             file_execution_id (str): UUID for a single run of a file
-            file_name (str): Name of the file to process
             execution_type (ExecutionType): STEP or COMPLETE
 
         Raises:
@@ -168,16 +166,6 @@ class WorkflowExecutionService:
         # only. While supporting more tools in a workflow, correct the tool container
         # name to avoid conflicts.
         for step, sandbox in enumerate(self.tool_sandboxes):
-            container_name = UnstractUtils.build_tool_container_name(
-                tool_image=sandbox.image_name,
-                tool_version=sandbox.image_tag,
-                run_id=file_execution_id,
-            )
-            logger.info(
-                f"Running execution: '{self.execution_id}',  "
-                f"tool: '{sandbox.image_name}:{sandbox.image_tag}', "
-                f"file '{file_name}', container: '{container_name}'"
-            )
             self._execute_step(
                 step=step,
                 sandbox=sandbox,
@@ -224,7 +212,7 @@ class WorkflowExecutionService:
                 component=tool_instance_id,
             )
             result = self.tool_utils.run_tool(
-                run_id=self.file_execution_id, tool_sandbox=sandbox
+                file_execution_id=self.file_execution_id, tool_sandbox=sandbox
             )
             if result and result.get("error"):
                 raise ToolOutputNotFoundException(result.get("error"))


### PR DESCRIPTION
## What

- Passed container name from `backend` to `runner`
- MINOR: Renamed `run_id` to `file_execution_id` in parts concerning WF execution

## Why

- Previously container name was logged in the `backend` and a different one was generated and used by the `runner` which resulted in confusion during debugging and tracing
- Ensuring a single container name is logged for a run and using the same throughout

## How

- Passed via the HTTP call to the `runner`

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, changes made with defaults - tests and and all associated code is updated

## Dependencies Versions

- Added `unstract-core` to `unstract-tool-sandbox`

## Notes on Testing

- Tested a WF run locally and it works against docker

## Screenshots
![image](https://github.com/user-attachments/assets/0ed25e88-a12f-4372-8ec1-dc46629c687c)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
