### PR TITLE
[DEP] Bump structure tool version to 0.0.72

### DIFF
--- a/backend/sample.env
+++ b/backend/sample.env
@@ -75,9 +75,9 @@ PROMPT_STUDIO_FILE_PATH=/app/prompt-studio-data
 
 # Structure Tool Image (Runs prompt studio exported tools)
 # https://hub.docker.com/r/unstract/tool-structure
-STRUCTURE_TOOL_IMAGE_URL="docker:unstract/tool-structure:0.0.71"
+STRUCTURE_TOOL_IMAGE_URL="docker:unstract/tool-structure:0.0.72"
 STRUCTURE_TOOL_IMAGE_NAME="unstract/tool-structure"
-STRUCTURE_TOOL_IMAGE_TAG="0.0.71"
+STRUCTURE_TOOL_IMAGE_TAG="0.0.72"
 
 # Feature Flags
 EVALUATION_SERVER_IP=unstract-flipt

--- a/tools/structure/src/config/properties.json
+++ b/tools/structure/src/config/properties.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.0.1",
   "displayName": "Structure Tool",
   "functionName": "structure_tool",
-  "toolVersion": "0.0.71",
+  "toolVersion": "0.0.72",
   "description": "This is a template tool which can answer set of input prompts designed in the Prompt Studio",
   "input": {
     "description": "File that needs to be indexed and parsed for answers"


### PR DESCRIPTION
## What
PR to bump tool version 0.0.72
...

## Why
To support the stabilization fixes.
...

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
Yes, the v2 changes are breaking changes.
-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs
https://github.com/Zipstack/unstract-cloud/pull/684
https://github.com/Zipstack/unstract/pull/1237
...

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
