### PR TITLE
UN-2603 [FIX] Fix ToolMetadataNotFound error when use_file_history is true

### DIFF
--- a/backend/workflow_manager/endpoint_v2/destination.py
+++ b/backend/workflow_manager/endpoint_v2/destination.py
@@ -172,6 +172,9 @@ class DestinationConnector(BaseConnector):
             return True
 
         # Otherwise use existing workflow-based HITL logic
+        # Skip HITL validation if we're using file_history and no execution result is available
+        if self.use_file_history:
+            return False
         execution_result = self.get_tool_execution_result()
         if WorkflowUtil.validate_db_rule(
             execution_result, workflow, file_hash.file_destination


### PR DESCRIPTION
## What

- Fixed ToolMetadataNotFound error that occurs when `use_file_history` is set to true

## Why

- When `use_file_history` is true, the `_should_handle_hitl` method calls `get_tool_execution_result()` which attempts to read metadata that may not exist
- This causes a ToolMetadataNotFound exception and breaks the workflow execution

## How

- Added a check in `_should_handle_hitl` to skip HITL validation when `use_file_history` is true
- This prevents calling `get_tool_execution_result()` which requires metadata that may not be available
- Minimal 3-line fix that maintains existing behavior for all other scenarios

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this PR cannot break existing features because:
  - The fix only adds a condition to skip HITL validation when `use_file_history` is true
  - All other code paths remain unchanged
  - When `hitl_queue_name` is present, it takes priority as before
  - Normal workflow-based HITL logic continues to work when `use_file_history` is false

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

- Created flow.md documenting the HITL decision flow with all parameter combinations

## Related Issues or PRs

- Related to UN-2603: Changes to support pushing from API to HITL

## Dependencies Versions

- None

## Notes on Testing

- Tested with `use_file_history=false` - works as before
- Tested with `use_file_history=true` - no longer throws ToolMetadataNotFound
- Tested with `hitl_queue_name` present - works as before
- All existing pre-commit hooks pass

## Screenshots

N/A - Backend logic change

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).