### PR TITLE
[FIX] Use importlib.util.find_spec for pluggable worker discovery

### DIFF
--- a/workers/shared/infrastructure/config/builder.py
+++ b/workers/shared/infrastructure/config/builder.py
@@ -323,27 +323,26 @@ class WorkerBuilder:
 
         try:
             import importlib
-            from pathlib import Path
+            import importlib.util
 
-            # Check if the worker.py file exists
-            # Path resolution: builder.py is at /app/workers/shared/infrastructure/config/
-            # We need to get to /app/workers/, so go up 3 levels
-            pluggable_worker_path = (
-                Path(__file__).resolve().parents[3]
-                / "pluggable_worker"
-                / worker_type.value
-                / "worker.py"
-            )
+            # Ask Python's import system whether the module is resolvable.
+            # find_spec() consults all registered finders and handles every
+            # module representation (source .py, Nuitka/Cython .so, .pyc,
+            # namespace packages, zipimports) — unlike a filesystem check
+            # for a specific file extension, which breaks for compiled plugins.
+            module_path = f"pluggable_worker.{worker_type.value}.worker"
 
-            if not pluggable_worker_path.exists():
-                logger.error(f"Pluggable worker file not found: {pluggable_worker_path}")
+            if importlib.util.find_spec(module_path) is None:
+                logger.error(f"Pluggable worker module not importable: {module_path}")
                 return False
 
-            # Try to import the module to verify it's valid
-            module_path = f"pluggable_worker.{worker_type.value}.worker"
+            # Load it to catch findable-but-broken modules (e.g. import errors
+            # inside worker.py that find_spec wouldn't surface).
             importlib.import_module(module_path)
 
-        except ImportError:
+        except (ImportError, ValueError):
+            # ValueError: find_spec raises this when sys.modules[module_path] is
+            # populated but has __spec__ = None (from a prior failed import).
             logger.exception(f"Failed to import pluggable worker {worker_type.value}")
             return False
         except (OSError, AttributeError):

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -448,8 +448,10 @@ if worker_type.is_pluggable():
     worker_directory = os.path.join("pluggable_worker", worker_type.value)
     worker_path = os.path.join(base_dir, worker_directory)
 else:
-    # Core workers use their value directly (with hyphens converted to underscores where needed)
-    worker_directory = worker_type.value.replace("-", "_")
+    # Enum values use underscores (Python module names); a few on-disk dirs
+    # still use hyphens (e.g. api-deployment). Derive the directory from the
+    # authoritative import-path map on WorkerType instead of a blind replace.
+    worker_directory = worker_type.to_import_path().rsplit(".", 1)[0]
     worker_path = os.path.join(base_dir, worker_directory)
 
 # Add worker directory to path for task imports


### PR DESCRIPTION
## What

- Forward-port of #1918 (originally hotfixed on `v0.163.2-hotfix`, merged as e6bb412e) onto `main`.
- Replace the filesystem `.py` check in `_verify_pluggable_worker_exists()` with `importlib.util.find_spec()`.
- Broaden the exception handler to also catch `ValueError`.
- Derive the `api-deployment` worker directory from `to_import_path()` instead of a naive `.replace("-", "_")`.

## Why

- The filesystem check rejected plugins whose `worker.py` had been compiled away to a `.so` (Nuitka / Cython / any C extension), even though the module was perfectly importable — so on-prem images with compiled plugins silently failed discovery.
- `find_spec()` can raise `ValueError` when `sys.modules[path]` has `__spec__ = None` from a prior failed import; the previous `except ImportError` let it propagate and crash boot.
- `worker_type.value.replace("-", "_")` was a no-op for every enum except `API_DEPLOYMENT` (`api-deployment`), where it produced `/app/api_deployment`, which doesn't exist. Boot logged a spurious `❌ Worker directory not found: /app/api_deployment` at ERROR level, masking real failures in log scans.

## How

- `_verify_pluggable_worker_exists()` now calls `importlib.util.find_spec(f"pluggable_worker.{name}.worker")` and returns `spec is not None`. This honors every registered finder — source `.py`, compiled `.so`, bytecode, namespace packages, zipimports.
- The `except` is broadened to `(ImportError, ValueError)` with a comment explaining the `ValueError` edge case.
- Directory resolution goes through `WorkerType.to_import_path()` which already handles the hyphen case.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. Behavior is preserved for all existing deployments:
  - Images with no `pluggable_worker/<name>/` subpackage → `find_spec` raises `ModuleNotFoundError` (an `ImportError` subclass) → returns `False` (same as before).
  - Images with source `.py` → `find_spec` resolves the `.py` → returns `True` (same as before).
  - Images with compiled `.so` → `find_spec` resolves the `.so` → returns `True` (previously returned `False`, which is the bug being fixed).
- The api-deployment log-noise fix only touches a log line; the task registration path (`builder` + celery `autodiscover` via `to_import_path`) was already correct and is unchanged.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- None.

## Related Issues or PRs

- Cherry-picked from #1918 (merged to `v0.163.2-hotfix`).
- Paired with unstract-cloud#1453 which is the on-prem build that produces the compiled `.so` plugins this fix makes discoverable.

## Dependencies Versions

- None.

## Notes on Testing

- CI must remain green on this branch.
- Source-only (.py) worker image should boot and register tasks exactly as before.
- On-prem compiled-plugin worker image should now discover `pluggable_worker/*` plugins (was the reason for the hotfix).
- Boot log should no longer print `❌ Worker directory not found: /app/api_deployment`.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
