### PR TITLE
missing organization_id in statestore for worker

### DIFF
--- a/backend/workflow_manager/workflow_v2/file_execution_tasks.py
+++ b/backend/workflow_manager/workflow_v2/file_execution_tasks.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 from uuid import UUID
 
+from account_v2.constants import Common
 from plugins.workflow_manager.workflow_v2.utils import WorkflowUtil
 from tool_instance_v2.constants import ToolInstanceKey
 from tool_instance_v2.models import ToolInstance
@@ -130,7 +131,11 @@ class FileExecutionTasks:
         workflow_id = file_data.workflow_id
         # Reconstruct necessary objects
         workflow = FileExecutionTasks.get_workflow_by_id(str(workflow_id))
-        workflow_execution = WorkflowExecution.objects.get(id=UUID(execution_id))
+        workflow_execution: WorkflowExecution = WorkflowExecution.objects.get(
+            id=UUID(execution_id)
+        )
+        log_events_id = workflow_execution.execution_log_id
+        StateStore.set(Common.LOG_EVENTS_ID, log_events_id)
 
         total_files = len(file_batch_data.files)
         q_file_no_list = (
@@ -212,6 +217,8 @@ class FileExecutionTasks:
         organization = workflow.organization
         organization_id = organization.organization_id
         pipeline_id = str(workflow_execution.pipeline_id)
+        log_events_id = workflow_execution.execution_log_id
+        StateStore.set(Common.LOG_EVENTS_ID, log_events_id)
 
         # Set organization ID in StateStore
         StateStore.set(Account.ORGANIZATION_ID, organization_id)

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -710,11 +710,13 @@ class WorkflowHelper:
                 or workflow_execution.execution_type != WorkflowExecution.Type.COMPLETE
             ):
                 raise InvalidRequest(WorkflowErrors.INVALID_EXECUTION_ID)
+            organization_identifier = UserContext.get_organization_identifier()
             return WorkflowHelper.run_workflow(
                 workflow=workflow,
                 workflow_execution=workflow_execution,
                 hash_values_of_files=hash_values_of_files,
                 use_file_history=use_file_history,
+                organization_id=organization_identifier,
             )
         except WorkflowExecution.DoesNotExist:
             return WorkflowHelper.create_and_make_execution_response(


### PR DESCRIPTION
## What

- organization_id was missed to pass from the normal workflow run

## Why

-

## How

- Passed it by getting from stateStore

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
