### PR TITLE
UN-3358 [FIX] List only S3 buckets the connector credentials can browse

### DIFF
--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
@@ -1,4 +1,36 @@
+from enum import Enum
+
+from botocore.exceptions import ClientError
+
 from unstract.connectors.exceptions import ConnectorError
+
+
+class BucketProbeDisposition(Enum):
+    """Action for a `list_objects_v2` probe failure, per S3 error code."""
+
+    DROP = "drop"  # Credentials genuinely lack access — hide the bucket.
+    FAIL_OPEN = "fail_open"  # Region mismatch — keep bucket visible.
+    RETRY_FAIL_OPEN = "retry_fail_open"  # Throttled — retry once, then keep.
+
+
+# One row per S3 `Error.Code` → disposition. Same shape as
+# `S3FS_EXC_TO_UNSTRACT_EXC` below (code → meaning). Codes absent from
+# this table propagate as real errors instead of silently hiding a bucket.
+BUCKET_PROBE_DISPOSITION: dict[str, BucketProbeDisposition] = {
+    "AccessDenied": BucketProbeDisposition.DROP,
+    "AllAccessDisabled": BucketProbeDisposition.DROP,
+    "PermanentRedirect": BucketProbeDisposition.FAIL_OPEN,
+    "IllegalLocationConstraintException": BucketProbeDisposition.FAIL_OPEN,
+    "SlowDown": BucketProbeDisposition.RETRY_FAIL_OPEN,
+    "Throttling": BucketProbeDisposition.RETRY_FAIL_OPEN,
+    "ThrottlingException": BucketProbeDisposition.RETRY_FAIL_OPEN,
+    "RequestTimeTooSkewed": BucketProbeDisposition.RETRY_FAIL_OPEN,
+}
+
+
+def client_error_code(exc: ClientError) -> str:
+    return str(exc.response.get("Error", {}).get("Code", "") or "")
+
 
 S3FS_EXC_TO_UNSTRACT_EXC: dict[str, str] = {
     # Auth errors

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
@@ -31,12 +31,18 @@ BUCKET_PROBE_DISPOSITION: dict[str, BucketProbeDisposition] = {
 def s3_error_code(exc: BaseException) -> str:
     """Return the S3 `Error.Code` from a `ClientError` or its s3fs-translated
     wrapper (`PermissionError` / `FileNotFoundError` / `OSError`).
+
+    Walks `__cause__` first (explicit `raise X from original`), then falls
+    back to `__context__` (implicit chaining inside an `except` block). A
+    `seen` set guards against pathological cycles.
     """
+    seen: set[int] = set()
     target: BaseException | None = exc
-    while target is not None:
+    while target is not None and id(target) not in seen:
+        seen.add(id(target))
         if isinstance(target, ClientError):
             return str(target.response.get("Error", {}).get("Code", "") or "")
-        target = target.__cause__
+        target = target.__cause__ or target.__context__
     return ""
 
 

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
@@ -8,28 +8,36 @@ from unstract.connectors.exceptions import ConnectorError
 class BucketProbeDisposition(Enum):
     """Action for a `list_objects_v2` probe failure, per S3 error code."""
 
-    DROP = "drop"  # Credentials genuinely lack access — hide the bucket.
+    DROP = "drop"  # Hide the bucket (no access, or bucket gone).
     FAIL_OPEN = "fail_open"  # Region mismatch — keep bucket visible.
     RETRY_FAIL_OPEN = "retry_fail_open"  # Throttled — retry once, then keep.
 
 
-# One row per S3 `Error.Code` → disposition. Same shape as
-# `S3FS_EXC_TO_UNSTRACT_EXC` below (code → meaning). Codes absent from
-# this table propagate as real errors instead of silently hiding a bucket.
+# S3 `Error.Code` → probe disposition. Unlisted codes propagate.
+# `RequestTimeTooSkewed` is omitted deliberately: it's a system-wide clock
+# issue, not a bucket outcome — let it surface via `handle_s3fs_exception`.
 BUCKET_PROBE_DISPOSITION: dict[str, BucketProbeDisposition] = {
     "AccessDenied": BucketProbeDisposition.DROP,
     "AllAccessDisabled": BucketProbeDisposition.DROP,
+    "NoSuchBucket": BucketProbeDisposition.DROP,
     "PermanentRedirect": BucketProbeDisposition.FAIL_OPEN,
     "IllegalLocationConstraintException": BucketProbeDisposition.FAIL_OPEN,
     "SlowDown": BucketProbeDisposition.RETRY_FAIL_OPEN,
     "Throttling": BucketProbeDisposition.RETRY_FAIL_OPEN,
     "ThrottlingException": BucketProbeDisposition.RETRY_FAIL_OPEN,
-    "RequestTimeTooSkewed": BucketProbeDisposition.RETRY_FAIL_OPEN,
 }
 
 
-def client_error_code(exc: ClientError) -> str:
-    return str(exc.response.get("Error", {}).get("Code", "") or "")
+def s3_error_code(exc: BaseException) -> str:
+    """Return the S3 `Error.Code` from a `ClientError` or its s3fs-translated
+    wrapper (`PermissionError` / `FileNotFoundError` / `OSError`).
+    """
+    target: BaseException | None = exc
+    while target is not None:
+        if isinstance(target, ClientError):
+            return str(target.response.get("Error", {}).get("Code", "") or "")
+        target = target.__cause__
+    return ""
 
 
 S3FS_EXC_TO_UNSTRACT_EXC: dict[str, str] = {

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
@@ -5,35 +5,38 @@ from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any
 
+from botocore.exceptions import ClientError
 from s3fs.core import S3FileSystem
 
 from unstract.connectors.filesystems.unstract_file_system import UnstractFileSystem
 
-from .exceptions import handle_s3fs_exception
+from .exceptions import (
+    BUCKET_PROBE_DISPOSITION,
+    BucketProbeDisposition,
+    client_error_code,
+    handle_s3fs_exception,
+)
 
 logger = logging.getLogger(__name__)
 
 # Cap concurrent per-bucket probes to avoid S3 503 SlowDown on large accounts.
 _MAX_CONCURRENT_BUCKET_PROBES = 16
+_BUCKET_PROBE_RETRY_DELAY_SECONDS = 0.5
 
 
 class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
     """S3FileSystem that lists only buckets the credentials can browse.
 
-    `s3:ListAllMyBuckets` (account-level) returns every bucket in the
-    account, which is wider than `s3:ListBucket` (per-bucket). We probe
-    each bucket with a 1-key `list_objects_v2` and drop any that fail.
+    Probes each bucket with `list_objects_v2(MaxKeys=1)` and looks up the
+    resulting `ClientError.Code` in `BUCKET_PROBE_DISPOSITION`. Unknown
+    codes propagate so real failures aren't silently hidden.
     """
 
     async def _lsbuckets(self, refresh: bool = False) -> list[dict[str, Any]]:
-        if not refresh and "" in self.dircache:
-            return self.dircache[""]  # type: ignore[no-any-return]
         buckets: list[dict[str, Any]] = await super()._lsbuckets(refresh=refresh)
         if not buckets:
             return buckets
-        accessible = await self._filter_accessible_buckets(buckets)
-        self.dircache[""] = accessible
-        return accessible
+        return await self._filter_accessible_buckets(buckets)
 
     async def _filter_accessible_buckets(
         self, buckets: list[dict[str, Any]]
@@ -45,15 +48,55 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
                 return await self._is_bucket_accessible(name)
 
         results = await asyncio.gather(*(_probe(b["name"]) for b in buckets))
-        return [b for b, ok in zip(buckets, results, strict=True) if ok]
+        accessible = [b for b, ok in zip(buckets, results, strict=True) if ok]
+        dropped = len(buckets) - len(accessible)
+        if dropped:
+            logger.info(
+                "[S3/MinIO] Bucket filter: kept %d of %d; dropped %d on "
+                "AccessDenied/AllAccessDisabled.",
+                len(accessible),
+                len(buckets),
+                dropped,
+            )
+        return accessible
 
     async def _is_bucket_accessible(self, name: str) -> bool:
         try:
             await self._call_s3("list_objects_v2", Bucket=name, MaxKeys=1)
             return True
-        except Exception as exc:
-            logger.debug("[S3/MinIO] Dropping inaccessible bucket '%s': %s", name, exc)
-            return False
+        except ClientError as exc:
+            code = client_error_code(exc)
+            disposition = BUCKET_PROBE_DISPOSITION.get(code)
+            if disposition is BucketProbeDisposition.DROP:
+                return False
+            if disposition is BucketProbeDisposition.FAIL_OPEN:
+                logger.info(
+                    "[S3/MinIO] Bucket '%s' probe returned %s; keeping in listing.",
+                    name,
+                    code,
+                )
+                return True
+            if disposition is BucketProbeDisposition.RETRY_FAIL_OPEN:
+                return await self._retry_probe_fail_open(name, code)
+            raise
+
+    async def _retry_probe_fail_open(self, name: str, first_code: str) -> bool:
+        await asyncio.sleep(_BUCKET_PROBE_RETRY_DELAY_SECONDS)
+        try:
+            await self._call_s3("list_objects_v2", Bucket=name, MaxKeys=1)
+            return True
+        except ClientError as retry_exc:
+            retry_code = client_error_code(retry_exc)
+            if BUCKET_PROBE_DISPOSITION.get(retry_code) is BucketProbeDisposition.DROP:
+                return False
+            logger.info(
+                "[S3/MinIO] Bucket '%s' still transient after retry "
+                "(first=%s, retry=%s); keeping in listing.",
+                name,
+                first_code,
+                retry_code,
+            )
+            return True
 
 
 class MinioFS(UnstractFileSystem):

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import random
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any
@@ -51,8 +52,8 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
         dropped = len(buckets) - len(accessible)
         if dropped:
             logger.info(
-                "[S3/MinIO] Bucket filter: kept %d of %d; dropped %d on "
-                "AccessDenied/AllAccessDisabled.",
+                "[S3/MinIO] Bucket filter: kept %d of %d; "
+                "dropped %d on DROP dispositions.",
                 len(accessible),
                 len(buckets),
                 dropped,
@@ -69,18 +70,30 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
             if disposition is BucketProbeDisposition.DROP:
                 return False
             if disposition is BucketProbeDisposition.FAIL_OPEN:
-                logger.info(
-                    "[S3/MinIO] Bucket '%s' probe returned %s; keeping in listing.",
+                logger.warning(
+                    "[S3/MinIO] Bucket %r probe returned %s; keeping in listing.",
                     name,
                     code,
                 )
                 return True
             if disposition is BucketProbeDisposition.RETRY_FAIL_OPEN:
                 return await self._retry_probe_fail_open(name, code)
+            # Unclassified code: log which bucket before propagating so the
+            # gather-cancellation has a breadcrumb.
+            logger.exception(
+                "[S3/MinIO] Unclassified probe failure for bucket %r "
+                "(code=%r); propagating.",
+                name,
+                code,
+            )
             raise
 
     async def _retry_probe_fail_open(self, name: str, first_code: str) -> bool:
-        await asyncio.sleep(_BUCKET_PROBE_RETRY_DELAY_SECONDS)
+        # Full jitter avoids correlated retries under SlowDown thundering herd.
+        await asyncio.sleep(
+            _BUCKET_PROBE_RETRY_DELAY_SECONDS
+            + random.uniform(0, _BUCKET_PROBE_RETRY_DELAY_SECONDS)
+        )
         try:
             await self._call_s3("list_objects_v2", Bucket=name, MaxKeys=1)
             return True
@@ -90,11 +103,18 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
             if disposition is BucketProbeDisposition.DROP:
                 return False
             if disposition is BucketProbeDisposition.FAIL_OPEN:
+                logger.warning(
+                    "[S3/MinIO] Bucket %r fail-open on retry "
+                    "(first=%s, retry=%s); keeping in listing.",
+                    name,
+                    first_code,
+                    retry_code,
+                )
                 return True
             if disposition is BucketProbeDisposition.RETRY_FAIL_OPEN:
                 # Still transient after one retry — keep to avoid flapping.
                 logger.info(
-                    "[S3/MinIO] Bucket '%s' still transient after retry "
+                    "[S3/MinIO] Bucket %r still transient after retry "
                     "(first=%s, retry=%s); keeping in listing.",
                     name,
                     first_code,
@@ -102,7 +122,14 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
                 )
                 return True
             # Unclassified retry failure (e.g. credentials expired mid-probe):
-            # re-raise so the real error surfaces instead of being hidden.
+            # log the bucket, then re-raise so the real error surfaces.
+            logger.exception(
+                "[S3/MinIO] Unclassified retry probe failure for bucket %r "
+                "(first=%s, retry=%s); propagating.",
+                name,
+                first_code,
+                retry_code,
+            )
             raise
 
 

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
@@ -13,37 +13,39 @@ from .exceptions import handle_s3fs_exception
 
 logger = logging.getLogger(__name__)
 
+# Cap concurrent per-bucket probes to avoid S3 503 SlowDown on large accounts.
+_MAX_CONCURRENT_BUCKET_PROBES = 16
+
 
 class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
     """S3FileSystem that lists only buckets the credentials can browse.
 
-    The parent's `_lsbuckets` returns every bucket reachable via
-    `s3:ListAllMyBuckets`. That set is wider than what the caller can
-    actually read — especially under IRSA, where `ListAllMyBuckets` may
-    be granted account-wide while `s3:ListBucket` is scoped to a handful
-    of buckets. We probe each returned bucket with a 1-key
-    `list_objects_v2` (the exact IAM action required to browse) and drop
-    any that respond with AccessDenied / NoSuchBucket / other errors.
+    `s3:ListAllMyBuckets` (account-level) returns every bucket in the
+    account, which is wider than `s3:ListBucket` (per-bucket). We probe
+    each bucket with a 1-key `list_objects_v2` and drop any that fail.
     """
 
     async def _lsbuckets(self, refresh: bool = False) -> list[dict[str, Any]]:
+        if not refresh and "" in self.dircache:
+            return self.dircache[""]  # type: ignore[no-any-return]
         buckets: list[dict[str, Any]] = await super()._lsbuckets(refresh=refresh)
         if not buckets:
             return buckets
         accessible = await self._filter_accessible_buckets(buckets)
-        # Replace the cached entry populated by the parent so subsequent
-        # cache reads return the filtered view.
         self.dircache[""] = accessible
         return accessible
 
     async def _filter_accessible_buckets(
         self, buckets: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        results = await asyncio.gather(
-            *(self._is_bucket_accessible(b["name"]) for b in buckets),
-            return_exceptions=True,
-        )
-        return [b for b, ok in zip(buckets, results, strict=False) if ok is True]
+        sem = asyncio.Semaphore(_MAX_CONCURRENT_BUCKET_PROBES)
+
+        async def _probe(name: str) -> bool:
+            async with sem:
+                return await self._is_bucket_accessible(name)
+
+        results = await asyncio.gather(*(_probe(b["name"]) for b in buckets))
+        return [b for b, ok in zip(buckets, results, strict=True) if ok]
 
     async def _is_bucket_accessible(self, name: str) -> bool:
         try:
@@ -55,6 +57,10 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
 
 
 class MinioFS(UnstractFileSystem):
+    # Subclasses can override with plain `S3FileSystem` to skip bucket-access
+    # filtering (e.g. for platform-managed storage).
+    _FS_CLASS: type[S3FileSystem] = _AccessFilteredS3FileSystem
+
     def __init__(self, settings: dict[str, Any]):
         super().__init__("MinioFS/S3")
         key = (settings.get("key") or "").strip()
@@ -71,7 +77,7 @@ class MinioFS(UnstractFileSystem):
         if endpoint_url:
             creds["endpoint_url"] = endpoint_url
 
-        self.s3 = _AccessFilteredS3FileSystem(
+        self.s3 = self._FS_CLASS(
             anon=False,
             use_listings_cache=False,
             default_fill_cache=False,

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
@@ -13,8 +13,8 @@ from unstract.connectors.filesystems.unstract_file_system import UnstractFileSys
 from .exceptions import (
     BUCKET_PROBE_DISPOSITION,
     BucketProbeDisposition,
-    client_error_code,
     handle_s3fs_exception,
+    s3_error_code,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,11 +25,10 @@ _BUCKET_PROBE_RETRY_DELAY_SECONDS = 0.5
 
 
 class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
-    """S3FileSystem that lists only buckets the credentials can browse.
+    """Lists only buckets the credentials can browse.
 
-    Probes each bucket with `list_objects_v2(MaxKeys=1)` and looks up the
-    resulting `ClientError.Code` in `BUCKET_PROBE_DISPOSITION`. Unknown
-    codes propagate so real failures aren't silently hidden.
+    Probes each bucket and looks up the S3 `Error.Code` in
+    `BUCKET_PROBE_DISPOSITION`. Unlisted codes propagate.
     """
 
     async def _lsbuckets(self, refresh: bool = False) -> list[dict[str, Any]]:
@@ -64,8 +63,8 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
         try:
             await self._call_s3("list_objects_v2", Bucket=name, MaxKeys=1)
             return True
-        except ClientError as exc:
-            code = client_error_code(exc)
+        except (ClientError, OSError) as exc:
+            code = s3_error_code(exc)
             disposition = BUCKET_PROBE_DISPOSITION.get(code)
             if disposition is BucketProbeDisposition.DROP:
                 return False
@@ -85,18 +84,26 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
         try:
             await self._call_s3("list_objects_v2", Bucket=name, MaxKeys=1)
             return True
-        except ClientError as retry_exc:
-            retry_code = client_error_code(retry_exc)
-            if BUCKET_PROBE_DISPOSITION.get(retry_code) is BucketProbeDisposition.DROP:
+        except (ClientError, OSError) as retry_exc:
+            retry_code = s3_error_code(retry_exc)
+            disposition = BUCKET_PROBE_DISPOSITION.get(retry_code)
+            if disposition is BucketProbeDisposition.DROP:
                 return False
-            logger.info(
-                "[S3/MinIO] Bucket '%s' still transient after retry "
-                "(first=%s, retry=%s); keeping in listing.",
-                name,
-                first_code,
-                retry_code,
-            )
-            return True
+            if disposition is BucketProbeDisposition.FAIL_OPEN:
+                return True
+            if disposition is BucketProbeDisposition.RETRY_FAIL_OPEN:
+                # Still transient after one retry — keep to avoid flapping.
+                logger.info(
+                    "[S3/MinIO] Bucket '%s' still transient after retry "
+                    "(first=%s, retry=%s); keeping in listing.",
+                    name,
+                    first_code,
+                    retry_code,
+                )
+                return True
+            # Unclassified retry failure (e.g. credentials expired mid-probe):
+            # re-raise so the real error surfaces instead of being hidden.
+            raise
 
 
 class MinioFS(UnstractFileSystem):

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from datetime import UTC, datetime
@@ -11,6 +12,46 @@ from unstract.connectors.filesystems.unstract_file_system import UnstractFileSys
 from .exceptions import handle_s3fs_exception
 
 logger = logging.getLogger(__name__)
+
+
+class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
+    """S3FileSystem that lists only buckets the credentials can browse.
+
+    The parent's `_lsbuckets` returns every bucket reachable via
+    `s3:ListAllMyBuckets`. That set is wider than what the caller can
+    actually read — especially under IRSA, where `ListAllMyBuckets` may
+    be granted account-wide while `s3:ListBucket` is scoped to a handful
+    of buckets. We probe each returned bucket with a 1-key
+    `list_objects_v2` (the exact IAM action required to browse) and drop
+    any that respond with AccessDenied / NoSuchBucket / other errors.
+    """
+
+    async def _lsbuckets(self, refresh: bool = False) -> list[dict[str, Any]]:
+        buckets: list[dict[str, Any]] = await super()._lsbuckets(refresh=refresh)
+        if not buckets:
+            return buckets
+        accessible = await self._filter_accessible_buckets(buckets)
+        # Replace the cached entry populated by the parent so subsequent
+        # cache reads return the filtered view.
+        self.dircache[""] = accessible
+        return accessible
+
+    async def _filter_accessible_buckets(
+        self, buckets: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        results = await asyncio.gather(
+            *(self._is_bucket_accessible(b["name"]) for b in buckets),
+            return_exceptions=True,
+        )
+        return [b for b, ok in zip(buckets, results, strict=False) if ok is True]
+
+    async def _is_bucket_accessible(self, name: str) -> bool:
+        try:
+            await self._call_s3("list_objects_v2", Bucket=name, MaxKeys=1)
+            return True
+        except Exception as exc:
+            logger.debug("[S3/MinIO] Dropping inaccessible bucket '%s': %s", name, exc)
+            return False
 
 
 class MinioFS(UnstractFileSystem):
@@ -30,7 +71,7 @@ class MinioFS(UnstractFileSystem):
         if endpoint_url:
             creds["endpoint_url"] = endpoint_url
 
-        self.s3 = S3FileSystem(
+        self.s3 = _AccessFilteredS3FileSystem(
             anon=False,
             use_listings_cache=False,
             default_fill_cache=False,

--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py
@@ -57,8 +57,9 @@ class _AccessFilteredS3FileSystem(S3FileSystem):  # type: ignore[misc]
 
 
 class MinioFS(UnstractFileSystem):
-    # Subclasses can override with plain `S3FileSystem` to skip bucket-access
-    # filtering (e.g. for platform-managed storage).
+    # Override with plain S3FileSystem in a subclass when the credentials are
+    # known to have full access to every bucket they list, so the per-bucket
+    # access probe in _AccessFilteredS3FileSystem can be skipped.
     _FS_CLASS: type[S3FileSystem] = _AccessFilteredS3FileSystem
 
     def __init__(self, settings: dict[str, Any]):

--- a/unstract/connectors/src/unstract/connectors/filesystems/ucs/ucs.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/ucs/ucs.py
@@ -1,5 +1,7 @@
 import os
 
+from s3fs.core import S3FileSystem
+
 from unstract.connectors.filesystems.minio.minio import MinioFS
 
 
@@ -8,6 +10,11 @@ class UnstractCloudStorage(MinioFS):
 
     Implemented with Google Cloud Storage through Minio.
     """
+
+    # UCS credentials always have full access to UCS buckets, so skip the
+    # per-bucket access probe that MinioFS runs on its fsspec filesystem.
+    # The probe adds latency and could hide a bucket on a transient S3 error.
+    _FS_CLASS = S3FileSystem
 
     @staticmethod
     def get_id() -> str:

--- a/unstract/connectors/tests/filesystems/test_miniofs.py
+++ b/unstract/connectors/tests/filesystems/test_miniofs.py
@@ -1,7 +1,12 @@
+import asyncio
 import os
 import unittest
+from unittest.mock import AsyncMock, patch
 
-from unstract.connectors.filesystems.minio.minio import MinioFS
+from unstract.connectors.filesystems.minio.minio import (
+    MinioFS,
+    _AccessFilteredS3FileSystem,
+)
 
 
 class TestMinoFS(unittest.TestCase):
@@ -37,6 +42,63 @@ class TestMinoFS(unittest.TestCase):
         )
 
         print(s3.get_fsspec_fs().ls("/minio-test"))  # type:ignore
+
+
+class TestAccessFilteredS3FileSystem(unittest.TestCase):
+    """Unit tests for the bucket-access filter added for UN-3358."""
+
+    def _make_fs(self) -> _AccessFilteredS3FileSystem:
+        # Bypass __init__ to avoid touching the network / event loop.
+        return _AccessFilteredS3FileSystem.__new__(_AccessFilteredS3FileSystem)
+
+    def test_is_bucket_accessible_true_when_list_succeeds(self) -> None:
+        fs = self._make_fs()
+        with patch.object(fs, "_call_s3", new=AsyncMock(return_value={})):
+            self.assertTrue(asyncio.run(fs._is_bucket_accessible("allowed")))
+
+    def test_is_bucket_accessible_false_on_error(self) -> None:
+        fs = self._make_fs()
+        with patch.object(
+            fs, "_call_s3", new=AsyncMock(side_effect=PermissionError("AccessDenied"))
+        ):
+            self.assertFalse(asyncio.run(fs._is_bucket_accessible("denied")))
+
+    def test_filter_accessible_buckets_drops_denied(self) -> None:
+        fs = self._make_fs()
+        buckets = [{"name": "allowed"}, {"name": "denied"}, {"name": "also-allowed"}]
+
+        async def fake_call_s3(action: str, **kwargs: object) -> dict[str, object]:
+            if kwargs.get("Bucket") == "denied":
+                raise PermissionError("AccessDenied")
+            return {}
+
+        with patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call_s3)):
+            result = asyncio.run(fs._filter_accessible_buckets(buckets))
+
+        self.assertEqual([b["name"] for b in result], ["allowed", "also-allowed"])
+
+    def test_lsbuckets_populates_dircache_with_filtered_list(self) -> None:
+        fs = self._make_fs()
+        fs.dircache = {}
+        parent_buckets = [{"name": "allowed"}, {"name": "denied"}]
+
+        async def fake_call_s3(action: str, **kwargs: object) -> dict[str, object]:
+            if kwargs.get("Bucket") == "denied":
+                raise PermissionError("AccessDenied")
+            return {}
+
+        with (
+            patch(
+                "unstract.connectors.filesystems.minio.minio."
+                "S3FileSystem._lsbuckets",
+                new=AsyncMock(return_value=parent_buckets),
+            ),
+            patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call_s3)),
+        ):
+            result = asyncio.run(fs._lsbuckets())
+
+        self.assertEqual([b["name"] for b in result], ["allowed"])
+        self.assertEqual([b["name"] for b in fs.dircache[""]], ["allowed"])
 
 
 if __name__ == "__main__":

--- a/unstract/connectors/tests/filesystems/test_miniofs.py
+++ b/unstract/connectors/tests/filesystems/test_miniofs.py
@@ -1,12 +1,7 @@
-import asyncio
 import os
 import unittest
-from unittest.mock import AsyncMock, patch
 
-from unstract.connectors.filesystems.minio.minio import (
-    MinioFS,
-    _AccessFilteredS3FileSystem,
-)
+from unstract.connectors.filesystems.minio.minio import MinioFS
 
 
 class TestMinoFS(unittest.TestCase):
@@ -42,63 +37,6 @@ class TestMinoFS(unittest.TestCase):
         )
 
         print(s3.get_fsspec_fs().ls("/minio-test"))  # type:ignore
-
-
-class TestAccessFilteredS3FileSystem(unittest.TestCase):
-    """Unit tests for the bucket-access filter added for UN-3358."""
-
-    def _make_fs(self) -> _AccessFilteredS3FileSystem:
-        # Bypass __init__ to avoid touching the network / event loop.
-        return _AccessFilteredS3FileSystem.__new__(_AccessFilteredS3FileSystem)
-
-    def test_is_bucket_accessible_true_when_list_succeeds(self) -> None:
-        fs = self._make_fs()
-        with patch.object(fs, "_call_s3", new=AsyncMock(return_value={})):
-            self.assertTrue(asyncio.run(fs._is_bucket_accessible("allowed")))
-
-    def test_is_bucket_accessible_false_on_error(self) -> None:
-        fs = self._make_fs()
-        with patch.object(
-            fs, "_call_s3", new=AsyncMock(side_effect=PermissionError("AccessDenied"))
-        ):
-            self.assertFalse(asyncio.run(fs._is_bucket_accessible("denied")))
-
-    def test_filter_accessible_buckets_drops_denied(self) -> None:
-        fs = self._make_fs()
-        buckets = [{"name": "allowed"}, {"name": "denied"}, {"name": "also-allowed"}]
-
-        async def fake_call_s3(action: str, **kwargs: object) -> dict[str, object]:
-            if kwargs.get("Bucket") == "denied":
-                raise PermissionError("AccessDenied")
-            return {}
-
-        with patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call_s3)):
-            result = asyncio.run(fs._filter_accessible_buckets(buckets))
-
-        self.assertEqual([b["name"] for b in result], ["allowed", "also-allowed"])
-
-    def test_lsbuckets_populates_dircache_with_filtered_list(self) -> None:
-        fs = self._make_fs()
-        fs.dircache = {}
-        parent_buckets = [{"name": "allowed"}, {"name": "denied"}]
-
-        async def fake_call_s3(action: str, **kwargs: object) -> dict[str, object]:
-            if kwargs.get("Bucket") == "denied":
-                raise PermissionError("AccessDenied")
-            return {}
-
-        with (
-            patch(
-                "unstract.connectors.filesystems.minio.minio."
-                "S3FileSystem._lsbuckets",
-                new=AsyncMock(return_value=parent_buckets),
-            ),
-            patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call_s3)),
-        ):
-            result = asyncio.run(fs._lsbuckets())
-
-        self.assertEqual([b["name"] for b in result], ["allowed"])
-        self.assertEqual([b["name"] for b in fs.dircache[""]], ["allowed"])
 
 
 if __name__ == "__main__":

