### PR TITLE
UN-3344 [FIX] Activate litellm retry for all LLM providers

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/llm.py
+++ b/unstract/sdk1/src/unstract/sdk1/llm.py
@@ -467,12 +467,14 @@ class LLM:
         the gap by copying max_retries into num_retries so httpx-based providers
         (Anthropic, Vertex, Bedrock, Mistral, etc.) also get retries.
 
-        litellm internally sets max_retries=0 during wrapper retries to prevent
-        double-retry with SDK providers.
+        SDK-based providers (OpenAI, Azure) default to max_retries=2 internally,
+        which would multiply with wrapper retries. Setting max_retries=0 ensures
+        all retries go through the wrapper uniformly.
         """
         max_retries = completion_kwargs.get("max_retries")
         if max_retries:
             completion_kwargs["num_retries"] = max_retries
+            completion_kwargs["max_retries"] = 0
             completion_kwargs["retry_strategy"] = "exponential_backoff_retry"
 
     def _record_usage(

--- a/unstract/sdk1/src/unstract/sdk1/llm.py
+++ b/unstract/sdk1/src/unstract/sdk1/llm.py
@@ -207,6 +207,7 @@ class LLM:
 
             completion_kwargs = self.adapter.validate({**self.kwargs, **kwargs})
             completion_kwargs.pop("cost_model", None)
+            self._set_litellm_retry_params(completion_kwargs)
 
             # if hasattr(self, "model") and self.model not in O1_MODELS:
             #     completion_kwargs["temperature"] = 0.003
@@ -295,6 +296,7 @@ class LLM:
 
             completion_kwargs = self.adapter.validate({**self.kwargs, **kwargs})
             completion_kwargs.pop("cost_model", None)
+            self._set_litellm_retry_params(completion_kwargs)
 
             for chunk in litellm.completion(
                 messages=messages,
@@ -363,6 +365,7 @@ class LLM:
 
             completion_kwargs = self.adapter.validate({**self.kwargs, **kwargs})
             completion_kwargs.pop("cost_model", None)
+            self._set_litellm_retry_params(completion_kwargs)
 
             response = await litellm.acompletion(
                 messages=messages,
@@ -453,6 +456,24 @@ class LLM:
 
     def get_usage_reason(self) -> object:
         return self.platform_kwargs.get("llm_usage_reason")
+
+    @staticmethod
+    def _set_litellm_retry_params(completion_kwargs: dict) -> None:
+        """Activate litellm's wrapper-level retry for all providers.
+
+        litellm's retry mechanism (completion_with_retries) only activates when
+        num_retries is set. Our adapters pass max_retries (from user UI config)
+        which only works for SDK-based providers (OpenAI, Azure). This bridges
+        the gap by copying max_retries into num_retries so httpx-based providers
+        (Anthropic, Vertex, Bedrock, Mistral, etc.) also get retries.
+
+        litellm internally sets max_retries=0 during wrapper retries to prevent
+        double-retry with SDK providers.
+        """
+        max_retries = completion_kwargs.get("max_retries")
+        if max_retries:
+            completion_kwargs["num_retries"] = max_retries
+            completion_kwargs["retry_strategy"] = "exponential_backoff_retry"
 
     def _record_usage(
         self,

--- a/unstract/sdk1/src/unstract/sdk1/llm.py
+++ b/unstract/sdk1/src/unstract/sdk1/llm.py
@@ -458,7 +458,7 @@ class LLM:
         return self.platform_kwargs.get("llm_usage_reason")
 
     @staticmethod
-    def _set_litellm_retry_params(completion_kwargs: dict) -> None:
+    def _set_litellm_retry_params(completion_kwargs: dict[str, object]) -> None:
         """Activate litellm's wrapper-level retry for all providers.
 
         litellm's retry mechanism (completion_with_retries) only activates when
@@ -472,10 +472,16 @@ class LLM:
         all retries go through the wrapper uniformly.
         """
         max_retries = completion_kwargs.get("max_retries")
-        if max_retries:
+        # Use explicit `is not None and > 0` so an explicit max_retries=0
+        # (opt-out) is honored and non-int / negative values don't slip through.
+        if isinstance(max_retries, int) and max_retries > 0:
             completion_kwargs["num_retries"] = max_retries
             completion_kwargs["max_retries"] = 0
             completion_kwargs["retry_strategy"] = "exponential_backoff_retry"
+            logger.debug(
+                "[sdk1][LLM] Activated litellm wrapper retry: "
+                f"num_retries={max_retries}, retry_strategy=exponential_backoff_retry"
+            )
 
     def _record_usage(
         self,


### PR DESCRIPTION
## What

- Bridge litellm's wrapper-level retry (`completion_with_retries`) to work for all providers
- Copy user-configured `max_retries` to `num_retries` parameter before calling litellm
- Set `retry_strategy` to `exponential_backoff_retry` for all LLM completion calls

## Why

Users configure `max_retries` in the adapter UI (defaults 3-5), but this only works for SDK-based providers (OpenAI, Azure). For httpx-based providers (Anthropic, Vertex AI, Bedrock, Mistral, Azure AI Foundry), retries are silently ignored — zero retries on transient errors.

Production incident: Anthropic API 500 error after ~9 minutes caused immediate execution failure (ID: 23194211-ac04-442f-8a04-dde0ecf06195).

litellm has a separate wrapper-level retry mechanism that works for ALL providers, but only activates when `num_retries` is set. Our code never set it.

## How

Modified `LLM.complete()`, `LLM.stream_complete()`, and `LLM.acomplete()` in the SDK to:
1. Copy `max_retries` from kwargs to `num_retries`
2. Set `retry_strategy` to `exponential_backoff_retry`
3. Let litellm handle wrapper-level retries with exponential backoff (1s→2s→4s→8s→10s cap)

litellm internally sets `max_retries=0` during wrapper retries to prevent double-retry with SDK providers.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No. This only activates litellm's existing wrapper retry mechanism with user-configured values. SDK-based providers (OpenAI, Azure) continue to use their native retry via `max_retries` (litellm sets it to 0 during wrapper retries). httpx-based providers now benefit from proper retry handling instead of failing immediately on transient errors.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

- litellm retry strategy: https://docs.litellm.ai/docs/completion/retries

## Related Issues or PRs

- Fixes UN-3344

## Dependencies Versions

- None

## Notes on Testing

The fix can be validated by checking prompt-service logs for retry-related entries when transient LLM errors occur. Previously, errors would show a single failure; with the fix, you should see multiple retry attempts before final failure. Exponential backoff is applied (1s, 2s, 4s, 8s, 10s cap).

## Screenshots

-

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).