### PR TITLE
[FIX] Import issue related to connectors

### DIFF
--- a/backend/connector_processor/connector_processor.py
+++ b/backend/connector_processor/connector_processor.py
@@ -20,7 +20,6 @@ from unstract.connectors.connectorkit import Connectorkit
 from unstract.connectors.enums import ConnectorMode
 from unstract.connectors.exceptions import ConnectorError, FSAccessDeniedError
 from unstract.connectors.filesystems.ucs import UnstractCloudStorage
-from unstract.connectors.queues.redis import RedisQueue
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +71,10 @@ class ConnectorProcessor:
         """Function to return list of all supported connectors except PCS."""
         supported_connectors = []
         updated_connectors = []
-        # Connectors that are marked active but not supported explicitly
-        unsupported_connectors = [RedisQueue.get_id()]
+
+        # HACK: Connectors that are marked active but not supported explicitly
+        # TODO: Remove RedisQueue from the list of connectors and use separately instead
+        unsupported_connectors = ["redisqueue|79e1d681-9b8b-4f6b-b972-1a6a095312f45"]
 
         if type == ConnectorKeys.INPUT:
             updated_connectors = fetch_connectors_by_key_value(


### PR DESCRIPTION
## What

- Fixed an import issue related to Unstract Connectors

## Why

- Import error on OSS when a redis related subpackage was imported

## How

- Removed the import since it was used to fetch an ID. Replaced it by directly specifying the ID
- This sort of a check was done in the frontend previously which got removed in a recent PR

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No,

## Related Issues or PRs

- [Commit](https://github.com/Zipstack/unstract/commit/f90b141de739fe091047c2525fec58f89baefd61#diff-400724df174514442f8118d13dbb721835f0bb9ee50d249e0bd247446e2ae048R23-R78) from #1476

## Notes on Testing

- Checked if the OSS ran fine

## Screenshots
- No redis connector was also added here
<img width="1479" height="968" alt="image" src="https://github.com/user-attachments/assets/9ec83fbe-616d-498b-a84c-62debfd12a55" />


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