--- a/unstract/connectors/tests/filesystems/test_miniofs.py
+++ b/unstract/connectors/tests/filesystems/test_miniofs.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import AsyncMock, patch
 
 from botocore.exceptions import ClientError
+from s3fs.errors import translate_boto_error
 
 from unstract.connectors.filesystems.minio.minio import (
     MinioFS,
@@ -46,8 +47,17 @@ class TestMinoFS(unittest.TestCase):
         print(s3.get_fsspec_fs().ls("/minio-test"))
 
 
-def _client_error(code: str) -> ClientError:
-    return ClientError({"Error": {"Code": code, "Message": code}}, "ListObjectsV2")
+def _translated_error(code: str) -> BaseException:
+    """Mirror what s3fs `_call_s3` actually raises in production.
+
+    s3fs routes every raise through `translate_boto_error`, which converts
+    `ClientError` into `PermissionError` / `FileNotFoundError` / `OSError`
+    with the original `ClientError` preserved as `__cause__`. Tests must
+    raise the translated form or they won't exercise the real catch path.
+    """
+    ce = ClientError({"Error": {"Code": code, "Message": code}}, "ListObjectsV2")
+    translated: BaseException = translate_boto_error(ce)
+    return translated
 
 
 class TestAccessFilteredS3FileSystem(unittest.TestCase):
@@ -70,13 +80,26 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
             self.assertTrue(asyncio.run(fs._is_bucket_accessible("allowed")))
 
     def test_access_denied_bucket_is_dropped(self) -> None:
+        # s3fs translates `AccessDenied` → `PermissionError`; the filter
+        # must still drop the bucket by recovering the code from `__cause__`.
         fs = self._make_fs()
         with patch.object(
             fs,
             "_call_s3",
-            new=AsyncMock(side_effect=_client_error("AccessDenied")),
+            new=AsyncMock(side_effect=_translated_error("AccessDenied")),
         ):
             self.assertFalse(asyncio.run(fs._is_bucket_accessible("denied")))
+
+    def test_no_such_bucket_is_dropped(self) -> None:
+        # Race: bucket deleted between `list_buckets` and probe → `NoSuchBucket`
+        # (translated to `FileNotFoundError`). Drop it rather than surface.
+        fs = self._make_fs()
+        with patch.object(
+            fs,
+            "_call_s3",
+            new=AsyncMock(side_effect=_translated_error("NoSuchBucket")),
+        ):
+            self.assertFalse(asyncio.run(fs._is_bucket_accessible("deleted")))
 
     def test_permanent_redirect_bucket_is_kept(self) -> None:
         # Fail-open: region mismatch keeps the bucket listed.
@@ -84,7 +107,7 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
         with patch.object(
             fs,
             "_call_s3",
-            new=AsyncMock(side_effect=_client_error("PermanentRedirect")),
+            new=AsyncMock(side_effect=_translated_error("PermanentRedirect")),
         ):
             self.assertTrue(asyncio.run(fs._is_bucket_accessible("other-region")))
 
@@ -92,7 +115,7 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
         fs = self._make_fs()
 
         async def fake_call(_action: str, **_kwargs: object) -> dict[str, object]:
-            raise _client_error("SlowDown")
+            raise _translated_error("SlowDown")
 
         call = AsyncMock(side_effect=fake_call)
         with (
@@ -107,7 +130,7 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
         codes = ["SlowDown", "AccessDenied"]
 
         async def fake_call(_action: str, **_kwargs: object) -> dict[str, object]:
-            raise _client_error(codes.pop(0))
+            raise _translated_error(codes.pop(0))
 
         with (
             patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call)),
@@ -115,16 +138,44 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
         ):
             self.assertFalse(asyncio.run(fs._is_bucket_accessible("slow-then-denied")))
 
