### PR TITLE
UN-2544 [MISC] Consolidate build notifications into single summary

### DIFF
--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -89,27 +89,72 @@ jobs:
             *.cache-from=type=gha,scope=${{ matrix.service_name }}
             *.cache-to=type=gha,mode=max,scope=${{ matrix.service_name }}
 
-      # Notify Slack on successful build
-      - name: Notify Slack on Success
-        if: success()
+  # Summary job that runs after all builds
+  build-summary:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Generate build summary
+        id: summary
+        run: |
+          # Initialize variables
+          TOTAL_SERVICES=6
+          JOBS_JSON='${{ toJson(needs.build-and-push) }}'
+          
+          # Check overall result
+          if echo "$JOBS_JSON" | grep -q '"result":"success"'; then
+            SUMMARY_STATUS="✅ All Docker builds successful"
+            SUMMARY_COLOR="good"
+          else
+            SUMMARY_STATUS="❌ Some Docker builds failed"
+            SUMMARY_COLOR="danger"
+          fi
+          
+          echo "summary_status=$SUMMARY_STATUS" >> $GITHUB_OUTPUT
+          echo "summary_color=$SUMMARY_COLOR" >> $GITHUB_OUTPUT
+          echo "total_count=$TOTAL_SERVICES" >> $GITHUB_OUTPUT
+
+      # Write to GitHub Summary
+      - name: Write GitHub Summary
+        run: |
+          echo "# 🐳 Docker Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status**: ${{ steps.summary.outputs.summary_status }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag**: ${{ github.event.release.tag_name || github.event.inputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Total Services**: ${{ steps.summary.outputs.total_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Services" >> $GITHUB_STEP_SUMMARY
+          echo "- backend" >> $GITHUB_STEP_SUMMARY
+          echo "- frontend" >> $GITHUB_STEP_SUMMARY
+          echo "- platform-service" >> $GITHUB_STEP_SUMMARY
+          echo "- prompt-service" >> $GITHUB_STEP_SUMMARY
+          echo "- runner" >> $GITHUB_STEP_SUMMARY
+          echo "- x2text-service" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+
+      # Send summary notification to Slack
+      - name: Send Slack summary notification
+        if: always()
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "✅ Docker Build Successful",
+              "text": "${{ steps.summary.outputs.summary_status }}",
               "attachments": [
                 {
-                  "color": "good",
+                  "color": "${{ steps.summary.outputs.summary_color }}",
                   "fields": [
                     {
-                      "title": "Service",
-                      "value": "${{ matrix.service_name }}",
+                      "title": "Docker Tag",
+                      "value": "${{ github.event.release.tag_name || github.event.inputs.tag }}",
                       "short": true
                     },
                     {
-                      "title": "Tag",
-                      "value": "${{ env.DOCKER_VERSION_TAG }}",
+                      "title": "Total Services",
+                      "value": "${{ steps.summary.outputs.total_count }}",
                       "short": true
                     },
                     {
@@ -123,60 +168,21 @@ jobs:
                       "short": true
                     },
                     {
-                      "title": "Run URL",
+                      "title": "Services",
+                      "value": "backend, frontend, platform-service, prompt-service, runner, x2text-service",
+                      "short": false
+                    },
+                    {
+                      "title": "Workflow Run",
                       "value": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                       "short": false
                     }
                   ],
-                  "footer": "GitHub Actions"
+                  "footer": "GitHub Actions",
+                  "ts": "${{ github.event.head_commit.timestamp }}"
                 }
               ]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      # Notify Slack on failed build
-      - name: Notify Slack on Failure
-        if: failure()
-        uses: slackapi/slack-github-action@v2.1.0
-        with:
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "❌ Docker Build Failed",
-              "attachments": [
-                {
-                  "color": "danger",
-                  "fields": [
-                    {
-                      "title": "Service",
-                      "value": "${{ matrix.service_name }}",
-                      "short": true
-                    },
-                    {
-                      "title": "Tag",
-                      "value": "${{ env.DOCKER_VERSION_TAG }}",
-                      "short": true
-                    },
-                    {
-                      "title": "Repository",
-                      "value": "${{ github.repository }}",
-                      "short": true
-                    },
-                    {
-                      "title": "Workflow",
-                      "value": "${{ github.workflow }}",
-                      "short": true
-                    },
-                    {
-                      "title": "Run URL",
-                      "value": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                      "short": false
-                    }
-                  ],
-                  "footer": "GitHub Actions"
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -101,7 +101,7 @@ jobs:
           # Initialize variables
           TOTAL_SERVICES=6
           JOBS_JSON='${{ toJson(needs.build-and-push) }}'
-          
+
           # Check overall result
           if echo "$JOBS_JSON" | grep -q '"result":"success"'; then
             SUMMARY_STATUS="✅ All Docker builds successful"
@@ -110,7 +110,7 @@ jobs:
             SUMMARY_STATUS="❌ Some Docker builds failed"
             SUMMARY_COLOR="danger"
           fi
-          
+
           echo "summary_status=$SUMMARY_STATUS" >> $GITHUB_OUTPUT
           echo "summary_color=$SUMMARY_COLOR" >> $GITHUB_OUTPUT
           echo "total_count=$TOTAL_SERVICES" >> $GITHUB_OUTPUT
@@ -185,4 +185,3 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-


### PR DESCRIPTION
## What

- Remove individual Slack notifications for each service build
- Add build-summary job that runs after all builds complete
- Generate GitHub workflow summary with build status and service list
- Send single consolidated Slack notification with overall build results

## Why

- Reduces notification spam from 6 individual messages to 1 consolidated summary
- Provides cleaner overview of build status in both Slack and GitHub UI
- Makes it easier to see overall build health at a glance
- Improves signal-to-noise ratio in Slack channels

## How

- Removed the individual success/failure Slack notification steps from build-and-push job
- Added new build-summary job that depends on build-and-push completion
- Summary job checks overall build status and generates consolidated report
- Uses GitHub's GITHUB_STEP_SUMMARY for workflow UI summary
- Sends single Slack notification with all service build results

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this PR cannot break existing features because:
  - Only modifies notification behavior, not build logic
  - Build process remains unchanged
  - Summary job runs with `if: always()` so it won't block workflow
  - Slack notifications are optional - workflow continues if webhook is missing

## Database Migrations

- None required

## Env Config

- Uses existing `SLACK_WEBHOOK_URL` repository secret (no changes)

## Relevant Docs

- GitHub Actions workflow summary documentation
- Slack incoming webhooks documentation

## Related Issues or PRs

- UN-2544
- Builds on PR #1379 (adds initial Slack notifications)

## Dependencies Versions

- Uses existing `slackapi/slack-github-action@v2.1.0` action

## Notes on Testing

- Trigger production build workflow to verify single summary notification
- Check GitHub Actions UI for workflow summary display
- Verify Slack receives one consolidated message instead of six
- Test both success and failure scenarios

## Screenshots

- N/A (workflow notifications)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.ai/code)