### PR TITLE
fix: Custom markdown component regex fixed for code blocks

### DIFF
--- a/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
+++ b/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
@@ -21,7 +21,7 @@ const CustomMarkdown = ({
     - New line: \n
   */
   const patterns = [
-    { type: "tripleCode", regex: /```([^`]{1,1000})```/g },
+    { type: "tripleCode", regex: /```\n([\s\S]*?)\n```/g },
     { type: "inlineCode", regex: /`([^`]{1,100})`/g },
     { type: "bold", regex: /\*\*([^*]{1,100})\*\*/g },
     { type: "link", regex: /\[([^\]]{1,100})\]\(([^)]{1,200})\)/g },


### PR DESCRIPTION
## What

- Updated FE regex to identify code blocks

## Why

- Helps render error messages without an additional new line char

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No


## Notes on Testing

- Tested locally with a markdown based error sent from the BE

## Screenshots
- Before fix
![image](https://github.com/user-attachments/assets/23aa1cf9-b1d4-40a1-9c46-a05e7fbf0e3f)

- After fix
![image](https://github.com/user-attachments/assets/a29d1640-8b00-4eb9-9a9a-5878e4b7bfdb)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
