### PR TITLE
UN-2749 [MISC]: Add path ignore patterns to CI workflow

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docker/**'
+      - 'frontend/**'
+      - 'docs/**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
+    paths-ignore:
+      - 'docker/**'
+      - 'frontend/**'
+      - 'docs/**'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Add path ignore patterns to CI workflow to skip runs for docker/, frontend/, and docs/ directory changes
- Optimizes CI resource usage by avoiding unnecessary test runs for non-backend changes

## Test plan
- [ ] Verify CI workflow doesn't trigger for changes to docker/ directory
- [ ] Verify CI workflow doesn't trigger for changes to frontend/ directory  
- [ ] Verify CI workflow doesn't trigger for changes to docs/ directory
- [ ] Verify CI workflow still triggers for backend code changes