-    def test_unknown_client_error_propagates(self) -> None:
-        # Unknown codes must NOT be silently hidden.
+    def test_throttling_then_unknown_on_retry_propagates(self) -> None:
+        # Unknown error on retry (e.g. credentials expire mid-probe) must NOT
+        # be silently swallowed — it has to surface as a real failure.
+        fs = self._make_fs()
+        codes = ["SlowDown", "SomeWeirdUnknownCode"]
+
+        async def fake_call(_action: str, **_kwargs: object) -> dict[str, object]:
+            raise _translated_error(codes.pop(0))
+
+        with (
+            patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call)),
+            patch("asyncio.sleep", new=AsyncMock(return_value=None)),
+        ):
+            with self.assertRaises(OSError):
+                asyncio.run(fs._is_bucket_accessible("slow-then-mystery"))
+
+    def test_unknown_error_propagates(self) -> None:
+        # Unknown codes must NOT be silently hidden on first probe either.
         fs = self._make_fs()
         with patch.object(
             fs,
             "_call_s3",
-            new=AsyncMock(side_effect=_client_error("SomeWeirdUnknownCode")),
+            new=AsyncMock(side_effect=_translated_error("SomeWeirdUnknownCode")),
         ):
-            with self.assertRaises(ClientError):
+            with self.assertRaises(OSError):
                 asyncio.run(fs._is_bucket_accessible("mystery"))
