### PR TITLE
UN-2579 [FIX] Add fallback to application/octet-stream for files with missing MIME type

### DIFF
--- a/backend/workflow_manager/endpoint_v2/source.py
+++ b/backend/workflow_manager/endpoint_v2/source.py
@@ -928,6 +928,12 @@ class SourceConnector(BaseConnector):
 
             mime_type = file.content_type
             logger.info(f"Detected MIME type: {mime_type} for file {file_name}")
+            if not mime_type:
+                logger.info(
+                    f"MIME type not found for file {file_name}, using default MIME type: {AllowedFileTypes.OCTET_STREAM.value}"
+                )
+                mime_type = AllowedFileTypes.OCTET_STREAM.value
+
             if not AllowedFileTypes.is_allowed(mime_type):
                 log_message = f"Skipping file '{file_name}' to stage due to unsupported MIME type '{mime_type}'"
                 workflow_log.log_info(logger=logger, message=log_message)


### PR DESCRIPTION
## What

- Add fallback mechanism to handle files uploaded without `Content-Type` header by defaulting to application/octet-stream MIME type.
 
## Why

-  Files uploaded without `Content-Type` headers were causing downstream processing errors due to None/empty MIME type values. This resulted in application crashes and failed file
  processing workflows.

## How

- Fallback to `AllowedFileTypes.OCTET_STREAM.value` when MIME type is missing
- Added comprehensive logging for MIME type detection and fallback scenarios

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
