### PR TITLE
[FIX] Added aws as optional dependency for tools

### DIFF
--- a/tools/classifier/requirements.txt
+++ b/tools/classifier/requirements.txt
@@ -4,5 +4,5 @@
 # aws alone is needed here
 # because tools use transient temporary storage.
 
--e file:/unstract/sdk1
+-e file:/unstract/sdk1[aws]
 -e file:/unstract/flags

--- a/tools/structure/requirements.txt
+++ b/tools/structure/requirements.txt
@@ -3,6 +3,6 @@
 # Required for all unstract tools
 # aws alone is needed here
 # because tools use transient temporary storage.
--e file:/unstract/sdk1
+-e file:/unstract/sdk1[aws]
 -e file:/unstract/flags
 json-repair>=0.25.0

--- a/tools/text_extractor/requirements.txt
+++ b/tools/text_extractor/requirements.txt
@@ -4,5 +4,5 @@
 # aws alone is needed here
 # because tools use transient temporary storage.
 
--e file:/unstract/sdk1
+-e file:/unstract/sdk1[aws]
 -e file:/unstract/flags


### PR DESCRIPTION
## What

- Added aws as optional dependency for tools

## Why

- Without these optional dependencies the file storage was failing

## How

- Added optional dependency aws for the tools in their respective requirements.txt files.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this cannot break any change siince this is a dependency change.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
