### PR TITLE
misc: Redacted celery broker password that was printed in tool-sidecar

### DIFF
--- a/tool-sidecar/src/unstract/tool_sidecar/log_processor.py
+++ b/tool-sidecar/src/unstract/tool_sidecar/log_processor.py
@@ -18,6 +18,7 @@ from unstract.core.tool_execution_status import (
     ToolExecutionStatus,
     ToolExecutionTracker,
 )
+from unstract.core.utilities import redact_sensitive_string
 
 from .constants import Env, LogLevel, LogType
 from .dto import LogLineDTO
@@ -280,7 +281,7 @@ def main():
         Env.REDIS_PORT: redis_port,
         Env.CELERY_BROKER_BASE_URL: celery_broker_base_url,
         Env.CELERY_BROKER_USER: celery_broker_user,
-        Env.CELERY_BROKER_PASS: celery_broker_pass,
+        Env.CELERY_BROKER_PASS: redact_sensitive_string(celery_broker_pass),
     }
 
     logger.info(f"Log processor started with params: {required_params}")

--- a/unstract/core/src/unstract/core/utilities.py
+++ b/unstract/core/src/unstract/core/utilities.py
@@ -51,3 +51,22 @@ class UnstractUtils:
                 f"Truncated container name: {container_name[:63]}"
             )
         return container_name[:63]
+
+
+## Static utility functions  ##
+def redact_sensitive_string(str_to_redact: str, reveal_length: int = 4) -> str:
+    """Hides sensitive information partially. Useful for logging keys.
+
+    Args:
+        str_to_redact (str): String to redact
+
+    Returns:
+        str: Redacted string
+    """
+    if reveal_length < 0:
+        raise ValueError("Reveal length must be a non-negative integer")
+
+    redacted_length = max(len(str_to_redact) - reveal_length, 0)
+    revealed_part = str_to_redact[:reveal_length]
+    redacted_part = "x" * redacted_length
+    return revealed_part + redacted_part


### PR DESCRIPTION
## What

- Redacted sensitive information which was being logged in tool-sidecar

## Why

- Password was being logged

## How

- Added a utility to `unstract-core` that redacts sensitive information in a string

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, only redacts a string that is logged

## Notes on Testing

- Tested with a tool run

## Screenshots
![image](https://github.com/user-attachments/assets/0eb20450-a909-4753-8013-6576e8cbabc4)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
