### PR TITLE
UN-2854 [MISC] Set CELERY_TASK_REJECT_ON_WORKER_LOST to false by default to prevent duplicate task processing

### DIFF
--- a/workers/sample.env
+++ b/workers/sample.env
@@ -139,7 +139,7 @@ CALLBACK_TASK_SOFT_TIME_LIMIT=3300           # 55 minutes - Callback soft timeou
 # Retry Configuration
 CELERY_TASK_DEFAULT_RETRY_DELAY=60
 CELERY_TASK_MAX_RETRIES=3
-CELERY_TASK_REJECT_ON_WORKER_LOST=true
+CELERY_TASK_REJECT_ON_WORKER_LOST=false
 
 # Advanced Celery Configuration
 CELERY_WORKER_POOL_RESTARTS=true
@@ -242,8 +242,8 @@ UNSTRACT_RUNNER_API_BACKOFF_FACTOR=3
 # =============================================================================
 
 # File Storage Credentials (MinIO)
-WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS={"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}
-API_FILE_STORAGE_CREDENTIALS={"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}
+WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
+API_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 
 # File Execution Configuration
 WORKFLOW_EXECUTION_DIR_PREFIX=unstract/execution
@@ -269,7 +269,7 @@ ENABLE_WEBHOOK_DELIVERY=true
 
 # Tool Registry
 TOOL_REGISTRY_CONFIG_PATH=../unstract/tool-registry/tool_registry_config
-TOOL_REGISTRY_STORAGE_CREDENTIALS={"provider":"local"}
+TOOL_REGISTRY_STORAGE_CREDENTIALS='{"provider":"local"}'
 
 # =============================================================================
 # Optional Advanced Settings

--- a/workers/shared/models/worker_models.py
+++ b/workers/shared/models/worker_models.py
@@ -313,7 +313,7 @@ class WorkerCeleryConfig:
     prefetch_multiplier: int = 1
     max_tasks_per_child: int = 1000
     task_acks_late: bool = True
-    task_reject_on_worker_lost: bool = True
+    task_reject_on_worker_lost: bool = False
 
     # Timeouts
     task_time_limit: int = 7200  # 2 hours

--- a/workers/shared/models/worker_models.py
+++ b/workers/shared/models/worker_models.py
@@ -395,7 +395,10 @@ class WorkerCeleryConfig:
                 int,  # Prevent memory leaks
             ),
             "task_reject_on_worker_lost": get_celery_setting(
-                "TASK_REJECT_ON_WORKER_LOST", self.worker_type, True, bool
+                "TASK_REJECT_ON_WORKER_LOST",
+                self.worker_type,
+                self.task_reject_on_worker_lost,
+                bool,
             ),
             "task_acks_on_failure_or_timeout": get_celery_setting(
                 "TASK_ACKS_ON_FAILURE_OR_TIMEOUT", self.worker_type, True, bool


### PR DESCRIPTION
## What

- Changed default value of CELERY_TASK_REJECT_ON_WORKER_LOST from true to false
- Updated worker_models.py default configuration
- Updated sample.env to reflect new default
- Fixed JSON credential quoting in sample.env

## Why

- **Duplicate task processing**: With task_acks_late=true + task_reject_on_worker_lost=true, long-running tasks (10+ minutes) were being processed twice when Celery detected worker connection loss
- **Production issue**: Same file was processed by different workers ~3 minutes apart (verified in logs with identical trace_id but different span_id)
- **Backend never had this issue**: Backend uses task_acks_late=true but defaults task_reject_on_worker_lost to false (Celery default)
- **Root cause**: When worker connection is detected as lost, task is rejected back to RabbitMQ which redelivers to another worker, causing duplicate processing

## How

- Changed default in WorkerCeleryConfig dataclass (worker_models.py:316): \`task_reject_on_worker_lost: bool = False\`
- Updated sample.env (line 142): \`CELERY_TASK_REJECT_ON_WORKER_LOST=false\`
- Fixed JSON credential quoting in sample.env (using single quotes instead of double quotes for shell compatibility)
- Existing idempotency guard in service.py (checks COMPLETED status) provides secondary protection
- Configuration hierarchy still allows override via environment variables: WORKER_TYPE_TASK_REJECT_ON_WORKER_LOST or CELERY_TASK_REJECT_ON_WORKER_LOST

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

**No, this PR cannot break existing features:**

1. **Aligns with Celery defaults**: Celery's default for task_reject_on_worker_lost is False, we were overriding it to True which caused the issue
2. **Matches backend behavior**: Backend has used False (default) for years without issues
3. **Crash recovery preserved**: Workers can still resume IN_PROGRESS tasks via the FileExecutionTracker (intentional design)
4. **Idempotency maintained**: Existing guard in service.py checks COMPLETED status to prevent re-processing finished files
5. **Trade-off accepted**: Small risk of lost task if worker crashes AND connection loss detection fails, but prevents guaranteed duplicates from connection loss alone
6. **Environment override available**: Can still set to true if needed via env vars

## Database Migrations

- None

## Env Config

**Changed:**
- \`CELERY_TASK_REJECT_ON_WORKER_LOST\`: Default changed from \`true\` to \`false\`

**Impact:**
- Prevents duplicate task delivery when worker connection is lost
- Tasks will not be automatically rejected back to broker on connection loss
- Existing workers will need to pick up new default or set env var explicitly

## Relevant Docs

- Updated: \`workers/sample.env\`
- Related: \`workers/docs/ENVIRONMENT_CONFIGURATION.md\` (documents the setting)
- Code: \`workers/shared/models/worker_models.py\` (configuration defaults)

## Related Issues or PRs

- Part of UN-2470: Remove Django dependency from Celery workers
- Addresses duplicate file processing issue observed in production logs

## Dependencies Versions

- No dependency changes

## Notes on Testing

**Evidence of duplicate processing (from production logs):**
- Same file processed twice by different workers (Process 371 at 06:09:21, Process 143 at 06:12:03)
- Identical trace_id but different span_id/process/thread
- ~3 minute gap between duplicate executions

**Testing recommendations:**
- Monitor file processing logs for duplicate trace_ids
- Verify long-running tasks (10+ minutes) complete without duplication
- Check that crash recovery still works (worker restart during task execution)
- Confirm idempotency guard catches any edge cases

## Screenshots

N/A - Configuration change

## Checklist

✅ I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)