### PR TITLE
UN-3398 [FIX] Pre-populate connector form with schema defaults

### DIFF
--- a/frontend/src/components/input-output/add-source/AddSource.jsx
+++ b/frontend/src/components/input-output/add-source/AddSource.jsx
@@ -154,7 +154,7 @@ function AddSource({
       .finally(() => {
         setIsLoading(false);
       });
-  }, [selectedSourceId]);
+  }, [selectedSourceId, isLLMWPaidSchema]);
 
   useEffect(() => {
     if (editItemId?.length && metadata && Object.keys(metadata)?.length) {

--- a/frontend/src/components/input-output/add-source/AddSource.jsx
+++ b/frontend/src/components/input-output/add-source/AddSource.jsx
@@ -1,3 +1,5 @@
+import { getDefaultFormState } from "@rjsf/utils";
+import validator from "@rjsf/validator-ajv8";
 import { Typography } from "antd";
 import PropTypes from "prop-types";
 import { useEffect, useMemo, useState } from "react";
@@ -121,12 +123,22 @@ function AddSource({
     axiosPrivate(requestOptions)
       .then((res) => {
         const data = res?.data;
-        setFormData(metadata || {});
+        const jsonSchema = isLLMWPaidSchema
+          ? transformLlmWhispererJsonSchema(data?.json_schema || {})
+          : data?.json_schema || {};
 
-        if (isLLMWPaidSchema) {
-          setSpec(transformLlmWhispererJsonSchema(data?.json_schema || {}));
+        setSpec(jsonSchema);
+
+        if (metadata && Object.keys(metadata).length > 0) {
+          setFormData(metadata);
         } else {
-          setSpec(data?.json_schema || {});
+          const defaults = getDefaultFormState(
+            validator,
+            jsonSchema,
+            {},
+            jsonSchema,
+          );
+          setFormData(defaults || {});
         }
 
         if (data?.oauth) {

--- a/unstract/connectors/src/unstract/connectors/filesystems/sharepoint/sharepoint.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/sharepoint/sharepoint.py
@@ -170,9 +170,11 @@ class SharePointFileSystem(AbstractFileSystem):
         if self.client_secret:
             if not self.user_email:
                 error_msg = (
-                    "OneDrive client credentials require user email. Provide either \n"
-                    "- user_email (e.g., user@company.onmicrosoft.com) \n"
-                    "- OR use OAuth with access_token instead."
+                    "No Site URL provided. "
+                    "To access a SharePoint site, provide the Site URL "
+                    "(e.g., https://contoso.sharepoint.com/sites/mysite). "
+                    "To access OneDrive, provide the User Email "
+                    "(e.g., user@company.onmicrosoft.com)."
                 )
                 raise ConnectorError(
                     error_msg,

--- a/unstract/connectors/src/unstract/connectors/filesystems/sharepoint/static/json_schema.json
+++ b/unstract/connectors/src/unstract/connectors/filesystems/sharepoint/static/json_schema.json
@@ -10,12 +10,6 @@
       "default": "SharePoint / OneDrive Connector",
       "description": "A friendly name to identify this connector"
     },
-    "is_personal": {
-      "type": "boolean",
-      "title": "Personal Account",
-      "default": false,
-      "description": "Enable for OneDrive Personal (consumer Microsoft accounts). Leave disabled for SharePoint or OneDrive for Business (work/school accounts)."
-    },
     "site_url": {
       "type": "string",
       "title": "Site URL",
@@ -27,7 +21,7 @@
     },
     "drive_id": {
       "type": "string",
-      "title": "Drive ID (Optional)",
+      "title": "Drive ID",
       "description": "Specific Drive/Document Library ID. Leave empty to use the default drive."
     },
     "auth_type": {


### PR DESCRIPTION
## What

- Updated `AddSource.jsx` to populate form data with JSON schema default values when creating a new connector
- Added `getDefaultFormState` from `@rjsf/utils` to extract defaults from the connector's JSON schema
- Removed `is_personal` field from SharePoint top-level schema (was only relevant for Client Credentials)
- Handled `site_url` error message

## Why

- When adding a new connector, required fields with schema defaults (e.g. `connectorName`) were shown in the UI but not included in the form data. Submitting without manually touching these fields caused a validation error ("This field is required") despite a default value being visible.
- The `is_personal` field was incorrectly at the top level, making it visible for OAuth users who don't need it.

## How

- Used RJSF's `getDefaultFormState` utility to initialize `formData` with schema defaults for new connectors (when `metadata` is empty). Existing connectors continue to use their saved metadata.
- Cleaned up SharePoint JSON schema to remove misplaced fields.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. For existing connectors, behavior is unchanged (metadata is used as before). For new connectors, the only difference is that default values are now included in formData from the start, matching what the user already sees in the form. The `is_personal` field removal has no backend impact — the connector code still handles the field if present in saved metadata.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

-

## Related Issues or PRs

- #1912 (SharePoint OAuth multi-tenant fix)

## Dependencies Versions

- None (uses existing `@rjsf/utils` and `@rjsf/validator-ajv8` already in package.json)

## Notes on Testing

- Create a new connector (e.g. SharePoint) and submit without modifying the connector name field — it should succeed using the default value
- Edit an existing connector — form should still load with saved metadata
- Verify SharePoint connector no longer shows `is_personal` at top level

## Screenshots
<img width="3353" height="1321" alt="15" src="https://github.com/user-attachments/assets/4a290f3f-d844-4cde-826f-ce5d1b5c5c1f" />


## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).