### PR TITLE
[FIX] Vertex AI conditional field bug and update default max_tokens to 4096

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/anthropic.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/anthropic.json
@@ -26,7 +26,7 @@
       "type": "number",
       "minimum": 0,
       "multipleOf": 1,
-      "default": 512,
+      "default": 4096,
       "title": "Maximum Output Tokens",
       "description": "Maximum number of output tokens to limit LLM replies, the maximum possible differs from model to model."
     },

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/anyscale.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/anyscale.json
@@ -39,7 +39,7 @@
       "minimum": 0,
       "multipleOf": 1,
       "title": "Maximum Output Tokens",
-      "default": 256,
+      "default": 4096,
       "description": "Maximum number of output tokens to limit LLM replies, maximum possible varies from model to model."
     },
     "max_retries": {

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/azure.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/azure.json
@@ -50,6 +50,7 @@
       "minimum": 0,
       "multipleOf": 1,
       "title": "Maximum Output Tokens",
+      "default": 4096,
       "description": "Maximum number of output tokens to limit LLM replies, leave it empty to use the maximum possible for the selected model."
     },
     "max_retries": {

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
@@ -42,7 +42,7 @@
       "type": "number",
       "minimum": 0,
       "multipleOf": 1,
-      "default": 512,
+      "default": 4096,
       "title": "Maximum Output Tokens",
       "description": "Maximum number of output tokens to limit LLM replies, the maximum possible differs from model to model."
     },

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/mistral.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/mistral.json
@@ -37,7 +37,7 @@
       "type": "number",
       "minimum": 0,
       "multipleOf": 1,
-      "default": 512,
+      "default": 4096,
       "title": "Maximum Output Tokens",
       "description": "Maximum number of output tokens to limit LLM replies, the maximum possible differs from model to model."
     },

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/openai.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/openai.json
@@ -43,6 +43,7 @@
       "minimum": 0,
       "multipleOf": 1,
       "title": "Maximum Output Tokens",
+      "default": 4096,
       "description": "Maximum number of output tokens to limit LLM replies, leave it empty to use the maximum possible for the selected model."
     },
     "max_retries": {

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/vertex_ai.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/vertex_ai.json
@@ -45,7 +45,7 @@
       "minimum": 0,
       "multipleOf": 1,
       "title": "Max output tokens",
-      "default": 2048,
+      "default": 4096,
       "description": "Maximum number of output tokens to generate. This is limited by the maximum supported by the model and will vary from model to model"
     },
     "safety_settings": {


### PR DESCRIPTION
## What

- Vertex AI conditional field bug and update default max_tokens to 4096

## Why

- The bug in the json schema was cauing issues with how the thinking budget field was displayed
- The previous defaults for max output was very low(512, 256)

## How

- There was a syntax error in the json schema of the vextai.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No, this is a fix for how the form is being rendered.

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

- Tested the budget tokens feature functional with different LLM models.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
