### PR TITLE
Fix FormDataItem TypeError and improve LLM profile UI

### DIFF
--- a/backend/api_v2/postman_collection/dto.py
+++ b/backend/api_v2/postman_collection/dto.py
@@ -24,6 +24,7 @@ class FormDataItem:
     type: str
     src: str | None = None
     value: str | None = None
+    description: str | None = None
 
     def __post_init__(self) -> None:
         if self.type == "file":

--- a/frontend/src/components/custom-tools/manage-llm-profiles/ManageLlmProfiles.jsx
+++ b/frontend/src/components/custom-tools/manage-llm-profiles/ManageLlmProfiles.jsx
@@ -116,32 +116,22 @@ function ManageLlmProfiles() {
     const modifiedRows = llmProfiles.map((item) => {
       return {
         key: item?.profile_id,
-        name: (
-          <div>
-            <div>{item?.profile_name || ""}</div>
-            <div className="profile-id-container">
-              <Typography.Text type="secondary" className="profile-id-text">
-                {item?.profile_id}
-              </Typography.Text>
-              <Tooltip title="Copy Profile ID">
-                <Button
-                  size="small"
-                  type="text"
-                  className="profile-copy-button"
-                  onClick={() => copyProfileId(item?.profile_id)}
-                >
-                  <CopyOutlined className="profile-copy-icon" />
-                </Button>
-              </Tooltip>
-            </div>
-          </div>
-        ),
+        name: item?.profile_name || "",
         llm: item?.llm || "",
         embedding_model: item?.embedding_model || "",
         vector_db: item?.vector_store || "",
         text_extractor: item?.x2text || "",
         actions: (
           <div className="action-buttons-container">
+            <Tooltip title="Copy Profile ID">
+              <Button
+                size="small"
+                className="display-flex-align-center"
+                onClick={() => copyProfileId(item?.profile_id)}
+              >
+                <CopyOutlined classID="manage-llm-pro-icon" />
+              </Button>
+            </Tooltip>
             <Button
               size="small"
               className="display-flex-align-center"


### PR DESCRIPTION
## What

- Fixed TypeError in Postman collection generation and improved LLM profile UI layout

## Why

- FormDataItem class was missing description field causing TypeError when generating Postman collections
- Profile ID display in name column created cluttered UI with poor UX for copy functionality

## How

- Added optional description field to FormDataItem dataclass in dto.py
- Moved copy profile ID button from Name column to Actions column
- Removed profile ID text display from under profile name
- Consolidated all interactive buttons (copy, edit, delete) in Actions column

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots
![image](https://github.com/user-attachments/assets/7ad6a385-e7ed-440d-ac14-3646f05675d0)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
