### PR TITLE
fix: Added log expiry env to runner and prompt-service,

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -131,7 +131,7 @@ LOG_HISTORY_CONSUMER_INTERVAL = int(
 )
 LOGS_BATCH_LIMIT = int(get_required_setting("LOGS_BATCH_LIMIT", "30"))
 LOGS_EXPIRATION_TIME_IN_SECOND = int(
-    get_required_setting("LOGS_EXPIRATION_TIME_IN_SECOND")
+    get_required_setting("LOGS_EXPIRATION_TIME_IN_SECOND", 86400)
 )
 CELERY_BROKER_URL = get_required_setting(
     "CELERY_BROKER_URL", f"redis://{REDIS_HOST}:{REDIS_PORT}"

--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -131,7 +131,7 @@ LOG_HISTORY_CONSUMER_INTERVAL = int(
 )
 LOGS_BATCH_LIMIT = int(get_required_setting("LOGS_BATCH_LIMIT", "30"))
 LOGS_EXPIRATION_TIME_IN_SECOND = int(
-    get_required_setting("LOGS_EXPIRATION_TIME_IN_SECOND", 86400)
+    get_required_setting("LOGS_EXPIRATION_TIME_IN_SECOND", "86400")
 )
 CELERY_BROKER_URL = get_required_setting(
     "CELERY_BROKER_URL", f"redis://{REDIS_HOST}:{REDIS_PORT}"

--- a/prompt-service/sample.env
+++ b/prompt-service/sample.env
@@ -22,6 +22,9 @@ LOG_LEVEL=INFO
 #Celery for PublishLogs
 CELERY_BROKER_URL="redis://unstract-redis:6379"
 
+# Logs Expiry of 24 hours
+LOGS_EXPIRATION_TIME_IN_SECOND=86400
+
 # Feature Flags
 EVALUATION_SERVER_IP=unstract-flipt
 EVALUATION_SERVER_PORT=9000

--- a/runner/sample.env
+++ b/runner/sample.env
@@ -17,6 +17,8 @@ REMOVE_CONTAINER_ON_EXIT=True
 # Client module path of the container engine to be used.
 CONTAINER_CLIENT_PATH=unstract.runner.clients.docker
 
+# Logs Expiry of 24 hours
+LOGS_EXPIRATION_TIME_IN_SECOND=86400
 
 # Feature Flags
 FLIPT_SERVICE_AVAILABLE=False

--- a/unstract/core/src/unstract/core/pubsub_helper.py
+++ b/unstract/core/src/unstract/core/pubsub_helper.py
@@ -150,17 +150,12 @@ class LogPublisher:
             log_data = json.dumps(payload)
             # Check if the payload type is "LOG"
             if payload["type"] == "LOG":
-                logs_expiration = os.environ.get("LOGS_EXPIRATION_TIME_IN_SECOND")
-
-                # Extract timestamp from payload
+                logs_expiration = os.environ.get(
+                    "LOGS_EXPIRATION_TIME_IN_SECOND", 86400
+                )  # Defaults to 1 day
                 timestamp = payload["timestamp"]
-
-                # Construct Redis key using channel and timestamp
                 redis_key = f"{channel}:{timestamp}"
-
-                # Store logs in Redis with expiration of 1 hour
                 cls.r.setex(redis_key, logs_expiration, log_data)
-
         except Exception as e:
             logging.error(f"Failed to publish '{channel_id}' <= {payload}: {e}")
             return False


### PR DESCRIPTION
## What
 
- Added log expiry env (defaults to 1 day) to runner and prompt-service

## Why

- Env used but not defined, had no default also


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, env added with default

## Env Config
```
# Logs Expiry of 24 hours
LOGS_EXPIRATION_TIME_IN_SECOND=86400
```

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/1089


## Notes on Testing

- No explicit testing done

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
