### PR TITLE
Revert "UN-2175 Avoid extracting when doc is already extracted during indexing"

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -427,6 +427,7 @@ class PromptStudioHelper:
             run_id=run_id,
             enable_highlight=tool.enable_highlight,
             doc_id=doc_id,
+            reindex=True,
         )
         if tool.summarize_context:
             summarize_file_path = PromptStudioHelper.summarize(
@@ -1331,6 +1332,7 @@ class PromptStudioHelper:
         profile_manager: ProfileManager,
         document_id: str,
         doc_id: str,
+        reindex: bool | None = False,
     ) -> str:
         x2text = str(profile_manager.x2text.id)
         is_extracted: bool = False
@@ -1348,7 +1350,7 @@ class PromptStudioHelper:
             profile_manager=profile_manager,
             doc_id=doc_id,
         )
-        if is_extracted:
+        if is_extracted and not reindex:
             fs_instance = EnvHelper.get_storage(
                 storage_type=StorageType.PERMANENT,
                 env_name=FileStorageKeys.PERMANENT_REMOTE_STORAGE,


### PR DESCRIPTION
Reverts Zipstack/unstract#1605

# Why

- Current solution made for #1605 causes a regression when highlighting is enabled or disabled
- The long term solution needs to keep track of this information during extraction which can in turn require some form of a migration -> either lazily or a dedicated data migration
- Hence reverting these changes in order to incorporate a better solution with no regressions