### PR TITLE
[FIX] Fixing exporting line-item for new prompts

### DIFF
--- a/backend/prompt_studio/prompt_studio_registry_v2/constants.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/constants.py
@@ -11,6 +11,7 @@ class PromptStudioRegistryKeys:
     UNDEFINED = "undefined"
     TABLE = "table"
     RECORD = "record"
+    LINE_ITEM = "line-item"
 
 
 class PromptStudioRegistryErrors:

--- a/backend/prompt_studio/prompt_studio_registry_v2/prompt_studio_registry_helper.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/prompt_studio_registry_helper.py
@@ -342,10 +342,12 @@ class PromptStudioRegistryHelper:
             output[JsonSchemaKey.SECTION] = prompt.profile_manager.section
             output[JsonSchemaKey.REINDEX] = prompt.profile_manager.reindex
             output[JsonSchemaKey.EMBEDDING_SUFFIX] = embedding_suffix
-
+            # Retaining the old fields in condition
+            # for backward compatibility. To be removed in future.
             if (
                 prompt.enforce_type == PromptStudioRegistryKeys.TABLE
                 or prompt.enforce_type == PromptStudioRegistryKeys.RECORD
+                or prompt.enforce_type == PromptStudioRegistryKeys.LINE_ITEM
             ):
                 for modifier_plugin in modifier_plugins:
                     cls = modifier_plugin[ModifierConfig.METADATA][


### PR DESCRIPTION
## What
PR to fix line-item enforce type in newer prompts. 
Tool exports with line-item enforce type prompt failed in tool runs. 
This PR fixes this issue. 
...

## Why
`table_settings` field is not added and so the tool run fails with KeyError
...

## How
Added the new enforce type checks. 
...

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
No, it is a fix for the newer cell type merge feature
...

## Database Migrations
Not applicable.
...

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
