### PR TITLE
UN-1722 [FEAT] Add export reminder for Prompt Studio projects in use

### DIFF
--- a/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
+++ b/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
@@ -83,7 +83,7 @@ function DocumentParser({
             return updatedPromptsCopy[itemPromptId];
           }
           return item;
-        }
+        },
       );
       modifiedDetails["prompts"] = modifiedPrompts;
       updateCustomTool({ details: modifiedDetails });
@@ -116,8 +116,12 @@ function DocumentParser({
       }
     }
 
+    // Mark that changes have been made when any prompt field is modified
+    const { setHasUnsavedChanges } = useCustomToolStore.getState();
+    setHasUnsavedChanges(true);
+
     const index = promptsAndNotes.findIndex(
-      (item) => item?.prompt_id === promptId
+      (item) => item?.prompt_id === promptId,
     );
 
     if (index === -1) {
@@ -172,7 +176,7 @@ function DocumentParser({
       .then(() => {
         const modifiedDetails = { ...details };
         const modifiedPrompts = [...(modifiedDetails?.prompts || [])].filter(
-          (item) => item?.prompt_id !== promptId
+          (item) => item?.prompt_id !== promptId,
         );
         modifiedDetails["prompts"] = modifiedPrompts;
         updateCustomTool({ details: modifiedDetails });

--- a/frontend/src/components/custom-tools/export-reminder-bar/ExportReminderBar.css
+++ b/frontend/src/components/custom-tools/export-reminder-bar/ExportReminderBar.css
@@ -1,0 +1,31 @@
+.export-reminder-bar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  width: 100%;
+}
+
+.export-reminder-bar .ant-alert {
+  border-radius: 0;
+  border: none;
+  background-color: #fffbe6;
+  border-bottom: 1px solid #ffe58f;
+}
+
+.export-reminder-content {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.export-reminder-text {
+  flex: 1;
+  max-width: 800px;
+  text-align: left;
+}
+
+.export-reminder-button {
+  margin-left: auto;
+}

--- a/frontend/src/components/custom-tools/export-reminder-bar/ExportReminderBar.jsx
+++ b/frontend/src/components/custom-tools/export-reminder-bar/ExportReminderBar.jsx
@@ -1,0 +1,43 @@
+import { ExclamationCircleOutlined } from "@ant-design/icons";
+import { Alert, Button, Space } from "antd";
+import PropTypes from "prop-types";
+import "./ExportReminderBar.css";
+
+function ExportReminderBar({ message, onExport, isExporting }) {
+  return (
+    <div className="export-reminder-bar">
+      <Alert
+        message={
+          <Space className="export-reminder-content">
+            <ExclamationCircleOutlined />
+            <span className="export-reminder-text">{message}</span>
+            <Button
+              type="primary"
+              size="small"
+              onClick={onExport}
+              loading={isExporting}
+              className="export-reminder-button"
+            >
+              Export Now
+            </Button>
+          </Space>
+        }
+        type="warning"
+        banner
+        closable={false}
+      />
+    </div>
+  );
+}
+
+ExportReminderBar.propTypes = {
+  message: PropTypes.string.isRequired,
+  onExport: PropTypes.func.isRequired,
+  isExporting: PropTypes.bool,
+};
+
+ExportReminderBar.defaultProps = {
+  isExporting: false,
+};
+
+export { ExportReminderBar };

--- a/frontend/src/components/custom-tools/header/Header.jsx
+++ b/frontend/src/components/custom-tools/header/Header.jsx
@@ -44,7 +44,8 @@ function Header({
   setOpenCloneModal,
 }) {
   const [isExportLoading, setIsExportLoading] = useState(false);
-  const { details, isPublicSource } = useCustomToolStore();
+  const { details, isPublicSource, markChangesAsExported } =
+    useCustomToolStore();
   const { sessionDetails } = useSessionStore();
   const { setAlertDetails } = useAlertStore();
   const axiosPrivate = useAxiosPrivate();
@@ -69,7 +70,7 @@ function Header({
     selectedUsers,
     toolDetail,
     isSharedWithEveryone,
-    forcedExport = false
+    forcedExport = false,
   ) => {
     const body = {
       is_shared_with_org: isSharedWithEveryone,
@@ -92,6 +93,8 @@ function Header({
           type: "success",
           content: "Custom tool exported successfully",
         });
+        // Clear the export reminder after successful export
+        markChangesAsExported();
       })
       .catch((err) => {
         if (err?.response?.data?.errors[0]?.code === "warning") {
@@ -117,7 +120,7 @@ function Header({
 
     handleExport(selectedUsers, toolDetail, isSharedWithEveryone, true);
     setConfirmModalVisible(false);
-  }, [lastExportParams]);
+  }, [lastExportParams, handleExport]);
 
   const handleShare = (isEdit) => {
     try {
@@ -170,7 +173,7 @@ function Header({
           users.map((user) => ({
             id: user?.id,
             email: user?.email,
-          }))
+          })),
         );
         return users;
       })
@@ -271,7 +274,7 @@ function Header({
       })
       .catch((err) => {
         setAlertDetails(
-          handleException(err, "Failed to check existing deployments")
+          handleException(err, "Failed to check existing deployments"),
         );
         // If check fails, still allow proceeding
         setOpenCreateApiDeploymentModal(true);

--- a/frontend/src/store/custom-tool-store.js
+++ b/frontend/src/store/custom-tool-store.js
@@ -23,6 +23,9 @@ const defaultState = {
   isChallengeEnabled: false,
   adapters: [],
   selectedHighlight: null,
+  hasUnsavedChanges: false,
+  lastExportedAt: null,
+  deploymentUsageInfo: null,
 };
 
 const defaultPromptInstance = {
@@ -49,7 +52,8 @@ const useCustomToolStore = create((setState, getState) => ({
     setState({ ...defaultState });
   },
   setCustomTool: (entireState) => {
-    setState(entireState);
+    // Reset unsaved changes when loading a new tool
+    setState({ ...entireState, hasUnsavedChanges: false });
   },
   updateCustomTool: (entireState) => {
     setState((state) => ({ state, ...entireState }));
@@ -68,15 +72,19 @@ const useCustomToolStore = create((setState, getState) => ({
       promptsAndNotes.push(newNote);
     }
     newState["details"]["prompts"] = [...promptsAndNotes];
+    // Mark as having unsaved changes when a new prompt/note is added
+    newState["hasUnsavedChanges"] = true;
     setState({ ...newState });
   },
   deleteInstance: (promptId) => {
     const newState = { ...getState() };
     const promptsAndNotes = newState?.details?.prompts;
     const filteredData = promptsAndNotes.filter(
-      (item) => item?.prompt_id !== promptId
+      (item) => item?.prompt_id !== promptId,
     );
     newState["details"]["prompts"] = filteredData;
+    // Mark as having unsaved changes when a prompt/note is deleted
+    newState["hasUnsavedChanges"] = true;
     setState({ ...newState });
   },
   getDropdownItems: (propertyName) => {
@@ -95,10 +103,25 @@ const useCustomToolStore = create((setState, getState) => ({
   deleteIndexDoc: (docId) => {
     const existingState = { ...getState() };
     const docs = [...(existingState?.indexDocs || [])].filter(
-      (item) => item !== docId
+      (item) => item !== docId,
     );
     existingState.indexDocs = docs;
     setState(existingState);
+  },
+  setHasUnsavedChanges: (hasChanges) => {
+    setState({ hasUnsavedChanges: hasChanges });
+  },
+  setLastExportedAt: (timestamp) => {
+    setState({ lastExportedAt: timestamp });
+  },
+  setDeploymentUsageInfo: (info) => {
+    setState({ deploymentUsageInfo: info });
+  },
+  markChangesAsExported: () => {
+    setState({
+      hasUnsavedChanges: false,
+      lastExportedAt: new Date().toISOString(),
+    });
   },
 }));
 


### PR DESCRIPTION
## What

- Added export reminder notification system for Prompt Studio projects that are actively used in deployments
- Backend API endpoint to check if project is used in API Deployments, ETL Pipelines, Task Pipelines, or Manual Review
- Frontend change tracking when users edit, add, or delete prompts
- Yellow notification bar with immediate "Export Now" action
- State management to clear notifications after successful export

## Why

- Users were confused when editing prompts in Prompt Studio for projects used in deployments, expecting changes to take effect immediately
- By design, Prompt Studio projects must be exported as Tools for changes to take effect in deployments
- No visual indication was provided to users that their changes needed to be exported

## How

### Backend Changes:
- Extracted existing usage checking logic into reusable `_check_tool_usage()` helper method
- Added `check_deployment_usage` API endpoint that checks all deployment types
- Returns proper message with specific deployment types where the tool is used

### Frontend Changes:
- Added state management for `hasUnsavedChanges`, `deploymentUsageInfo` in custom-tool-store
- Created `ExportReminderBar` component with yellow notification styling
- Integrated change detection in `DocumentParser` for all prompt modifications
- Added deployment usage checking in `ToolIde` component with proper orchestration
- Ensured both header and notification exports clear the reminder

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No, this PR will not break any existing features because:
- It only adds new functionality without modifying existing APIs or data structures
- All changes are additive - new state variables, new components, and new endpoints
- Existing export functionality remains unchanged and continues to work as before
- The notification system is purely visual and doesn't interfere with existing workflows
- Proper error handling ensures graceful degradation if API calls fail

## Database Migrations

- N/A (No database schema changes required)

## Env Config

- N/A (No new environment variables required)

## Relevant Docs

- Feature addresses UN-1722 JIRA ticket requirements

## Related Issues or PRs

- UN-1722: Export reminder for Prompt Studio projects in use

## Dependencies Versions

- N/A (No new dependencies added)

## Notes on Testing

- ✅ Tested change detection for editing, adding, and deleting prompts
- ✅ Verified API correctly identifies all deployment types (API, ETL, Task, Manual Review)
- ✅ Confirmed notification only shows when both conditions are met (changes + deployed)
- ✅ Tested export functionality from both notification bar and header
- ✅ Verified proper state clearing after successful export
- ✅ Tested edge cases: tool not exported, API errors, export errors
- ✅ Confirmed proper state reset when switching between tools

## Screenshots

[Yellow notification bar will appear at the top of Prompt Studio when changes are made to projects that are actively deployed]

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).