### PR TITLE
update status codes

### DIFF
--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -457,7 +457,7 @@ class WorkflowHelper:
         Returns:
             ExecutionResponse: _description_
         """
-        execution = WorkflowExecution.objects.get(id=execution_id)
+        execution: WorkflowExecution = WorkflowExecution.objects.get(id=execution_id)
         if not execution.task_id:
             raise TaskDoesNotExistError(
                 f"No task ID found for execution: {execution_id}"


### PR DESCRIPTION
## What

- Updated HTTP response handling for workflow execution status checks.
- `EXECUTING` and `PENDING` now return `202 Accepted` instead of `422`, indicating that the task is still in progress.
- `COMPLETED` continues to return `200 OK` as expected (No Changes).
- `ERROR` and `STOPPED` now return `422 Unprocessable Entity` to indicate abnormal or interrupted terminations.
- `406 Not Acceptable` returned when the result has already been acknowledged (No Changes).
- Cleaned up status handling logic using an if-else structure for clarity and maintainability.

### TODO: Updated API documentation to reflect new status mappings.

## Why

- Returning **422** for valid in-progress states like `EXECUTING` or `PENDING` was incorrect and misleading.

## How

- Mapped statuses explicitly to HTTP response codes:
  - `EXECUTING`, `PENDING` → 202 Accepted
  - `COMPLETED` → 200 OK
  - `ERROR`, `STOPPED` → 422 Unprocessable Entity
  - `Result already acknowledged` → 406 Not Acceptable

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
