### PR TITLE
[MISC] Add frontend development configuration with hot-reloading

### DIFF
--- a/docker/docker-compose.build.yaml
+++ b/docker/docker-compose.build.yaml
@@ -4,6 +4,7 @@ services:
     build:
       dockerfile: docker/dockerfiles/frontend.Dockerfile
       context: ..
+      target: production
   backend:
     image: unstract/backend:${VERSION}
     build:

--- a/docker/dockerfiles/frontend.Dockerfile
+++ b/docker/dockerfiles/frontend.Dockerfile
@@ -1,17 +1,32 @@
-# Use a smaller base image for the builder stage
-FROM node:16-alpine AS builder
+# Multi-stage build for both development and production
 
-# Build-time environment variables
+# Base stage with common setup
+FROM node:16-alpine AS base
 ENV BUILD_CONTEXT_PATH=frontend
-ENV REACT_APP_BACKEND_URL=""
-
-# Set the working directory inside the container
 WORKDIR /app
 
-# Copy only the files needed for installing dependencies
-COPY ${BUILD_CONTEXT_PATH}/package.json ${BUILD_CONTEXT_PATH}/package-lock.json ./
+### FOR DEVELOPMENT ###
+# Development stage for hot-reloading
+FROM base AS development
 
-# Install dependencies (this layer will be cached unless package.json or package-lock.json changes)
+# Copy only package files for dependency caching
+COPY ${BUILD_CONTEXT_PATH}/package.json ${BUILD_CONTEXT_PATH}/package-lock.json ./
+RUN npm install --ignore-scripts
+
+# Copy the rest of the application files
+COPY ${BUILD_CONTEXT_PATH}/ /app/
+
+EXPOSE 3000
+
+CMD ["npm", "start"]
+
+### FOR PRODUCTION ###
+# Builder stage for production build
+FROM base AS builder
+ENV REACT_APP_BACKEND_URL=""
+
+# Copy package files and install dependencies
+COPY ${BUILD_CONTEXT_PATH}/package.json ${BUILD_CONTEXT_PATH}/package-lock.json ./
 RUN npm install --ignore-scripts
 
 # Copy the rest of the application files
@@ -20,13 +35,9 @@ COPY ${BUILD_CONTEXT_PATH}/ .
 # Build the React app
 RUN npm run build
 
-# Use a smaller base image for the final stage
-FROM nginx:1.25-alpine
-
+# Production stage
+FROM nginx:1.25-alpine AS production
 LABEL maintainer="Zipstack Inc."
-
-# Remove the default NGINX configuration (if needed)
-# RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy built assets from the builder stage
 COPY --from=builder /app/build /usr/share/nginx/html

--- a/docker/sample.compose.override.yaml
+++ b/docker/sample.compose.override.yaml
@@ -12,6 +12,12 @@ services:
 # Watch configuration
 # Refer https://docs.docker.com/compose/how-tos/file-watch/
   frontend:
+    build:
+      dockerfile: docker/dockerfiles/frontend.Dockerfile
+      context: ..
+      target: development
+    env_file:
+      - ../frontend/.env
     develop:
       watch:
       # Sync the frontend directory with the container

--- a/frontend/sample.env
+++ b/frontend/sample.env
@@ -1,1 +1,12 @@
 REACT_APP_BACKEND_URL=http://localhost:8000
+
+# For development
+NODE_ENV=development
+# Enable file watching via polling instead of filesystem events
+# These are critical for hot reloading to work properly in Docker containers
+# as the normal filesystem event notification doesn't work reliably with mounted volumes
+CHOKIDAR_USEPOLLING=true
+WATCHPACK_POLLING=true
+# Configure WebSocket port for hot module replacement (HMR)
+WDS_SOCKET_PORT=3000
+FAST_REFRESH=true


### PR DESCRIPTION
## What

Add frontend development configuration with hot-reloading support for improved developer experience.

## Why

This change improves the frontend development workflow by:
- Enabling hot-reloading for faster development iterations
- Properly configuring Docker Compose watch for frontend files
- Setting up environment variables needed for development

## How

- Created a multi-stage Dockerfile with separate development and production targets
- Added development-specific configuration in Docker Compose
- Set up environment variables for hot-reloading in Docker containers
- Configured file watching to sync frontend changes to the container

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No, these changes only affect the development environment and don't modify any production code or behavior. The production build process remains unchanged, as we're only adding a separate development target.

## Database Migrations

None

## Env Config

Added development environment variables in `frontend/sample.env`:
- `NODE_ENV=development`
- `CHOKIDAR_USEPOLLING=true`
- `WATCHPACK_POLLING=true`
- `WDS_SOCKET_PORT=3000`
- `FAST_REFRESH=true`

## Relevant Docs

- [Docker Compose Watch Documentation](https://docs.docker.com/compose/how-tos/file-watch/)
- [React Development Environment](https://create-react-app.dev/docs/advanced-configuration)

## Related Issues or PRs

#1378 

## Dependencies Versions

No new dependencies added.

## Notes on Testing

To test this change:
1. Copy the sample.env file to .env in the frontend directory
2. Run the frontend service with Docker Compose watch:
   ```bash
   VERSION=test docker compose -f docker-compose.yaml -f compose.override.yaml watch frontend
   ```
3. Make changes to frontend files and verify they're automatically reflected in the browser

## Screenshots

N/A

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).