### PR TITLE
UN-2592 [FIX] Fixing public share for API deployment from Prompt Studio

### DIFF
--- a/frontend/src/components/custom-tools/header/Header.jsx
+++ b/frontend/src/components/custom-tools/header/Header.jsx
@@ -322,11 +322,13 @@ function Header({
           loading={isExportLoading}
           toolDetails={toolDetails}
         />
-        <CreateApiDeploymentFromPromptStudio
-          open={openCreateApiDeploymentModal}
-          setOpen={setOpenCreateApiDeploymentModal}
-          toolDetails={details}
-        />
+        {!isPublicSource && (
+          <CreateApiDeploymentFromPromptStudio
+            open={openCreateApiDeploymentModal}
+            setOpen={setOpenCreateApiDeploymentModal}
+            toolDetails={details}
+          />
+        )}
       </div>
       <Modal
         onOk={handleConfirmForceExport} // Pass the confirm action


### PR DESCRIPTION
## What
Conditionally renders the CreateApiDeploymentFromPromptStudio component only when isPublicSource is false.
...

## Why

To restrict API deployment functionality to authenticated users.

Ensures the modal is not exposed or triggered in public contexts.
...

## How
Wrapped the component inside a conditional expression
...

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
No, this change only affects UI visibility and does not alter any core logic or backend functionality.
...

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
