### PR TITLE
[MISC] Fix Docker builds for OTEL dependencies and non-root user improvements

### DIFF
--- a/docker/dockerfiles/backend.Dockerfile
+++ b/docker/dockerfiles/backend.Dockerfile
@@ -50,6 +50,7 @@ COPY ${BUILD_PACKAGES_PATH}/ /unstract/
 
 # Install external dependencies from pyproject.toml
 RUN uv sync --group deploy --locked --no-install-project --no-dev && \
+    .venv/bin/python3 -m ensurepip --upgrade && \
     uv run opentelemetry-bootstrap -a install
 
 # -----------------------------------------------

--- a/docker/dockerfiles/platform.Dockerfile
+++ b/docker/dockerfiles/platform.Dockerfile
@@ -49,8 +49,12 @@ COPY --chown=${APP_USER}:${APP_USER} ${BUILD_CONTEXT_PATH}/pyproject.toml ${BUIL
 COPY --chown=${APP_USER}:${APP_USER} ${BUILD_PACKAGES_PATH}/core /unstract/core
 COPY --chown=${APP_USER}:${APP_USER} ${BUILD_PACKAGES_PATH}/flags /unstract/flags
 
+# Switch to non-root user
+USER ${APP_USER}
+
 # Install external dependencies from pyproject.toml
 RUN uv sync --group deploy --locked --no-install-project --no-dev && \
+    .venv/bin/python3 -m ensurepip --upgrade && \
     uv run opentelemetry-bootstrap -a install
 
 # -----------------------------------------------
@@ -61,11 +65,11 @@ FROM ext-dependencies AS production
 # Copy application code (this layer changes most frequently)
 COPY --chown=${APP_USER}:${APP_USER} ${BUILD_CONTEXT_PATH} ./
 
+# Switch to non-root user
+USER ${APP_USER}
+
 # Install the application in non-editable mode to avoid permission issues
 RUN uv sync --group deploy --locked
-
-# Switch to non-root user for the rest of the operations
-USER ${APP_USER}
 
 EXPOSE 3001
 

--- a/docker/dockerfiles/prompt.Dockerfile
+++ b/docker/dockerfiles/prompt.Dockerfile
@@ -51,8 +51,12 @@ COPY --chown=${APP_USER}:${APP_USER} ${BUILD_CONTEXT_PATH}/pyproject.toml ${BUIL
 COPY --chown=${APP_USER}:${APP_USER} ${BUILD_PACKAGES_PATH}/core /unstract/core
 COPY --chown=${APP_USER}:${APP_USER} ${BUILD_PACKAGES_PATH}/flags /unstract/flags
 
+# Switch to non-root user
+USER ${APP_USER}
+
 # Install external dependencies from pyproject.toml
 RUN uv sync --group deploy --locked --no-install-project --no-dev && \
+    .venv/bin/python3 -m ensurepip --upgrade && \
     uv run opentelemetry-bootstrap -a install
 
 # -----------------------------------------------
@@ -62,6 +66,9 @@ FROM ext-dependencies AS production
 
 # Copy application code (this layer changes most frequently)
 COPY --chown=${APP_USER}:${APP_USER} ${BUILD_CONTEXT_PATH} ./
+
+# Switch to non-root user
+USER ${APP_USER}
 
 # Install just the application in editable mode
 RUN uv sync --group deploy --locked
@@ -76,9 +83,6 @@ RUN for dir in "${TARGET_PLUGINS_PATH}"/*/; do \
     fi; \
     done && \
     mkdir -p prompt-studio-data
-
-# Switch to non-root user
-USER ${APP_USER}
 
 EXPOSE 3003
 

--- a/docker/dockerfiles/runner.Dockerfile
+++ b/docker/dockerfiles/runner.Dockerfile
@@ -47,6 +47,7 @@ COPY ${BUILD_PACKAGES_PATH}/flags /unstract/flags
 
 # Install external dependencies from pyproject.toml
 RUN uv sync --group deploy --locked --no-install-project --no-dev && \
+    .venv/bin/python3 -m ensurepip --upgrade && \
     uv run opentelemetry-bootstrap -a install
 
 # -----------------------------------------------


### PR DESCRIPTION
## What
This PR improves Docker builds by:
1. Adding `.venv/bin/python3 -m ensurepip --upgrade` to all Dockerfiles to ensure pip is available for OpenTelemetry bootstrap
2. Reorganizing USER directives to switch to non-root user at appropriate stages
3. Ensuring consistent user context for dependency installation and application execution

## Why
- Fixes issues with OpenTelemetry installation in Docker builds
- Improves security by running more operations as non-root user where possible
- Ensures consistent file ownership and permissions across all services

## How
- Added `ensurepip` step to all service Dockerfiles to ensure pip is available
- Moved USER directives to switch to non-root user earlier in the build process
- Maintained proper file ownership with `--chown` directives

## Related PRs

#1377 

## Notes on Testing
The changes have been tested with local Docker builds to ensure:
- All services build successfully
- File permissions are set correctly for runtime operations

No functional changes to the application code were made, only build process improvements.