### PR TITLE
UN-2625 [FEAT] Support for bedrock in rent rolls

### DIFF
--- a/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
@@ -181,7 +181,9 @@ def prompt_processor() -> Any:
             llm_config = adapter_parent_data.get("adapter_metadata")
             adapter_id = adapter_parent_data.get("adapter_id")
             adapter_prefix = adapter_id.split("|")[0]
+            llm_provider = llm._usage_kwargs.get("provider")
             llm_adapter_config = {"adapter_id": adapter_prefix}
+            llm_adapter_config["provider"] = llm_provider
             if adapter_prefix == "azureopenai":
                 llm_adapter_config["model"] = llm_config.get("model")
                 llm_adapter_config["api_key"] = llm_config.get("api_key")
@@ -200,6 +202,15 @@ def prompt_processor() -> Any:
                 llm_adapter_config["model"] = llm_config.get("model")
                 llm_adapter_config["api_key"] = llm_config.get("api_key")
                 llm_adapter_config["max_retries"] = llm_config.get("max_retries")
+                llm_adapter_config["timeout"] = llm_config.get("timeout")
+            if adapter_prefix == "bedrock":
+                llm_adapter_config["model"] = llm_config.get("model")
+                llm_adapter_config["aws_access_key_id"] = llm_config.get("aws_access_key_id")
+                llm_adapter_config["aws_secret_access_key"] = llm_config.get("aws_secret_access_key")
+                llm_adapter_config["max_retries"] = llm_config.get("max_retries")
+                llm_adapter_config["budget_tokens"] = llm_config.get("budget_tokens")
+                llm_adapter_config["max_tokens"] = llm_config.get("max_tokens")
+                llm_adapter_config["region_name"] = llm_config.get("region_name")
                 llm_adapter_config["timeout"] = llm_config.get("timeout")
             table_settings = output[PSKeys.TABLE_SETTINGS]
             document_type: str = table_settings.get(PSKeys.DOCUMENT_TYPE)

--- a/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
@@ -205,8 +205,12 @@ def prompt_processor() -> Any:
                 llm_adapter_config["timeout"] = llm_config.get("timeout")
             if adapter_prefix == "bedrock":
                 llm_adapter_config["model"] = llm_config.get("model")
-                llm_adapter_config["aws_access_key_id"] = llm_config.get("aws_access_key_id")
-                llm_adapter_config["aws_secret_access_key"] = llm_config.get("aws_secret_access_key")
+                llm_adapter_config["aws_access_key_id"] = llm_config.get(
+                    "aws_access_key_id"
+                )
+                llm_adapter_config["aws_secret_access_key"] = llm_config.get(
+                    "aws_secret_access_key"
+                )
                 llm_adapter_config["max_retries"] = llm_config.get("max_retries")
                 llm_adapter_config["budget_tokens"] = llm_config.get("budget_tokens")
                 llm_adapter_config["max_tokens"] = llm_config.get("max_tokens")


### PR DESCRIPTION
## What

- Added support for Bedrock-based LLM adapters by injecting credentials and configuration dynamically at runtime into `llm_adapter_config`.
- Extracted `provider` information from `llm.usage_kwargs` and included it in `llm_adapter_config`.

## Why

- To support dynamic runtime configuration of AWS Bedrock LLMs using user-provided credentials without relying solely on environment variables.
- Enables use of `AnthropicBedrockChatCompletionClient` in AutoGen when users provide credentials during execution.

## How

- Added a conditional block for `adapter_prefix == "bedrock"` to extract and pass:
  - AWS access key, secret key, (optionally session token)
  - Bedrock-specific config such as model, region, timeout, retries, and token budgets

## Can this PR break any existing features?

- **No**, existing adapters (e.g., `azureopenai`) are unaffected—their logic remains untouched.
- The new logic only executes when `adapter_prefix == "bedrock"`.

## Database Migrations

- None

## Env Config

- Not required if credentials are passed via runtime `llm_config`.

## Relevant Docs

- Anthropic Bedrock Auth
- AutoGen LLM Clients

## Related Issues or PRs

- Addresses credential resolution error: “could not resolve credentials from session”

## Dependencies Versions

- Requires a working `boto3` setup and Anthropic Bedrock client support in `autogen_ext`

## Notes on Testing

- Verified user-entered credentials at runtime and validated permissions via `sts.get_caller_identity()`
- Tested behavior when no environment variables are set (e.g., in CI/CD or CLI-only setups)
-

## Screenshots
<img width="916" height="328" alt="image" src="https://github.com/user-attachments/assets/94b3e894-98fc-4cc0-9fe1-0d68de0e6a44" />

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
