### PR TITLE
[FIX] Making cell type merge backward compatible in APIs

### DIFF
--- a/backend/sample.env
+++ b/backend/sample.env
@@ -75,9 +75,9 @@ PROMPT_STUDIO_FILE_PATH=/app/prompt-studio-data
 
 # Structure Tool Image (Runs prompt studio exported tools)
 # https://hub.docker.com/r/unstract/tool-structure
-STRUCTURE_TOOL_IMAGE_URL="docker:unstract/tool-structure:0.0.76"
+STRUCTURE_TOOL_IMAGE_URL="docker:unstract/tool-structure:0.0.77"
 STRUCTURE_TOOL_IMAGE_NAME="unstract/tool-structure"
-STRUCTURE_TOOL_IMAGE_TAG="0.0.76"
+STRUCTURE_TOOL_IMAGE_TAG="0.0.77"
 
 # Feature Flags
 EVALUATION_SERVER_IP=unstract-flipt

--- a/prompt-service/src/unstract/prompt_service/constants.py
+++ b/prompt-service/src/unstract/prompt_service/constants.py
@@ -92,6 +92,7 @@ class PromptServiceConstants:
         "Please try again after some time"
     )
     COMBINED_PROMPT = "combined_prompt"
+    TOOL = "tool"
 
 
 class RunLevel(Enum):

--- a/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
@@ -81,6 +81,19 @@ def prompt_processor() -> Any:
         app.logger.info(f"[{tool_id}] chunk size: {chunk_size}")
         util = PromptServiceBaseTool(platform_key=platform_key)
         index = Index(tool=util, run_id=run_id, capture_metrics=True)
+        # To support backward compatability for cell types
+        # line-item, table and record.
+        if execution_source == PSKeys.TOOL:
+            if output[PSKeys.TYPE] == PSKeys.LINE_ITEM:
+                try:
+                    output[PSKeys.TABLE_SETTINGS]
+                except KeyError:
+                    output[PSKeys.TYPE] == PSKeys.JSON
+            if (output[PSKeys.TYPE] == PSKeys.TABLE) or (
+                output[PSKeys.TYPE] == PSKeys.RECORD
+            ):
+                output[PSKeys.TYPE] = PSKeys.LINE_ITEM
+
         if VariableReplacementService.is_variables_present(prompt_text=prompt_text):
             prompt_text = VariableReplacementService.replace_variables_in_prompt(
                 prompt=output,

--- a/tools/structure/src/config/properties.json
+++ b/tools/structure/src/config/properties.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.0.1",
   "displayName": "Structure Tool",
   "functionName": "structure_tool",
-  "toolVersion": "0.0.76",
+  "toolVersion": "0.0.77",
   "description": "This is a template tool which can answer set of input prompts designed in the Prompt Studio",
   "input": {
     "description": "File that needs to be indexed and parsed for answers"

--- a/tools/structure/src/constants.py
+++ b/tools/structure/src/constants.py
@@ -78,6 +78,7 @@ class SettingsKeys:
     METRICS = "metrics"
     INDEXING = "indexing"
     EXECUTION_ID = "execution_id"
+    IS_DIRECTORY_MODE = "is_directory_mode"
 
 
 class IndexingConstants:

--- a/tools/structure/src/main.py
+++ b/tools/structure/src/main.py
@@ -208,7 +208,11 @@ class StructureTool(BaseTool):
             for output in outputs:
                 if SettingsKeys.TABLE_SETTINGS in output:
                     table_settings = output[SettingsKeys.TABLE_SETTINGS]
+                    is_directory_mode: bool = table_settings.get(
+                        SettingsKeys.IS_DIRECTORY_MODE, False
+                    )
                     table_settings[SettingsKeys.INPUT_FILE] = extracted_input_file
+                    table_settings[SettingsKeys.IS_DIRECTORY_MODE] = is_directory_mode
                     output.update({SettingsKeys.TABLE_SETTINGS: table_settings})
 
             self.stream_log(f"Fetching responses for {len(outputs)} prompt(s)...")


### PR DESCRIPTION
## What
PR to make cell type merge backward compatible in APIs
...

## Why
The PR helps in not breaking the APis deployment, even when the tool is not exported with newer changes.
...

## How
Internally moved table or record to line-item and the same logic for JSON
...

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
No, this is a fall back and fool proof approach
...

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/5f7d23df-3184-4517-8261-f838128b2c8e)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
