### PR TITLE
[FIX] Prompt Studio V2 stabilization fixes

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -377,6 +377,13 @@ class PromptStudioHelper:
             fs=fs_instance,
             tool=util,
         )
+        if DocumentIndexingService.is_document_indexing(
+            org_id=org_id, user_id=user_id, doc_id_key=doc_id
+        ):
+            return {
+                "status": IndexingStatus.PENDING_STATUS.value,
+                "output": IndexingStatus.DOCUMENT_BEING_INDEXED.value,
+            }
         extracted_text = PromptStudioHelper.dynamic_extractor(
             profile_manager=default_profile,
             file_path=file_path,
@@ -827,6 +834,13 @@ class PromptStudioHelper:
             fs=fs_instance,
             tool=util,
         )
+        if DocumentIndexingService.is_document_indexing(
+            org_id=org_id, user_id=user_id, doc_id_key=doc_id
+        ):
+            return {
+                "status": IndexingStatus.PENDING_STATUS.value,
+                "output": IndexingStatus.DOCUMENT_BEING_INDEXED.value,
+            }
         logger.info(f"Extracting text from {file_path} for {doc_id}")
         extracted_text = PromptStudioHelper.dynamic_extractor(
             profile_manager=profile_manager,

--- a/tools/structure/src/main.py
+++ b/tools/structure/src/main.py
@@ -179,7 +179,11 @@ class StructureTool(BaseTool):
                         payload[SettingsKeys.OUTPUTS] = outputs
                         payload[SettingsKeys.FILE_HASH] = summarize_file_hash
                         break
-                    if reindex or not summarize_as_source:
+                    if (
+                        reindex
+                        or not summarize_as_source
+                        and not output[SettingsKeys.CHUNK_SIZE] == 0
+                    ):
                         self.stream_log("Sucessfully extracted text, indexing..")
                         STHelper.dynamic_indexing(
                             tool_settings=tool_settings,


### PR DESCRIPTION
## What
PR for prompt service V2 stabilization
1. Preventing call of extraction if cached 
2. SKipping VDB in tools
...

## Why

...

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