+
+    def test_request_time_too_skewed_propagates(self) -> None:
+        # Clock skew is system-wide, not bucket-level; it must surface so
+        # `handle_s3fs_exception` can show the clock-skew message.
+        fs = self._make_fs()
+        with patch.object(
+            fs,
+            "_call_s3",
+            new=AsyncMock(side_effect=_translated_error("RequestTimeTooSkewed")),
+        ):
+            with self.assertRaises(PermissionError):
+                asyncio.run(fs._is_bucket_accessible("any-bucket"))
 
     def test_lsbuckets_override_wires_to_filter(self) -> None:
         # Regression guard for s3fs signature drift on `_lsbuckets`/`_call_s3`.
@@ -133,7 +184,7 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
 
         async def fake_call(_action: str, **kwargs: object) -> dict[str, object]:
             if kwargs.get("Bucket") == "denied":
-                raise _client_error("AccessDenied")
+                raise _translated_error("AccessDenied")
             return {}
 
         with (

--- a/unstract/connectors/tests/filesystems/test_miniofs.py
+++ b/unstract/connectors/tests/filesystems/test_miniofs.py
@@ -4,12 +4,15 @@ import unittest
 from unittest.mock import AsyncMock, patch
 
 from botocore.exceptions import ClientError
+from s3fs.core import S3FileSystem
 from s3fs.errors import translate_boto_error
 
+from unstract.connectors.filesystems.minio.exceptions import s3_error_code
 from unstract.connectors.filesystems.minio.minio import (
     MinioFS,
     _AccessFilteredS3FileSystem,
 )
+from unstract.connectors.filesystems.ucs.ucs import UnstractCloudStorage
 
 
 class TestMinoFS(unittest.TestCase):
@@ -61,7 +64,7 @@ def _translated_error(code: str) -> BaseException:
 
 
 class TestAccessFilteredS3FileSystem(unittest.TestCase):
-    """Unit tests for the bucket-access filter added in UN-3358.
+    """Unit tests for the per-bucket access filter in _AccessFilteredS3FileSystem.
 
     These tests don't need a live MinIO/S3. They bypass
     `_AccessFilteredS3FileSystem.__init__` and monkey-patch `_call_s3` /
@@ -201,6 +204,32 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
     def test_default_fs_class_is_filtered(self) -> None:
         # MinioFS defaults to the access-filtered filesystem; subclasses can opt out.
         self.assertIs(MinioFS._FS_CLASS, _AccessFilteredS3FileSystem)
+
+    def test_ucs_opts_out_of_access_filter(self) -> None:
+        # UCS credentials are expected to have full access, so the per-bucket
+        # probe must be skipped. Guards against a future refactor dropping
+        # the `_FS_CLASS = S3FileSystem` override in ucs.py.
+        self.assertIs(UnstractCloudStorage._FS_CLASS, S3FileSystem)
+        self.assertIsNot(UnstractCloudStorage._FS_CLASS, _AccessFilteredS3FileSystem)
+
+    def test_error_code_walks_context_when_cause_absent(self) -> None:
+        # Guards against future wrapper layers that use implicit exception
+        # chaining (`raise X` inside an `except`). The original `ClientError`
+        # lands on `__context__`, not `__cause__` — the helper must still
+        # recover the disposition code or we silently propagate AccessDenied.
+        client_exc = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "AccessDenied"}},
+            "ListObjectsV2",
+        )
+        try:
+            try:
+                raise client_exc
+            except ClientError:
+                # Implicit chaining: no `from` clause, so ClientError lands
+                # on __context__ of the OSError below.
+                raise OSError("translated")  # noqa: B904
+        except OSError as outer:
+            self.assertEqual(s3_error_code(outer), "AccessDenied")
 
 
 if __name__ == "__main__":

