### PR TITLE
[MISC] Added compose watch configuration for easy development

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     # For file watching
     "inotify>=0.2.10",
     "poethepoet>=0.33.1",
+    "debugpy>=1.8.14"
 ]
 test = ["pytest>=8.0.1", "pytest-dotenv==0.5.2"]
 deploy = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -710,6 +710,19 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/75/087fe07d40f490a78782ff3b0a30e3968936854105487decdb33446d4b0e/debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322", size = 1641444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/2a/ac2df0eda4898f29c46eb6713a5148e6f8b2b389c8ec9e425a4a1d67bf07/debugpy-1.8.14-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84", size = 2501268 },
+    { url = "https://files.pythonhosted.org/packages/10/53/0a0cb5d79dd9f7039169f8bf94a144ad3efa52cc519940b3b7dde23bcb89/debugpy-1.8.14-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826", size = 4221077 },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/84e01821f362327bf4828728aa31e907a2eca7c78cd7c6ec062780d249f8/debugpy-1.8.14-cp312-cp312-win32.whl", hash = "sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f", size = 5255127 },
+    { url = "https://files.pythonhosted.org/packages/33/16/1ed929d812c758295cac7f9cf3dab5c73439c83d9091f2d91871e648093e/debugpy-1.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f", size = 5297249 },
+    { url = "https://files.pythonhosted.org/packages/97/1a/481f33c37ee3ac8040d3d51fc4c4e4e7e61cb08b8bc8971d6032acc2279f/debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20", size = 5256230 },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3904,6 +3917,7 @@ deploy = [
     { name = "opentelemetry-exporter-otlp" },
 ]
 dev = [
+    { name = "debugpy" },
     { name = "inotify" },
     { name = "poethepoet" },
     { name = "unstract-connectors" },
@@ -3966,6 +3980,7 @@ deploy = [
     { name = "opentelemetry-exporter-otlp" },
 ]
 dev = [
+    { name = "debugpy", specifier = ">=1.8.14" },
     { name = "inotify", specifier = ">=0.2.10" },
     { name = "poethepoet", specifier = ">=0.33.1" },
     { name = "unstract-connectors", editable = "../unstract/connectors" },

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,6 +8,9 @@ VERSION=dev docker compose -f docker-compose.build.yaml build
 
 # Build a specific service alone
 VERSION=dev docker compose -f docker-compose.build.yaml build frontend
+
+# Build optional services also
+VERSION=dev docker compose -f docker-compose.build.yaml --profile optional build
 ```
 
 ## Docker Run
@@ -20,25 +23,16 @@ VERSION=dev docker compose -f docker-compose.yaml up -d
 
 # Up a specific service alone
 VERSION=dev docker compose -f docker-compose.yaml up -d frontend
-```
 
-Now access frontend at http://frontend.unstract.localhost
-
-## Docker Build and Run Optional Services
-
-Some services are kept optional and will not be built or started by default. Run them as follows.
-
-```bash
-# Build optional services also
-VERSION=dev docker compose -f docker-compose.build.yaml --profile optional build
 # Up optional services also
 VERSION=dev docker compose -f docker-compose.yaml --profile optional up -d
 ```
 
+Now access frontend at http://frontend.unstract.localhost
+
 ## Overriding a service's config
 
-By making use of the [merge compose files](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/) feature its
-possible to override some configuration that's used by the services.
+By making use of the [merge compose files](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/) feature its possible to override some configuration that's used by the services.
 
 Copy and rename the `sample.compose.override.yaml` to `compose.override.yaml` and update it as necessary.
 
@@ -49,11 +43,94 @@ cp sample.compose.override.yaml compose.override.yaml
 VERSION=dev docker compose -f docker-compose.yaml -f compose.override.yaml up -d
 ```
 
-This can be useful during development to
+This can be useful during development to:
 
-- not run some memory intensive services
-- use commands with different arguments to save resources
-- mount additional volumes or define additional env to configure behaviour
+- Not run some memory intensive services
+- Use commands with different arguments to save resources
+- Mount additional volumes or define additional env to configure behaviour
+
+## Development with Docker Compose Watch
+
+[Docker Compose Watch](https://docs.docker.com/compose/how-tos/file-watch/) (available in Docker Compose v2.22.0+) enables a streamlined development workflow by automatically syncing code changes to containers and restarting services as needed.
+
+### Setting Up Watch Mode
+
+1. Ensure you're using Docker Compose v2.22.0 or higher
+
+   ```bash
+   docker compose version
+   ```
+
+2. Create your `compose.override.yaml` with watch configurations
+
+   ```bash
+   cp sample.compose.override.yaml compose.override.yaml
+   ```
+
+3. Start services with watch mode enabled
+
+   ```bash
+   VERSION=dev docker compose -f docker-compose.yaml -f compose.override.yaml watch
+   ```
+
+### Example Workflow
+
+1. Start services with watch mode:
+
+   ```bash
+   VERSION=dev docker compose -f docker-compose.yaml -f compose.override.yaml watch
+   ```
+
+1. Make changes to your code in your local editor
+1. Changes are automatically synced to the container and services restart as needed
+1. For debugging:
+   - Configure IDE to connect to the appropriate debugpy port
+   Here's an example `launch.json` (for VSCode) to attach to a the `backend` container on port 5678.
+   It assumes that a workspace involving unstract and unstract-sdk is setup.
+   For more information on this refer [VSCode docs](https://code.visualstudio.com/docs/devcontainers/attach-container#_attach-to-a-docker-container).
+
+   ```json
+    {
+      "name": "Docker: Backend Remote Debug",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder:unstract}/backend",
+          "remoteRoot": "/app"
+        },
+        {
+          "localRoot": "${workspaceFolder:unstract}/unstract",
+          "remoteRoot": "/unstract"
+        },
+        // Uncomment below to use and debug local version of unstract-sdk
+        // {
+        // 	"localRoot": "${workspaceFolder:unstract-sdk}/src/unstract/sdk",
+        // 	"remoteRoot": "/unstract-sdk/src/unstract/sdk"
+        // },
+      ],
+      "justMyCode": false,
+      "django": true,
+      "presentation": {
+        "group": "docker-debug"
+      }
+    }
+   ```
+
+   - Set breakpoints in your code
+   - Trigger the code path and the debugger will pause at your breakpoints
+
+1. View logs in real-time:
+
+   ```bash
+   docker compose logs -f [service_name]
+   ```
+
+This workflow eliminates the need to rebuild containers or manually restart services during development, significantly improving productivity.
 
 ## `src` Folder Layout and `gunicorn`
 

--- a/docker/sample.compose.override.yaml
+++ b/docker/sample.compose.override.yaml
@@ -1,14 +1,162 @@
 # Refer https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/
-# This is an example configuration which aims to minimize the number of celery workers
-# It helps reduce memory usage during development
+# Minimize celery workers to reduce memory usage of Unstract (aids development)
 services:
   worker:
     command: "-A backend worker --loglevel=info -Q celery,celery_periodic_logs,celery_log_task_queue,celery_api_deployments --autoscale=${WORKER_AUTOSCALE}"
-  worker-file-processing:
-    command: "-A backend.workers.file_processing worker --loglevel=info -Q file_processing,api_file_processing --autoscale=${WORKER_FILE_PROCESSING_AUTOSCALE}"
-  worker-file-processing-callback:
-    command: "-A backend.workers.file_processing_callback worker --loglevel=info -Q file_processing_callback,api_file_processing_callback --autoscale=${WORKER_FILE_PROCESSING_CALLBACK_AUTOSCALE}"
 
   worker-logging:
     profiles:
       - high_memory
+
+
+# Watch configuration
+# Refer https://docs.docker.com/compose/how-tos/file-watch/
+  frontend:
+    develop:
+      watch:
+      # Sync the frontend directory with the container
+      - action: sync
+        path: ../frontend/
+        target: /app
+        ignore: node_modules/
+      # Rebuild when dependencies change
+      - action: rebuild
+        path: ../frontend/package-lock.json
+      - action: rebuild
+        path: ../frontend/package.json
+
+  backend:
+    entrypoint: ["bash", "-c"]
+    command: [
+      "source .venv/bin/activate && \
+      uv sync --all-groups && \
+      python /tmp/debugpy --listen 0.0.0.0:5678 .venv/bin/gunicorn \
+        --bind 0.0.0.0:8000 \
+        --workers 2 \
+        --threads 4 \
+        --worker-class gthread \
+        --log-level debug \
+        --timeout 900 \
+        --access-logfile - \
+        --reload --graceful-timeout 5 backend.wsgi:application"
+    ]
+    develop:
+      watch:
+      # Sync the backend directory with the container
+      - action: sync+restart
+        path: ../backend/
+        target: /app
+        ignore: [.venv/, __pycache__/, "*.pyc", .pytest_cache/, .mypy_cache/]
+      # Rebuild when dependencies change
+      - action: rebuild
+        path: ../backend/uv.lock
+    ## Uncomment below lines to use local version of unstract-sdk
+    ## NOTE: Restart the containers on code change though
+    # environment:
+    #   - PYTHONPATH=/unstract-sdk/src
+    # volumes:
+    #   - <path_to_unstract_sdk>/unstract-sdk:/unstract-sdk
+
+  runner:
+    entrypoint: ["bash", "-c"]
+    command: [
+      "source .venv/bin/activate && \
+      uv sync --all-groups && \
+      python /tmp/debugpy --listen 0.0.0.0:5681 .venv/bin/gunicorn \
+        --bind 0.0.0.0:5002 \
+        --workers 2 \
+        --threads 2 \
+        --worker-class gthread \
+        --log-level debug \
+        --timeout 900 \
+        --access-logfile - \
+        --reload --graceful-timeout 5 unstract.runner:app"
+    ]
+    develop:
+      watch:
+      # Sync the runner directory with the container
+      - action: sync+restart
+        path: ../runner/
+        target: /app
+        ignore: [.venv/, __pycache__/, "*.pyc", .pytest_cache/, .mypy_cache/]
+      # Rebuild when dependencies change
+      - action: rebuild
+        path: ../runner/uv.lock
+
+  platform-service:
+    entrypoint: ["bash", "-c"]
+    command: [
+      "source .venv/bin/activate && \
+      uv sync --all-groups && \
+      python /tmp/debugpy --listen 0.0.0.0:5679 .venv/bin/gunicorn \
+        --bind 0.0.0.0:3001 \
+        --workers 2 \
+        --threads 2 \
+        --worker-class gevent \
+        --log-level debug \
+        --timeout 900 \
+        --access-logfile - \
+        --reload --graceful-timeout 5 unstract.platform_service.run:app"
+    ]
+    develop:
+      watch:
+      # Sync the platform-service directory with the container
+      - action: sync+restart
+        path: ../platform-service/
+        target: /app
+        ignore: [.venv/, __pycache__/, "*.pyc", .pytest_cache/, .mypy_cache/]
+      # Rebuild when dependencies change
+      - action: rebuild
+        path: ../platform-service/uv.lock
+
+  prompt-service:
+    entrypoint: ["bash", "-c"]
+    command: [
+      "source .venv/bin/activate && \
+      uv sync --all-groups && \
+      python /tmp/debugpy --listen 0.0.0.0:5680 .venv/bin/gunicorn \
+        --bind 0.0.0.0:3003 \
+        --workers 2 \
+        --threads 2 \
+        --worker-class gthread \
+        --log-level debug \
+        --timeout 900 \
+        --access-logfile - \
+        --reload --graceful-timeout 5 unstract.prompt_service.run:app"
+    ]
+    develop:
+      watch:
+      # Sync the prompt-service directory with the container
+      - action: sync+restart
+        path: ../prompt-service/
+        target: /app
+        ignore: [.venv/, __pycache__/, "*.pyc", .pytest_cache/, .mypy_cache/]
+      # Rebuild when dependencies change
+      - action: rebuild
+        path: ../prompt-service/uv.lock
+
+  x2text-service:
+    entrypoint: ["bash", "-c"]
+    command: [
+      "source .venv/bin/activate && \
+      uv sync --all-groups && \
+      python /tmp/debugpy --listen 0.0.0.0:5682 .venv/bin/gunicorn \
+        --bind 0.0.0.0:3004 \
+        --workers 2 \
+        --threads 2 \
+        --worker-class gthread \
+        --log-level debug \
+        --timeout 900 \
+        --access-logfile - \
+        --reload --graceful-timeout 5 unstract.x2text_service.run:app"
+    ]
+    develop:
+      watch:
+      # Sync the x2text-service directory with the container
+      - action: sync+restart
+        path: ../x2text-service/
+        target: /app
+        ignore: [.venv/, __pycache__/, "*.pyc", .pytest_cache/, .mypy_cache/]
+      # Rebuild when dependencies change
+      - action: rebuild
+        path: ../x2text-service/uv.lock

--- a/platform-service/pyproject.toml
+++ b/platform-service/pyproject.toml
@@ -32,7 +32,7 @@ deploy = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
 ]
-dev = ["poethepoet>=0.33.1"]
+dev = ["poethepoet>=0.33.1", "debugpy>=1.8.14"]
 
 # [project.scripts]
 # platform_service = "./entrypoint.sh"

--- a/platform-service/uv.lock
+++ b/platform-service/uv.lock
@@ -501,6 +501,19 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/75/087fe07d40f490a78782ff3b0a30e3968936854105487decdb33446d4b0e/debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322", size = 1641444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/2a/ac2df0eda4898f29c46eb6713a5148e6f8b2b389c8ec9e425a4a1d67bf07/debugpy-1.8.14-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84", size = 2501268 },
+    { url = "https://files.pythonhosted.org/packages/10/53/0a0cb5d79dd9f7039169f8bf94a144ad3efa52cc519940b3b7dde23bcb89/debugpy-1.8.14-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826", size = 4221077 },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/84e01821f362327bf4828728aa31e907a2eca7c78cd7c6ec062780d249f8/debugpy-1.8.14-cp312-cp312-win32.whl", hash = "sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f", size = 5255127 },
+    { url = "https://files.pythonhosted.org/packages/33/16/1ed929d812c758295cac7f9cf3dab5c73439c83d9091f2d91871e648093e/debugpy-1.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f", size = 5297249 },
+    { url = "https://files.pythonhosted.org/packages/97/1a/481f33c37ee3ac8040d3d51fc4c4e4e7e61cb08b8bc8971d6032acc2279f/debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20", size = 5256230 },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3089,6 +3102,7 @@ deploy = [
     { name = "opentelemetry-exporter-otlp" },
 ]
 dev = [
+    { name = "debugpy" },
     { name = "poethepoet" },
 ]
 test = [
@@ -3115,7 +3129,10 @@ deploy = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
 ]
-dev = [{ name = "poethepoet", specifier = ">=0.33.1" }]
+dev = [
+    { name = "debugpy", specifier = ">=1.8.14" },
+    { name = "poethepoet", specifier = ">=0.33.1" },
+]
 test = [{ name = "pytest", specifier = ">=8.0.1" }]
 
 [[package]]

--- a/prompt-service/pyproject.toml
+++ b/prompt-service/pyproject.toml
@@ -42,7 +42,7 @@ deploy = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
 ]
-dev = ["poethepoet>=0.33.1"]
+dev = ["poethepoet>=0.33.1", "debugpy>=1.8.14"]
 
 [build-system]
 requires = ["hatchling"]

--- a/prompt-service/uv.lock
+++ b/prompt-service/uv.lock
@@ -505,6 +505,19 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/75/087fe07d40f490a78782ff3b0a30e3968936854105487decdb33446d4b0e/debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322", size = 1641444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/2a/ac2df0eda4898f29c46eb6713a5148e6f8b2b389c8ec9e425a4a1d67bf07/debugpy-1.8.14-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84", size = 2501268 },
+    { url = "https://files.pythonhosted.org/packages/10/53/0a0cb5d79dd9f7039169f8bf94a144ad3efa52cc519940b3b7dde23bcb89/debugpy-1.8.14-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826", size = 4221077 },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/84e01821f362327bf4828728aa31e907a2eca7c78cd7c6ec062780d249f8/debugpy-1.8.14-cp312-cp312-win32.whl", hash = "sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f", size = 5255127 },
+    { url = "https://files.pythonhosted.org/packages/33/16/1ed929d812c758295cac7f9cf3dab5c73439c83d9091f2d91871e648093e/debugpy-1.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f", size = 5297249 },
+    { url = "https://files.pythonhosted.org/packages/97/1a/481f33c37ee3ac8040d3d51fc4c4e4e7e61cb08b8bc8971d6032acc2279f/debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20", size = 5256230 },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3106,6 +3119,7 @@ deploy = [
     { name = "opentelemetry-exporter-otlp" },
 ]
 dev = [
+    { name = "debugpy" },
     { name = "poethepoet" },
 ]
 test = [
@@ -3138,7 +3152,10 @@ deploy = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
 ]
-dev = [{ name = "poethepoet", specifier = ">=0.33.1" }]
+dev = [
+    { name = "debugpy", specifier = ">=1.8.14" },
+    { name = "poethepoet", specifier = ">=0.33.1" },
+]
 test = [
     { name = "flask-wtf", specifier = "~=1.1" },
     { name = "pytest", specifier = "~=8.0.1" },

--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["unstract-core[flask]", "poethepoet>=0.33.1"]
+dev = ["unstract-core[flask]", "poethepoet>=0.33.1", "debugpy>=1.8.14"]
 test = [
     "pytest>=8.2.2",
     "pytest-mock>=3.14.0",

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -141,6 +141,19 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/75/087fe07d40f490a78782ff3b0a30e3968936854105487decdb33446d4b0e/debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322", size = 1641444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/2a/ac2df0eda4898f29c46eb6713a5148e6f8b2b389c8ec9e425a4a1d67bf07/debugpy-1.8.14-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84", size = 2501268 },
+    { url = "https://files.pythonhosted.org/packages/10/53/0a0cb5d79dd9f7039169f8bf94a144ad3efa52cc519940b3b7dde23bcb89/debugpy-1.8.14-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826", size = 4221077 },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/84e01821f362327bf4828728aa31e907a2eca7c78cd7c6ec062780d249f8/debugpy-1.8.14-cp312-cp312-win32.whl", hash = "sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f", size = 5255127 },
+    { url = "https://files.pythonhosted.org/packages/33/16/1ed929d812c758295cac7f9cf3dab5c73439c83d9091f2d91871e648093e/debugpy-1.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f", size = 5297249 },
+    { url = "https://files.pythonhosted.org/packages/97/1a/481f33c37ee3ac8040d3d51fc4c4e4e7e61cb08b8bc8971d6032acc2279f/debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20", size = 5256230 },
+]
+
+[[package]]
 name = "docker"
 version = "6.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -872,6 +885,7 @@ deploy = [
     { name = "opentelemetry-exporter-otlp" },
 ]
 dev = [
+    { name = "debugpy" },
     { name = "poethepoet" },
     { name = "unstract-core", extra = ["flask"] },
 ]
@@ -899,6 +913,7 @@ deploy = [
     { name = "opentelemetry-exporter-otlp" },
 ]
 dev = [
+    { name = "debugpy", specifier = ">=1.8.14" },
     { name = "poethepoet", specifier = ">=0.33.1" },
     { name = "unstract-core", extras = ["flask"], editable = "../unstract/core" },
 ]

--- a/x2text-service/pyproject.toml
+++ b/x2text-service/pyproject.toml
@@ -23,3 +23,4 @@ deploy = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
 ]
+dev = ["debugpy>=1.8.14"]

--- a/x2text-service/uv.lock
+++ b/x2text-service/uv.lock
@@ -77,6 +77,19 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/75/087fe07d40f490a78782ff3b0a30e3968936854105487decdb33446d4b0e/debugpy-1.8.14.tar.gz", hash = "sha256:7cd287184318416850aa8b60ac90105837bb1e59531898c07569d197d2ed5322", size = 1641444 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/2a/ac2df0eda4898f29c46eb6713a5148e6f8b2b389c8ec9e425a4a1d67bf07/debugpy-1.8.14-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:8899c17920d089cfa23e6005ad9f22582fd86f144b23acb9feeda59e84405b84", size = 2501268 },
+    { url = "https://files.pythonhosted.org/packages/10/53/0a0cb5d79dd9f7039169f8bf94a144ad3efa52cc519940b3b7dde23bcb89/debugpy-1.8.14-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6bb5c0dcf80ad5dbc7b7d6eac484e2af34bdacdf81df09b6a3e62792b722826", size = 4221077 },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/84e01821f362327bf4828728aa31e907a2eca7c78cd7c6ec062780d249f8/debugpy-1.8.14-cp312-cp312-win32.whl", hash = "sha256:281d44d248a0e1791ad0eafdbbd2912ff0de9eec48022a5bfbc332957487ed3f", size = 5255127 },
+    { url = "https://files.pythonhosted.org/packages/33/16/1ed929d812c758295cac7f9cf3dab5c73439c83d9091f2d91871e648093e/debugpy-1.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:5aa56ef8538893e4502a7d79047fe39b1dae08d9ae257074c6464a7b290b806f", size = 5297249 },
+    { url = "https://files.pythonhosted.org/packages/97/1a/481f33c37ee3ac8040d3d51fc4c4e4e7e61cb08b8bc8971d6032acc2279f/debugpy-1.8.14-py2.py3-none-any.whl", hash = "sha256:5cd9a579d553b6cb9759a7908a41988ee6280b961f24f63336835d9418216a20", size = 5256230 },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -545,6 +558,9 @@ deploy = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
 ]
+dev = [
+    { name = "debugpy" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -562,6 +578,7 @@ deploy = [
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
 ]
+dev = [{ name = "debugpy", specifier = ">=1.8.14" }]
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
## What

- Added compose watch configuration for almost all of our services (haven't added for workers for brevity)
- Added some docs on how to use it and debug the containers

## Why

- For ease of development
- Developing in the container is good as it limits possiblity of venv issues and also emulates prod better

## How

- Made use of docker compose's watch feature to watch and reload on changes

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, only dev dependency added and doc changes


## Relevant Docs
- [Docker compose watch](https://docs.docker.com/compose/how-tos/file-watch/)
- [Debugging containers in VSCode](https://code.visualstudio.com/docs/containers/docker-compose#_adding-docker-compose-support-to-your-project)

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/1377 makes build time slightly faster so dev experience improves

## Dependencies Versions

- `debugpy` added as a dev dependency

## Notes on Testing

- Tested changes locally with some `launch.json` changes that are described in the `README.md`
- Was able to place breakpoints, modify code for changes to reload immediately

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
