### PR TITLE
[MISC] Removed usage of old sdk library in tool

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/tool/executor.py
+++ b/unstract/sdk1/src/unstract/sdk1/tool/executor.py
@@ -5,7 +5,6 @@ from json import loads
 from pathlib import Path
 from typing import Any
 
-from unstract.sdk import get_sdk_version
 from unstract.sdk1.constants import Command
 from unstract.sdk1.tool.base import BaseTool
 from unstract.sdk1.tool.validator import ToolValidator
@@ -60,8 +59,7 @@ class ToolExecutor:
         self.tool.stream_log(
             f"Running tool '{tool_name}:{tool_version}' with "
             f"Workflow ID: {self.tool.workflow_id}, "
-            f"Execution ID: {self.tool.execution_id}, "
-            f"SDK Version: {get_sdk_version()}"
+            f"Execution ID: {self.tool.execution_id}"
         )
         validator = ToolValidator(self.tool)
         settings = validator.validate_pre_execution(settings=settings)


### PR DESCRIPTION
## What

- Removed import from the now removed `unstract-sdk` library

## Why

- [Uploading image.png…]()

## How

- Removed the import and the use of `get_sdk_version()` 

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, only fixes the error by removing the import


## Related Issues or PRs

- Related to #1666 

## Notes on Testing

- No explicit testing

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
