### PR TITLE
AH-27 [FEAT] Add hideSidebar option to PageLayout for API Hub UI redesign

### DIFF
--- a/frontend/src/components/navigations/side-nav-bar/SideNavBar.jsx
+++ b/frontend/src/components/navigations/side-nav-bar/SideNavBar.jsx
@@ -211,7 +211,11 @@ const SideNavBar = ({ collapsed }) => {
     unstractMenuItems[1].subMenu.unshift(dashboardSideMenuItem(orgName));
   }
 
-  const data = menu || unstractMenuItems;
+  // If selectedProduct is verticals and menu is null, don't show any sidebar items
+  const data =
+    selectedProduct === "verticals" && menu === null
+      ? []
+      : menu || unstractMenuItems;
 
   if (getMenuItem && flags?.app_deployment) {
     data[1]?.subMenu?.splice(1, 0, getMenuItem.default(orgName));

--- a/frontend/src/layouts/page-layout/PageLayout.jsx
+++ b/frontend/src/layouts/page-layout/PageLayout.jsx
@@ -13,6 +13,7 @@ function PageLayout({
   sideBarOptions,
   topNavBarOptions,
   showLogsAndNotifications = true,
+  hideSidebar = false,
 }) {
   const initialCollapsedValue =
     JSON.parse(localStorage.getItem("collapsed")) || false;
@@ -20,22 +21,25 @@ function PageLayout({
   useEffect(() => {
     localStorage.setItem("collapsed", JSON.stringify(collapsed));
   }, [collapsed]);
-
   return (
     <div className="landingPage">
       <TopNavBar topNavBarOptions={topNavBarOptions} />
       <Layout>
-        <SideNavBar collapsed={collapsed} {...sideBarOptions} />
+        {!hideSidebar && (
+          <SideNavBar collapsed={collapsed} {...sideBarOptions} />
+        )}
         <Layout>
-          <Button
-            shape="circle"
-            size="small"
-            icon={collapsed ? <RightOutlined /> : <LeftOutlined />}
-            onClick={() => setCollapsed(!collapsed)}
-            className="collapse_btn"
-          />
+          {!hideSidebar && (
+            <Button
+              shape="circle"
+              size="small"
+              icon={collapsed ? <RightOutlined /> : <LeftOutlined />}
+              onClick={() => setCollapsed(!collapsed)}
+              className="collapse_btn"
+            />
+          )}
           <Outlet />
-          <div className="height-40" />
+          {!hideSidebar && <div className="height-40" />}
           {showLogsAndNotifications && <DisplayLogsAndNotifications />}
         </Layout>
       </Layout>
@@ -46,6 +50,7 @@ PageLayout.propTypes = {
   sideBarOptions: PropTypes.any,
   topNavBarOptions: PropTypes.any,
   showLogsAndNotifications: PropTypes.bool,
+  hideSidebar: PropTypes.bool,
 };
 
 export { PageLayout };


### PR DESCRIPTION
## What

- Added hideSidebar prop to PageLayout component to conditionally hide sidebar and collapse button
- Modified SideNavBar to show empty array when selectedProduct is 'verticals' and menu is null
- Updated PageLayout PropTypes to include hideSidebar boolean prop

## Why

- Required for API Hub UI redesign to support layouts without sidebars
- Enables cleaner UI for verticals product when no menu items are available

## How

- Added hideSidebar boolean prop to PageLayout component with default value false
- Wrapped SideNavBar and collapse button in conditional rendering based on hideSidebar
- Added logic in SideNavBar to return empty array for verticals product when menu is null
- Updated PropTypes to include new hideSidebar prop

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No, this PR should not break existing features because:
- The hideSidebar prop has a default value of false, maintaining existing behavior
- All existing PageLayout usages will continue to work as before since hideSidebar is optional
- The SideNavBar changes only affect the specific case of verticals product with null menu
- The changes are purely additive and backward compatible

## Database Migrations

- N/A - Frontend only changes

## Env Config

- N/A - No environment configuration changes

## Relevant Docs

- N/A - Internal component changes

## Related Issues or PRs

- AH-27 API Hub UI redesign

## Dependencies Versions

- N/A - No dependency changes

## Notes on Testing

- Test sidebar visibility with hideSidebar=true/false
- Verify collapse button behavior
- Test verticals product with null menu shows empty sidebar
- Ensure existing layouts remain functional

## Screenshots

N/A

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).