### PR TITLE
UN-2708 [MISC] Remove unused clear cache functionality from platform

### DIFF
--- a/backend/workflow_manager/workflow_v2/constants.py
+++ b/backend/workflow_manager/workflow_v2/constants.py
@@ -48,9 +48,6 @@ class Tool:
 
 
 class WorkflowMessages:
-    CACHE_CLEAR_SUCCESS = "Cache cleared successfully."
-    CACHE_CLEAR_FAILED = "Failed to clear cache."
-    CACHE_EMPTY = "Cache is already empty."
     CELERY_TIMEOUT_MESSAGE = (
         "Your request is being processed. Please wait."
         "You can check the status using the status API."

--- a/backend/workflow_manager/workflow_v2/urls/workflow.py
+++ b/backend/workflow_manager/workflow_v2/urls/workflow.py
@@ -20,7 +20,6 @@ workflow_execute = WorkflowViewSet.as_view({"post": "execute", "put": "activate"
 execution_entity = WorkflowExecutionViewSet.as_view({"get": "retrieve"})
 execution_list = WorkflowExecutionViewSet.as_view({"get": "list"})
 execution_log_list = WorkflowExecutionLogViewSet.as_view({"get": "list"})
-workflow_clear_cache = WorkflowViewSet.as_view({"get": "clear_cache"})
 workflow_clear_file_marker = WorkflowViewSet.as_view({"get": "clear_file_marker"})
 workflow_schema = WorkflowViewSet.as_view({"get": "get_schema"})
 can_update = WorkflowViewSet.as_view({"get": "can_update"})
@@ -28,11 +27,6 @@ urlpatterns = format_suffix_patterns(
     [
         path("", workflow_list, name="workflow-list"),
         path("<uuid:pk>/", workflow_detail, name="workflow-detail"),
-        path(
-            "<uuid:pk>/clear-cache/",
-            workflow_clear_cache,
-            name="clear-cache",
-        ),
         path(
             "<uuid:pk>/clear-file-marker/",
             workflow_clear_file_marker,

--- a/backend/workflow_manager/workflow_v2/views.py
+++ b/backend/workflow_manager/workflow_v2/views.py
@@ -233,12 +233,6 @@ class WorkflowViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["get"])
-    def clear_cache(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        workflow = self.get_object()
-        response: dict[str, Any] = WorkflowHelper.clear_cache(workflow_id=workflow.id)
-        return Response(response.get("message"), status=response.get("status"))
-
-    @action(detail=True, methods=["get"])
     def can_update(self, request: Request, pk: str) -> Response:
         response: dict[str, Any] = WorkflowHelper.can_update_workflow(pk)
         return Response(response, status=status.HTTP_200_OK)

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -907,23 +907,6 @@ class WorkflowHelper:
             mode=workflow_execution.execution_mode,
         )
 
-    # TODO: Access cache through a manager
-    @staticmethod
-    def clear_cache(workflow_id: str) -> dict[str, Any]:
-        """Function to clear cache with a specific pattern."""
-        response: dict[str, Any] = {}
-        try:
-            key_pattern = f"*:cache:{workflow_id}:*"
-            CacheService.clear_cache(key_pattern)
-            response["message"] = WorkflowMessages.CACHE_CLEAR_SUCCESS
-            response["status"] = 200
-            return response
-        except Exception as exc:
-            logger.error(f"Error occurred while clearing cache : {exc}")
-            response["message"] = WorkflowMessages.CACHE_CLEAR_FAILED
-            response["status"] = 400
-            return response
-
     @staticmethod
     def clear_file_marker(workflow_id: str) -> dict[str, Any]:
         """Function to clear file marker from the cache."""

--- a/frontend/src/components/agency/agency/Agency.jsx
+++ b/frontend/src/components/agency/agency/Agency.jsx
@@ -12,7 +12,6 @@ import {
   BugOutlined,
   SettingOutlined,
   PlayCircleOutlined,
-  ClearOutlined,
   HistoryOutlined,
 } from "@ant-design/icons";
 import { useEffect, useState } from "react";
@@ -869,39 +868,6 @@ function Agency() {
     }
   };
 
-  // Handle Clear Cache action
-  const handleClearCache = () => {
-    const workflowId = details?.id;
-    if (!workflowId) {
-      setAlertDetails({
-        type: "error",
-        content: "Invalid workflow id",
-      });
-      return;
-    }
-
-    const requestOptions = {
-      method: "GET",
-      url: getUrl(`workflow/${workflowId}/clear-cache/`),
-    };
-
-    axiosPrivate(requestOptions)
-      .then((res) => {
-        const msg = res?.data;
-        setAlertDetails({
-          type: "success",
-          content: msg,
-        });
-      })
-      .catch((err) => {
-        const msg = err?.response?.data || "Failed to clear cache.";
-        setAlertDetails({
-          type: "error",
-          content: msg,
-        });
-      });
-  };
-
   // Handle tool selection from sidebar
   const handleToolSelection = async (functionName) => {
     setSelectedTool(functionName);
@@ -1013,9 +979,6 @@ function Agency() {
       case "run-workflow":
         handleRunWorkflow();
         break;
-      case "clear-cache":
-        handleClearCache();
-        break;
       case "clear-history":
         handleClearFileMarker();
         break;
@@ -1029,11 +992,6 @@ function Agency() {
       key: "run-workflow",
       label: "Run Workflow",
       icon: <PlayCircleOutlined />,
-    },
-    {
-      key: "clear-cache",
-      label: "Clear Cache",
-      icon: <ClearOutlined />,
     },
     {
       key: "clear-history",

--- a/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
+++ b/frontend/src/components/pipelines-or-deployments/pipelines/Pipelines.jsx
@@ -1,5 +1,4 @@
 import {
-  ClearOutlined,
   DeleteOutlined,
   EllipsisOutlined,
   SyncOutlined,
@@ -270,27 +269,6 @@ function Pipelines({ type }) {
       });
   };
 
-  const clearCache = () => {
-    const requestOptions = {
-      method: "GET",
-      url: `/api/v1/unstract/${sessionDetails?.orgId}/workflow/${selectedPorD.workflow_id}/clear-cache/`,
-      headers: {
-        "X-CSRFToken": sessionDetails?.csrfToken,
-      },
-    };
-    axiosPrivate(requestOptions)
-      .then(() => {
-        setOpenDeleteModal(false);
-        setAlertDetails({
-          type: "success",
-          content: "Pipeline Cache Cleared Successfully",
-        });
-      })
-      .catch((err) => {
-        setAlertDetails(handleException(err));
-      });
-  };
-
   const clearFileMarkers = () => {
     const requestOptions = {
       method: "GET",
@@ -408,19 +386,6 @@ function Pipelines({ type }) {
         <Space
           direction="horizontal"
           className="action-items"
-          onClick={() => clearCache()}
-        >
-          <ClearOutlined />
-          <Typography.Text>Clear Cache</Typography.Text>
-        </Space>
-      ),
-    },
-    {
-      key: "7",
-      label: (
-        <Space
-          direction="horizontal"
-          className="action-items"
           onClick={() => clearFileMarkers()}
         >
           <HighlightOutlined />
@@ -429,7 +394,7 @@ function Pipelines({ type }) {
       ),
     },
     {
-      key: "8",
+      key: "7",
       label: (
         <Space
           direction="horizontal"
@@ -446,7 +411,7 @@ function Pipelines({ type }) {
       ),
     },
     {
-      key: "9",
+      key: "8",
       label: (
         <Space
           direction="horizontal"

--- a/frontend/src/components/workflows/workflow/workflow-service.js
+++ b/frontend/src/components/workflows/workflow/workflow-service.js
@@ -58,16 +58,6 @@ function workflowService() {
       };
       return axiosPrivate(options);
     },
-    clearCache: (id) => {
-      options = {
-        url: `${path}/workflow/${id}/clear-cache/`,
-        method: "GET",
-        headers: {
-          "X-CSRFToken": csrfToken,
-        },
-      };
-      return axiosPrivate(options);
-    },
     clearFileMarkers: (id) => {
       options = {
         url: `${path}/workflow/${id}/clear-file-marker/`,

--- a/tools/classifier/src/config/properties.json
+++ b/tools/classifier/src/config/properties.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.0.1",
   "displayName": "File Classifier",
   "functionName": "classify",
-  "toolVersion": "0.0.66",
+  "toolVersion": "0.0.67",
   "description": "Classifies a file into a bin based on its contents",
   "input": {
     "description": "File to be classified"


### PR DESCRIPTION
## What

- Removed unused clear cache functionality from the entire platform
- Cleaned up backend API endpoints, view methods, and helper functions
- Removed clear cache UI components from Agency and Pipelines pages
- Simplified classifier tool by removing deprecated cache logic
- Fixed menu item key numbering in Pipelines component

## Why

- The clear cache functionality was a remnant from the old tool-classifier design
- No redis keys with the pattern `*:cache:*` are being created anywhere in the current system
- This functionality adds no value to the existing system and only creates confusion
- Removing it simplifies the codebase and reduces maintenance overhead

## How

- **Backend changes:**
  - Removed clear-cache API endpoint and URL routing from `workflow_manager/workflow_v2/urls/workflow.py`
  - Removed `clear_cache` view method from `WorkflowViewSet`
  - Removed `clear_cache` helper method from `WorkflowHelper` class
  - Removed unused constants `CACHE_CLEAR_SUCCESS` and `CACHE_CLEAR_FAILED`

- **Frontend changes:**
  - Removed `handleClearCache` function and "Clear Cache" menu item from Agency component
  - Removed `clearCache` function and menu item from Pipelines component
  - Removed `clearCache` method from workflow service
  - Fixed menu item key numbering to be sequential

- **Tool classifier changes:**
  - Simplified `find_classification` method to remove cache logic
  - Removed `get_result_from_cache` and `save_result_to_cache` methods
  - Removed unused imports (`ToolCache`, `ToolEnv`, `ToolUtils`)

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- **No, this PR will not break any existing features** because:
  - The clear cache functionality was never actually functional in the current system
  - No redis keys with the cache pattern were being created or used
  - The tool-classifier that originally used caching is being deprecated
  - All removed code was dead code that served no purpose
  - Frontend components continue to work normally without the cache clearing option
  - Backend API continues to function with all other endpoints intact

## Database Migrations

- No database migrations required - only code cleanup

## Env Config

- No environment configuration changes required

## Relevant Docs

- No documentation updates needed as this removes unused functionality

## Related Issues or PRs

- UN-2708: Remove clear cache functionality

## Dependencies Versions

- No dependency version changes

## Notes on Testing

- Verified backend and frontend services start without errors
- Confirmed prettier formatting passes for all modified files
- Pre-commit hooks passed successfully
- Manual testing confirmed Agency and Pipelines components load correctly
- API endpoints function normally (tested workflow operations)

## Screenshots

N/A - This is purely a code cleanup/removal task

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

**Summary:** Removes 185 lines of dead code while maintaining full functionality. This is a clean, safe removal of unused legacy functionality.