### PR TITLE
[fix] Run platform merge env issue for tool containers

### DIFF
--- a/run-platform.sh
+++ b/run-platform.sh
@@ -190,6 +190,14 @@ setup_env() {
   DEFAULT_AUTH_KEY="unstract"
 
   for service in "${services[@]}"; do
+    # Skip services that are spawned at runtime
+    for ignore_service in "${spawned_services[@]}"; do
+      if [[ "$service" == "$ignore_service" ]]; then
+        echo -e "Skipped env for ${blue_text}$service${default_text} as it's spawned at runtime"
+        continue 2
+      fi
+    done
+
     sample_env_path="$script_dir/$service/sample.env"
     env_path="$script_dir/$service/.env"
 
@@ -298,13 +306,14 @@ run_services() {
     echo -e "to a secure location:\n"
     echo -e "- ""$red_text""backend/.env""$default_text"
     echo -e "- ""$red_text""platform-service/.env""$default_text"
-    echo -e "\nAapter credentials are encrypted by the platform using this key."
+    echo -e "\nAdapter credentials are encrypted by the platform using this key."
     echo -e "Its loss or change will make all existing adapters inaccessible!"
     echo -e "###################################################################"
   fi
 
   popd 1>/dev/null
 }
+
 
 #
 # Run Unstract platform - BEGIN
@@ -320,8 +329,9 @@ opt_version="latest"
 
 script_dir=$(dirname "$(readlink -f "$BASH_SOURCE")")
 first_setup=false
-# Extract service names from docker compose file.
+# Extract service names from docker compose file
 services=($(VERSION=$opt_version $docker_compose_cmd -f "$script_dir/docker/docker-compose.build.yaml" config --services))
+spawned_services=("tool-structure" "tool-sidecar")
 current_version=""
 target_branch=""
 


### PR DESCRIPTION
## What

- Skipped env creation for tool containers - `tool-structure` and `tool-sidecar`
- MINOR: Typo fix in warning message 

## Why

- These will be spawned at runtime and the env need not be created
- While merging envs they threw an error since the expected files / paths were not found

## How

- Created a list `spawned_services` that can be checked to ignore during env creation

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, it has been tested locally as well

## Notes on Testing

- Ran the script locally and was also able to start the containers

## Screenshots
![image](https://github.com/user-attachments/assets/04dafb36-d897-4a09-bd02-e4aa1d332e39)
![image](https://github.com/user-attachments/assets/04dafb36-d897-4a09-bd02-e4aa1d332e39)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
