### PR TITLE
UN-3099 [WIP] Fix trailing line from logs table left border

### DIFF
--- a/frontend/src/components/logging/logs-table/LogsTable.css
+++ b/frontend/src/components/logging/logs-table/LogsTable.css
@@ -26,7 +26,6 @@
 }
 
 .logs-table-container .ant-table-container {
-  flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

Removes `flex: 1` CSS property from `.logs-table-container .ant-table-container` that was causing the left border to extend outside the table container.

## Why

The CSS property was causing the logs table border styling issue where the left border of the table extended beyond its container boundaries on the Execution Logs page
<img width="3496" height="1698" alt="image" src="https://github.com/user-attachments/assets/53731841-3b96-48cf-87d3-1a9b2e21e14c" />


## How

- Removed the `flex: 1` property from the `.logs-table-container .ant-table-container` CSS selector

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. This is a purely visual CSS fix that corrects a layout issue. The table functionality remains unchanged.

## Related Issues or PRs

- UN-3099

## Dependencies Versions

- None
## Notes on Testing

Manual testing of the Execution Logs page to verify the table border displays correctly within its container.

## Screenshots
<img width="2347" height="1112" alt="image" src="https://github.com/user-attachments/assets/b4014050-2fbb-4b04-b7f7-2f60f892567a" />


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🧠 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>