### PR TITLE
AH-87 [FIX]: Restore user session on verticals routes refresh

### DIFF
--- a/frontend/src/routes/Router.jsx
+++ b/frontend/src/routes/Router.jsx
@@ -168,10 +168,10 @@ function Router() {
             <Route path="llm-whisperer">{llmWhispererRouter()}</Route>
           )}
         </Route>
+        {verticalsRouter && verticalsRouter()}
       </Route>
       <Route path="*" element={<NotFound />} />
       <Route path="oauth-status" element={<OAuthStatus />} />
-      {verticalsRouter && verticalsRouter()}
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary

When a logged-in user refreshes the `/verticals/subscriptions` page (or any route under `/verticals/*`), the user session was not restored, causing the page to show "Please login to view your subscriptions" even though the user is authenticated.

## Root Cause

The `verticalsRouter` routes were placed outside the `PersistentLogin` component wrapper in `Router.jsx`. The `PersistentLogin` component is responsible for calling `checkSessionValidity()` which restores the user session from cookies/API on page load. When routes are outside this wrapper, session restoration is skipped on direct page load or refresh.

## Fix

Move `{verticalsRouter && verticalsRouter()}` inside the `<Route path="" element={<PersistentLogin />}>` wrapper in `frontend/src/routes/Router.jsx`.

## Notes

- Public routes like `/verticals/` remain accessible without authentication since `PersistentLogin` only restores sessions but doesn't enforce authentication (that's handled by `RequireAuth`).