### PR TITLE
adding maximum retry count for chord for file processing worker

### DIFF
--- a/backend/backend/workers/file_processing/celery_config.py
+++ b/backend/backend/workers/file_processing/celery_config.py
@@ -1,3 +1,5 @@
+import os
+
 from kombu import Queue
 
 from backend.celery_config import CeleryConfig as BaseCeleryConfig
@@ -16,5 +18,16 @@ class CeleryConfig(BaseCeleryConfig):
     ]
 
     task_default_queue = QueueNames.FILE_PROCESSING
+
+    task_annotations = {
+        "celery.chord_unlock": {
+            "max_retries": int(
+                os.environ.get("FILE_PROCESSING_CELERY_RESULT_CHORD_RETRY_COUNT", 3)
+            ),  # Number of retries for chord unlock
+            "default_retry_delay": int(
+                os.environ.get("FILE_PROCESSING_CELERY_RESULT_CHORD_RETRY_INTERVAL", 1)
+            ),  # Delay in seconds between retries
+        }
+    }
 
     imports = ["workflow_manager.workflow_v2.file_execution_tasks"]


### PR DESCRIPTION
## What

- Configure a **maximum retry count** for Celery's `chord_unlock` callback specifically in the **file-processing worker.**
- This change has **no effect unless a chord retry is triggered**, making it safe for normal operation.
- Helps prevent **infinite retry loops** and allows automatic cleanup of **orphaned or garbage chord retries**.

## Why

- Setting retry limits improves system stability and observability, especially during error scenarios or ungraceful worker shutdowns.

## How

- Introduced a task annotation for `celery.chord_unlock` to:
  - Limit the number of retries (`FILE_PROCESSING_CELERY_RESULT_CHORD_RETRY_COUNT`, default: 3).
  - Set a retry interval (`FILE_PROCESSING_CELERY_RESULT_CHORD_RETRY_INTERVAL`, default: 1 second).

- These are configurable via environment variables.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

### These are optional No need to specify unless it required

- `FILE_PROCESSING_CELERY_RESULT_CHORD_RETRY_COUNT` (optional, default: 3)
- `FILE_PROCESSING_CELERY_RESULT_CHORD_RETRY_INTERVAL` (optional, default: 1)

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
