### PR TITLE
UN-2677 [MISC] Add is_staff flag to user session data

### DIFF
--- a/backend/account_v2/dto.py
+++ b/backend/account_v2/dto.py
@@ -61,6 +61,7 @@ class UserSessionInfo:
     user: UserInfo
     role: str
     provider: str
+    is_staff: bool = False
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "UserSessionInfo":
@@ -71,6 +72,7 @@ class UserSessionInfo:
             organization_id=data["organization_id"],
             role=data["role"],
             provider=data["provider"],
+            is_staff=data.get("is_staff", False),
         )
 
     def to_dict(self) -> Any:
@@ -80,6 +82,7 @@ class UserSessionInfo:
             "email": self.email,
             "organization_id": self.organization_id,
             "role": self.role,
+            "is_staff": self.is_staff,
         }
 
 

--- a/backend/account_v2/serializer.py
+++ b/backend/account_v2/serializer.py
@@ -13,8 +13,7 @@ class OrganizationSignupSerializer(serializers.Serializer):
     def validate_organization_id(self, value):  # type: ignore
         if not re.match(r"^[a-z0-9_-]+$", value):
             raise serializers.ValidationError(
-                "organization_code should only contain "
-                "alphanumeric characters,_ and -."
+                "organization_code should only contain alphanumeric characters,_ and -."
             )
         return value
 
@@ -120,3 +119,4 @@ class UserSessionResponseSerializer(serializers.Serializer):
     organization_id = serializers.CharField()
     role = serializers.CharField()
     provider = serializers.CharField()
+    is_staff = serializers.BooleanField()

--- a/backend/account_v2/views.py
+++ b/backend/account_v2/views.py
@@ -150,6 +150,7 @@ def make_session_response(
             organization_id=UserSessionUtils.get_organization_id(request),
             role=UserSessionUtils.get_organization_member_role(request),
             provider=provider,
+            is_staff=request.user.is_staff,
         )
     ).data
 

--- a/frontend/src/helpers/GetSessionData.js
+++ b/frontend/src/helpers/GetSessionData.js
@@ -27,6 +27,7 @@ function getSessionData(sessionData) {
     flags: sessionData?.flags,
     role: sessionData?.role,
     provider: sessionData?.provider,
+    isStaff: sessionData?.is_staff,
   };
 }
 

--- a/frontend/src/hooks/useSessionValid.js
+++ b/frontend/src/hooks/useSessionValid.js
@@ -115,6 +115,7 @@ function useSessionValid() {
       userAndOrgDetails["orgId"] = orgId;
       userAndOrgDetails["csrfToken"] = csrfToken;
       userAndOrgDetails["logEventsId"] = setOrgRes?.data?.log_events_id;
+      userAndOrgDetails["is_staff"] = userSessionData?.is_staff;
 
       requestOptions["method"] = "GET";
 


### PR DESCRIPTION
## Summary

This PR adds the `is_staff` flag to user session data, making it available in both backend and frontend components.

## Changes

### Backend Changes
- **account_v2/dto.py**: Added `is_staff` field to `UserSessionInfo` dataclass with default value False
- **account_v2/serializer.py**: Added `is_staff` field to `UserSessionResponseSerializer`
- **account_v2/views.py**: Populated `is_staff` flag from `request.user.is_staff` in session response

### Frontend Changes
- **helpers/GetSessionData.js**: Added `isStaff` property to session data extraction
- **hooks/useSessionValid.js**: Added `is_staff` field to user and organization details

## Motivation

This enhancement allows the frontend to determine if a user has staff privileges, enabling conditional UI elements and staff-only functionality.

## Related Issues

N/A - Enhancement for user session management

## Testing

- [ ] Verify staff users have `is_staff: true` in session data
- [ ] Verify non-staff users have `is_staff: false` in session data
- [ ] Test that frontend correctly receives and processes the `isStaff` flag
- [ ] Ensure backward compatibility with existing session handling

## Checklist

- [x] Code follows project coding standards
- [x] Changes are backward compatible
- [x] Frontend and backend changes are synchronized
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)