### PR TITLE
UN-2678 [MISC]: Add latest tag along with specific tag for Docker image builds 

### DIFF
--- a/.github/workflows/docker-tools-build-push.yaml
+++ b/.github/workflows/docker-tools-build-push.yaml
@@ -17,6 +17,11 @@ on:
           - tool-structure
           - tool-text-extractor
           - tool-sidecar
+      add_latest_tag:
+        description: "Also tag as 'latest'"
+        required: false
+        default: true
+        type: boolean
 
 run-name: "[${{ inputs.service_name }}:${{ inputs.tag }}] Docker Image Build and Push (Development)"
 
@@ -67,15 +72,15 @@ jobs:
             echo "dockerfile=docker/dockerfiles/tool-sidecar.Dockerfile" >> $GITHUB_OUTPUT
           fi
 
-      # Determine tags based on input tag
+      # Determine tags based on inputs
       - name: Determine Docker tags
         id: tags
         run: |
           TAG="${{ github.event.inputs.tag }}"
           TAGS="unstract/${{ github.event.inputs.service_name }}:${TAG}"
 
-          # Add latest tag only if tag doesn't contain 'rc' or 'snapshot'
-          if [[ ! "$TAG" =~ rc ]] && [[ ! "$TAG" =~ snapshot ]]; then
+          # Add latest tag if checkbox is checked
+          if [ "${{ github.event.inputs.add_latest_tag }}" == "true" ]; then
             TAGS="${TAGS}\nunstract/${{ github.event.inputs.service_name }}:latest"
           fi
 

--- a/.github/workflows/docker-tools-build-push.yaml
+++ b/.github/workflows/docker-tools-build-push.yaml
@@ -67,6 +67,22 @@ jobs:
             echo "dockerfile=docker/dockerfiles/tool-sidecar.Dockerfile" >> $GITHUB_OUTPUT
           fi
 
+      # Determine tags based on input tag
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          TAGS="unstract/${{ github.event.inputs.service_name }}:${TAG}"
+
+          # Add latest tag only if tag doesn't contain 'rc' or 'snapshot'
+          if [[ ! "$TAG" =~ rc ]] && [[ ! "$TAG" =~ snapshot ]]; then
+            TAGS="${TAGS}\nunstract/${{ github.event.inputs.service_name }}:latest"
+          fi
+
+          echo "tags<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$TAGS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       # Build and push Docker image
       - name: Build and push ${{ github.event.inputs.service_name }}
         uses: docker/build-push-action@v5
@@ -75,8 +91,6 @@ jobs:
           file: ${{ steps.build-config.outputs.dockerfile }}
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: |
-            unstract/${{ github.event.inputs.service_name }}:${{ github.event.inputs.tag }}
-            unstract/${{ github.event.inputs.service_name }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha,scope=${{ github.event.inputs.service_name }}
           cache-to: type=gha,mode=max,scope=${{ github.event.inputs.service_name }}

--- a/.github/workflows/docker-tools-build-push.yaml
+++ b/.github/workflows/docker-tools-build-push.yaml
@@ -75,6 +75,8 @@ jobs:
           file: ${{ steps.build-config.outputs.dockerfile }}
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: unstract/${{ github.event.inputs.service_name }}:${{ github.event.inputs.tag }}
+          tags: |
+            unstract/${{ github.event.inputs.service_name }}:${{ github.event.inputs.tag }}
+            unstract/${{ github.event.inputs.service_name }}:latest
           cache-from: type=gha,scope=${{ github.event.inputs.service_name }}
           cache-to: type=gha,mode=max,scope=${{ github.event.inputs.service_name }}


### PR DESCRIPTION
## Summary

This PR enhances the Docker image build workflow to tag images with both the specified tag and the `latest` tag, improving discoverability and following Docker best practices.

## Changes

- Modified `.github/workflows/docker-tools-build-push.yaml` to include both specific tag and `latest` tag
- Updated the `tags` configuration to use multi-line format for better readability
- Ensures backward compatibility with existing versioning scheme

## Motivation

Currently, Docker images are only tagged with the specific version provided during the workflow dispatch. This creates challenges for:
- Users who want to pull the latest version without knowing the exact tag
- Automated systems that rely on the `latest` tag convention
- Following Docker Hub best practices for image tagging

## Related Issues

- Fixes UN-2678

## Testing

- [x] Workflow file passes YAML validation
- [x] Pre-commit hooks pass successfully
- [ ] Manual testing of workflow dispatch (to be done post-merge)

## Impact

### Benefits
- **Improved UX**: Users can now pull images using either specific tags or `latest`
- **Docker Best Practices**: Follows standard Docker tagging conventions
- **Automation Friendly**: Systems can rely on `latest` tag for getting most recent builds
- **Backward Compatible**: Existing specific tag functionality remains unchanged

### Example Usage
After this change, when building with tag `v1.2.3`, both tags will be created:
- `unstract/tool-structure:v1.2.3`
- `unstract/tool-structure:latest`

## Checklist

- [x] Code follows project coding standards
- [x] Changes have been tested locally
- [x] Pre-commit hooks pass
- [x] Commit message follows conventional commit format
- [x] Related issue is referenced
- [x] Documentation updated (if applicable)
- [x] No breaking changes introduced