### PR TITLE
UN-2533 [FEAT] Enhance Preamble/Postamble UX: Auto-resize Text Areas and Add Expandable View

### DIFF
--- a/frontend/src/components/custom-tools/pre-and-post-amble-modal/PreAndPostAmbleModal.css
+++ b/frontend/src/components/custom-tools/pre-and-post-amble-modal/PreAndPostAmbleModal.css
@@ -21,3 +21,64 @@
     border-radius: 0px 0px 10px 10px;
     padding: 16px;
 }
+
+/* Text area container and expand button styles */
+.text-area-container {
+    position: relative;
+}
+
+.text-area-wrapper {
+    position: relative;
+}
+
+.expand-button {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    z-index: 2;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 4px;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.expand-button:hover {
+    background: rgba(240, 240, 240, 0.9);
+}
+
+/* Ensure text area retains its size between sessions */
+.text-area-wrapper .ant-input {
+    transition: height 0.2s;
+    min-height: 80px; /* Approx 4 rows */
+    max-height: 600px; /* Limit height and enable scrolling */
+    overflow-y: auto; /* Enable vertical scrolling */
+}
+
+/* Modal styles */
+.expanded-modal-body {
+    padding: 20px;
+}
+
+.expanded-modal-body .ant-modal-body {
+    padding: 0;
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+
+
+.expanded-textarea {
+    width: 100%;
+    margin-bottom: 20px;
+    height: auto; /* Let content determine height */
+    min-height: 300px; /* Minimum height */
+    overflow-y: visible; /* Let the parent container handle scrolling */
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+}


### PR DESCRIPTION
## What

- Add auto-resizing functionality to text areas based on content
- Implement expandable view with modal for better content visibility
- Add expand button for quick access to full-screen editing
- Implement scrollable modal for handling long content
- Ensure text areas maintain appropriate size between sessions
- Improve overall usability when working with large text blocks

## Why

- UX issue where users had to manually resize text boxes each time they returned to Preamble/Postamble options.

## How

- Added auto-resizing functionality using a custom adjustTextAreaHeight function
- Implemented an expand button with modal for full-screen editing
- Added scrolling for both regular and expanded views
- Created dedicated CSS classes and removed inline styles
- Used responsive design with relative sizing (vh units and percentages)
- Set appropriate min/max height constraints with overflow handling
- Added smooth transitions for height changes

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

![image](https://github.com/user-attachments/assets/b60626c8-a3be-4d03-9209-ece5abb2217d)
![image](https://github.com/user-attachments/assets/0911f019-fd10-4e89-a620-e8eeaf4dc1f6)


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
