### PR TITLE
Include azure dependencies

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "social-auth-core==4.4.2",         # For OAuth
     # TODO: Temporarily removing the extra dependencies of aws and gcs from unstract-sdk
     # to resolve lock file. Will have to be re-looked into
-    "unstract-sdk~=0.71.0",
+    "unstract-sdk[azure]~=0.71.0",
     "gcsfs==2024.10.0",
     "s3fs==2024.10.0",
     "azure-identity==1.16.0",

--- a/prompt-service/pyproject.toml
+++ b/prompt-service/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "json-repair~=0.42.0",
     # TODO: Temporarily removing the extra dependencies of aws and gcs from unstract-sdk
     # to resolve lock file. Will have to be re-looked into
-    "unstract-sdk~=0.71.0",
+    "unstract-sdk[azure]~=0.71.0",
     "gcsfs==2024.10.0",
     "s3fs==2024.10.0",
     "redis>=5.0.3,<5.3",


### PR DESCRIPTION
## What

- Bring back Azure dependency to support On-prem installations on Azure

## Why

- Supporting On-Prem instllations on Azure

## How

- Bringing back the dependency. This was there earlier. However during one of the SDK version rolls  while pgrading to uv, this got missed.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Prompt studio features need testing on Azure

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