--- a/unstract/connectors/tests/filesystems/test_miniofs.py
+++ b/unstract/connectors/tests/filesystems/test_miniofs.py
@@ -1,7 +1,14 @@
+import asyncio
 import os
 import unittest
+from unittest.mock import AsyncMock, patch
 
-from unstract.connectors.filesystems.minio.minio import MinioFS
+from botocore.exceptions import ClientError
+
+from unstract.connectors.filesystems.minio.minio import (
+    MinioFS,
+    _AccessFilteredS3FileSystem,
+)
 
 
 class TestMinoFS(unittest.TestCase):
@@ -36,7 +43,113 @@ class TestMinoFS(unittest.TestCase):
             }
         )
 
-        print(s3.get_fsspec_fs().ls("/minio-test"))  # type:ignore
+        print(s3.get_fsspec_fs().ls("/minio-test"))
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, "ListObjectsV2")
+
+
+class TestAccessFilteredS3FileSystem(unittest.TestCase):
+    """Unit tests for the bucket-access filter added in UN-3358.
+
+    These tests don't need a live MinIO/S3. They bypass
+    `_AccessFilteredS3FileSystem.__init__` and monkey-patch `_call_s3` /
+    `S3FileSystem._lsbuckets` to exercise the override end-to-end. If s3fs
+    renames or re-signatures either internal, these tests fail loudly in
+    CI instead of silently reverting to the unfiltered parent behavior.
+    """
+
+    def _make_fs(self) -> _AccessFilteredS3FileSystem:
+        # Bypass __init__ to avoid touching the network / event loop.
+        return _AccessFilteredS3FileSystem.__new__(_AccessFilteredS3FileSystem)
+
+    def test_accessible_bucket_is_kept(self) -> None:
+        fs = self._make_fs()
+        with patch.object(fs, "_call_s3", new=AsyncMock(return_value={})):
+            self.assertTrue(asyncio.run(fs._is_bucket_accessible("allowed")))
+
+    def test_access_denied_bucket_is_dropped(self) -> None:
+        fs = self._make_fs()
+        with patch.object(
+            fs,
+            "_call_s3",
+            new=AsyncMock(side_effect=_client_error("AccessDenied")),
+        ):
+            self.assertFalse(asyncio.run(fs._is_bucket_accessible("denied")))
+
+    def test_permanent_redirect_bucket_is_kept(self) -> None:
+        # Fail-open: region mismatch keeps the bucket listed.
+        fs = self._make_fs()
+        with patch.object(
+            fs,
+            "_call_s3",
+            new=AsyncMock(side_effect=_client_error("PermanentRedirect")),
+        ):
+            self.assertTrue(asyncio.run(fs._is_bucket_accessible("other-region")))
+
+    def test_throttling_retries_then_fails_open(self) -> None:
+        fs = self._make_fs()
+
+        async def fake_call(_action: str, **_kwargs: object) -> dict[str, object]:
+            raise _client_error("SlowDown")
+
+        call = AsyncMock(side_effect=fake_call)
+        with (
+            patch.object(fs, "_call_s3", new=call),
+            patch("asyncio.sleep", new=AsyncMock(return_value=None)),
+        ):
+            self.assertTrue(asyncio.run(fs._is_bucket_accessible("throttled")))
+        self.assertEqual(call.await_count, 2)  # initial + one retry
+
+    def test_throttling_then_denied_on_retry_is_dropped(self) -> None:
+        fs = self._make_fs()
+        codes = ["SlowDown", "AccessDenied"]
+
+        async def fake_call(_action: str, **_kwargs: object) -> dict[str, object]:
+            raise _client_error(codes.pop(0))
+
+        with (
+            patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call)),
+            patch("asyncio.sleep", new=AsyncMock(return_value=None)),
+        ):
+            self.assertFalse(asyncio.run(fs._is_bucket_accessible("slow-then-denied")))
+
+    def test_unknown_client_error_propagates(self) -> None:
+        # Unknown codes must NOT be silently hidden.
+        fs = self._make_fs()
+        with patch.object(
+            fs,
+            "_call_s3",
+            new=AsyncMock(side_effect=_client_error("SomeWeirdUnknownCode")),
+        ):
+            with self.assertRaises(ClientError):
+                asyncio.run(fs._is_bucket_accessible("mystery"))
+
+    def test_lsbuckets_override_wires_to_filter(self) -> None:
+        # Regression guard for s3fs signature drift on `_lsbuckets`/`_call_s3`.
+        fs = self._make_fs()
+        parent_buckets = [{"name": "allowed"}, {"name": "denied"}]
+
+        async def fake_call(_action: str, **kwargs: object) -> dict[str, object]:
+            if kwargs.get("Bucket") == "denied":
+                raise _client_error("AccessDenied")
+            return {}
+
+        with (
+            patch(
+                "unstract.connectors.filesystems.minio.minio."
+                "S3FileSystem._lsbuckets",
+                new=AsyncMock(return_value=parent_buckets),
+            ),
+            patch.object(fs, "_call_s3", new=AsyncMock(side_effect=fake_call)),
+        ):
+            result = asyncio.run(fs._lsbuckets(refresh=True))
+        self.assertEqual([b["name"] for b in result], ["allowed"])
+
+    def test_default_fs_class_is_filtered(self) -> None:
+        # MinioFS defaults to the access-filtered filesystem; subclasses can opt out.
+        self.assertIs(MinioFS._FS_CLASS, _AccessFilteredS3FileSystem)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

