### PR TITLE
UN-2551 [MISC] Enabled Redis cache invalidation script by exposing command path in Django base settings

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -264,6 +264,7 @@ SHARED_APPS = (
     "docs",
     # Plugins
     "plugins",
+    "plugins.authentication.auth0",
     "feature_flag",
     "django_celery_beat",
     # For additional helper commands


### PR DESCRIPTION
## What

- Enabling Redis cache invalidation script by exposing command path in Django base settings.
- Script was added in cloud repo.

## Why

- 

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract-cloud/pull/861

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
