### PR TITLE
UN-3420 [FIX] Remove duplicate INFILE write in _write_pipeline_outputs

### DIFF
--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -673,9 +673,6 @@ def _write_pipeline_outputs(
             copy_output_path,
         )
 
-        logger.info("Overwriting INFILE with %s output: %s", label, input_file_path)
-        fs.json_dump(path=input_file_path, data=structured_output)
-
         logger.info("Output written successfully to workflow storage")
         return None
     except Exception as e:


### PR DESCRIPTION
## What

Remove a duplicate `fs.json_dump(path=input_file_path, data=structured_output)` call in `_write_pipeline_outputs()` in `workers/file_processing/structure_tool_task.py`. The function wrote the INFILE overwrite twice — identical path, identical data, no intervening mutation.

## Why

PR #1849 (UN-3266) introduced a copy-paste artifact that causes an unnecessary extra MinIO PUT request per file execution. The `_write_pipeline_outputs()` function performs 4 writes when only 3 are needed:
1. Output file (`output_path`) — intentional
2. INFILE overwrite (`input_file_path`) — intentional
3. COPY_TO_FOLDER copy (`copy_output_path`) — intentional
4. INFILE overwrite (`input_file_path`) — **duplicate of #2**

This wastes I/O and causes existing test assertions (`json_dump.call_count == 3`) to fail.

## How

Deleted the 3-line duplicate block (`logger.info` + `fs.json_dump`) that repeated the INFILE overwrite. Pure deletion, no logic changes.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. The deleted write is an exact duplicate — same destination path, same data, with no mutation of `structured_output` between the original and the duplicate. The INFILE is still overwritten exactly once (write #2), satisfying the destination connector's requirement to read JSON instead of the original PDF. The COPY_TO_FOLDER write is untouched.

## Database Migrations

None.

## Env Config

No changes.

## Relevant Docs

N/A

## Related Issues or PRs

- UN-3266 / PR #1849 — introduced the duplicate as a copy-paste artifact

## Dependencies Versions

No dependency changes.

## Notes on Testing

- `workers/tests/test_sanity_phase3.py` already asserts `json_dump.call_count == 3` in two places — these assertions were written for the correct behavior and now pass
- Full workers test suite passes with no regressions
- Verified via grep that exactly one `json_dump(path=input_file_path` call remains in `_write_pipeline_outputs`

## Screenshots

N/A — backend-only fix, no UI changes.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
