### PR TITLE
fix: Skip secrets-dependent steps for forked PRs

### DIFF
--- a/.github/workflows/ci-container-build.yaml
+++ b/.github/workflows/ci-container-build.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: github.event.pull_request == null || github.event.pull_request.head.repo.fork == false
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -5,16 +5,16 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docker/**'
-      - 'frontend/**'
-      - 'docs/**'
+      - "docker/**"
+      - "frontend/**"
+      - "docs/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths-ignore:
-      - 'docker/**'
-      - 'frontend/**'
-      - 'docs/**'
+      - "docker/**"
+      - "frontend/**"
+      - "docs/**"
 
 jobs:
   test:
@@ -55,7 +55,7 @@ jobs:
 
       - name: Render combined test report to PR
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        if: always() && hashFiles('combined-test-report.md') != ''
+        if: always() && hashFiles('combined-test-report.md') != '' && github.event.pull_request.head.repo.fork == false
         with:
           header: test-results
           recreate: true


### PR DESCRIPTION
## Summary
Skip CI steps that require secrets or write permissions for forked PRs to prevent workflow failures.

## Changes
- **ci-test.yaml**: Skip PR comment step for fork PRs (sticky-pull-request-comment requires write access)
- **ci-container-build.yaml**: Skip Docker Hub login for fork PRs (secrets not available to forks)

## Why
Forked PRs don't have access to repository secrets and can't write comments to PRs, causing these steps to fail. This change allows the rest of the CI to run successfully for external contributors.