### PR TITLE
fix: Set chunk size for remote storage file transfer to 4MB

### DIFF
--- a/backend/workflow_manager/endpoint_v2/source.py
+++ b/backend/workflow_manager/endpoint_v2/source.py
@@ -574,7 +574,7 @@ class SourceConnector(BaseConnector):
         destination_storage: Any,
         source_path: str,
         destination_paths: list[str],
-        chunk_size: int = 4096,
+        chunk_size: int = 4194304,
     ) -> None:
         """
         Copy a file from a source storage to one or more paths in a
@@ -593,7 +593,7 @@ class SourceConnector(BaseConnector):
             destination_paths (list[str]): A list of paths where the file will be
                 copied in the destination storage.
             chunk_size (int, optional): The number of bytes to read per chunk.
-                Default is 4096 bytes.
+                (default is 4194304 bytes = 4 MB).
         """
         seek_position = 0  # Start from the beginning
         end_of_file = False


### PR DESCRIPTION
## What

-  Update chunk size default value

## Why

- To observe speedup for remote storage file uploads

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, only default value changed

## Related Issues or PRs

- #1214 

## Notes on Testing

- No explicit testing, checked a workflow run though

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