- S3 list down only buckets it has access to. Root user will see all buckets 
- `MinioFS` (S3/MinIO connector) now uses this subclass instead of `S3FileSystem`. No other connector method changes.
- `UnstractCloudStorage` opts out via a class-level `_FS_CLASS = S3FileSystem` hook, since its credentials always have full access to UCS buckets.

## Why

The S3/MinIO connector was listing every bucket in the account — including ones the caller cannot open — producing a long, misleading directory where most entries fail with "Access Denied" on click.

Root cause: `s3:ListAllMyBuckets` (account-level "show me the names") is a different IAM action from `s3:ListBucket` (per-bucket "let me look inside"). `s3fs.S3FileSystem._lsbuckets` calls `list_buckets`, which is gated only by the former. The caller's actual browse permission is never checked.

This hits IRSA customers (UN-2297) hardest: IRSA deployments typically grant `ListAllMyBuckets` account-wide but scope `ListBucket` to a handful of buckets, so the connector ends up surfacing dozens of buckets the role cannot use.

## How

After `_lsbuckets` returns the account-wide list, probe each bucket with `list_objects_v2(MaxKeys=1)` — the exact IAM action browsing needs — and drop any that fail. Probes run concurrently under an `asyncio.Semaphore(16)` cap. `UnstractCloudStorage` opts out via a `_FS_CLASS` hook.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No.

