### PR TITLE
UN-2354 [FIX] - Fix premature file stream closure in presigned URL handling for API Deployments

### DIFF
--- a/backend/api_v2/deployment_helper.py
+++ b/backend/api_v2/deployment_helper.py
@@ -403,12 +403,6 @@ class DeploymentHelper(BaseAPIKeyValidator):
                 url=sanitized_url, error_message=error_msg, status_code=status_code
             )
 
-        finally:
-            if file_stream:
-                try:
-                    file_stream.close()
-                except Exception as e:
-                    logger.warning(f"Failed to close file stream: {str(e)}")
 
     @staticmethod
     def load_presigned_files(


### PR DESCRIPTION
## What

- Fixed "I/O operation on closed file" error when processing presigned S3 URLs in API deployments
- Implemented proper file stream lifecycle management to prevent memory leaks with multiple file uploads
- Added explicit file closure after file processing is complete

## Why

- When uploading files via presigned S3 URLs, the API was failing with ValueError: I/O operation on closed file
- The finally block was closing the BytesIO stream immediately after creating the InMemoryUploadedFile object

## How

- Added a finally block that only closes the stream if the InMemoryUploadedFile wasn't created successfully (when file_stream is still not None).
- Added explicit file closure in `execute_workflow()` after `SourceConnector.add_input_file_to_api_storage()` completes.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this PR will not break any existing features. 
The changes are additive and defensive:
  1. File closure additions: The explicit file closure after processing is safe for all file types (InMemoryUploadedFile, TemporaryUploadedFile) and follows Django best practices
  2. Regular file uploads: Unchanged behavior for standard form-data file uploads through Postman/API clients
  3. Error handling: Enhanced error handling in the finally block only triggers in failure cases

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Test by uploading files via presigned S3 URLs to API deployments
- Test regular file uploads via form-data to ensure no regression
- Verify that files process successfully without "I/O operation on closed file" errors

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
