### PR TITLE
[MISC] Fixed build workflow involving multiple tags

### DIFF
--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -58,12 +58,12 @@ jobs:
           fi
 
           # Set latest tag for releases
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "latest=true" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAGS=unstract/${{ matrix.service_name }}:${{ env.DOCKER_VERSION_TAG }},unstract/${{ matrix.service_name }}:latest" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" = "release" ] && [ "${{ github.event.release.prerelease }}" != "true" ]; then
+            echo "SEMVER_IMAGE_TAG=unstract/${{ matrix.service_name }}:${{ env.DOCKER_VERSION_TAG }}" >> $GITHUB_ENV
+            echo "LATEST_IMAGE_TAG=unstract/${{ matrix.service_name }}:latest" >> $GITHUB_ENV
           else
-            echo "latest=false" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAGS=unstract/${{ matrix.service_name }}:${{ env.DOCKER_VERSION_TAG }}" >> $GITHUB_ENV
+            echo "SEMVER_IMAGE_TAG=unstract/${{ matrix.service_name }}:${{ env.DOCKER_VERSION_TAG }}" >> $GITHUB_ENV
+            echo "LATEST_IMAGE_TAG=" >> $GITHUB_ENV
           fi
 
       # Build and push using Docker Bake
@@ -75,9 +75,9 @@ jobs:
           files: ./docker/docker-compose.build.yaml
           targets: ${{ matrix.service_name }}
           push: true
-          # Context resolved along with docker-compose.build.yaml, ensure resolved path is repo root
           set: |
-            *.tags=${{ env.IMAGE_TAGS }}
+            *.tags=${{ env.SEMVER_IMAGE_TAG }}
+            ${{ env.LATEST_IMAGE_TAG && format('*.tags={0}', env.LATEST_IMAGE_TAG) || '' }}
             *.context=.
             *.args.VERSION=${{ env.DOCKER_VERSION_TAG }}
             *.cache-from=type=gha,scope=${{ matrix.service_name }}


### PR DESCRIPTION
## What

- Fixed `production-build.yaml` workflow involving multiple tags

## Why

- Build failed when multiple tags are passed on release creation
https://github.com/Zipstack/unstract/actions/runs/15731900127/job/44334749386

## How

- Passing the next `*.tags` in a separate line conditionally

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Yes, its untested and could cause a problem when multiple tags need to be built

## Related Issues or PRs

- #1368 


## Notes on Testing

- No explicit testing done for multiple tags, a release needs to be created for it

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
