### PR TITLE
[FEAT] Rolling window support fo

### DIFF
--- a/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
@@ -178,6 +178,7 @@ def prompt_processor() -> Any:
                     structured_output=structured_output,
                     llm=llm,
                     execution_source=execution_source,
+                    prompt=prompt_text
                 )
                 metadata = UsageHelper.query_usage_metadata(
                     token=platform_key, metadata=metadata

--- a/prompt-service/src/unstract/prompt_service/services/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/services/answer_prompt.py
@@ -191,12 +191,13 @@ class AnswerPromptService:
         structured_output: dict[str, Any],
         llm: LLM,
         execution_source: str,
+        prompt:str,
     ) -> dict[str, Any]:
         table_settings = output[PSKeys.TABLE_SETTINGS]
         table_extractor: dict[str, Any] = PluginManager().get_plugin("table-extractor")
         if not table_extractor:
             raise APIError(
-                "Unable to extract line-item details. "
+                "Unable to extract table details. "
                 "Please contact admin to resolve this issue."
             )
         fs_instance: FileStorage = FileStorage(FileStorageProvider.LOCAL)
@@ -211,10 +212,11 @@ class AnswerPromptService:
                 env_name=FileStorageKeys.TEMPORARY_REMOTE_STORAGE,
             )
         try:
-            answer = table_extractor["entrypoint_cls"].extract_large_table(
+            answer = table_extractor["entrypoint_cls"].run_table_extraction(
                 llm=llm,
                 table_settings=table_settings,
                 fs_instance=fs_instance,
+                prompt=prompt,
             )
             structured_output[output[PSKeys.NAME]] = answer
             # We do not support summary and eval for table.


### PR DESCRIPTION
## What

Added new extraction logic in the table extractor using a rolling window approach.

Introduced custom schema logic, allowing users to define their own JSON output structure via prompts.

Implemented post-processing flow where a Python script is dynamically generated by the LLM and executed in code.

This enables token-efficient parsing and allows fine-grained prompt control by users.

...

## Why

Existing extraction was limited by token constraints and lacked flexibility.

Users need more control over output schema.

...

## How

Updated table extraction to support rolling window comparison across pages.

Used LLM to generate Python code for TSV-to-JSON conversion, run it safely in an isolated subprocess.

Implemented validation logic.

...


## Can this PR break any existing features? If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No, this does not break existing features because:

Existing functionality is preserved by default behavior.

New logic is only triggered when custom schema prompt or rolling window config is present.
...

## Relevant Docs

-

## Related Issues or PRs
https://github.com/Zipstack/unstract-cloud/pull/765
...

## Dependencies Versions / Env Variables
flake8 in table extractor plugin

...

## Notes on Testing

...

## Screenshots
Ref Cloud PR for screenshot - Hiding senstive document data
...

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).
