### PR TITLE
UN-3421 [FIX] Use singular DeleteObject for MinIO cleanup fallback

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/file_storage/impl.py
+++ b/unstract/sdk1/src/unstract/sdk1/file_storage/impl.py
@@ -184,13 +184,22 @@ class FileStorage(FileStorageInterface):
     def _rm_files_individually(self, path: str) -> None:
         """Fallback deletion: delete files one at a time.
 
-        Used when bulk S3 DeleteObjects fails (e.g., MissingContentMD5
-        with certain S3-compatible providers).
+        Used when bulk S3 ``DeleteObjects`` fails (e.g., ``MissingContentMD5``
+        with MinIO 2024-12-18+ and other S3-compatible providers).
+
+        ``self.fs.rm()`` — even with ``recursive=False`` for a single path —
+        routes through ``s3fs._rm`` → ``_bulk_delete`` → ``DeleteObjects``,
+        which is exactly what failed upstream. Using ``rm_file()`` instead
+        dispatches to ``s3fs._rm_file`` → singular ``DeleteObject``, which
+        does not require ``Content-MD5``.
         """
         files = self.fs.find(path)
         for file_path in files:
-            self.fs.rm(file_path, recursive=False)
-        # Clean up the "directory" prefix if it still exists
+            try:
+                self.fs.rm_file(file_path)
+            except Exception as e:
+                logger.warning("Failed to delete %s: %s", file_path, e)
+        # Best-effort cleanup of any remaining "directory" prefix
         try:
             self.fs.rmdir(path)
         except Exception:

--- a/unstract/sdk1/tests/file_storage/test_impl_rm.py
+++ b/unstract/sdk1/tests/file_storage/test_impl_rm.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from unstract.sdk1.exceptions import FileOperationError
 from unstract.sdk1.file_storage.impl import FileStorage
 from unstract.sdk1.file_storage.provider import FileStorageProvider
@@ -101,9 +100,7 @@ class TestRmFallback:
         assert s3_file_storage.fs.rm_file.call_count == 3
         s3_file_storage.fs.rmdir.assert_called_once_with("bucket/prefix/")
 
-    def test_fallback_swallows_rmdir_error(
-        self, s3_file_storage: FileStorage
-    ) -> None:
+    def test_fallback_swallows_rmdir_error(self, s3_file_storage: FileStorage) -> None:
         """Missing directory prefix after cleanup is expected; don't raise."""
         s3_file_storage.fs.rm.side_effect = _missing_md5_error()
         s3_file_storage.fs.find.return_value = ["bucket/prefix/a.txt"]
