### PR TITLE
UN-1856 [Feat] - Docker build context to enable sdk1 imports in tool services

### DIFF
--- a/.github/workflows/docker-tools-build-push.yaml
+++ b/.github/workflows/docker-tools-build-push.yaml
@@ -59,14 +59,14 @@ jobs:
         id: build-config
         run: |
           if [ "${{ github.event.inputs.service_name }}" == "tool-classifier" ]; then
-            echo "context=./tools/classifier" >> $GITHUB_OUTPUT
-            echo "dockerfile=" >> $GITHUB_OUTPUT
+            echo "context=." >> $GITHUB_OUTPUT
+            echo "dockerfile=./tools/classifier/Dockerfile" >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.service_name }}" == "tool-structure" ]; then
-            echo "context=./tools/structure" >> $GITHUB_OUTPUT
-            echo "dockerfile=" >> $GITHUB_OUTPUT
+            echo "context=." >> $GITHUB_OUTPUT
+            echo "dockerfile=./tools/structure/Dockerfile"" >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.service_name }}" == "tool-text-extractor" ]; then
-            echo "context=./tools/text_extractor" >> $GITHUB_OUTPUT
-            echo "dockerfile=" >> $GITHUB_OUTPUT
+            echo "context=." >> $GITHUB_OUTPUT
+            echo "dockerfile=./tools/text_extractor/Dockerfile" >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.service_name }}" == "tool-sidecar" ]; then
             echo "context=." >> $GITHUB_OUTPUT
             echo "dockerfile=docker/dockerfiles/tool-sidecar.Dockerfile" >> $GITHUB_OUTPUT

--- a/.github/workflows/docker-tools-build-push.yaml
+++ b/.github/workflows/docker-tools-build-push.yaml
@@ -63,7 +63,7 @@ jobs:
             echo "dockerfile=./tools/classifier/Dockerfile" >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.service_name }}" == "tool-structure" ]; then
             echo "context=." >> $GITHUB_OUTPUT
-            echo "dockerfile=./tools/structure/Dockerfile"" >> $GITHUB_OUTPUT
+            echo "dockerfile=./tools/structure/Dockerfile" >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.service_name }}" == "tool-text-extractor" ]; then
             echo "context=." >> $GITHUB_OUTPUT
             echo "dockerfile=./tools/text_extractor/Dockerfile" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

- Updated Docker build context from tool-specific directories to project root for tool-classifier, tool-structure, and tool-text-extractor

## Why

- Tool Dockerfiles need to access shared dependencies (sdk1, flags) located in `/unstract/` directory
- Previous build context (`./tools/structure/`) was too narrow and couldn't access files outside the tool directory
- This caused `COPY ${BUILD_PACKAGES_PATH}/sdk1 /unstract/` commands to fail with "not found" errors

## How

- Changed build context to `.` (project root) in docker-compose.build.yaml
- Updated Dockerfile references to include full path (e.g., `./tools/structure/Dockerfile`)

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No, this PR should not break any existing features. The changes only modify the Docker build configuration:
- The build context is now broader, which allows access to more files but doesn't remove access to anything previously available

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract/pull/1482

## Dependencies Versions

-

## Notes on Testing

- Tested building the tools and used `docker exec` to execute the docker instances to check if the sdk1 and flag imports are successful.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
