### PR TITLE
[FIX] Fix PDF.js worker require is not defined error in staging

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# pdfjs worker file (copied from node_modules via postinstall)
+/public/pdf.worker.min.js
+
 # misc
 .DS_Store
 .env.local

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "zustand": "^4.3.8"
   },
   "scripts": {
+    "postinstall": "cp node_modules/pdfjs-dist/build/pdf.worker.min.js public/pdf.worker.min.js",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/frontend/src/helpers/pdfWorkerConfig.js
+++ b/frontend/src/helpers/pdfWorkerConfig.js
@@ -1,6 +1,4 @@
-// Webpack 5 / Vite compatible asset module
-// Works with both CRA (Webpack) and Vite bundlers
-export const PDF_WORKER_URL = new URL(
-  "pdfjs-dist/build/pdf.worker.min.js",
-  import.meta.url
-).toString();
+// Use the worker file from the public folder (served as static asset)
+// This avoids Webpack processing which incorrectly bundles it with require() statements
+// Note: The ?url import suffix only works in Vite, not in CRA (Webpack)
+export const PDF_WORKER_URL = "/pdf.worker.min.js";


### PR DESCRIPTION
## What

  Fix PDF viewer failing in staging with error:                                                                                                                                               
 "ReferenceError: require is not defined" in pdf.worker.min.js      

## Why

  The previous implementation used `new URL("pdfjs-dist/build/pdf.worker.min.js", import.meta.url)`                                                                                           
  pattern which causes Webpack (CRA) to bundle the worker file through its JavaScript loaders,                                                                                                
  incorrectly adding CommonJS `require()` statements. Workers run in a separate JavaScript                                                                                                    
  context where `require` is unavailable.                                                                                                                                                     
                                                                                                                                                                                              
  Note: The `?url` import suffix only works in Vite, not in CRA (Webpack).                                                                                                                    
                                                                         

## How

  - Changed pdfWorkerConfig.js to use static path `/pdf.worker.min.js` from public folder                                                                                                     
  - Copy worker file to public/ folder (bypasses Webpack processing)                                                                                                                          
  - Added postinstall script to automatically copy worker after npm install                                                                                                                   
  - Added worker file to .gitignore (generated from node_modules)                                                                                                                             

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
