### PR TITLE
Update source.py by increasing file read chunk size

### DIFF
--- a/backend/workflow_manager/endpoint_v2/source.py
+++ b/backend/workflow_manager/endpoint_v2/source.py
@@ -460,14 +460,14 @@ class SourceConnector(BaseConnector):
             raise ValueError(f"Unsupported hash_method: {hash_method}")
 
     def get_file_content(
-        self, input_file_path: str, chunk_size: int = 8192
+        self, input_file_path: str, chunk_size: int = 131072
     ) -> tuple[bytes, Optional[int]]:
         """Read the content of a file from a remote filesystem in chunks.
 
         Args:
             input_file_path (str): The path of the input file.
             chunk_size (int): The size of the chunks to read at a time
-            (default is 8192 bytes).
+            (default is 131072 bytes = 128 KB).
 
         Returns:
             tuple[bytes, int]:

--- a/backend/workflow_manager/endpoint_v2/source.py
+++ b/backend/workflow_manager/endpoint_v2/source.py
@@ -460,14 +460,14 @@ class SourceConnector(BaseConnector):
             raise ValueError(f"Unsupported hash_method: {hash_method}")
 
     def get_file_content(
-        self, input_file_path: str, chunk_size: int = 131072
+        self, input_file_path: str, chunk_size: int = 4194304
     ) -> tuple[bytes, Optional[int]]:
         """Read the content of a file from a remote filesystem in chunks.
 
         Args:
             input_file_path (str): The path of the input file.
             chunk_size (int): The size of the chunks to read at a time
-            (default is 131072 bytes = 128 KB).
+            (default is 4194304 bytes = 4 MB).
 
         Returns:
             tuple[bytes, int]:


### PR DESCRIPTION
## What

- Update source.py by increasing file read chunk size to 4 MB (from 8 KB).

## Why

- Improves file reading performance by reducing the number of read operations.
- Helps when handling large files without excessive memory consumption.

## How

- Updated get_file_content function to use chunk_size = 4194304 (4 MB).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
