### PR TITLE
UN-2541 [FIX] Enabled platform key support in text extractor adapter configuration edit

### DIFF
--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -292,12 +292,12 @@ class AdapterInstanceViewSet(ModelViewSet):
         # Check if adapter metadata is being updated and contains the platform key flag
         use_platform_unstract_key = False
         adapter_metadata = request.data.get(AdapterKeys.ADAPTER_METADATA)
-        
+
         if adapter_metadata and adapter_metadata.get(
             AdapterKeys.PLATFORM_PROVIDED_UNSTRACT_KEY, False
         ):
             use_platform_unstract_key = True
-        
+
         # Get the adapter instance and check if it's an X2TEXT adapter
         adapter = self.get_object()
         if adapter.adapter_type == AdapterKeys.X2TEXT and use_platform_unstract_key:
@@ -308,7 +308,7 @@ class AdapterInstanceViewSet(ModelViewSet):
                     adapter_metadata_b, is_paid_subscription=True
                 )
                 request.data[AdapterKeys.ADAPTER_METADATA_B] = updated_metadata_b
-        
+
         if AdapterKeys.SHARED_USERS in request.data:
             # find the deleted users
             adapter = self.get_object()


### PR DESCRIPTION
## What

- A bug has been identified where updating an existing Text Extractor adapter using the platform key is not functioning as expected.


## Why

Issue Details:
- When editing an existing adapter and selecting the option to update using a platform key, the update does not apply correctly.
- This results in incorrect or failed configurations, preventing the adapter from functioning as intended.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
