### PR TITLE
UN-2445 [FEAT] Skipped unsupported files based on extension and MIME type to reduce processing failures and resource usage

### DIFF
--- a/backend/workflow_manager/endpoint_v2/constants.py
+++ b/backend/workflow_manager/endpoint_v2/constants.py
@@ -1,3 +1,7 @@
+import os
+from fnmatch import fnmatch
+
+
 class TableColumns:
     CREATED_BY = "created_by"
     CREATED_AT = "created_at"
@@ -80,22 +84,38 @@ class FilePattern:
         "*.bmp",
         "*.tif",
         "*.tiff",
+        "*.webp",
     ]
-    UNSUPPORTED_FILE_EXTENSIONS = [
-        # Archive formats
-        "*.zip",
-        "*.tar",
-        "*.gz",
-        "*.tar.gz",
-        "*.xz",
-        "*.tar.xz",
-        "*.7z",
-        "*.rar",
-        "*.bz2",
-        "*.tar.bz2",
-        "*.tgz",
-        "*.tbz2",
-    ]
+    SPREADSHEETS = ["*.xls", "*.xlsx", "*.ods"]
+    PRESENTATIONS = ["*.ppt", "*.pptx", "*.odp"]
+    OPEN_DOCS = ["*.odt"]
+    DATA_FILES = ["*.csv", "*.json"]
+    OTHER_FILES = ["*.cdfv2"]
+
+    @classmethod
+    def get_supported_extensions(cls) -> list[str]:
+        """Aggregate all supported file extensions."""
+        return [
+            *cls.PDF_DOCUMENTS,
+            *cls.TEXT_DOCUMENTS,
+            *cls.IMAGES,
+            *cls.SPREADSHEETS,
+            *cls.PRESENTATIONS,
+            *cls.OPEN_DOCS,
+            *cls.DATA_FILES,
+            *cls.OTHER_FILES,
+        ]
+
+    @classmethod
+    def is_supported(cls, filename: str) -> bool:
+        """Check if the file extension of the given filename is supported."""
+        _, ext = os.path.splitext(filename)
+        if not ext:
+            return True  # allow files with no extension
+        return any(
+            fnmatch(filename.lower(), pattern)
+            for pattern in cls.get_supported_extensions()
+        )
 
 
 class SourceConstant:

--- a/backend/workflow_manager/endpoint_v2/enums.py
+++ b/backend/workflow_manager/endpoint_v2/enums.py
@@ -1,0 +1,28 @@
+from enum import Enum
+
+
+class AllowedFileTypes(Enum):
+    PLAIN_TEXT = "text/plain"
+    PDF = "application/pdf"
+    JPEG = "image/jpeg"
+    PNG = "image/png"
+    TIFF = "image/tiff"
+    BMP = "image/bmp"
+    GIF = "image/gif"
+    WEBP = "image/webp"
+    DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    DOC = "application/msword"
+    XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    XLS = "application/vnd.ms-excel"
+    PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    PPT = "application/vnd.ms-powerpoint"
+    ODT = "application/vnd.oasis.opendocument.text"
+    ODS = "application/vnd.oasis.opendocument.spreadsheet"
+    ODP = "application/vnd.oasis.opendocument.presentation"
+    CDFV2 = "application/CDFV2"
+    JSON = "application/json"
+    CSV = "text/csv"
+
+    @classmethod
+    def is_allowed(cls, mime_type: str) -> bool:
+        return mime_type in cls._value2member_map_

--- a/backend/workflow_manager/endpoint_v2/exceptions.py
+++ b/backend/workflow_manager/endpoint_v2/exceptions.py
@@ -112,3 +112,8 @@ class UnstractQueueException(APIException):
 class SourceFileOrInfilePathNotFound(APIException):
     status_code = 500
     default_detail = "Unable to obtain file (Source or Infile) for execution."
+
+
+class UnsupportedMimeTypeError(APIException):
+    status_code = 400
+    default_detail = "Unsupported MIME type."

--- a/backend/workflow_manager/utils/workflow_log.py
+++ b/backend/workflow_manager/utils/workflow_log.py
@@ -45,9 +45,19 @@ class WorkflowLog:
         )
         LogPublisher.publish(self.messaging_channel, log_details)
 
-    def log_error(self, logger: logging.Logger, message: str) -> None:
+    def log_error(self, logger: logging.Logger, message: str, **kwargs) -> None:
+        """Publishes an error log message to the configured logger and to the
+        websocket channel.
+
+        Args:
+            logger (logging.Logger): The logger to use for logging.
+            message (str): The log message to be published.
+
+        Returns:
+            None
+        """
         self.publish_log(message, level=LogLevel.ERROR)