- Non-root paths go through the parent's `_ls` unchanged.
- For users with broad S3 permissions, every bucket passes the probe — the filter is a no-op and the visible list is identical.
- No schema, env var, migration, or connector-reconfig change required.
- Added cost: up to 16 concurrent `list_objects_v2` calls on root-listing (~<1s for typical <50-bucket accounts).

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

- None

## Related Issues or PRs
- N/A

## Dependencies Versions

- None

## Notes on Testing

No automated tests in this PR. Verified manually against MinIO.

The IAM policy used for manual testing is the same one documented at [Unstract on-prem infra requirements — IAM Policy](https://docs.unstract.com/unstract/unstract_platform/user_guides/on_prem_infra_requirements/#iam-policy) (`s3:ListAllMyBuckets`, `s3:ListBucket` on the bucket, `s3:GetObject`/`s3:PutObject`/`s3:DeleteObject` on `bucket/*`).

**Manual steps (MinIO):**

1. Create a bucket: `test-iam-bucket`.
2. Create an IAM policy (from the docs above) scoping `s3:ListBucket` and the object actions to `test-iam-bucket` only.
3. Create a MinIO user (`test-user`), generate an access key + secret, and attach the policy.
4. Configure the S3/MinIO connector with `test-user`'s credentials + the MinIO endpoint URL.
5. Browse the connector root → only `test-iam-bucket` appears. Drill in → object listing is unchanged.
6. Sanity check with root credentials → the connector root lists every bucket (the filter is a no-op for full-access principals, confirming no regression for that path).

## Screenshots
<img width="3328" height="1102" alt="1" src="https://github.com/user-attachments/assets/b6dcbdb6-0723-4ce5-829c-e4187fe4d84d" />

<img width="3408" height="1099" alt="2" src="https://github.com/user-attachments/assets/7441dac1-5e86-41f7-a96b-5cf727138b4c" />

<img width="3433" height="1238" alt="3" src="https://github.com/user-attachments/assets/431f5363-a277-4924-9483-6e307655e013" />

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).