### PR TITLE
UN-2579 [HOT-FIX] Add fallback to application/octet-stream for files with missing MIME type

### DIFF
--- a/backend/workflow_manager/endpoint_v2/enums.py
+++ b/backend/workflow_manager/endpoint_v2/enums.py
@@ -22,6 +22,7 @@ class AllowedFileTypes(Enum):
     CDFV2 = "application/CDFV2"
     JSON = "application/json"
     CSV = "text/csv"
+    OCTET_STREAM = "application/octet-stream"
 
     @classmethod
     def is_allowed(cls, mime_type: str) -> bool:

--- a/backend/workflow_manager/endpoint_v2/source.py
+++ b/backend/workflow_manager/endpoint_v2/source.py
@@ -928,6 +928,12 @@ class SourceConnector(BaseConnector):
 
             mime_type = file.content_type
             logger.info(f"Detected MIME type: {mime_type} for file {file_name}")
+            if not mime_type:
+                logger.info(
+                    f"MIME type not found for file {file_name}, using default MIME type: {AllowedFileTypes.OCTET_STREAM.value}"
+                )
+                mime_type = AllowedFileTypes.OCTET_STREAM.value
+
             if not AllowedFileTypes.is_allowed(mime_type):
                 log_message = f"Skipping file '{file_name}' to stage due to unsupported MIME type '{mime_type}'"
                 workflow_log.log_info(logger=logger, message=log_message)


### PR DESCRIPTION
## What

- Add support for application/octet-stream MIME type in file validation to prevent valid files from being rejected during upload.
- Add fallback mechanism to handle files uploaded without Content-Type header by defaulting to application/octet-stream MIME type.


## Why

- Users were experiencing failures where PDF files and other valid documents were being skipped with "Unsupported MIME type: application/octet-stream" errors, breaking their existing
integrations and workflows.

## How

-  https://github.com/Zipstack/unstract/pull/1392
- https://github.com/Zipstack/unstract/pull/1394

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/1392
- https://github.com/Zipstack/unstract/pull/1394

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