-        logger.error(message, exc_info=True, stack_info=True)
+        logger.error(message, **kwargs)
 
     def log_info(self, logger: logging.Logger, message: str) -> None:
         """Publishes an info log message to the configured logger and to the

--- a/backend/workflow_manager/workflow_v2/file_execution_tasks.py
+++ b/backend/workflow_manager/workflow_v2/file_execution_tasks.py
@@ -38,6 +38,8 @@ from workflow_manager.endpoint_v2.dto import (
     FileHash,
     SourceConfig,
 )
+from workflow_manager.endpoint_v2.enums import AllowedFileTypes
+from workflow_manager.endpoint_v2.exceptions import UnsupportedMimeTypeError
 from workflow_manager.endpoint_v2.models import WorkflowEndpoint
 from workflow_manager.endpoint_v2.result_cache_utils import ResultCacheUtils
 from workflow_manager.endpoint_v2.source import SourceConnector
@@ -487,7 +489,9 @@ class FileExecutionTasks:
                 organization_id=file_data.organization_id,
                 pipeline_id=str(workflow_execution.pipeline_id),
             )
-            workflow_log.log_error(logger=logger, message=error_msg)
+            workflow_log.log_error(
+                logger=logger, message=error_msg, exc_info=True, stack_info=True
+            )
             result = FinalOutputResult(output=None, metadata=None, error=error_msg)
             return cls._build_final_result(
                 workflow_execution=workflow_execution,
@@ -499,8 +503,13 @@ class FileExecutionTasks:
                 destination=destination,
             )
         except Exception as error:
-            error_msg = f"File execution failed: {error}"
-            workflow_log.log_error(logger=logger, message=error_msg)
+            if isinstance(error, UnsupportedMimeTypeError):
+                error_msg = str(error)
+            else:
+                error_msg = f"File execution failed: {error}"
+                workflow_log.log_error(
+                    logger=logger, message=error_msg, exc_info=True, stack_info=True
+                )
             workflow_file_execution.update_status(
                 status=ExecutionStatus.ERROR, execution_error=error_msg[:500]
             )
@@ -667,6 +676,12 @@ class FileExecutionTasks:
 
         try:
             logger.info(f"Preparing file for processing: {file_hash.file_name}")
+            if file_hash.mime_type and not AllowedFileTypes.is_allowed(
+                file_hash.mime_type
+            ):
+                raise UnsupportedMimeTypeError(
+                    f"Unsupported MIME type '{file_hash.mime_type}'"
+                )
             content_hash = source.add_file_to_volume(
                 workflow_file_execution=workflow_file_exec,
                 tags=workflow_execution.tag_names,
@@ -675,13 +690,32 @@ class FileExecutionTasks:
             file_hash.file_hash = content_hash
             workflow_file_exec.update(file_hash=content_hash)
             return content_hash
+        except UnsupportedMimeTypeError as error:
+            error_msg = f"Unsupported MIME type: {error}"
+            logger_message = f"Skipping file {file_hash.file_name} due to {error_msg}"
+            workflow_log.log_error(logger=logger, message=logger_message)
+
+            # TODO: (Optional) Handle unsupported MIME types in file_history
+            #   Goal: Record failure to prevent retries, but cache_key is missing
+            #   Constraints:
+            #     - cache_key required (NOT NULL) but unavailable (file not fully read)
+            #   Solutions:
+            #     1. Allow null cache_key (schema change)
+            #     2. Generate fallback hash (e.g., f"UNSUPPORTED_{file_hash.file_name}")
+            #     3. Read full file for hash (performance cost)
+            #   Action: Requires team decision on preferred approach.
+            raise
         except FileNotFoundError as error:
             error_msg = f"File not Found in execution dir: {error}"
-            workflow_log.log_error(logger=logger, message=error_msg)
+            workflow_log.log_error(
+                logger=logger, message=error_msg, exc_info=True, stack_info=True
+            )
             raise WorkflowExecutionError(error_msg) from error
         except Exception as error:
             error_msg = f"File preparation failed: {error}"
-            workflow_log.log_error(logger=logger, message=error_msg)
+            workflow_log.log_error(
+                logger=logger, message=error_msg, exc_info=True, stack_info=True
+            )
             raise WorkflowExecutionError(error_msg) from error
 
     @classmethod


### PR DESCRIPTION
## What

- Skip execution of files with unsupported extensions or MIME types.
- Prevent such files from being added to file storage.

## Why

- Unsupported files do not need to be processed.
- Avoids unnecessary resource usage (CPU/storage).
- Improves system robustness by avoiding unnecessary failures.

## How

- Check file extension during `ETL/TASK` file discovery.
- Check MIME type during `file processing` or `API` file discovery.
- Use a predefined list of supported types for both checks.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. This change only affects workflow execution

## Database Migrations

-  No

## Env Config

-  No

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
