### PR TITLE
UN-1648 [FIX] - Fixed issue with row insertion in destination DB for failure scenarios

### DIFF
--- a/backend/workflow_manager/endpoint_v2/destination.py
+++ b/backend/workflow_manager/endpoint_v2/destination.py
@@ -345,7 +345,6 @@ class DestinationConnector(BaseConnector):
             destination_configurations.get(DestinationKey.EXECUTION_ID, "execution_id")
         )
 
-
         data = self.get_tool_execution_result() if not error else None
         metadata = self.get_combined_metadata()
 

--- a/backend/workflow_manager/endpoint_v2/destination.py
+++ b/backend/workflow_manager/endpoint_v2/destination.py
@@ -354,8 +354,7 @@ class DestinationConnector(BaseConnector):
 
         # Log when we're proceeding with error insertion
         if error and not data:
-            error_context = f" for {input_file_path}" if input_file_path else ""
-            logger.info(f"Proceeding with error record insertion{error_context}: {error}")
+            logger.info(f"Proceeding with error record insertion for {input_file_path}: {error}")
 
         if isinstance(data, dict):
             data.pop("metadata", None)

--- a/backend/workflow_manager/endpoint_v2/destination.py
+++ b/backend/workflow_manager/endpoint_v2/destination.py
@@ -354,7 +354,9 @@ class DestinationConnector(BaseConnector):
 
         # Log when we're proceeding with error insertion
         if error and not data:
-            logger.info(f"Proceeding with error record insertion for {input_file_path}: {error}")
+            logger.info(
+                f"Proceeding with error record insertion for {input_file_path}: {error}"
+            )
 
         if isinstance(data, dict):
             data.pop("metadata", None)


### PR DESCRIPTION
## What

- Fixed issue with row insertion in the destination DB for failure scenarios.
- Fixed issue where the insert_into_db() was expecting error as a required parameter.

## Why

- It was preventing the insertion of rows in cases of failures in workflow execution.
- HITL was failing due to the required `error` parameter.

## How

- Added a condition to only fetch data when there are no errors.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested failure scenarios for db insertion and success scenarios.
- Test HITL flow

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
