### PR TITLE
package installation issue fixed on individual plugins

### DIFF
--- a/docker/dockerfiles/prompt.Dockerfile
+++ b/docker/dockerfiles/prompt.Dockerfile
@@ -53,18 +53,17 @@ USER ${APP_USER}
 
 # Install dependencies in a single layer
 RUN uv sync --frozen && \
-    uv sync && \
     . .venv/bin/activate && \
+    uv sync --group deploy && \
+    # Install plugins in development mode from root directory
     for dir in "${TARGET_PLUGINS_PATH}"/*/; do \
     dirpath=${dir%*/}; \
-    if [ "${dirpath##*/}" != "*" ]; then \
-    cd "$dirpath" && \
-    echo "Installing plugin: ${dirpath##*/}..." && \
-    uv sync && \
-    cd -; \
+    dirname=${dirpath##*/}; \
+    if [ "${dirname}" != "*" ]; then \
+    echo "Installing plugin: ${dirname}..." && \
+    uv pip install -e "${TARGET_PLUGINS_PATH}/${dirname}"; \
     fi; \
     done && \
-    uv sync --group deploy && \
     .venv/bin/python3 -m ensurepip --upgrade && \
     uv run opentelemetry-bootstrap -a install && \
     mkdir -p prompt-studio-data

--- a/docker/dockerfiles/prompt.Dockerfile
+++ b/docker/dockerfiles/prompt.Dockerfile
@@ -61,7 +61,7 @@ RUN uv sync --frozen && \
     dirname=${dirpath##*/}; \
     if [ "${dirname}" != "*" ]; then \
     echo "Installing plugin: ${dirname}..." && \
-    uv pip install -e "${TARGET_PLUGINS_PATH}/${dirname}"; \
+    uv pip install "${TARGET_PLUGINS_PATH}/${dirname}"; \
     fi; \
     done && \
     .venv/bin/python3 -m ensurepip --upgrade && \


### PR DESCRIPTION
## What

- not found issue when importing prompt service plugin

## Why

- uv sync installs the package in each subfolder/ plugin itself. not in root. so replaced `uv sync` with `uv pip install -e "${TARGET_PLUGINS_PATH}/${dirname}"; to install it in root

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
