### PR TITLE
feat: Added execution time to execution logs table

### DIFF
--- a/frontend/src/components/logging/execution-logs/ExecutionLogs.jsx
+++ b/frontend/src/components/logging/execution-logs/ExecutionLogs.jsx
@@ -121,6 +121,7 @@ function ExecutionLogs() {
             status: item?.status,
             successfulFiles: item?.successful_files,
             failedFiles: item?.failed_files,
+            execution_time: item?.execution_time,
           };
 
           // If status is no longer executing, remove from polling
@@ -200,6 +201,7 @@ function ExecutionLogs() {
           failedFiles: item?.failed_files,
           totalFiles: item?.total_files,
           status: item?.status,
+          execution_time: item?.execution_time,
         };
       });
       setDataList(formattedData);

--- a/frontend/src/components/logging/logs-table/LogsTable.jsx
+++ b/frontend/src/components/logging/logs-table/LogsTable.jsx
@@ -103,6 +103,12 @@ const LogsTable = ({
       key: "filesProcessed",
       render: (text, record) => `${record?.processed}/${record?.totalFiles}`,
     },
+    {
+      title: "Execution Time",
+      dataIndex: "executionTime",
+      key: "executionTime",
+      render: (_, record) => record?.execution_time || "-",
+    },
   ];
 
   const handleTableChange = (pagination, filters, sorter) => {


### PR DESCRIPTION
## What

- Added execution time to the logs table

## Why

- Data was anyway being returned, added for more insights about an execution in first glance


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No


## Related Issues or PRs

- 

## Dependencies Versions

-## Notes on Testing

- Tested locally

## Screenshots
![image](https://github.com/user-attachments/assets/57e1944c-983f-4246-b569-4f87aabda9b2)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
