### PR TITLE
[MISC] Removed purge of periodic logs celery queue

### DIFF
--- a/backend/backend/celery_service.py
+++ b/backend/backend/celery_service.py
@@ -6,7 +6,6 @@ import os
 from pprint import pformat
 
 from celery import Celery
-from utils.constants import ExecutionLogConstants
 
 from backend.celery_task import TaskRegistry
 from backend.settings.base import LOGGING
@@ -33,16 +32,3 @@ app.config_from_object("backend.celery_config.CeleryConfig")
 app.autodiscover_tasks()
 
 logger.debug(f"Celery Configuration:\n {pformat(app.conf.table(with_defaults=True))}")
-
-# Define the queues to purge when the Celery broker is restarted.
-queues_to_purge = [ExecutionLogConstants.CELERY_QUEUE_NAME]
-with app.connection() as connection:
-    channel = connection.channel()
-    for queue_name in queues_to_purge:
-        try:
-            # Declare the queue (will be created if it doesn't exist)
-            channel.queue_declare(queue=queue_name, durable=True, auto_delete=False)
-            channel.queue_purge(queue_name)
-            logger.info(f"Successfully purged queue: {queue_name}")
-        except Exception as e:
-            logger.warning(f"Could not purge queue {queue_name}: {str(e)}")


### PR DESCRIPTION
## What

- Removed purge of a celery queue - `periodic_logs`

## Why

- This is done at the startup of every celery broker and can impact the time it takes to push logs during a worker restart


## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Yes - since we're purging a queue of tasks that get added periodically, this purge might actually help reduce the number of these redundant tasks


## Notes on Testing

- No explicit testing is done for this change

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
