### PR TITLE
[FIX] Added missing stream_update() Method

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/tool/stream.py
+++ b/unstract/sdk1/src/unstract/sdk1/tool/stream.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os
 from typing import Any
-from deprecated import deprecated
 
+from deprecated import deprecated
 from unstract.sdk1.constants import Command, LogLevel, LogStage, ToolEnv
 from unstract.sdk1.exceptions import SdkError
 from unstract.sdk1.utils.common import Utils


### PR DESCRIPTION
## What

- Added missing `stream_update()` method from unstract-sdk to sdk1

## Why

- This missing method was causing issues with structure tool.

## How

- Added the missing method

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
