### PR TITLE
UN-2609 [FEAT] Added dumb-init wrapper to forward SIGTERM to Python processes in tool containers 

### DIFF
--- a/runner/src/unstract/runner/runner.py
+++ b/runner/src/unstract/runner/runner.py
@@ -455,7 +455,7 @@ class UnstractRunner:
         )
 
         container_config = self.client.get_container_run_config(
-            command=["/bin/sh", "-c", container_command],
+            command=["dumb-init", "/bin/sh", "-c", container_command],
             file_execution_id=file_execution_id,
             shared_log_dir=shared_log_dir,  # Pass directory for mounting
             container_name=container_name,

--- a/tools/classifier/Dockerfile
+++ b/tools/classifier/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Zipstack Inc."
 
 
 # Install dependencies for unstructured library's partition
-RUN apt-get update && apt-get --no-install-recommends -y install libmagic-dev poppler-utils\
+RUN apt-get update && apt-get --no-install-recommends -y install libmagic-dev poppler-utils dumb-init\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/structure/Dockerfile
+++ b/tools/structure/Dockerfile
@@ -22,7 +22,7 @@ ENV \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ffmpeg libsm6 libxext6 libmagic-dev poppler-utils \
-    libreoffice freetds-dev freetds-bin && \
+    libreoffice freetds-dev freetds-bin dumb-init && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 

--- a/tools/text_extractor/Dockerfile
+++ b/tools/text_extractor/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Zipstack Inc."
 
 
 # Install dependencies for unstructured library's partition
-RUN apt-get update && apt-get --no-install-recommends -y install libmagic-dev poppler-utils\
+RUN apt-get update && apt-get --no-install-recommends -y install libmagic-dev poppler-utils dumb-init\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What

-

## Why

-

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
