### PR TITLE
UN-2850 [FIX] Add INPROGRESS notification for scheduled ETL executions and adjust status mapping

### DIFF
--- a/unstract/core/src/unstract/core/data_models.py
+++ b/unstract/core/src/unstract/core/data_models.py
@@ -473,6 +473,7 @@ class NotificationStatus(Enum):
     COMPLETED = "COMPLETED"
     ERROR = "ERROR"
     STOPPED = "STOPPED"
+    INPROGRESS = "INPROGRESS"
 
     def __str__(self):
         """Return enum value for Django CharField compatibility."""
@@ -487,6 +488,7 @@ class NotificationSource(Enum):
     PIPELINE_COMPLETION = "pipeline-completion"
     API_EXECUTION = "api-execution"
     MANUAL_TRIGGER = "manual-trigger"
+    SCHEDULED_EXECUTION = "scheduled-execution"
 
     def __str__(self):
         """Return enum value for Django CharField compatibility."""
@@ -586,7 +588,11 @@ class NotificationPayload:
         """
         # Map execution status to notification status
         if execution_status in [ExecutionStatus.COMPLETED]:
-            notification_status = NotificationStatus.COMPLETED
+            if workflow_type in [WorkflowType.API]:
+                notification_status = NotificationStatus.COMPLETED
+            else:
+                # For Backward compatibility
+                notification_status = NotificationStatus.SUCCESS
         elif execution_status in [ExecutionStatus.ERROR]:
             notification_status = NotificationStatus.ERROR
         elif execution_status in [ExecutionStatus.STOPPED]:

--- a/workers/notification/providers/slack_webhook.py
+++ b/workers/notification/providers/slack_webhook.py
@@ -101,13 +101,13 @@ class SlackWebhook(WebhookProvider):
             # Format value based on type
             formatted_value = self._format_value(value)
 
-            # Create section block
+            # Create section block with inline format
             blocks.append(
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"*{formatted_key}:*\n{formatted_value}",
+                        "text": f"*{formatted_key}:* {formatted_value}",
                     },
                 }
             )
@@ -179,8 +179,8 @@ class SlackWebhook(WebhookProvider):
             "Status": "Status",
             "Error": "Error",
             "Success": "Success",
-            "Execution Id": "Execution ID",
-            "Organization Id": "Organization ID",
+            "Execution Id": "Execution Id",
+            "Organization Id": "Organization Id",
         }
 
         return key_mapping.get(formatted, formatted)


### PR DESCRIPTION
## What
- Worker V2 Fixes
- Added support for INPROGRESS notification status for scheduled ETL executions
- Added SCHEDULED_EXECUTION as a new notification source
- Fixed notification status mapping for backward compatibility between API and ETL workflows
- Updated Slack webhook message formatting to inline format
- Standardized key naming in Slack notifications

## Why

- Scheduled ETL executions need to send notifications when they start (INPROGRESS status)
- Different workflow types (API vs ETL/TASK) require different status mappings for backward compatibility
- Improved Slack message readability with inline formatting
- Consistent key naming across notification messages

## How

- Extended NotificationStatus enum with INPROGRESS
- Extended NotificationSource enum with SCHEDULED_EXECUTION
- Added conditional logic in NotificationPayload to map COMPLETED to SUCCESS for non-API workflows
- Modified Slack webhook blocks to use inline text format
- Implemented notification trigger in scheduler when pipeline status changes to INPROGRESS

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. Changes maintain backward compatibility:
- API workflows continue using COMPLETED status as before
- ETL/TASK workflows now correctly use SUCCESS status (fixing previous inconsistency)
- New INPROGRESS status is additive and only used for scheduled executions
- Notification infrastructure remains unchanged, only payload structure enhanced

## Database Migrations

- No database migrations required

## Env Config

- No environment configuration changes required

## Relevant Docs

- Related to webhook notification system
- Impacts scheduled execution workflows

## Related Issues or PRs

- Jira: UN-2850

## Dependencies Versions

- No dependency changes

## Notes on Testing

- Test scheduled ETL execution triggers INPROGRESS notification
- Verify API workflows still use COMPLETED status
- Verify ETL/TASK workflows use SUCCESS status
- Check Slack webhook formatting displays inline
- Validate notification is sent at pipeline start

## Screenshots

N/A

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)