### PR TITLE
1110 [FIX] Fix cross-platform line ending issues for shell scripts on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Ensure shell scripts always use LF line endings on all platforms
+*.sh text eol=lf
+
+# Ensure other script files use LF line endings
+*.bash text eol=lf
+*.py text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.sql text eol=lf
+
+# Docker files should use LF
+Dockerfile text eol=lf
+*.Dockerfile text eol=lf
+
+# Configuration files
+*.conf text eol=lf
+*.ini text eol=lf
+*.cfg text eol=lf
+*.env text eol=lf
+*.toml text eol=lf
+
+# Binary files should not be converted
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary


### PR DESCRIPTION
## What

- Add .gitattributes file to enforce LF line endings for shell scripts
- Prevent Windows users from experiencing Docker script execution failures
- Fix database schema creation issues on Windows systems (issue #1110)

## Why

Windows users are experiencing database migration failures when running ./run-platform.sh because the db_setup.sh script has Windows line endings (CRLF \r\n) instead of Unix line endings (LF \n). This causes the script to fail execution inside the Linux Docker container, preventing the 'unstract' schema from being created and resulting in errors like:

- "unstract" does not exist at character 28
- CREATE TABLE IF NOT EXISTS "unstract"."x2text_audit" fails
- Database migration fails with schema-related errors

## How

Created .gitattributes file that:
- Forces all .sh files to use LF line endings on all platforms  
- Covers other text file types for consistency
- Prevents future line ending issues for all contributors
- Ensures proper shebang execution (#\!/bin/bash without \r)

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No, this PR cannot break any existing features because:
- .gitattributes only affects how Git handles line endings during checkout/commit
- All existing files already have proper LF line endings (verified)
- The change only prevents future Windows contributors from introducing CRLF
- Unix/Linux systems already expect and work with LF line endings
- This is purely a file format normalization, not a functional change

## Database Migrations

- No database migrations required
- This fix enables proper database setup for Windows users

## Env Config

- No environment configuration changes required

## Relevant Docs

- Git documentation on .gitattributes: https://git-scm.com/docs/gitattributes
- Related to contribution guide line ending standards

## Related Issues or PRs

- Fixes #1110 (Error running in windows)
- Related to #1385 (Database migration fails) 
- Related to #1333 (WSL not working)

## Dependencies Versions

- No dependency changes required

## Notes on Testing

- Verified current db_setup.sh already has proper LF line endings
- Tested dos2unix conversion successfully transforms CRLF → LF  
- Confirmed .gitattributes rules apply correctly to shell scripts
- For current Windows users: run dos2unix docker/scripts/db-setup/db_setup.sh

## Screenshots

N/A - This is a configuration file change

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).