### PR TITLE
[FIX] Update Gemini embedding default model to gemini-embedding-001

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -1027,7 +1027,7 @@ class GeminiEmbeddingParameters(BaseEmbeddingParameters):
         if not model:
             raise ValueError(
                 "The 'model' field is required for the Gemini embedding adapter. "
-                "Example: 'gemini/gemini-embedding-001'"
+                "Example: 'gemini-embedding-001'"
             )
         if not model.startswith("gemini/"):
             model = f"gemini/{model}"

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -1027,7 +1027,7 @@ class GeminiEmbeddingParameters(BaseEmbeddingParameters):
         if not model:
             raise ValueError(
                 "The 'model' field is required for the Gemini embedding adapter. "
-                "Example: 'gemini/text-embedding-004'"
+                "Example: 'gemini/gemini-embedding-001'"
             )
         if not model.startswith("gemini/"):
             model = f"gemini/{model}"

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/gemini.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/gemini.json
@@ -17,7 +17,7 @@
       "type": "string",
       "title": "Model",
       "default": "gemini-embedding-001",
-      "description": "Provide the name of the model. Recommended: gemini-embedding-001 (stable, text-only). For multimodal input, use gemini-embedding-2-preview."
+      "description": "Provide the name of the model. The gemini/ prefix will be added automatically if omitted. Recommended: gemini-embedding-001 (stable, text-only). For multimodal input, use gemini-embedding-2-preview."
     },
     "api_key": {
       "type": "string",

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/gemini.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/gemini.json
@@ -16,8 +16,8 @@
     "model": {
       "type": "string",
       "title": "Model",
-      "default": "gemini/text-embedding-004",
-      "description": "Provide the name of the model. The gemini/ prefix will be added automatically if omitted. Recommended: gemini/text-embedding-004"
+      "default": "gemini-embedding-001",
+      "description": "Provide the name of the model. Recommended: gemini-embedding-001 (stable, text-only). For multimodal input, use gemini-embedding-2-preview."
     },
     "api_key": {
       "type": "string",

--- a/unstract/sdk1/tests/test_gemini_embedding.py
+++ b/unstract/sdk1/tests/test_gemini_embedding.py
@@ -49,25 +49,25 @@ class TestGeminiEmbeddingAdapter:
 
     def test_json_schema_model_default(self) -> None:
         schema = json.loads(GeminiEmbeddingAdapter.get_json_schema())
-        assert schema["properties"]["model"]["default"] == "gemini/text-embedding-004"
+        assert schema["properties"]["model"]["default"] == "gemini-embedding-001"
 
     def test_validate_model_adds_prefix(self) -> None:
-        meta = {"model": "text-embedding-004", "api_key": "test"}
+        meta = {"model": "gemini-embedding-001", "api_key": "test"}
         result = GeminiEmbeddingAdapter.validate_model(meta)
-        assert result == "gemini/text-embedding-004"
+        assert result == "gemini/gemini-embedding-001"
 
     def test_validate_model_idempotent(self) -> None:
-        meta = {"model": "gemini/text-embedding-004", "api_key": "test"}
+        meta = {"model": "gemini/gemini-embedding-001", "api_key": "test"}
         result = GeminiEmbeddingAdapter.validate_model(meta)
-        assert result == "gemini/text-embedding-004"
+        assert result == "gemini/gemini-embedding-001"
 
     def test_validate_model_does_not_mutate_input(self) -> None:
-        meta = {"model": "text-embedding-004", "api_key": "test"}
+        meta = {"model": "gemini-embedding-001", "api_key": "test"}
         GeminiEmbeddingAdapter.validate_model(meta)
-        assert meta["model"] == "text-embedding-004"
+        assert meta["model"] == "gemini-embedding-001"
 
     def test_validate_does_not_mutate_input(self) -> None:
-        meta = {"model": "text-embedding-004", "api_key": "test-key"}
+        meta = {"model": "gemini-embedding-001", "api_key": "test-key"}
         original_model = meta["model"]
         GeminiEmbeddingAdapter.validate(meta)
         assert meta["model"] == original_model
@@ -105,23 +105,23 @@ class TestGeminiEmbeddingAdapter:
     def test_validate_missing_api_key_raises(self) -> None:
         from pydantic import ValidationError
 
-        meta = {"model": "gemini/text-embedding-004"}
+        meta = {"model": "gemini/gemini-embedding-001"}
         with pytest.raises(ValidationError):
             GeminiEmbeddingAdapter.validate(meta)
 
     def test_validate_calls_validate_model(self) -> None:
-        meta = {"model": "text-embedding-004", "api_key": "test-key"}
+        meta = {"model": "gemini-embedding-001", "api_key": "test-key"}
         validated = GeminiEmbeddingAdapter.validate(meta)
-        assert validated["model"] == "gemini/text-embedding-004"
+        assert validated["model"] == "gemini/gemini-embedding-001"
 
     def test_validate_embed_batch_size_none_by_default(self) -> None:
-        meta = {"model": "gemini/text-embedding-004", "api_key": "test-key"}
+        meta = {"model": "gemini/gemini-embedding-001", "api_key": "test-key"}
         validated = GeminiEmbeddingAdapter.validate(meta)
         assert validated["embed_batch_size"] is None
 
     def test_validate_embed_batch_size_preserved(self) -> None:
         meta = {
-            "model": "gemini/text-embedding-004",
+            "model": "gemini/gemini-embedding-001",
             "api_key": "test-key",
             "embed_batch_size": 50,
         }
@@ -130,7 +130,7 @@ class TestGeminiEmbeddingAdapter:
 
     def test_validate_strips_extra_fields(self) -> None:
         meta = {
-            "model": "gemini/text-embedding-004",
+            "model": "gemini/gemini-embedding-001",
             "api_key": "test-key",
             "adapter_name": "my-adapter",
             "unknown_field": "should_be_dropped",
@@ -140,7 +140,7 @@ class TestGeminiEmbeddingAdapter:
         assert "unknown_field" not in validated
 
     def test_validate_includes_base_fields(self) -> None:
-        meta = {"model": "gemini/text-embedding-004", "api_key": "test-key"}
+        meta = {"model": "gemini/gemini-embedding-001", "api_key": "test-key"}
         validated = GeminiEmbeddingAdapter.validate(meta)
         assert "timeout" in validated
         assert "max_retries" in validated


### PR DESCRIPTION
## What

- Change the Gemini embedding adapter default model from `gemini/text-embedding-004` (legacy) to `gemini-embedding-001` (current stable GA).
- Drop the `gemini/` prefix from the user-facing default; validation still prepends it before passing to litellm, so routing is unaffected.
- Update description to also mention `gemini-embedding-2-preview` as the multimodal option.
- Update tests to reflect the new default and example model names.

## Why

- `text-embedding-004` is no longer a valid/supported model on Google AI Studio, so existing adapter instances using the default would fail at embed time.
- Per [Google AI docs](https://ai.google.dev/gemini-api/docs/embeddings), the current supported models are `gemini-embedding-001` (stable, text-only) and `gemini-embedding-2-preview` (multimodal preview).
- Keeping the user-facing default prefix-free is cleaner — the `gemini/` provider prefix is an implementation detail of litellm routing, not something end users should type.

## How

- `unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/gemini.json`: default + description updated.
- `unstract/sdk1/src/unstract/sdk1/adapters/base1.py`: example in the `validate_model` error message updated. Prefix auto-prepend logic unchanged.
- `unstract/sdk1/tests/test_gemini_embedding.py`: all assertions and fixture model names switched to `gemini-embedding-001`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Only the default and docstring/example values change. Any adapter instance already configured with an explicit model (including `text-embedding-004`) continues to validate and route the same way.
- Users who relied on the default and created adapters before this change will still have `gemini/text-embedding-004` stored — they should update their adapter model to `gemini-embedding-001` since the legacy model is no longer served.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- https://ai.google.dev/gemini-api/docs/embeddings

## Related Issues or PRs

- Follow-up to #1891 (UN-3412 — Add Gemini embedding adapter for Google AI Studio).

## Dependencies Versions

- None.

## Notes on Testing

- `uv run pytest tests/test_gemini_embedding.py -v` — all 27 tests pass.
- Manual verification pending: create a Gemini embedding adapter with the new default against a live Google AI Studio API key and confirm successful embed.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).