### PR TITLE
Un 2218 enforce max file size

### DIFF
--- a/backend/file_management/constants.py
+++ b/backend/file_management/constants.py
@@ -3,6 +3,6 @@ class FileInformationKey:
     FILE_TYPE = "type"
     FILE_LAST_MODIFIED = "LastModified"
     FILE_SIZE = "size"
-    FILE_UPLOAD_MAX_SIZE = 100 * 1024 * 1024
+    FILE_UPLOAD_MAX_SIZE = 200 * 1024 * 1024
     FILE_UPLOAD_ALLOWED_EXT = ["pdf"]
     FILE_UPLOAD_ALLOWED_MIME = ["application/pdf"]

--- a/tools/classifier/src/config/properties.json
+++ b/tools/classifier/src/config/properties.json
@@ -63,7 +63,7 @@
     }
   },
   "restrictions": {
-    "maxFileSize": "50MB",
+    "maxFileSize": "200MB",
     "allowedFileTypes": [
       "*"
     ]

--- a/tools/text_extractor/src/config/properties.json
+++ b/tools/text_extractor/src/config/properties.json
@@ -45,7 +45,7 @@
     }
   },
   "restrictions": {
-    "maxFileSize": "10MB",
+    "maxFileSize": "200MB",
     "allowedFileTypes": [
       "*"
     ]


### PR DESCRIPTION
## What

- Enforce 200MB on file limitation

## Why

- In the context of Unstract around file size, we enforce a limit at a few areas - its either 

   100 MB(for prompt studio / WF page upload)
   50 MB] (for structure, classifier tool)
   10 MB (for text-extractor tool, I guess this is unused)
We need to enforce a max file size limit of 200MB

## How

- 

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- N/A

## Database Migrations

- N/A

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested by running backend locally, and tools built locally

## Screenshots
![Screenshot from 2025-05-21 12-36-37](https://github.com/user-attachments/assets/254dec30-4cfa-4baf-b717-86c0c4666db9)
![Screenshot from 2025-05-21 11-43-32](https://github.com/user-attachments/assets/4385183f-560e-4efe-a7ad-c4ecfea2fa5c)
![Screenshot from 2025-05-21 11-37-20](https://github.com/user-attachments/assets/0b91e010-2ae1-43d2-a52b-a37051817dc9)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
