### PR TITLE
UN-1722 [FIX] Persist export reminder state across page reloads

### DIFF
--- a/frontend/src/components/custom-tools/tool-ide/ToolIde.jsx
+++ b/frontend/src/components/custom-tools/tool-ide/ToolIde.jsx
@@ -157,6 +157,19 @@ function ToolIde() {
     }
   }, [hasUnsavedChanges, checkDeploymentUsage]);
 
+  // Restore unsaved changes from sessionStorage on page reload
+  useEffect(() => {
+    if (details?.tool_id) {
+      const { restoreUnsavedChangesFromSession } =
+        useCustomToolStore.getState();
+      const restored = restoreUnsavedChangesFromSession(details.tool_id);
+      // Reset the check flag so deployment usage check runs after restore
+      if (restored) {
+        hasCheckedForCurrentSessionRef.current = false;
+      }
+    }
+  }, [details?.tool_id]);
+
   // Cleanup abort controller on unmount
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## What

- Added sessionStorage persistence for the export reminder notification state
- State is now preserved across page reloads within the same browser session

## Why

- The export reminder notification (added in PR #1547) would disappear after page reload
- Users who made changes and then reloaded the page would lose the visual reminder that they need to export
- This caused confusion as users expected the reminder to persist until they actually exported

## How

### Frontend Changes:
- Added sessionStorage key prefix `unstract-unsaved-changes-{toolId}` for per-tool state isolation
- Modified `setHasUnsavedChanges` in custom-tool-store to persist to sessionStorage
- Modified `markChangesAsExported` to clear sessionStorage on successful export
- Added `restoreUnsavedChangesFromSession` action to restore state from sessionStorage
- Added useEffect in `ToolIde` to restore state when tool is loaded

### Storage Pattern:
- Uses sessionStorage (not localStorage) for session-based expiration
- State automatically clears when browser tab is closed
- Each tool has isolated state via scoped keys

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No, this PR will not break any existing features because:
- It only extends the existing export reminder functionality from PR #1547
- All changes are additive - new storage logic wraps existing state management
- The notification system continues to work exactly as before, but now persists across reloads
- Follows existing sessionStorage patterns used elsewhere in the codebase (OAuth flows)

## Database Migrations

- N/A (No database schema changes required)

## Env Config

- N/A (No new environment variables required)

## Relevant Docs

- Extends functionality from UN-1722 JIRA ticket

## Related Issues or PRs

- PR #1547: Original export reminder implementation
- UN-1722: Export reminder for Prompt Studio projects in use

## Dependencies Versions

- N/A (No new dependencies added)

## Notes on Testing

- ✅ Make changes to prompts → verify reminder appears
- ✅ Reload page → verify reminder still shows (sessionStorage persisted)
- ✅ Export changes → verify reminder clears and sessionStorage cleared
- ✅ Close browser tab, reopen → verify reminder is cleared (session-based)
- ✅ Test with multiple tools in different tabs (state should be isolated per tool_id)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)