### PR TITLE
UN-1725 [FIX] Remove CheckableTag enabled/disabled toggle from LLM profiles

### DIFF
--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.css
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.css
@@ -166,7 +166,7 @@
 .prompt-info {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
 }
 
 .prompt-card-llm-container {
@@ -250,16 +250,6 @@
 
 .prompt-output-title {
   font-size: 18px;
-}
-
-.prompt-output-icon-enabled {
-  color: #52c41a;
-  margin-left: 5px;
-}
-
-.prompt-output-icon-disabled {
-  color: #babbbc;
-  margin-left: 5px;
 }
 
 .chunk-highlight {

--- a/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
@@ -76,9 +76,6 @@ function PromptCardItems({
   const [expandCard, setExpandCard] = useState(true);
   const [llmProfileDetails, setLlmProfileDetails] = useState([]);
   const [openIndexProfile, setOpenIndexProfile] = useState(null);
-  const [enabledProfiles, setEnabledProfiles] = useState(
-    llmProfiles.map((profile) => profile.profile_id)
-  );
   const [isIndexOpen, setIsIndexOpen] = useState(false);
   const isNotSingleLlmProfile = llmProfiles.length > 1;
   const divRef = useRef(null);
@@ -163,13 +160,10 @@ function PromptCardItems({
         .map((profile) => ({
           ...profile,
           isDefault: profile?.profile_id === selectedLlmProfileId,
-          isEnabled: enabledProfiles.includes(profile?.profile_id),
         }))
         .sort((a, b) => {
           if (a?.isDefault) return -1; // Default profile comes first
           if (b?.isDefault) return 1;
-          if (a?.isEnabled && !b?.isEnabled) return -1; // Enabled profiles come before disabled
-          if (!a?.isEnabled && b?.isEnabled) return 1;
           return 0;
         })
     );
@@ -181,7 +175,7 @@ function PromptCardItems({
 
   useEffect(() => {
     getAdapterInfo(adapters);
-  }, [llmProfiles, selectedLlmProfileId, enabledProfiles]);
+  }, [llmProfiles, selectedLlmProfileId]);
 
   return (
     <Card
@@ -208,7 +202,6 @@ function PromptCardItems({
             setIsEditingTitle={setIsEditingTitle}
             expandCard={expandCard}
             setExpandCard={setExpandCard}
-            enabledProfiles={enabledProfiles}
             spsLoading={spsLoading}
             handleSpsLoading={handleSpsLoading}
             enforceType={enforceType}
@@ -315,8 +308,6 @@ function PromptCardItems({
               spsLoading={spsLoading}
               llmProfileDetails={llmProfileDetails}
               setOpenIndexProfile={setOpenIndexProfile}
-              enabledProfiles={enabledProfiles}
-              setEnabledProfiles={setEnabledProfiles}
               isNotSingleLlmProfile={isNotSingleLlmProfile}
               setIsIndexOpen={setIsIndexOpen}
               enforceType={enforceType}

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -1,7 +1,5 @@
 import {
-  CheckCircleOutlined,
   DatabaseOutlined,
-  ExclamationCircleFilled,
   InfoCircleOutlined,
   PlayCircleFilled,
   PlayCircleOutlined,
@@ -18,7 +16,6 @@ import {
   Typography,
 } from "antd";
 import { motion, AnimatePresence } from "framer-motion";
-import CheckableTag from "antd/es/tag/CheckableTag";
 import { useState } from "react";
 
 import {
@@ -60,8 +57,6 @@ function PromptOutput({
   handleSelectDefaultLLM,
   llmProfileDetails,
   setOpenIndexProfile,
-  enabledProfiles,
-  setEnabledProfiles,
   isNotSingleLlmProfile,
   setIsIndexOpen,
   enforceType,
@@ -96,14 +91,6 @@ function PromptOutput({
       ))}
     </div>
   );
-
-  const handleTagChange = (checked, profileId) => {
-    setEnabledProfiles((prevState) =>
-      checked
-        ? [...prevState, profileId]
-        : prevState.filter((id) => id !== profileId)
-    );
-  };
 
   const handleTable = (profileId, promptOutputData) => {
     if (tableSettings?.document_type !== "rent_rolls")
@@ -254,7 +241,6 @@ function PromptOutput({
           const promptId = promptDetails?.prompt_id;
           const docId = selectedDoc?.document_id;
           const profileId = profile?.profile_id;
-          const isChecked = enabledProfiles.includes(profileId);
           const tokenUsageId = promptId + "__" + docId + "__" + profileId;
           let promptOutputData = {};
           if (promptOutputs && Object.keys(promptOutputs)) {
@@ -383,77 +369,53 @@ function PromptOutput({
                     </Typography.Text>
                   </div>
                   <div className="prompt-info">
-                    <div>
-                      <CheckableTag
-                        checked={isChecked}
-                        onChange={(checked) =>
-                          handleTagChange(checked, profileId)
+                    <Tooltip title="Run LLM for current document">
+                      <Button
+                        size="small"
+                        type="text"
+                        className="prompt-card-action-button"
+                        onClick={() =>
+                          handleRun(
+                            PROMPT_RUN_TYPES.RUN_ONE_PROMPT_ONE_LLM_ONE_DOC,
+                            promptDetails?.prompt_id,
+                            profileId,
+                            selectedDoc?.document_id
+                          )
                         }
-                        disabled={isPublicSource}
-                        className={isChecked ? "checked" : "unchecked"}
+                        disabled={isPromptLoading || isPublicSource}
                       >
-                        {isChecked ? (
-                          <span>
-                            Enabled
-                            <CheckCircleOutlined className="prompt-output-icon-enabled" />
-                          </span>
-                        ) : (
-                          <span>
-                            Disabled
-                            <ExclamationCircleFilled className="prompt-output-icon-disabled" />
-                          </span>
-                        )}
-                      </CheckableTag>
-                    </div>
-                    <div>
-                      <Tooltip title="Run LLM for current document">
-                        <Button
-                          size="small"
-                          type="text"
-                          className="prompt-card-action-button"
-                          onClick={() =>
-                            handleRun(
-                              PROMPT_RUN_TYPES.RUN_ONE_PROMPT_ONE_LLM_ONE_DOC,
-                              promptDetails?.prompt_id,
-                              profileId,
-                              selectedDoc?.document_id
-                            )
-                          }
-                          disabled={isPromptLoading || isPublicSource}
-                        >
-                          <PlayCircleOutlined className="prompt-card-actions-head" />
-                        </Button>
-                      </Tooltip>
-                      <Tooltip title="Run LLM for all documents">
-                        <Button
-                          size="small"
-                          type="text"
-                          className="prompt-card-action-button"
-                          onClick={() =>
-                            handleRun(
-                              PROMPT_RUN_TYPES.RUN_ONE_PROMPT_ONE_LLM_ALL_DOCS,
-                              promptDetails?.prompt_id,
-                              profileId,
-                              null
-                            )
-                          }
-                          disabled={isPromptLoading || isPublicSource}
-                        >
-                          <PlayCircleFilled className="prompt-card-actions-head" />
-                        </Button>
-                      </Tooltip>
-                      <PromptOutputExpandBtn
-                        promptId={promptDetails?.prompt_id}
-                        llmProfiles={llmProfileDetails}
-                        enforceType={enforceType}
-                        tableSettings={tableSettings}
-                        displayLlmProfile={true}
-                        promptOutputs={promptOutputs}
-                        promptRunStatus={promptRunStatus}
-                        openExpandModal={openExpandModal}
-                        setOpenExpandModal={setOpenExpandModal}
-                      />
-                    </div>
+                        <PlayCircleOutlined className="prompt-card-actions-head" />
+                      </Button>
+                    </Tooltip>
+                    <Tooltip title="Run LLM for all documents">
+                      <Button
+                        size="small"
+                        type="text"
+                        className="prompt-card-action-button"
+                        onClick={() =>
+                          handleRun(
+                            PROMPT_RUN_TYPES.RUN_ONE_PROMPT_ONE_LLM_ALL_DOCS,
+                            promptDetails?.prompt_id,
+                            profileId,
+                            null
+                          )
+                        }
+                        disabled={isPromptLoading || isPublicSource}
+                      >
+                        <PlayCircleFilled className="prompt-card-actions-head" />
+                      </Button>
+                    </Tooltip>
+                    <PromptOutputExpandBtn
+                      promptId={promptDetails?.prompt_id}
+                      llmProfiles={llmProfileDetails}
+                      enforceType={enforceType}
+                      tableSettings={tableSettings}
+                      displayLlmProfile={true}
+                      promptOutputs={promptOutputs}
+                      promptRunStatus={promptRunStatus}
+                      openExpandModal={openExpandModal}
+                      setOpenExpandModal={setOpenExpandModal}
+                    />
                   </div>
                 </Space>
                 <>
@@ -508,8 +470,6 @@ PromptOutput.propTypes = {
   selectedLlmProfileId: PropTypes.string,
   llmProfileDetails: PropTypes.array.isRequired,
   setOpenIndexProfile: PropTypes.func.isRequired,
-  enabledProfiles: PropTypes.array.isRequired,
-  setEnabledProfiles: PropTypes.func.isRequired,
   isNotSingleLlmProfile: PropTypes.bool.isRequired,
   setIsIndexOpen: PropTypes.func.isRequired,
   enforceType: PropTypes.string,


### PR DESCRIPTION
## What

- Remove the CheckableTag enabled/disabled toggle from prompt card LLM profiles
- Remove related CSS styles and state management code

## Why

- When a second LLM profile is added in Prompt Studio, it appears as disabled by default
- Only after page refresh does it show as enabled
- This creates confusing UX and makes users think profiles aren't working

## How

- Removed `CheckableTag` component and its imports from `PromptOutput.jsx`
- Removed `enabledProfiles` state and `setEnabledProfiles` from `PromptCardItems.jsx`
- Removed `handleTagChange` function that managed the toggle state
- Removed related CSS classes `.prompt-output-icon-enabled` and `.prompt-output-icon-disabled`
- Simplified LLM profile sorting logic (now only sorts by default profile)

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why.

- No. The enabled/disabled toggle was purely UI state that wasn't persisted or used elsewhere. Removing it simplifies the code and fixes the confusing default state behavior.

## Relevant Docs

- N/A

## Related Issues or PRs

- UN-1725

## Dependencies Versions / Env Variables

- No changes

## Notes on Testing

- Add multiple LLM profiles in Prompt Studio
- Verify all profiles appear correctly without disabled state
- Verify profiles can still be run individually or all together

## Screenshots
<img width="501" height="300" alt="image" src="https://github.com/user-attachments/assets/22d2307f-73aa-4cd5-abb7-5e4fa8f9731a" />

...

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).