### PR TITLE
UN-2869 [FIX] Add broker heartbeat configuration to prevent RabbitMQ connection timeouts causing false duplicate detection

### DIFF
--- a/workers/shared/models/worker_models.py
+++ b/workers/shared/models/worker_models.py
@@ -366,6 +366,9 @@ class WorkerCeleryConfig:
             # Connection settings
             "broker_url": broker_url,
             "result_backend": result_backend,
+            "broker_heartbeat": get_celery_setting(
+                "BROKER_HEARTBEAT", self.worker_type, 30, int
+            ),
             # Task routing
             "task_routes": self.task_routing.to_celery_config(),
             # Serialization (configurable from env)


### PR DESCRIPTION
## What

- Added `broker_heartbeat` configuration to `WorkerCeleryConfig` in workers architecture
- Sets 30-second heartbeat interval for all Celery workers to maintain RabbitMQ connections

## Why

- RabbitMQ disconnects idle workers after 60 seconds by default
- Disconnected workers leave tasks in IN_PROGRESS state in database
- Stale IN_PROGRESS records cause false duplicate file detection
- Files are incorrectly rejected as "already being processed" when they are not

## How

- Added `broker_heartbeat` setting to `WorkerCeleryConfig.to_celery_config()` method
- Uses `get_celery_setting()` for hierarchical configuration:
  - Worker-specific env var: `{WORKER_TYPE}_BROKER_HEARTBEAT`
  - Global env var: `CELERY_BROKER_HEARTBEAT`
  - Default value: 30 seconds (half of RabbitMQ's 60s timeout)
- Heartbeat keeps connections alive during long-running tasks
- Prevents connection drops and stale cache/DB entries

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

**No, this PR will not break existing features.**

- This is an additive configuration change with safe defaults
- The 30-second heartbeat is recommended by RabbitMQ and Celery best practices
- Existing workers will continue to function normally, but with more reliable connections
- No changes to task logic, routing, or execution
- Backward compatible - workers without this setting will use RabbitMQ defaults

## Database Migrations

- No database migrations required

## Env Config

**Optional configuration (has safe defaults):**

- `CELERY_BROKER_HEARTBEAT=30` - Global setting for all workers (default: 30)
- `FILE_PROCESSING_BROKER_HEARTBEAT=30` - Worker-specific override (optional)
- `CALLBACK_BROKER_HEARTBEAT=30` - Worker-specific override (optional)
- `GENERAL_BROKER_HEARTBEAT=30` - Worker-specific override (optional)
- `API_DEPLOYMENT_BROKER_HEARTBEAT=30` - Worker-specific override (optional)
- `NOTIFICATION_BROKER_HEARTBEAT=30` - Worker-specific override (optional)
- `LOG_CONSUMER_BROKER_HEARTBEAT=30` - Worker-specific override (optional)

**Recommended:** Use global `CELERY_BROKER_HEARTBEAT=30` for all workers.

## Relevant Docs

- RabbitMQ heartbeat documentation: https://www.rabbitmq.com/heartbeats.html
- Celery broker configuration: https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-heartbeat

## Related Issues or PRs

- Addresses false duplicate detection issues reported in production
- Related to UN-2869 (Jira ticket)

## Dependencies Versions

- No dependency changes

## Notes on Testing

**Testing checklist:**
1. Deploy workers with `CELERY_BROKER_HEARTBEAT=30`
2. Verify RabbitMQ connections remain active during long-running tasks
3. Monitor for false duplicate detection (should be eliminated)
4. Check that files process successfully without duplicate errors
5. Verify connection statistics in RabbitMQ management console

**Local testing:**
```bash
# Set in docker-compose.yaml or .env
CELERY_BROKER_HEARTBEAT=30

# Start workers and monitor logs
docker compose logs -f worker-file-processing-new

# Verify heartbeat in RabbitMQ
# Check connection properties in RabbitMQ management UI (port 15672)
```

## Screenshots

N/A - Infrastructure/configuration change

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)