### PR TITLE
Changed parameter declaration in add_file_to_volume function 

### DIFF
--- a/backend/workflow_manager/endpoint_v2/source.py
+++ b/backend/workflow_manager/endpoint_v2/source.py
@@ -627,7 +627,7 @@ class SourceConnector(BaseConnector):
         self,
         input_file_path: str,
         workflow_file_execution: WorkflowFileExecution,
-        tags=list[str],
+        tags: list[str] = [],
     ) -> str:
         """Add input file to execution directory.
 


### PR DESCRIPTION
## What

- Fixed incorrect parameter declaration `tags=list[str]` in `add_file_to_volume` method

## Why

- The original syntax `tags=list[str]` is incorrect - it attempts to use the type annotation as a default value
- This could cause runtime errors as Python would try to evaluate `list[str]` as a value
- The new syntax properly separates the type hint (`: list[str]`) from the default value (`= []`)

## How

- Changed to proper type hint syntax with default value: `tags: list[str] = []`

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No functional changes, only parameter declaration improvement

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
