### PR TITLE
feat: Dropbox note updated and minor exception handling changes

### DIFF
--- a/unstract/connectors/src/unstract/connectors/filesystems/zs_dropbox/exceptions.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/zs_dropbox/exceptions.py
@@ -1,3 +1,5 @@
+import logging
+
 from dropbox.auth import AuthError
 from dropbox.exceptions import ApiError
 from dropbox.exceptions import AuthError as ExcAuthError
@@ -5,9 +7,11 @@ from dropbox.exceptions import DropboxException
 
 from unstract.connectors.exceptions import ConnectorError
 
+logger = logging.getLogger(__name__)
+
 
 def handle_dropbox_exception(e: DropboxException) -> ConnectorError:
-    user_msg = "Error from Dropbox while testing connection: "
+    user_msg = ""
     if isinstance(e, ExcAuthError):
         if isinstance(e.error, AuthError):
             if e.error.is_expired_access_token():
@@ -22,7 +26,12 @@ def handle_dropbox_exception(e: DropboxException) -> ConnectorError:
                 )
             else:
                 user_msg += e.error._tag
-    elif isinstance(e, ApiError):
-        if e.user_message_text is not None:
-            user_msg += e.user_message_text
+    elif isinstance(e, ApiError) and e.user_message_text is not None:
+        user_msg += e.user_message_text
+
+    if not user_msg:
+        logger.warning(f"Unhandled dropbox exception: {e}")
+        user_msg = str(e)
+
+    user_msg = "Error from Dropbox while testing connection\n```\n" + user_msg + "\n```"
     return ConnectorError(message=user_msg, treat_as_user_message=True)

--- a/unstract/connectors/src/unstract/connectors/filesystems/zs_dropbox/static/json_schema.json
+++ b/unstract/connectors/src/unstract/connectors/filesystems/zs_dropbox/static/json_schema.json
@@ -1,6 +1,6 @@
 {
     "title": "Dropbox",
-    "description": "A connector that allows for fetching data from your Dropbox storage. Please note that this connector is in aplha and is limited by the access token's expiry.",
+    "description": "Helps connect to Dropbox. Please note that this connector is in `alpha` status and is limited by the access token's expiry (short-lived tokens of ~4 hour expiry). OAuth support is yet to be added to make this production-ready.",
     "type": "object",
     "required": [
       "connectorName",


### PR DESCRIPTION
## What

- Updated note for dropbox connector
- Minor exception handling changes to log the message

## Why

- In some cases error is not logged or correctly displayed
- Fixed a typo in the connector's description - made it more explicit


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Notes on Testing

- Tested changes locally by using an expired token

## Screenshots
![image](https://github.com/user-attachments/assets/40bfd039-d8e0-40f4-bfc5-9aadbf27dd5d)

![image](https://github.com/user-attachments/assets/c90de081-7e9f-4657-9332-b3c934862386)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
