### PR TITLE
feat: Implement graceful shutdown for tool and sidecar containers

### DIFF
--- a/unstract/core/src/unstract/core/pubsub_helper.py
+++ b/unstract/core/src/unstract/core/pubsub_helper.py
@@ -189,3 +189,19 @@ class LogPublisher:
                 f"Failed to store unified notification log for '{event}' "
                 f"<= {payload}: {e}\n{traceback.format_exc()}"
             )
+
+    @classmethod
+    def cleanup(cls) -> None:
+        """Close publisher connections for graceful shutdown."""
+        try:
+            if cls.kombu_conn:
+                cls.kombu_conn.release()
+                logging.debug("LogPublisher Kombu connection released")
+        except Exception as e:
+            logging.error(f"Failed to close Kombu connection: {e}")
+        try:
+            if cls.r:
+                cls.r.close()
+                logging.debug("LogPublisher Redis connection closed")
+        except Exception as e:
+            logging.error(f"Failed to close Redis connection: {e}")

--- a/unstract/core/src/unstract/core/tool_execution_status.py
+++ b/unstract/core/src/unstract/core/tool_execution_status.py
@@ -214,3 +214,12 @@ class ToolExecutionTracker:
                 f"Failed to update TTL for tool execution {tool_execution_data.execution_id}: {e}. "
             )
             return
+
+    def cleanup(self) -> None:
+        """Close Redis connection for graceful shutdown."""
+        try:
+            if self.redis_client:
+                self.redis_client.close()
+                logger.debug("ToolExecutionTracker Redis connection closed")
+        except Exception as e:
+            logger.error(f"Failed to close Redis connection: {e}")

--- a/unstract/sdk1/src/unstract/sdk1/tool/entrypoint.py
+++ b/unstract/sdk1/src/unstract/sdk1/tool/entrypoint.py
@@ -19,6 +19,8 @@ class ToolEntrypoint:
         signal_name = sig.name
         logger.warning(f"RECEIVED SIGNAL: {signal_name}")
         logger.warning("Initiating graceful shutdown...")
+        # Exit with standard signal exit code (128 + signal number)
+        raise SystemExit(128 + signum)
 
     @staticmethod
     def launch(tool: BaseTool, args: list[str]) -> None:


### PR DESCRIPTION
## Summary

Implements proper graceful shutdown handling for both the tool container and sidecar container when running in Docker/Kubernetes.

## Problem

Both signal handlers in `entrypoint.py` and `log_processor.py` only logged signals but didn't actually stop execution or clean up resources. When Docker/Kubernetes sends SIGTERM, the containers continued running until forcibly killed.

## Changes

### 1. ToolExecutionTracker (`unstract/core/src/unstract/core/tool_execution_status.py`)
- Added `cleanup()` method to close Redis connection

### 2. LogPublisher (`unstract/core/src/unstract/core/pubsub_helper.py`)
- Added `cleanup()` class method to close Kombu and Redis connections

### 3. LogProcessor (`tool-sidecar/src/unstract/tool_sidecar/log_processor.py`)
- Added `_shutdown_requested` class-level flag
- Signal handler now sets the shutdown flag
- `monitor_logs()` checks the flag and exits gracefully, updating tool execution status to FAILED
- Added `cleanup()` method to close all connections
- `main()` now calls `processor.cleanup()` in a `finally` block

### 4. ToolEntrypoint (`unstract/sdk1/src/unstract/sdk1/tool/entrypoint.py`)
- Signal handler now raises `SystemExit(128 + signum)` for proper exit with standard signal exit code

## Why Both Handlers Are Needed

Both signal handlers are required because they run in **separate containers** within the same Kubernetes pod:
- **Tool container** (`entrypoint.py`): Runs the actual tool code
- **Sidecar container** (`log_processor.py`): Monitors tool logs and publishes to Redis

When Kubernetes terminates a pod, both containers receive SIGTERM independently.

## Testing

- Manual testing: Send `docker kill --signal=SIGTERM` to containers and verify graceful shutdown
- Verify logs show "Shutdown requested, exiting monitor loop"
- Verify tool execution status is updated to FAILED on signal
- Verify Redis connections are closed cleanly