### PR TITLE
Allow only same origin for websocket connection

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -430,7 +430,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
-            "rest_framework.renderers.JSONRenderer",
+        "rest_framework.renderers.JSONRenderer",
     ],
     "DEFAULT_PERMISSION_CLASSES": [],  # TODO: Update once auth is figured
     "TEST_REQUEST_DEFAULT_FORMAT": "json",

--- a/backend/utils/log_events.py
+++ b/backend/utils/log_events.py
@@ -21,7 +21,8 @@ sio = socketio.Server(
     async_mode="threading",
     # Make sure only the web app origin and other explicitly added CORS_ALLOWED_ORIGINS are allowed to create socket connection
     # TODO: this is a temporary fix we should refactor `CORS_ALLOWED_ORIGINS` in to base to include settings.WEB_APP_ORIGIN_URL alone.
-    cors_allowed_origins=(settings.CORS_ALLOWED_ORIGINS or []) + [settings.WEB_APP_ORIGIN_URL], 
+    cors_allowed_origins=(settings.CORS_ALLOWED_ORIGINS or [])
+    + [settings.WEB_APP_ORIGIN_URL],
     logger=False,
     engineio_logger=False,
     always_connect=True,

--- a/backend/utils/log_events.py
+++ b/backend/utils/log_events.py
@@ -23,8 +23,9 @@ sio = socketio.Server(
     # CORS_ALLOWED_ORIGINS are allowed to create socket connection
     # TODO: this is a temporary fix we should refactor `CORS_ALLOWED_ORIGINS`
     # in to base to include settings.WEB_APP_ORIGIN_URL alone.
-    cors_allowed_origins=(settings.CORS_ALLOWED_ORIGINS or [])
-    + [settings.WEB_APP_ORIGIN_URL],
+    cors_allowed_origins=(
+        (settings.CORS_ALLOWED_ORIGINS or []) + [settings.WEB_APP_ORIGIN_URL]
+    ),
     logger=False,
     engineio_logger=False,
     always_connect=True,

--- a/backend/utils/log_events.py
+++ b/backend/utils/log_events.py
@@ -19,10 +19,13 @@ logger = logging.getLogger(__name__)
 sio = socketio.Server(
     # Allowed values: {threading, eventlet, gevent, gevent_uwsgi}
     async_mode="threading",
-    # Make sure only the web app origin and other explicitly added CORS_ALLOWED_ORIGINS are allowed to create socket connection
-    # TODO: this is a temporary fix we should refactor `CORS_ALLOWED_ORIGINS` in to base to include settings.WEB_APP_ORIGIN_URL alone.
-    cors_allowed_origins=(settings.CORS_ALLOWED_ORIGINS or [])
-    + [settings.WEB_APP_ORIGIN_URL],
+    # Make sure only the web app origin and other explicitly added 
+    # CORS_ALLOWED_ORIGINS are allowed to create socket connection
+    # TODO: this is a temporary fix we should refactor `CORS_ALLOWED_ORIGINS` 
+    # in to base to include settings.WEB_APP_ORIGIN_URL alone.
+    cors_allowed_origins=(
+        settings.CORS_ALLOWED_ORIGINS or []
+    ) + [settings.WEB_APP_ORIGIN_URL],
     logger=False,
     engineio_logger=False,
     always_connect=True,

--- a/backend/utils/log_events.py
+++ b/backend/utils/log_events.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 sio = socketio.Server(
     # Allowed values: {threading, eventlet, gevent, gevent_uwsgi}
     async_mode="threading",
-    cors_allowed_origins=settings.CORS_ALLOWED_ORIGINS,
+    # Make sure only the web app origin and other explicitly added CORS_ALLOWED_ORIGINS are allowed to create socket connection
+    # TODO: this is a temporary fix we should refactor `CORS_ALLOWED_ORIGINS` in to base to include settings.WEB_APP_ORIGIN_URL alone.
+    cors_allowed_origins=(settings.CORS_ALLOWED_ORIGINS or []) + [settings.WEB_APP_ORIGIN_URL], 
     logger=False,
     engineio_logger=False,
     always_connect=True,

--- a/backend/utils/log_events.py
+++ b/backend/utils/log_events.py
@@ -19,13 +19,12 @@ logger = logging.getLogger(__name__)
 sio = socketio.Server(
     # Allowed values: {threading, eventlet, gevent, gevent_uwsgi}
     async_mode="threading",
-    # Make sure only the web app origin and other explicitly added 
+    # Make sure only the web app origin and other explicitly added
     # CORS_ALLOWED_ORIGINS are allowed to create socket connection
-    # TODO: this is a temporary fix we should refactor `CORS_ALLOWED_ORIGINS` 
+    # TODO: this is a temporary fix we should refactor `CORS_ALLOWED_ORIGINS`
     # in to base to include settings.WEB_APP_ORIGIN_URL alone.
-    cors_allowed_origins=(
-        settings.CORS_ALLOWED_ORIGINS or []
-    ) + [settings.WEB_APP_ORIGIN_URL],
+    cors_allowed_origins=(settings.CORS_ALLOWED_ORIGINS or [])
+    + [settings.WEB_APP_ORIGIN_URL],
     logger=False,
     engineio_logger=False,
     always_connect=True,


### PR DESCRIPTION
## What

- Allow only same origin for websocket connection

## How

- By adding URL of unstract in to the cors_allowed. 

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Ideally it shouldn't since the change is only specifically for socket. (Even though we need to consider changing this globally)

## Notes on Testing

- Havent tested it explicitly. But the logic is verified with some standalone examples.
<img width="317" alt="image" src="https://github.com/user-attachments/assets/3a519b5b-f0a1-4165-a3eb-8ff153c5e880" />


## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
