### PR TITLE
UN-2579 [FIX] Support application/octet-stream MIME type for file uploads

### DIFF
--- a/backend/workflow_manager/endpoint_v2/enums.py
+++ b/backend/workflow_manager/endpoint_v2/enums.py
@@ -22,6 +22,7 @@ class AllowedFileTypes(Enum):
     CDFV2 = "application/CDFV2"
     JSON = "application/json"
     CSV = "text/csv"
+    OCTET_STREAM = "application/octet-stream"
 
     @classmethod
     def is_allowed(cls, mime_type: str) -> bool:


### PR DESCRIPTION
## What

- Add support for `application/octet-stream` MIME type in file validation to prevent valid files from being rejected during upload.

## Why

- Users were experiencing failures where PDF files and other valid documents were being skipped with "Unsupported MIME type: application/octet-stream" errors, breaking their existing
   integrations and workflows.

## How

- Added `application/octet-stream` to the AllowedFileTypes enum to include this MIME type in validation checks.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing
- 

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
