### PR TITLE
UN-2882 [FIX] Fix BigQuery float precision issue in metadata serialization

### DIFF
--- a/workers/shared/infrastructure/database/utils.py
+++ b/workers/shared/infrastructure/database/utils.py
@@ -6,6 +6,7 @@ of backend/workflow_manager/endpoint_v2/database_utils.py without Django depende
 
 import datetime
 import json
+import math
 from typing import Any
 
 from shared.enums.status_enums import FileProcessingStatus
@@ -96,8 +97,6 @@ class WorkerDatabaseUtils:
             >>> _sanitize_floats_for_database({"time": 22.770092, "count": 5})
             {'time': 22.770092, 'count': 5}
         """
-        import math
-
         if isinstance(data, float):
             # Handle special float values that databases don't support in JSON
             if math.isnan(data) or math.isinf(data):


### PR DESCRIPTION
## What

- Fixed BigQuery insertion failures caused by problematic float values (e.g., `22.770092`) in workflow metadata
- Added `_sanitize_floats_for_database()` helper function to normalize float precision across all database types
- Modified metadata serialization to sanitize floats before JSON encoding

## Why

- BigQuery's `PARSE_JSON()` function rejects float values that cannot "round-trip" through string representation
- Float values like `22.770092` have internal binary representations that fail BigQuery's validation
- This caused intermittent workflow execution failures when inserting metadata into BigQuery destinations
- The issue affected timing data (`total_elapsed_time`, `elapsed_time`), costs (`cost_in_dollars`), and timestamps

## How

- Implemented `_sanitize_floats_for_database()` that recursively normalizes float values using `float(f"{data:.{precision}f}")`
- This string formatting creates a clean binary representation that BigQuery accepts
- The function handles nested structures (dicts, lists) recursively
- Converts NaN and Infinity to None (databases don't support these in JSON)
- Integrated sanitization into `_add_processing_columns()` before `json.dumps()`
- Preserves 6 decimal places (microsecond/sub-cent precision)

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

**No, this PR cannot break existing features because:**

- The changes only normalize float precision, not data types or structure
- 6 decimal precision is more than sufficient for all use cases (timing: microseconds, cost: sub-cent)
- Only affects metadata serialization before database insertion
- Other data types (int, str, bool, None, dict, list) are completely preserved
- Backward compatible - existing data remains valid
- Tested with both problematic values (22.770092) and successful values (16.594318)
- All pre-commit hooks passed (ruff, ruff-format, pycln, pyupgrade)

## Database Migrations

- No database migrations required
- This is a data serialization fix only

## Env Config

- No environment configuration changes required

## Relevant Docs

- Issue identified in logs: BigQuery error "Input number: 22.770092 cannot round-trip through string representation"
- Affects: `workers/shared/infrastructure/database/utils.py`

## Related Issues or PRs

- Jira Ticket: UN-2882
- Fixes BigQuery destination insertion failures for workflow executions

## Dependencies Versions

- No dependency changes

## Notes on Testing

- Tested with exact problematic metadata from failed execution (Amex.pdf with total_elapsed_time: 22.770092)
- Verified successful metadata from working execution (scanned_bill.pdf with total_elapsed_time: 16.594318)
- Edge cases tested: NaN, Infinity, nested structures, mixed data types
- All assertions passed for precision preservation and type safety
- Pre-commit hooks validated code quality

## Screenshots

N/A - Backend/infrastructure fix

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).