### PR TITLE
UN-2653 [FIX] Fixed wrong parsing of nested json array values

### DIFF
--- a/prompt-service/src/unstract/prompt_service/services/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/services/answer_prompt.py
@@ -253,12 +253,12 @@ class AnswerPromptService:
                 json_str="[" + answer, return_objects=True, ensure_ascii=False
             )
 
-            # Heuristic: if wrapping only added '[' and ']', len(b) - len(a) == 2 → original was valid, use 'a'
+            # Heuristic: if wrapping only added '[' and ']', len(b) - len(a) >= 2 → original was valid, use 'a'
             # Otherwise, fallback to 'b' which likely fixed multiple items or invalid top-level structure
             dump_a = json.dumps(a, ensure_ascii=False)
             dump_b = json.dumps(b, ensure_ascii=False)
             ARRAY_WRAP_DELTA = 2  # '[' and ']'
-            parsed_data = a if len(dump_b) - len(dump_a) == ARRAY_WRAP_DELTA else b
+            parsed_data = a if len(dump_b) - len(dump_a) >= ARRAY_WRAP_DELTA else b
 
             if isinstance(parsed_data, str):
                 err_msg = "Error parsing response (to json)\n" f"Candidate JSON: {answer}"


### PR DESCRIPTION
## What

- Fixed wrong parsing of nested json array values

## Why

- `repair_json` library breaks the array in the fallback logic with '[' added. 

## How

- Added >= condition because it was observed in the above case the length was actually lesser than 2.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
