### PR TITLE
[FIX] Fixed challenge_llm getting acccessed before init

### DIFF
--- a/prompt-service/src/unstract/prompt_service/main.py
+++ b/prompt-service/src/unstract/prompt_service/main.py
@@ -102,6 +102,7 @@ def prompt_processor() -> Any:
         raise NoPayloadError
     tool_settings = payload.get(PSKeys.TOOL_SETTINGS, {})
     enable_challenge = tool_settings.get(PSKeys.ENABLE_CHALLENGE, False)
+    challenge_llm = None
     # TODO: Rename "outputs" to "prompts" in payload
     prompts = payload.get(PSKeys.OUTPUTS, [])
     tool_id: str = payload.get(PSKeys.TOOL_ID, "")
@@ -655,7 +656,7 @@ def prompt_processor() -> Any:
         finally:
             challenge_metrics = (
                 {f"{challenge_llm.get_usage_reason()}_llm": challenge_llm.get_metrics()}
-                if enable_challenge
+                if enable_challenge and challenge_llm
                 else {}
             )
             metrics.setdefault(prompt_name, {}).update(


### PR DESCRIPTION
## What

- Initialized `challenge_llm` as None in the beginning.
- Added check to access challlenge_llm only if it is not None

## Why

- challenge_llm variable gets accessed in finally block. In case of unexpected errors, the variable won't be initialized. So, we have an unhandled error where variable gets accessed before assignment.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
