### PR TITLE
[MISC] Updated chord retry to parse values as float for v2 workers

### DIFF
--- a/workers/shared/models/worker_models.py
+++ b/workers/shared/models/worker_models.py
@@ -495,7 +495,7 @@ class WorkerCeleryConfig:
         if self.worker_type in chord_workers:
             # Chord retry interval - defaults to Celery standard (1 second)
             config["result_chord_retry_interval"] = get_celery_setting(
-                "RESULT_CHORD_RETRY_INTERVAL", self.worker_type, 1, int
+                "RESULT_CHORD_RETRY_INTERVAL", self.worker_type, 1, float
             )
 
     def to_cli_args(self) -> list[str]:


### PR DESCRIPTION
## What

- Updated a celery config's parsing as float for v2 workers

## Why

- Was previously parsed as int and the sample.env had a float value which caused v2 workers to throw a value error

## How

- Updated parsing into float

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, backward compatible changes only

## Related Issues or PRs

- #1563

## Notes on Testing

- Rebuilt workers and checked explicitly if it loads fine

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
