### PR TITLE
[MISC] Added build definitions to compose override

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -70,7 +70,7 @@ This can be useful during development to:
 3. Start services with watch mode enabled
 
    ```bash
-   VERSION=dev docker compose -f docker-compose.yaml -f compose.override.yaml -f docker-compose.build.yaml watch
+   VERSION=dev docker compose -f docker-compose.yaml -f compose.override.yaml watch
    ```
 
 > **NOTE**: Make sure to specify the build definitions also in your `compose.override.yaml` file or specify [docker-compose.build.yaml](/docker/docker-compose.build.yaml) while running the above command.

--- a/docker/sample.compose.override.yaml
+++ b/docker/sample.compose.override.yaml
@@ -32,6 +32,9 @@ services:
         path: ../frontend/package.json
 
   backend:
+    build:
+      dockerfile: docker/dockerfiles/backend.Dockerfile
+      context: ..
     entrypoint: ["bash", "-c"]
     command: [
       "source .venv/bin/activate && \
@@ -64,6 +67,9 @@ services:
     #   - <path_to_unstract_sdk>/unstract-sdk:/unstract-sdk
 
   runner:
+    build:
+      dockerfile: docker/dockerfiles/runner.Dockerfile
+      context: ..
     entrypoint: ["bash", "-c"]
     command: [
       "source .venv/bin/activate && \
@@ -90,6 +96,9 @@ services:
         path: ../runner/uv.lock
 
   platform-service:
+    build:
+      dockerfile: docker/dockerfiles/platform.Dockerfile
+      context: ..
     entrypoint: ["bash", "-c"]
     command: [
       "source .venv/bin/activate && \
@@ -116,6 +125,9 @@ services:
         path: ../platform-service/uv.lock
 
   prompt-service:
+    build:
+      dockerfile: docker/dockerfiles/prompt.Dockerfile
+      context: ..
     entrypoint: ["bash", "-c"]
     command: [
       "source .venv/bin/activate && \
@@ -142,6 +154,9 @@ services:
         path: ../prompt-service/uv.lock
 
   x2text-service:
+    build:
+      dockerfile: docker/dockerfiles/x2text.Dockerfile
+      context: ..
     entrypoint: ["bash", "-c"]
     command: [
       "source .venv/bin/activate && \


### PR DESCRIPTION
## What
Added build definitions to Docker Compose override configuration.

## Why
To improve the local development experience by enabling Docker Compose watch functionality for hot reloading.

## How
Updated the `compose.override.yaml` file to include proper build configurations with appropriate file watching settings.

## Notes on Testing
The changes can be tested by running Docker Compose with the watch flag:
```bash
VERSION=test docker compose -f docker-compose.yaml -f compose.override.yaml watch <service_name>
```

This should enable hot reloading of the services when code changes are detected.