### PR TITLE
UN-2807 [FEAT] Add packet processing support for HITL workflows

### DIFF
--- a/backend/api_v2/api_deployment_views.py
+++ b/backend/api_v2/api_deployment_views.py
@@ -70,6 +70,7 @@ class DeploymentExecution(views.APIView):
         tag_names = serializer.validated_data.get(ApiExecution.TAGS)
         llm_profile_id = serializer.validated_data.get(ApiExecution.LLM_PROFILE_ID)
         hitl_queue_name = serializer.validated_data.get(ApiExecution.HITL_QUEUE_NAME)
+        packet_id = serializer.validated_data.get(ApiExecution.PACKET_ID)
 
         if presigned_urls:
             DeploymentHelper.load_presigned_files(presigned_urls, file_objs)
@@ -85,6 +86,7 @@ class DeploymentExecution(views.APIView):
             tag_names=tag_names,
             llm_profile_id=llm_profile_id,
             hitl_queue_name=hitl_queue_name,
+            packet_id=packet_id,
             request_headers=dict(request.headers),
         )
         if "error" in response and response["error"]:

--- a/backend/api_v2/constants.py
+++ b/backend/api_v2/constants.py
@@ -10,4 +10,5 @@ class ApiExecution:
     TAGS: str = "tags"
     LLM_PROFILE_ID: str = "llm_profile_id"
     HITL_QUEUE_NAME: str = "hitl_queue_name"
+    PACKET_ID: str = "packet_id"
     PRESIGNED_URLS: str = "presigned_urls"

--- a/backend/api_v2/deployment_helper.py
+++ b/backend/api_v2/deployment_helper.py
@@ -155,6 +155,7 @@ class DeploymentHelper(BaseAPIKeyValidator):
         tag_names: list[str] = [],
         llm_profile_id: str | None = None,
         hitl_queue_name: str | None = None,
+        packet_id: str | None = None,
         request_headers=None,
     ) -> ReturnDict:
         """Execute workflow by api.
@@ -168,6 +169,7 @@ class DeploymentHelper(BaseAPIKeyValidator):
             tag_names (list(str)): list of tag names
             llm_profile_id (str, optional): LLM profile ID for overriding tool settings
             hitl_queue_name (str, optional): Custom queue name for manual review
+            packet_id (str, optional): Packet ID for packet-based review
 
         Returns:
             ReturnDict: execution status/ result
@@ -177,6 +179,10 @@ class DeploymentHelper(BaseAPIKeyValidator):
         if hitl_queue_name:
             logger.info(
                 f"API execution with HITL: hitl_queue_name={hitl_queue_name}, api_name={api.api_name}"
+            )
+        if packet_id:
+            logger.info(
+                f"API execution with Packet: packet_id={packet_id}, api_name={api.api_name}"
             )
         tags = Tag.bulk_get_or_create(tag_names=tag_names)
         workflow_execution = WorkflowExecutionServiceHelper.create_workflow_execution(
@@ -234,6 +240,7 @@ class DeploymentHelper(BaseAPIKeyValidator):
                 use_file_history=use_file_history,
                 llm_profile_id=llm_profile_id,
                 hitl_queue_name=hitl_queue_name,
+                packet_id=packet_id,
             )
             result.status_api = DeploymentHelper.construct_status_endpoint(
                 api_endpoint=api.api_endpoint, execution_id=execution_id

--- a/backend/workflow_manager/endpoint_v2/dto.py
+++ b/backend/workflow_manager/endpoint_v2/dto.py
@@ -92,6 +92,7 @@ class DestinationConfig:
     use_file_history: bool
     file_execution_id: str | None = None
     hitl_queue_name: str | None = None
+    packet_id: str | None = None
 
     def to_json(self) -> dict[str, Any]:
         """Serialize the DestinationConfig instance to a JSON string."""
@@ -104,6 +105,7 @@ class DestinationConfig:
             "use_file_history": self.use_file_history,
             "file_execution_id": file_execution_id,
             "hitl_queue_name": self.hitl_queue_name,
+            "packet_id": self.packet_id,
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Added packet-based processing support for HITL workflows
- Enables grouping of documents into packets for batch review
- Maintains backward compatibility with existing HITL queue implementation

## Changes
- Added `packet_id` parameter to API deployment execution flow
- Enhanced destination connector to route documents to packet queues when packet_id is provided
- Updated DTOs and serializers to include packet_id field throughout the workflow execution chain

## Technical Details
The implementation allows API consumers to specify a `packet_id` during workflow execution, which will:
1. Override the default HITL queue routing
2. Group documents into the specified packet for batch review
3. Use the `PacketQueueUtils` for packet-based queue management

## Test Plan
- [ ] Test API execution without packet_id (should use existing HITL flow)
- [ ] Test API execution with packet_id (should route to packet queue)
- [ ] Verify packet grouping works correctly for multiple documents
- [ ] Ensure backward compatibility with existing HITL workflows
- [ ] Test error handling when invalid packet_id is provided

## Related
- Ticket: UN-2807

🤖 Generated with [Claude Code](https://claude.ai/code)