### PR TITLE
UN-3413 [MISC] Replace deprecated app-id input with client-id in release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -51,7 +51,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PUSH_TO_MAIN_APP_ID }}
+          client-id: ${{ vars.PUSH_TO_MAIN_APP_CLIENT_ID }}
           private-key: ${{ secrets.PUSH_TO_MAIN_APP_PRIVATE_KEY }}
           owner: Zipstack
           repositories: |


### PR DESCRIPTION
## What

- Replaced the deprecated `app-id` input of `actions/create-github-app-token@v3` with `client-id` in `.github/workflows/create-release.yaml`.
- Switched the referenced repository variable from `PUSH_TO_MAIN_APP_ID` to `PUSH_TO_MAIN_APP_CLIENT_ID`.

## Why

- The latest run of the Create Release workflow surfaced a deprecation warning: `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` (run [24551143115](https://github.com/Zipstack/unstract/actions/runs/24551143115)).
- Moving to `client-id` aligns with the action's current API and avoids a future breaking change when the deprecated input is removed.

## How

- Updated the single workflow step that generates the GitHub App token to use `client-id` with a new `PUSH_TO_MAIN_APP_CLIENT_ID` repo variable (the App's Client ID from the GitHub App settings page).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Yes, if the `PUSH_TO_MAIN_APP_CLIENT_ID` repo variable is not populated with the GitHub App's Client ID before the next release run, the Create Release workflow will fail to mint an App token. Action item: set this variable in repo settings prior to merge.

## Database Migrations

- None.

## Env Config

- New repository variable required: `PUSH_TO_MAIN_APP_CLIENT_ID` (GitHub App Client ID, e.g. `Iv23li...`). Existing `PUSH_TO_MAIN_APP_ID` is no longer referenced.

## Relevant Docs

- [actions/create-github-app-token](https://github.com/actions/create-github-app-token) — `client-id` input.

## Related Issues or PRs

- Follow-up to #1915 (which introduced the release workflow).

## Dependencies Versions

- None.

## Notes on Testing

- Workflow only runs on `workflow_dispatch`; verification requires triggering Create Release after the new repo variable is set, and confirming the deprecation warning no longer appears and token generation succeeds.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).