### PR TITLE
[Fix] Passed timeout as 1 minute for Post processing function

### DIFF
--- a/prompt-service/src/unstract/prompt_service/services/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/services/answer_prompt.py
@@ -353,6 +353,7 @@ class AnswerPromptService:
                                 webhook_enabled=True,
                                 webhook_url=webhook_url,
                                 highlight_data=highlight_data,
+                                timeout=60,
                             )
                         except Exception as e:
                             app.logger.warning(


### PR DESCRIPTION
## What

- Passed timeout as 1 minute for Post processing function

## Why

- Missed setting the timeout to 1 minute for the post-processing function, so it defaulted to 2s, which isn’t enough.

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
