### PR TITLE
fix: Replace CDN URL with local import for PDF worker

### DIFF
--- a/frontend/src/helpers/pdfWorkerConfig.js
+++ b/frontend/src/helpers/pdfWorkerConfig.js
@@ -1,5 +1,3 @@
 // Load the worker file from the installed pdfjs-dist package
 // The ?url suffix tells Webpack 5 to return the URL of the asset
-import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.js?url";
-
-export const PDF_WORKER_URL = pdfjsWorker;
+export { default as PDF_WORKER_URL } from "pdfjs-dist/build/pdf.worker.min.js?url";


### PR DESCRIPTION
## Summary

This PR replaces the external CDN URL for the pdf.js worker with a local import from the installed `pdfjs-dist` package.

## Changes

- Updated `frontend/src/helpers/pdfWorkerConfig.js` to use Webpack 5's asset module import syntax
- Changed from hardcoded CDN URL (`unpkg.com`) to local package import

### Before
```javascript
export const PDF_WORKER_URL =
  "https://unpkg.com/pdfjs-dist@3.11.174/build/pdf.worker.min.js";
```

### After
```javascript
import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.js?url";

export const PDF_WORKER_URL = pdfjsWorker;
```

## Technical Details: Webpack 5 Asset Module Feature (`?url` suffix)

Webpack 5 introduced **Asset Modules** as a built-in way to handle static assets without needing additional loaders like `file-loader` or `url-loader`.

### How the `?url` suffix works

When you append `?url` to an import path, Webpack treats the import as an **asset/resource** module:

1. **At build time**: Webpack copies the file (pdf.worker.min.js) to the output directory with a unique hash in the filename
2. **At runtime**: The import returns the **public URL** to that file (e.g., `/static/js/pdf.worker.min.abc123.js`)

This is equivalent to configuring:
```javascript
{
  test: /pdf\.worker\.min\.js$/,
  type: 'asset/resource'
}
```

### Asset Module Types in Webpack 5

| Type | Description | Equivalent Loader |
|------|-------------|-------------------|
| `asset/resource` | Emits file and exports URL | `file-loader` |
| `asset/inline` | Exports data URI | `url-loader` |
| `asset/source` | Exports source code | `raw-loader` |
| `asset` | Auto chooses based on size | `url-loader` with limit |

The `?url` suffix specifically triggers `asset/resource` behavior.

### References
- [Webpack 5 Asset Modules Documentation](https://webpack.js.org/guides/asset-modules/)
- [Webpack 5 Release Notes](https://webpack.js.org/blog/2020-10-10-webpack-5-release/)

## Benefits

- **No external network dependency**: PDF rendering works without reaching out to unpkg.com CDN
- **Automatic version sync**: Worker version stays in sync with the installed `pdfjs-dist` package
- **Offline support**: Application can render PDFs without internet connectivity
- **Faster loading**: Worker is bundled and served from the same origin
- **Consistency**: Aligns with the existing pattern used in `ExtractionModal.jsx`

## Testing

- [ ] PDF viewer loads and renders documents correctly
- [ ] No network requests to unpkg.com for pdf.worker.min.js
- [ ] Application builds without errors