### PR TITLE
Fix/Subscription-period-end-check

### DIFF
--- a/frontend/src/components/navigations/side-nav-bar/SideNavBar.jsx
+++ b/frontend/src/components/navigations/side-nav-bar/SideNavBar.jsx
@@ -227,7 +227,7 @@ const SideNavBar = ({ collapsed }) => {
       return false;
     }
 
-    return unstractSubscriptionPlan?.remainingDays <= 0;
+    return unstractSubscriptionPlan?.remainingDays < 0;
   }, [unstractSubscriptionPlan]);
 
   data.forEach((mainMenuItem) => {


### PR DESCRIPTION
## What

- Subscription check should only block after the period end.

## Why

- Users blocked on the final day.

## How

- Expired cases have ` < 0 ` value here.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
