### PR TITLE
Resolve logger warnings

### DIFF
--- a/backend/connector_auth_v2/views.py
+++ b/backend/connector_auth_v2/views.py
@@ -30,7 +30,7 @@ class ConnectorAuthViewSet(viewsets.ViewSet):
                 f"Keys not configured for {backend}, add env vars "
                 f"`GOOGLE_OAUTH2_KEY` and `GOOGLE_OAUTH2_SECRET`."
             )
-            logger.warn(msg)
+            logger.warning(msg)
             raise KeyNotConfigured(
                 f"{msg}\nRefer to: "
                 "https://developers.google.com/identity/protocols/oauth2#1.-"


### PR DESCRIPTION
## What
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```


## Why
Because `logger.warn()` is depercated.

## How
Replace `loger.warn()` with `logger.warning()`.

## Database Migrations


## Env Config


## Relevant Docs


## Related Issues or PRs


## Dependencies Versions


## Notes on Testing

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
