### PR TITLE
fix: Added traceback for log publisher related errors

### DIFF
--- a/unstract/core/src/unstract/core/pubsub_helper.py
+++ b/unstract/core/src/unstract/core/pubsub_helper.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 import traceback
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -127,11 +128,9 @@ class LogPublisher:
     @classmethod
     def publish(cls, channel_id: str, payload: dict[str, Any]) -> bool:
         """Publish a message to the queue."""
-        channel = f"logs:{channel_id}"
         try:
-
+            event = f"logs:{channel_id}"
             with cls.kombu_conn.Producer(serializer="json") as producer:
-                event = f"logs:{channel_id}"
                 task_message = cls._get_task_message(
                     user_session_id=channel_id,
                     event=event,
@@ -148,15 +147,10 @@ class LogPublisher:
                     retry=True,
                 )
                 logging.debug(f"Published '{channel_id}' <= {payload}")
-            log_data = json.dumps(payload)
-            # Check if the payload type is "LOG"
-            if payload["type"] == "LOG":
-                logs_expiration = os.environ.get(
-                    "LOGS_EXPIRATION_TIME_IN_SECOND", 86400
-                )  # Defaults to 1 day
-                timestamp = payload["timestamp"]
-                redis_key = f"{channel}:{timestamp}"
-                cls.r.setex(redis_key, logs_expiration, log_data)
+
+                # Persisting messages for unified notification
+                if payload["type"] == "LOG":
+                    cls.store_for_unified_notification(event, payload)
         except Exception as e:
             logging.error(
                 f"Failed to publish '{channel_id}' <= {payload}"
@@ -164,3 +158,30 @@ class LogPublisher:
             )
             return False
         return True
+
+    @classmethod
+    def store_for_unified_notification(
+        cls, event: str, payload: dict[str, Any]
+    ) -> None:
+        """Helps persist messages for unified notification.
+
+        Message is stored in redis with a configurable TTL.
+        Will be used to display such messages in the UI.
+
+        Args:
+            event (str): User session ID
+            payload (dict[str, Any]): Message being sent
+        """
+        try:
+            logs_expiration = os.environ.get(
+                "LOGS_EXPIRATION_TIME_IN_SECOND", "86400"
+            )  # Defaults to 1 day
+            timestamp = payload.get("timestamp", round(time.time(), 6))
+            redis_key = f"{event}:{timestamp}"
+            log_data = json.dumps(payload)
+            cls.r.setex(redis_key, logs_expiration, log_data)
+        except Exception as e:
+            logging.error(
+                f"Failed to store unified notification log for '{event}' "
+                f"<= {payload}: {e}\n{traceback.format_exc()}"
+            )

--- a/unstract/core/src/unstract/core/pubsub_helper.py
+++ b/unstract/core/src/unstract/core/pubsub_helper.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import traceback
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -125,8 +126,8 @@ class LogPublisher:
 
     @classmethod
     def publish(cls, channel_id: str, payload: dict[str, Any]) -> bool:
-        channel = f"logs:{channel_id}"
         """Publish a message to the queue."""
+        channel = f"logs:{channel_id}"
         try:
 
             with cls.kombu_conn.Producer(serializer="json") as producer:
@@ -157,6 +158,9 @@ class LogPublisher:
                 redis_key = f"{channel}:{timestamp}"
                 cls.r.setex(redis_key, logs_expiration, log_data)
         except Exception as e:
-            logging.error(f"Failed to publish '{channel_id}' <= {payload}: {e}")
+            logging.error(
+                f"Failed to publish '{channel_id}' <= {payload}"
+                f": {e}\n{traceback.format_exc()}"
+            )
             return False
         return True

--- a/unstract/core/src/unstract/core/pubsub_helper.py
+++ b/unstract/core/src/unstract/core/pubsub_helper.py
@@ -149,7 +149,7 @@ class LogPublisher:
                 logging.debug(f"Published '{channel_id}' <= {payload}")
 
                 # Persisting messages for unified notification
-                if payload["type"] == "LOG":
+                if payload.get("type") == "LOG":
                     cls.store_for_unified_notification(event, payload)
         except Exception as e:
             logging.error(


### PR DESCRIPTION

## What

- Print traceback on log publisher errors

## Why

- No visibility on where the error stems from

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor logging change


## Notes on Testing

- No explicit testing done for this minor change

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
