### PR TITLE
update pipeline along with execution during no file to execute

### DIFF
--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -163,6 +163,12 @@ class WorkflowHelper:
             workflow_execution.update_execution(
                 status=ExecutionStatus.COMPLETED,
             )
+            PipelineUtils.update_pipeline_status(
+                pipeline_id=pipeline_id, workflow_execution=workflow_execution
+            )
+            logger.info(
+                f"Updated execution {workflow_execution.id} and pipeline {pipeline_id} status to COMPLETED"
+            )
             return
 
         batches = cls.get_file_batches(input_files=input_files)


### PR DESCRIPTION
## What

- Fix: Mark ETL execution as `Completed` when the last step is skipped due to having no files to process.

## Why

- Previously, the status was not updated correctly when there were no files, leading to incomplete ETL executions.

## How

- Added a call to the ETL status update method during the workflow execution update check when no files are present.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