@@ -146,9 +143,7 @@ class TestFallbackDoesNotReenterBulkDelete:
     ``DeleteObject`` is invoked.
     """
 
-    def test_only_singular_delete_called(
-        self, s3_file_storage: FileStorage
-    ) -> None:
+    def test_only_singular_delete_called(self, s3_file_storage: FileStorage) -> None:
         boto3_client = MagicMock()
         boto3_client.delete_objects.side_effect = _missing_md5_error()
         boto3_client.delete_object.return_value = {"ResponseMetadata": {}}
@@ -174,9 +169,5 @@ class TestFallbackDoesNotReenterBulkDelete:
         assert boto3_client.delete_objects.call_count == 1
         # Fallback used singular DeleteObject for every file.
         assert boto3_client.delete_object.call_count == 2
-        boto3_client.delete_object.assert_any_call(
-            Bucket="bucket", Key="prefix/a.txt"
-        )
-        boto3_client.delete_object.assert_any_call(
-            Bucket="bucket", Key="prefix/b.txt"
-        )
+        boto3_client.delete_object.assert_any_call(Bucket="bucket", Key="prefix/a.txt")
+        boto3_client.delete_object.assert_any_call(Bucket="bucket", Key="prefix/b.txt")

--- a/unstract/sdk1/tests/file_storage/test_impl_rm.py
+++ b/unstract/sdk1/tests/file_storage/test_impl_rm.py
@@ -1,0 +1,182 @@
+"""Tests for FileStorage.rm and the MissingContentMD5 fallback path.
+
+Regression coverage for UN-3421: MinIO 2024-12-18 rejects bulk
+``DeleteObjects`` with ``MissingContentMD5``; the fallback must route
+through singular ``DeleteObject`` via ``s3fs.rm_file``, not through
+``s3fs.rm`` (which still dispatches to ``_bulk_delete``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unstract.sdk1.exceptions import FileOperationError
+from unstract.sdk1.file_storage.impl import FileStorage
+from unstract.sdk1.file_storage.provider import FileStorageProvider
+
+
+@pytest.fixture
+def s3_file_storage() -> FileStorage:
+    """FileStorage with a mocked fsspec filesystem stand-in for s3fs."""
+    with patch(
+        "unstract.sdk1.file_storage.impl.FileStorageHelper.file_storage_init"
+    ) as mock_init:
+        mock_fs = MagicMock()
+        mock_init.return_value = mock_fs
+        storage = FileStorage(provider=FileStorageProvider.MINIO)
+    # Expose the mocked fs for per-test assertions/configuration.
+    storage.fs = mock_fs  # type: ignore[assignment]
+    return storage
+
+
+def _missing_md5_error() -> Exception:
+    return OSError(
+        "[Errno 5] An error occurred (MissingContentMD5) when calling the "
+        "DeleteObjects operation: Missing required header for this request: "
+        "Content-Md5."
+    )
+
+
+class TestRmHappyPath:
+    def test_bulk_delete_succeeds(self, s3_file_storage: FileStorage) -> None:
+        """When ``fs.rm`` succeeds, fallback must NOT be invoked."""
+        s3_file_storage.fs.rm.return_value = None
+
+        s3_file_storage.rm("bucket/prefix/", recursive=True)
+
+        s3_file_storage.fs.rm.assert_called_once_with(
+            path="bucket/prefix/", recursive=True
+        )
+        s3_file_storage.fs.find.assert_not_called()
+        s3_file_storage.fs.rm_file.assert_not_called()
+
+
+class TestRmFallback:
+    def test_missing_md5_triggers_individual_delete_via_rm_file(
+        self, s3_file_storage: FileStorage
+    ) -> None:
+        """On MissingContentMD5, fallback uses singular ``rm_file``.
+
+        Asserts we do NOT re-enter ``fs.rm`` (which would again hit the
+        broken ``DeleteObjects`` API).
+        """
+        s3_file_storage.fs.rm.side_effect = _missing_md5_error()
+        s3_file_storage.fs.find.return_value = [
+            "bucket/prefix/a.txt",
+            "bucket/prefix/b.txt",
+            "bucket/prefix/nested/c.txt",
+        ]
+
+        s3_file_storage.rm("bucket/prefix/", recursive=True)
+
+        # Bulk path was attempted exactly once.
+        s3_file_storage.fs.rm.assert_called_once_with(
+            path="bucket/prefix/", recursive=True
+        )
+        # Each file removed individually via singular DeleteObject.
+        assert s3_file_storage.fs.rm_file.call_count == 3
+        s3_file_storage.fs.rm_file.assert_any_call("bucket/prefix/a.txt")
+        s3_file_storage.fs.rm_file.assert_any_call("bucket/prefix/b.txt")
+        s3_file_storage.fs.rm_file.assert_any_call("bucket/prefix/nested/c.txt")
+        # Directory prefix cleanup attempted.
+        s3_file_storage.fs.rmdir.assert_called_once_with("bucket/prefix/")
+
+    def test_fallback_continues_on_per_file_error(
+        self, s3_file_storage: FileStorage
+    ) -> None:
+        """A single failing delete must not abort the rest of the cleanup."""
+        s3_file_storage.fs.rm.side_effect = _missing_md5_error()
+        s3_file_storage.fs.find.return_value = [
+            "bucket/prefix/a.txt",
+            "bucket/prefix/b.txt",
+            "bucket/prefix/c.txt",
+        ]
+        s3_file_storage.fs.rm_file.side_effect = [None, RuntimeError("boom"), None]
+
+        # Must not raise — best-effort semantics.
+        s3_file_storage.rm("bucket/prefix/", recursive=True)
+
+        assert s3_file_storage.fs.rm_file.call_count == 3
+        s3_file_storage.fs.rmdir.assert_called_once_with("bucket/prefix/")
+
+    def test_fallback_swallows_rmdir_error(
+        self, s3_file_storage: FileStorage
+    ) -> None:
+        """Missing directory prefix after cleanup is expected; don't raise."""
+        s3_file_storage.fs.rm.side_effect = _missing_md5_error()
+        s3_file_storage.fs.find.return_value = ["bucket/prefix/a.txt"]
+        s3_file_storage.fs.rmdir.side_effect = FileNotFoundError("no prefix")
+
+        # Must not raise.
+        s3_file_storage.rm("bucket/prefix/", recursive=True)
+
+        s3_file_storage.fs.rm_file.assert_called_once_with("bucket/prefix/a.txt")
+
+    def test_non_md5_error_propagates(self, s3_file_storage: FileStorage) -> None:
+        """Errors unrelated to MissingContentMD5 must bubble up."""
+        s3_file_storage.fs.rm.side_effect = PermissionError("denied")
+
+        with pytest.raises(FileOperationError):
+            s3_file_storage.rm("bucket/prefix/", recursive=True)
+
+        s3_file_storage.fs.rm_file.assert_not_called()
+
+    def test_md5_error_without_recursive_propagates(
+        self, s3_file_storage: FileStorage
+    ) -> None:
+        """Non-recursive calls must not silently fall back to directory walk."""
+        s3_file_storage.fs.rm.side_effect = _missing_md5_error()
+
+        with pytest.raises(FileOperationError):
+            s3_file_storage.rm("bucket/prefix/file.txt", recursive=False)
+
+        s3_file_storage.fs.find.assert_not_called()
+        s3_file_storage.fs.rm_file.assert_not_called()
+
+
+class TestFallbackDoesNotReenterBulkDelete:
+    """End-to-end check that the fix eliminates the original bug.
+
+    Simulates the s3fs boto3 layer: bulk ``DeleteObjects`` always fails with
+    MissingContentMD5; singular ``DeleteObject`` succeeds. Before the fix,
+    ``_rm_files_individually`` still ended up calling ``DeleteObjects`` via
+    ``fs.rm(recursive=False)`` and crashed. After the fix, only singular
+    ``DeleteObject`` is invoked.
+    """
+
+    def test_only_singular_delete_called(
+        self, s3_file_storage: FileStorage
+    ) -> None:
+        boto3_client = MagicMock()
+        boto3_client.delete_objects.side_effect = _missing_md5_error()
+        boto3_client.delete_object.return_value = {"ResponseMetadata": {}}
+
+        # Top-level fs.rm routes to bulk DeleteObjects (broken on MinIO).
+        s3_file_storage.fs.rm.side_effect = (
+            lambda path, recursive: boto3_client.delete_objects(  # noqa: ARG005
+                Bucket="bucket", Delete={"Objects": []}
+            )
+        )
+        # rm_file routes to singular DeleteObject.
+        s3_file_storage.fs.rm_file.side_effect = lambda p: boto3_client.delete_object(
+            Bucket=p.split("/", 1)[0], Key=p.split("/", 1)[1]
+        )
+        s3_file_storage.fs.find.return_value = [
+            "bucket/prefix/a.txt",
+            "bucket/prefix/b.txt",
+        ]
+
+        s3_file_storage.rm("bucket/prefix/", recursive=True)
+
+        # The broken bulk API was only attempted once (the initial call).
+        assert boto3_client.delete_objects.call_count == 1
+        # Fallback used singular DeleteObject for every file.
+        assert boto3_client.delete_object.call_count == 2
+        boto3_client.delete_object.assert_any_call(
+            Bucket="bucket", Key="prefix/a.txt"
+        )
+        boto3_client.delete_object.assert_any_call(
+            Bucket="bucket", Key="prefix/b.txt"
+        )


### PR DESCRIPTION
## What

- `_rm_files_individually()` in `unstract/sdk1/src/unstract/sdk1/file_storage/impl.py` now routes per-file deletion through `self.fs.rm_file(path)` instead of `self.fs.rm(path, recursive=False)`.
- Each per-file delete is wrapped in `try/except` so a single failure no longer aborts the remaining cleanup.
- New regression test module `unstract/sdk1/tests/file_storage/test_impl_rm.py` with 7 tests covering the bulk-delete happy path, the `MissingContentMD5` fallback, per-file and `rmdir` error tolerance, non-MD5 error propagation, non-recursive propagation, and an end-to-end assertion (with a mocked boto3 client) that the bulk `DeleteObjects` API is never re-entered from the fallback.

## Why

`FileStorage.rm(recursive=True)` → `s3fs.rm` → `_bulk_delete` → S3 `DeleteObjects` (bulk API). MinIO `2024-12-18` rejects this with `MissingContentMD5: Missing required header for this request: Content-Md5.`

The existing fallback caught the error, logged a warning, then looped and called `self.fs.rm(file_path, recursive=False)` per file — **which still routes through `_bulk_delete` in s3fs even for a single path**, so every per-file retry hit the same broken API. Net result: 100% of completed-execution cleanups were failing silently in production — 876 cleanups/hour with zero successes, orphaning `unstract/execution/<org>/<wf>/<exec>/<file_exec>/` directories on MinIO and causing unbounded `slab_reclaimable` growth.

Observed stack trace:

```
File "/app/callback/tasks.py", line 977, in _cleanup_directory
    file_storage.rm(directory_path, recursive=True)
File "/unstract/sdk1/src/unstract/sdk1/file_storage/helper.py", line 109, in wrapper
    raise FileOperationError(str(e)) from e
unstract.sdk1.exceptions.FileOperationError: [Errno 5] An error occurred (MissingContentMD5) when calling the DeleteObjects operation: Missing required header for this request: Content-Md5.
```

## How

- `s3fs.rm_file(path)` in s3fs dispatches to `_rm_file` → singular `DeleteObject`, which does **not** require `Content-MD5` and works on MinIO (this is the same API `mc rm` uses in production).
- The ticket's suggested snippet used `self.fs.s3.delete_object(...)` directly, but `s3fs.S3FileSystem.s3` is an **async `aiobotocore` client** — calling `delete_object()` on it returns a coroutine rather than a response. `rm_file()` hits the same singular `DeleteObject` API via s3fs's own sync wrapper (`mirror_sync_methods` on `AsyncFileSystem`), handles path splitting and cache invalidation, and is robust to future s3fs refactors.
- The outer `fs.rm(..., recursive=True)` call is preserved as the fast path; the fallback is only entered on `MissingContentMD5`.
- Per-file `try/except` preserves best-effort cleanup semantics so a single transient failure can no longer strand the rest of the directory.

Code change:

```python
def _rm_files_individually(self, path: str) -> None:
    files = self.fs.find(path)
    for file_path in files:
        try:
            self.fs.rm_file(file_path)  # singular DeleteObject
        except Exception as e:
            logger.warning("Failed to delete %s: %s", file_path, e)
    try:
        self.fs.rmdir(path)
    except Exception:
        pass  # Directory prefix may already be gone
```

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No breaking changes:

- **Happy path (bulk delete succeeds on AWS S3, GCS via s3-compatible endpoints, MinIO versions without the bug)**: Untouched — `self.fs.rm(path, recursive=True)` is still the first attempt. The fallback is only reached on `MissingContentMD5`.
- **Fallback path**: Was 100% broken prior to this fix (every call raised), so swapping the per-file call from `fs.rm` to `fs.rm_file` strictly improves behavior.
- **Local filesystem / other providers**: The fallback is guarded by `if "MissingContentMD5" in str(e) and recursive:`, so non-S3 providers never enter this code path. For completeness, `rm_file` is also defined on fsspec's `AbstractFileSystem` (delegates to `_rm`), so the code is safe even if entered accidentally.
- **Error surface change**: Previously a single per-file delete failure would raise and abort the remaining cleanup. Now it's logged at WARNING and cleanup continues — same semantics as `rmdir`'s existing best-effort handling. Failures are still observable in logs.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

- MinIO changelog for `2024-12-18` release (`MissingContentMD5` strictness on `DeleteObjects`): https://github.com/minio/minio/releases/tag/RELEASE.2024-12-18T13-15-44Z
- AWS S3 `DeleteObject` API (singular — no `Content-MD5` required): https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
- AWS S3 `DeleteObjects` API (bulk — requires `Content-MD5`): https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
- `s3fs._rm_file` implementation: https://github.com/fsspec/s3fs/blob/main/s3fs/core.py (uses `delete_object` singular)

## Related Issues or PRs

- Jira: [UN-3421](https://zipstack.atlassian.net/browse/UN-3421)
- Parent: [UN-3420](https://zipstack.atlassian.net/browse/UN-3420)
- Originating PR that introduced the broken fallback: #1849 (`impl.py:168-197`)
- Related earlier MinIO compatibility hotfix: [UN-2942](https://zipstack.atlassian.net/browse/UN-2942)

## Dependencies Versions

- No dependency changes. Fix relies on `s3fs.rm_file()` which has existed since s3fs added async support; the current pinned version (`s3fs[boto3]~=2024.10.0`) supports it.

## Notes on Testing

Local verification:

| Check | Result |
|---|---|
| New regression tests (`tests/file_storage/test_impl_rm.py`) | 7/7 passed |
| Full sdk1 test suite | 228/228 passed |
| Ruff on modified files | No new warnings (one pre-existing import-sort warning on `impl.py` confirmed on untouched `main`) |

Production-side acceptance criteria from the ticket (require deployment to verify):

- `mc ilm rule ls` shows no rules, then after an execution completes, the `unstract/execution/<org>/<wf>/<exec>/<file_exec>/` directory is empty on MinIO.
- Zero `MissingContentMD5` log lines from callback workers over a 1-hour production window.
- `slab_reclaimable` in `memory.stat` stops growing unboundedly.

Test matrix covered by the new regression tests:

| Test | Scenario | Assertion |
|---|---|---|
| `test_bulk_delete_succeeds` | `fs.rm` succeeds | Fallback is NOT invoked |
| `test_missing_md5_triggers_individual_delete_via_rm_file` | MD5 error + 3 files | `fs.rm_file` called per file, `fs.rmdir` called once |
| `test_fallback_continues_on_per_file_error` | 2nd file raises | All 3 files attempted, cleanup completes |
| `test_fallback_swallows_rmdir_error` | `rmdir` raises | No exception propagates |
| `test_non_md5_error_propagates` | `PermissionError` | Raised; fallback NOT invoked |
| `test_md5_error_without_recursive_propagates` | MD5 + `recursive=False` | Raised; no directory walk |
| `test_only_singular_delete_called` | Mocked boto3 client | `delete_objects` hit once (initial), `delete_object` called per file |

## Screenshots

N/A — backend-only fix in the SDK file-storage layer.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

[UN-3421]: https://zipstack.atlassian.net/browse/UN-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