### PR TITLE
UN-2942 [HOT-FIX] API deployments now properly clean up execution directories after completion

### DIFF
--- a/workers/callback/tasks.py
+++ b/workers/callback/tasks.py
@@ -1571,6 +1571,9 @@ def process_batch_callback_api(
                 execution_status=execution_status,
             )
 
+            # Handle resource cleanup (matching ETL workflow behavior)
+            cleanup_result = _cleanup_execution_resources(context)
+
             # Handle pipeline updates (skip for API deployments)
             pipeline_result = _handle_pipeline_updates_unified(
                 context=context, final_status=execution_status, is_api_deployment=True
@@ -1604,6 +1607,7 @@ def process_batch_callback_api(
                 "execution_update": execution_update_result,
                 "pipeline_update": pipeline_result,
                 "notifications": notification_result,
+                "cleanup_result": cleanup_result,
                 "optimization": {
                     "method": "unified_callback_functions",
                     "eliminated_code_duplication": True,


### PR DESCRIPTION
## What

- Added missing cleanup call to `process_batch_callback_api` function in `workers/callback/tasks.py`
- API deployments now properly clean up both API execution directories and workflow execution directories after completion

## Why

- API deployments were not cleaning up execution directories after workflow completion
- ETL workflows had the cleanup logic, but API callback implementation was missing this critical step
- This caused accumulation of execution files on disk over time for API deployments
- The cleanup function `_cleanup_execution_resources()` already existed and worked correctly for ETL workflows

## How

- Added `cleanup_result = _cleanup_execution_resources(context)` call after UI logs publishing (line 1574-1575)
- The cleanup function already handles API deployments correctly:
  - Skips cache cleanup for API deployments (preserves cache for subsequent requests)
  - Cleans both API execution directory (`unstract/api/...`) and workflow execution directory (`unstract/execution/...`)
  - Uses the same proven cleanup logic as ETL workflows

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

**No, this PR cannot break existing features:**

- This is a 2-line addition that adds missing functionality (bug fix)
- Uses the existing `_cleanup_execution_resources()` function that is already proven to work for ETL workflows
- No changes to API workflow execution logic, status updates, or pipeline handling
- No changes to cache behavior - cache is still preserved for API deployments as designed
- Only affects post-completion cleanup, which was completely missing before
- The cleanup operation is non-critical and failures are logged without breaking the callback flow
- Backward compatible - API deployments will simply start cleaning up directories (expected behavior)

## Database Migrations

- No database migrations required
- No database schema changes

## Env Config

- No environment configuration changes required
- No new environment variables added

## Relevant Docs

- Related to worker architecture documentation in `workers/ARCHITECTURE_DOCUMENTATION.md`
- Cleanup logic documented in `workers/callback/tasks.py` function comments

## Related Issues or PRs

- Jira Ticket: UN-2942
- Fixes issue where API deployment execution directories were not being cleaned up

## Dependencies Versions

- No dependency version changes
- No new dependencies added

## Notes on Testing

**Testing Steps:**
1. Deploy an API workflow with file processing
2. Check callback worker logs for cleanup messages:
   ```
   ℹ️  Cache cleanup skipped for API deployment (cache preserved)
   🧹 Starting directory cleanup for execution xxx (2 directories to clean)
   🧹 Cleaning api directory: unstract/api/...
   ✅ Successfully cleaned up api execution directory
   🧹 Cleaning workflow directory: unstract/execution/...
   ✅ Successfully cleaned up workflow execution directory
   ```
3. Verify directories are removed after execution completes
4. Verify API functionality still works correctly (cache preserved)
5. Compare with ETL workflow cleanup behavior (should be identical)

## Screenshots

N/A - Backend/worker change with no UI impact

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).