### PR TITLE
feat: Pass request id to runner

### DIFF
--- a/runner/pdm.lock
+++ b/runner/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "deploy", "dev", "test"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:363e1d439e707e00e3098fdce8679a0a94f4bd73e43fb449ce5953eb0322c593"
+content_hash = "sha256:ee8fd8ae3a54863e4b497793c14e2118d2dcde95cb7acf820df719db35df552f"
 
 [[package]]
 name = "amqp"
@@ -1032,7 +1032,7 @@ summary = "Core library that helps with executing workflows."
 groups = ["default", "dev"]
 dependencies = [
     "-e file:///${PROJECT_ROOT}/../unstract/core#egg=unstract-core",
-    "flask>=3.1.0",
+    "flask~=3.1.0",
 ]
 
 [[package]]

--- a/unstract/core/pdm.lock
+++ b/unstract/core/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "flask"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.2"
-content_hash = "sha256:d658c372f9057ef6ef0f011d86dd5229c44b138b8db1c06713f661af17ece855"
+content_hash = "sha256:e80a4c09d25b2b6e60298904c5d16ca6e2a210c96d2adb45ab7e70b8040df4d3"
 
 [[package]]
 name = "amqp"

--- a/unstract/tool-sandbox/src/unstract/tool_sandbox/helper.py
+++ b/unstract/tool-sandbox/src/unstract/tool_sandbox/helper.py
@@ -89,11 +89,14 @@ class ToolSandboxHelper:
             Optional[dict[str, Any]]: tool response
         """
         url = f"{self.base_url}{UnstractRunner.RUN_API_ENDPOINT}"
+        headers = {
+            "X-Request-ID": file_execution_id,
+        }
         data = self.create_tool_request_data(
             file_execution_id, image_name, image_tag, settings, retry_count
         )
 
-        response = requests.post(url, json=data)
+        response = requests.post(url, headers=headers, json=data)
         result: Optional[dict[str, Any]] = None
         if response.status_code == 200:
             result = response.json()


### PR DESCRIPTION
## What

- Pass request ID to `runner`
- Set it as `file_execution_id` (created for each tool / file run) to map each runner / tool being called

## Why

- Helps with tracing

## How

- Added to header - on top of other PRs

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor request header addition


## Related Issues or PRs

- #1209

## Notes on Testing

- Tested locally for a run

## Screenshots
1. From backend
![image](https://github.com/user-attachments/assets/8efbbaef-5872-480a-9ef8-c0ed01755bf2)
1. From runner 
![image](https://github.com/user-attachments/assets/4a76cb45-55e3-4885-9cff-b394841e103e)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
