### PR TITLE
UN-2781 [FEAT] Add LLM Whisperer custom checkout route

### DIFF
--- a/frontend/src/routes/Router.jsx
+++ b/frontend/src/routes/Router.jsx
@@ -23,6 +23,7 @@ let PaymentSuccessful;
 let SelectProduct;
 let UnstractSubscriptionEndPage;
 let CustomPlanCheckoutPage;
+let LlmWhispererCustomCheckoutPage;
 try {
   SimplePromptStudioHelper =
     require("../plugins/simple-prompt-studio/SimplePromptStudioHelper.jsx").SimplePromptStudioHelper;
@@ -46,6 +47,13 @@ let llmWhispererRouter;
 try {
   llmWhispererRouter =
     require("../plugins/routes/useLlmWhispererRoutes.js").useLlmWhispererRoutes;
+} catch (err) {
+  // Do nothing, Not-found Page will be triggered.
+}
+
+try {
+  LlmWhispererCustomCheckoutPage =
+    require("../plugins/llm-whisperer/pages/LlmWhispererCustomCheckoutPage.jsx").LlmWhispererCustomCheckoutPage;
 } catch (err) {
   // Do nothing, Not-found Page will be triggered.
 }
@@ -145,6 +153,12 @@ function Router() {
           <Route
             path="/subscription/custom"
             element={<CustomPlanCheckoutPage />}
+          />
+        )}
+        {LlmWhispererCustomCheckoutPage && (
+          <Route
+            path="/llm-whisperer/custom-checkout"
+            element={<LlmWhispererCustomCheckoutPage />}
           />
         )}
         <Route path="" element={<RequireAuth />}>


### PR DESCRIPTION
## What

- Add `/llm-whisperer/custom-checkout` route to support custom payment plans
- Add dynamic import for `LlmWhispererCustomCheckoutPage` component

## Why

- Support custom Stripe product checkout for LLM Whisperer
- Part of custom payment support implementation

## How

- Added dynamic import for `LlmWhispererCustomCheckoutPage` component in Router.jsx
- Added new route `/llm-whisperer/custom-checkout` following existing pattern

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

- No, this only adds a new route without modifying existing functionality
- The route is conditionally rendered only if the component exists
- Uses dynamic import with try-catch to prevent errors if plugin is missing

## Database Migrations

- None required

## Env Config

- None required

## Relevant Docs

- Updated CLAUDE.md with architecture information about plugin structure

## Related Issues or PRs

- Part of unstract-cloud PR to support custom payment functionality
- Ticket: UN-2781 Custom Payment Support for LLMW

## Dependencies Versions

- No dependency changes

## Notes on Testing

- Navigate to `/llm-whisperer/custom-checkout?product_id=prod_XXX`
- Verify route is accessible and component loads
- Test with valid Stripe product IDs

## Screenshots

- N/A (routing change only)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).