### PR TITLE
[FIX] Fix prompt logs in Variable replacement

### DIFF
--- a/prompt-service/src/unstract/prompt_service/services/variable_replacement.py
+++ b/prompt-service/src/unstract/prompt_service/services/variable_replacement.py
@@ -80,9 +80,6 @@ class VariableReplacementService:
                 custom_data=custom_data,
             )
         finally:
-            app.logger.info(
-                f"[{tool_id}] Prompt after variable replacement: {prompt_text}"
-            )
             publish_log(
                 log_events_id,
                 {
@@ -92,7 +89,7 @@ class VariableReplacementService:
                 },
                 LogLevel.DEBUG,
                 RunLevel.RUN,
-                f"Prompt after variable replacement:{prompt_text} ",
+                f"Variables replaced in prompt with key :{prompt_name}",
             )
         return prompt_text
 


### PR DESCRIPTION
## What
This PR removes direct logging of raw prompt_text after variable replacement and updates it to only log safe metadata (prompt_name).
It fixes leakage of sensitive customer data in logs during prompt variable replacement.
...

## Why
Previously, the service logged the full prompt_text after variable replacement.
Because prompt text may contain user/customer data, this caused PII exposure in logs.

This PR ensures that only non-sensitive metadata is logged, aligning with privacy and compliance requirements....

## How
Removed app.logger.info(f"[{tool_id}] Prompt after variable replacement: {prompt_text}")
...

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
No.
Reason:

The change affects only logging statements.

There is no modification to functional logic, output, or behavior of variable replacement.
...

## Database Migrations
Not applicable
...

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
