### PR TITLE
[MISC] Add missing PresignedURLFetchError class to resolve import error

### DIFF
--- a/backend/api_v2/exceptions.py
+++ b/backend/api_v2/exceptions.py
@@ -71,7 +71,6 @@ class PresignedURLFetchError(APIException):
         if detail is None:
             detail = f"Failed to fetch file from URL: {url}. Error: {error_message}"
         
-        # Set status_code as instance attribute, don't modify class attribute
         self.status_code = status_code
         super().__init__(detail, code)
     

--- a/backend/api_v2/exceptions.py
+++ b/backend/api_v2/exceptions.py
@@ -57,9 +57,10 @@ class NoActiveAPIKeyError(APIException):
             detail = f"No active API keys configured for {deployment_name}"
         super().__init__(detail, code)
 
+
 class PresignedURLFetchError(APIException):
     default_detail = "Failed to fetch file from presigned URL"
-    
+
     def __init__(
         self,
         url: str = "",
@@ -70,16 +71,16 @@ class PresignedURLFetchError(APIException):
     ):
         if detail is None:
             detail = f"Failed to fetch file from URL: {url}. Error: {error_message}"
-        
+
         self.status_code = status_code
         super().__init__(detail, code)
-    
+
     @classmethod
     def from_response_error(cls, url: str, response_status: int, error_message: str = ""):
         """Create exception with status code derived from HTTP response"""
         return cls(url=url, error_message=error_message, status_code=response_status)
-    
-    @classmethod  
+
+    @classmethod
     def from_request_exception(cls, url: str, exception: Exception):
         """Create exception with status code inferred from exception type"""
         status_code = 400  # default
@@ -87,5 +88,5 @@ class PresignedURLFetchError(APIException):
             status_code = 504
         elif "connection" in str(exception).lower():
             status_code = 502
-            
+
         return cls(url=url, error_message=str(exception), status_code=status_code)


### PR DESCRIPTION
## What

- Add missing PresignedURLFetchError class to resolve import error.

## Why

- This class was not included earlier with the S3 presigned url support for api deployments PR.

## How

- Implemented the class `PresignedURLFetchError` class.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/1485

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
