### PR TITLE
UN-2857 [MISC] Fix Redis unacked hash memory leak in log consumer worker

### DIFF
--- a/workers/log_consumer/tasks.py
+++ b/workers/log_consumer/tasks.py
@@ -37,7 +37,7 @@ sio = socketio.Server(
     async_mode="threading",
     logger=False,
     engineio_logger=False,
-    client_manager=socketio.KombuManager(url=socket_io_manager_url),
+    client_manager=socketio.KombuManager(url=socket_io_manager_url, write_only=True),
 )
 
 


### PR DESCRIPTION
## What

- Added `write_only=True` parameter to KombuManager in log_consumer worker
- Prevents creation of entries in Redis `unacked` hash for emit-only workers

## Why

- Redis `unacked` hash was consuming 145 MB with 110K entries in integration environment
- Log consumer worker only emits events (never receives), but was tracking message delivery
- Kombu creates `unacked` entries to track message acknowledgments, but has no TTL
- Integration environment (110K entries) vs Staging (2.6K entries) due to higher activity
- Memory leak caused by messages from disconnected clients never being cleaned up

## How

- Set `write_only=True` in `socketio.KombuManager()` constructor in `workers/log_consumer/tasks.py`
- This tells the worker: "You only publish, don't track delivery"
- Prevents future accumulation while maintaining message delivery to UI clients
- Backend (which receives WebSocket connections) continues to use default `write_only=False`

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

**No, this PR cannot break existing features:**

1. **Message delivery unchanged**: Log consumer emits to Redis, backend receives and forwards to UI
2. **Architecture preserved**: `write_only=True` only affects the worker's internal tracking, not the message flow
3. **Backend unaffected**: Backend SocketIO still receives and delivers messages normally
4. **WebSocket clients unaffected**: UI continues to receive real-time logs via WebSocket
5. **Single-line configuration change**: No logic changes, only optimization of message tracking
6. **Tested pattern**: `write_only=True` is the recommended configuration for emit-only workers per python-socketio documentation

## Database Migrations

- None

## Env Config

- No new environment variables required
- No changes to existing configuration

## Relevant Docs

- `workers/log_consumer/tasks.py` - KombuManager configuration
- Python-socketio KombuManager documentation: https://python-socketio.readthedocs.io/

## Related Issues or PRs

- Addresses Redis memory leak issue with `unacked` hash (internal investigation)
- Related to UN-2470: Remove Django dependency from Celery workers

## Dependencies Versions

- No dependency changes
- Uses existing python-socketio library

## Notes on Testing

**Testing strategy:**
1. Deploy to staging environment first
2. Verify UI still receives real-time logs in workflow execution
3. Monitor Redis `unacked` hash size - should stop growing
4. After 24-hour validation in staging, deploy to integration
5. Monitor integration for 48 hours to confirm leak is stopped

**Success criteria:**
- UI receives logs in real-time (no regression)
- `unacked` hash stops growing beyond current 110K entries
- Memory usage stabilizes

**Rollback plan:**
- Remove `write_only=True` parameter if any issues detected
- Single-line change makes rollback trivial

## Screenshots

N/A - Backend optimization, no UI changes

## Checklist

✅ I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)