### PR TITLE
UN-2608 [HOTFIX] Platform key no longer exposed when editing adapters for paid users

### DIFF
--- a/backend/adapter_processor_v2/serializers.py
+++ b/backend/adapter_processor_v2/serializers.py
@@ -56,6 +56,17 @@ class AdapterInstanceSerializer(BaseAdapterSerializer):
 
         rep.pop(AdapterKeys.ADAPTER_METADATA_B)
         adapter_metadata = instance.metadata
+
+        # Hide unstract_key when use_platform_provided_unstract_key is True
+        if (
+            adapter_metadata.get("use_platform_provided_unstract_key") is True
+            and "unstract_key" in adapter_metadata
+        ):
+            # Create a copy to avoid mutating the original metadata
+            adapter_metadata = adapter_metadata.copy()
+            # Set the unstract_key to an empty string instead of removing it
+            adapter_metadata["unstract_key"] = ""
+
         rep[AdapterKeys.ADAPTER_METADATA] = adapter_metadata
         # Retrieve context window if adapter is a LLM
         # For other adapter types, context_window is not relevant.


### PR DESCRIPTION
## What

- HOTFIX : bug has been identified where the platform key is visible during adapter edit for paid users who had manually created the adapter using a platform key.

## Why

-

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
