### PR TITLE
fix: Notification logs are passed to BE with a float timestamp

### DIFF
--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -1,3 +1,7 @@
+from dotenv import load_dotenv
+
 from .celery_service import app as celery_app
+
+load_dotenv()
 
 __all__ = ["celery_app"]

--- a/backend/backend/wsgi.py
+++ b/backend/backend/wsgi.py
@@ -12,10 +12,7 @@ import time
 
 from django.conf import settings
 from django.core.wsgi import get_wsgi_application
-from dotenv import load_dotenv
 from utils.log_events import start_server
-
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/backend/logs_helper/views.py
+++ b/backend/logs_helper/views.py
@@ -38,7 +38,7 @@ class LogsHelperViewSet(viewsets.ModelViewSet):
             logs.append(log_data)
 
         # Sort logs based on timestamp
-        sorted_logs = sorted(logs, key=lambda x: x["timestamp"])
+        sorted_logs = sorted(logs, key=lambda x: float(x["timestamp"]))
 
         return Response({"data": sorted_logs}, status=status.HTTP_200_OK)
 

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -129,8 +129,9 @@ LOGS_EXPIRATION_TIME_IN_SECOND=86400
 
 # Celery Configuration
 # Used by celery and to connect to queue to push logs
-CELERY_BROKER_URL = "redis://unstract-redis:6379"
-CELERY_BROKER_VISIBILITY_TIMEOUT = "86400"  # 1 day
+CELERY_BROKER_URL="redis://unstract-redis:6379"
+# Redis broker visibility set to 1 day
+CELERY_BROKER_VISIBILITY_TIMEOUT=86400
 
 # Indexing flag to prevent re-index
 INDEXING_FLAG_TTL=1800

--- a/frontend/src/store/socket-logs-store.js
+++ b/frontend/src/store/socket-logs-store.js
@@ -2,7 +2,6 @@ import { create } from "zustand";
 
 import { useSessionStore } from "./session-store";
 import axios from "axios";
-import { getDateTimeString } from "../helpers/GetStaticData";
 
 const STORE_VARIABLES = {
   logs: [],
@@ -16,7 +15,7 @@ const useSocketLogsStore = create((setState, getState) => ({
     let logsData = [...(existingState?.logs || [])];
 
     const newLogs = messages.map((msg, index) => ({
-      timestamp: getDateTimeString(msg?.timestamp),
+      timestamp: msg?.timestamp,
       key: logsData?.length + index + 1,
       level: msg?.level,
       stage: msg?.stage,


### PR DESCRIPTION
## What

- Avoided storing notification logs with string timestamp
- MINOR: Loaded env from `backend/__init__.py`

## Why

![image](https://github.com/user-attachments/assets/35b2504d-630a-45cd-bd4e-a5557255a1a6)


## How

- The function which was removed performed this string conversion instead of passing as a float

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No


## Related Issues or PRs

- #1089 

## Notes on Testing

- Tested it locally and checked the redis instance

## Screenshots
![image](https://github.com/user-attachments/assets/4d407616-fb48-460b-a8e5-3506ae0e515c)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
