### PR TITLE
[MISC] Fixed variable name typo 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -625,8 +625,14 @@ backend/plugins/subscription/*
 # API Deployment Plugins
 backend/plugins/api/**
 
-# Notfication plugins
+# Notfication Plugin
 backend/plugins/notification/**
+
+# Configuration Plugin
+backend/plugins/configuration/**
+
+# Verticals Usage Plugin
+backend/plugins/verticals_usage/**
 
 # BE pluggable-apps
 backend/pluggable_apps/*

--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -123,7 +123,7 @@ class AdapterProcessor:
                     ):
                         if (
                             adapter_metadata.get(
-                                AdapterKeys.PLATFORM_PROVIDED_UNSTRUCT_KEY
+                                AdapterKeys.PLATFORM_PROVIDED_UNSTRACT_KEY
                             )
                             and add_unstract_key
                         ):
@@ -153,7 +153,7 @@ class AdapterProcessor:
 
                 if adapter_metadata.pop(AdapterKeys.ADAPTER_TYPE) == AdapterKeys.X2TEXT:
                     if (
-                        adapter_metadata.get(AdapterKeys.PLATFORM_PROVIDED_UNSTRUCT_KEY)
+                        adapter_metadata.get(AdapterKeys.PLATFORM_PROVIDED_UNSTRACT_KEY)
                         and add_unstract_key
                     ):
                         adapter_metadata = add_unstract_key(adapter_metadata)

--- a/backend/utils/serializer/integrity_error_mixin.py
+++ b/backend/utils/serializer/integrity_error_mixin.py
@@ -1,5 +1,9 @@
+import logging
+
 from django.db import IntegrityError
 from rest_framework.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
 
 
 class IntegrityErrorMixin:
@@ -30,7 +34,7 @@ class IntegrityErrorMixin:
                 field = field_error_message_map.get("field")
                 message = field_error_message_map.get("message")
                 raise ValidationError({field: message})
-
+        logger.exception("IntegrityError: %s", error)
         # Default message if the error doesn't match any known unique constraints
         raise ValidationError(
             {"detail": "An error occurred while saving. Please try again."}


### PR DESCRIPTION
## What

- Fixed typo in usage of `AdapterKeys.PLATFORM_PROVIDED_UNSTRUCT_KEY` -> `AdapterKeys.PLATFORM_PROVIDED_UNSTRACT_KEY`
- Added gitignore entries for plugins
- Added log to add traceback for integrity errors raised in a helper function

## Why

- Runtime errors due to this typo

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, minor typo correction 

## Related Issues or PRs

- Introduced in #1482 

## Notes on Testing

- It was noticed while trying to create an ETL and it was fixed

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
