### PR TITLE
UN-3431 [FIX] Stream tool-run logs to workflow execution UI with markdown rendering

### DIFF
--- a/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
+++ b/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
@@ -55,7 +55,9 @@ const CustomMarkdown = ({
           </Text>
         );
       case "link": {
-        const isInternal = url?.startsWith("/");
+        // Protocol-relative URLs (`//evil.com/...`) also start with `/`
+        // so exclude them from the internal-route branch.
+        const isInternal = url?.startsWith("/") && !url.startsWith("//");
         if (isInternal) {
           const resolvedUrl = orgName ? `/${orgName}${url}` : url;
           return <RouterLink to={resolvedUrl}>{content}</RouterLink>;

--- a/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
+++ b/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
@@ -7,6 +7,18 @@ import { useSessionStore } from "../../../store/session-store";
 
 const { Text, Link, Paragraph } = Typography;
 
+const SAFE_URL_SCHEMES = ["http:", "https:", "mailto:", "tel:"];
+
+const isSafeExternalUrl = (url) => {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return SAFE_URL_SCHEMES.includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+};
+
 const CustomMarkdown = ({
   text = "",
   renderNewLines = true,
@@ -58,6 +70,11 @@ const CustomMarkdown = ({
         if (isInternal) {
           const resolvedUrl = orgName ? `/${orgName}${url}` : url;
           return <RouterLink to={resolvedUrl}>{content}</RouterLink>;
+        }
+        // Guard against unsafe schemes (e.g. javascript:, data:) since log
+        // content can originate from tool output or user input.
+        if (!isSafeExternalUrl(url)) {
+          return content;
         }
         return (
           <Link href={url} target="_blank" rel="noopener noreferrer">

--- a/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
+++ b/frontend/src/components/helpers/custom-markdown/CustomMarkdown.jsx
@@ -3,21 +3,10 @@ import PropTypes from "prop-types";
 import { useMemo } from "react";
 import { Link as RouterLink } from "react-router-dom";
 
+import { isSafeExternalUrl } from "../../../helpers/urlSafety";
 import { useSessionStore } from "../../../store/session-store";
 
 const { Text, Link, Paragraph } = Typography;
-
-const SAFE_URL_SCHEMES = ["http:", "https:", "mailto:", "tel:"];
-
-const isSafeExternalUrl = (url) => {
-  if (!url) return false;
-  try {
-    const parsed = new URL(url, window.location.origin);
-    return SAFE_URL_SCHEMES.includes(parsed.protocol);
-  } catch {
-    return false;
-  }
-};
 
 const CustomMarkdown = ({
   text = "",
@@ -71,8 +60,6 @@ const CustomMarkdown = ({
           const resolvedUrl = orgName ? `/${orgName}${url}` : url;
           return <RouterLink to={resolvedUrl}>{content}</RouterLink>;
         }
-        // Guard against unsafe schemes (e.g. javascript:, data:) since log
-        // content can originate from tool output or user input.
         if (!isSafeExternalUrl(url)) {
           return content;
         }

--- a/frontend/src/components/logging/log-modal/LogModal.jsx
+++ b/frontend/src/components/logging/log-modal/LogModal.jsx
@@ -13,6 +13,7 @@ import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import { useExceptionHandler } from "../../../hooks/useExceptionHandler";
 import useRequestUrl from "../../../hooks/useRequestUrl";
 import { useAlertStore } from "../../../store/alert-store";
+import CustomMarkdown from "../../helpers/custom-markdown/CustomMarkdown";
 import { FilterDropdown, FilterIcon } from "../filter-dropdown/FilterDropdown";
 
 function LogModal({
@@ -120,6 +121,7 @@ function LogModal({
       title: "Log",
       dataIndex: "log",
       key: "log",
+      render: (log) => <CustomMarkdown text={log || ""} />,
     },
   ];
 

--- a/frontend/src/components/pipelines-or-deployments/log-modal/LogsModal.jsx
+++ b/frontend/src/components/pipelines-or-deployments/log-modal/LogsModal.jsx
@@ -41,7 +41,7 @@ const LogsModal = ({
       .then((res) => {
         const logDetails = res?.data?.results?.map((item) => ({
           id: item?.id,
-          log: <CustomMarkdown text={item?.data?.log} />,
+          log: item?.data?.log,
           type: item?.data?.type,
           stage: item?.data?.stage,
           level: item?.data?.level,

--- a/frontend/src/components/pipelines-or-deployments/log-modal/LogsModal.jsx
+++ b/frontend/src/components/pipelines-or-deployments/log-modal/LogsModal.jsx
@@ -111,6 +111,7 @@ const LogsModal = ({
       title: "Log",
       dataIndex: "log",
       key: "log",
+      render: (log) => <CustomMarkdown text={log || ""} />,
     },
   ];
 

--- a/frontend/src/helpers/urlSafety.js
+++ b/frontend/src/helpers/urlSafety.js
@@ -3,11 +3,13 @@ const SAFE_URL_SCHEMES = ["http:", "https:", "mailto:", "tel:"];
 // Guards against unsafe schemes (e.g. `javascript:`, `data:`) when
 // rendering links built from user- or tool-derived content.
 const isSafeExternalUrl = (url) => {
-  if (!url) {
+  if (typeof url !== "string" || url === "") {
     return false;
   }
+  // Parse without a base so bare strings (e.g. "javascript", "../foo") fail
+  // instead of silently resolving to `https://<origin>/...` and passing.
   try {
-    const parsed = new URL(url, window.location.origin);
+    const parsed = new URL(url);
     return SAFE_URL_SCHEMES.includes(parsed.protocol);
   } catch {
     return false;

--- a/frontend/src/helpers/urlSafety.js
+++ b/frontend/src/helpers/urlSafety.js
@@ -1,0 +1,17 @@
+const SAFE_URL_SCHEMES = ["http:", "https:", "mailto:", "tel:"];
+
+// Guards against unsafe schemes (e.g. `javascript:`, `data:`) when
+// rendering links built from user- or tool-derived content.
+const isSafeExternalUrl = (url) => {
+  if (!url) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return SAFE_URL_SCHEMES.includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+};
+
+export { isSafeExternalUrl, SAFE_URL_SCHEMES };

--- a/unstract/sdk1/src/unstract/sdk1/execution/context.py
+++ b/unstract/sdk1/src/unstract/sdk1/execution/context.py
@@ -78,9 +78,7 @@ class ExecutionContext:
     executor_params: dict[str, Any] = field(default_factory=dict)
     request_id: str | None = None
     log_events_id: str | None = None
-    # Workflow-level IDs used for persistent log attribution in the
-    # execution_log table. Optional — callers running outside a
-    # workflow context (e.g. IDE test) may omit them.
+    # Workflow IDs used by LogDataDTO for execution_log persistence.
     execution_id: str | None = None
     file_execution_id: str | None = None
 

--- a/unstract/sdk1/src/unstract/sdk1/execution/context.py
+++ b/unstract/sdk1/src/unstract/sdk1/execution/context.py
@@ -78,6 +78,11 @@ class ExecutionContext:
     executor_params: dict[str, Any] = field(default_factory=dict)
     request_id: str | None = None
     log_events_id: str | None = None
+    # Workflow-level IDs used for persistent log attribution in the
+    # execution_log table. Optional — callers running outside a
+    # workflow context (e.g. IDE test) may omit them.
+    execution_id: str | None = None
+    file_execution_id: str | None = None
 
     def __post_init__(self) -> None:
         """Validate required fields after initialization."""
@@ -111,6 +116,8 @@ class ExecutionContext:
             "executor_params": self.executor_params,
             "request_id": self.request_id,
             "log_events_id": self.log_events_id,
+            "execution_id": self.execution_id,
+            "file_execution_id": self.file_execution_id,
         }
 
     @classmethod
@@ -125,4 +132,6 @@ class ExecutionContext:
             executor_params=data.get("executor_params", {}),
             request_id=data.get("request_id"),
             log_events_id=data.get("log_events_id"),
+            execution_id=data.get("execution_id"),
+            file_execution_id=data.get("file_execution_id"),
         )

--- a/unstract/sdk1/src/unstract/sdk1/execution/context.py
+++ b/unstract/sdk1/src/unstract/sdk1/execution/context.py
@@ -68,6 +68,11 @@ class ExecutionContext:
         log_events_id: Socket.IO channel ID for streaming progress
             logs to the frontend.  ``None`` when not in an IDE
             session (no logs published).
+        execution_id: Workflow execution identifier for log
+            correlation. When set, ``organization_id`` must also be
+            set (enforced in ``__post_init__``).
+        file_execution_id: Child identifier for per-file execution
+            within a workflow run. Optional.
     """
 
     executor_name: str
@@ -78,7 +83,6 @@ class ExecutionContext:
     executor_params: dict[str, Any] = field(default_factory=dict)
     request_id: str | None = None
     log_events_id: str | None = None
-    # Workflow IDs used by LogDataDTO for execution_log persistence.
     execution_id: str | None = None
     file_execution_id: str | None = None
 
@@ -92,6 +96,10 @@ class ExecutionContext:
             raise ValueError("run_id is required")
         if not self.execution_source:
             raise ValueError("execution_source is required")
+        # When execution_id is set, organization_id must be too — they
+        # travel together for workflow-level log correlation.
+        if self.execution_id and not self.organization_id:
+            raise ValueError("organization_id is required when execution_id is set")
 
         # Normalize enum values to plain strings for serialization
         if isinstance(self.operation, Operation):

--- a/workers/executor/executor_tool_shim.py
+++ b/workers/executor/executor_tool_shim.py
@@ -60,6 +60,9 @@ class ExecutorToolShim(StreamMixin):
         platform_api_key: str = "",
         log_events_id: str = "",
         component: dict[str, str] | None = None,
+        execution_id: str = "",
+        organization_id: str = "",
+        file_execution_id: str = "",
     ) -> None:
         """Initialize the shim.
 
@@ -72,10 +75,19 @@ class ExecutorToolShim(StreamMixin):
             component: Structured identifier dict for log correlation
                 (``tool_id``, ``run_id``, ``doc_name``, optionally
                 ``prompt_key``).
+            execution_id: Workflow execution id. When provided with
+                ``organization_id``, enables persistent log attribution
+                to the ``execution_log`` table.
+            organization_id: Tenant/org scope for log persistence.
+            file_execution_id: File execution id (child of workflow
+                execution). Optional — populated for per-file tool runs.
         """
         self.platform_api_key = platform_api_key
         self.log_events_id = log_events_id
         self.component = component or {}
+        self.execution_id = execution_id
+        self.organization_id = organization_id
+        self.file_execution_id = file_execution_id
         # Initialize StreamMixin.  EXECUTION_BY_TOOL is not set in
         # the worker environment, so _exec_by_tool will be False.
         super().__init__(log_level=LogLevel.INFO)
@@ -148,7 +160,9 @@ class ExecutorToolShim(StreamMixin):
         if self.log_events_id:
             try:
                 wf_level = _SDK_TO_WF_LEVEL.get(level, "INFO")
-                payload = LogPublisher.log_progress(
+                # PROGRESS: drives the IDE prompt-card live progress pane.
+                # Filtered out at the DB persist layer (LogType != LOG).
+                progress_payload = LogPublisher.log_progress(
                     component=self.component,
                     level=wf_level,
                     state=stage,
@@ -156,8 +170,26 @@ class ExecutorToolShim(StreamMixin):
                 )
                 LogPublisher.publish(
                     channel_id=self.log_events_id,
-                    payload=payload,
+                    payload=progress_payload,
                 )
+                # LOG: feeds the workflow execution logs UI and persists
+                # to the execution_log table. Requires the workflow IDs
+                # to pass LogDataDTO validation; skip silently when any
+                # are missing (e.g. older callsites that don't thread
+                # them through yet).
+                if self.execution_id and self.organization_id:
+                    log_payload = LogPublisher.log_workflow(
+                        stage=stage,
+                        message=log,
+                        level=wf_level,
+                        execution_id=self.execution_id,
+                        file_execution_id=self.file_execution_id or None,
+                        organization_id=self.organization_id,
+                    )
+                    LogPublisher.publish(
+                        channel_id=self.log_events_id,
+                        payload=log_payload,
+                    )
             except Exception:
                 logger.debug(
                     "Failed to publish progress log (non-fatal)",

--- a/workers/executor/executor_tool_shim.py
+++ b/workers/executor/executor_tool_shim.py
@@ -157,41 +157,55 @@ class ExecutorToolShim(StreamMixin):
             return
 
         # Publish progress to frontend via the log consumer queue.
-        if self.log_events_id:
-            try:
-                wf_level = _SDK_TO_WF_LEVEL.get(level, "INFO")
-                # PROGRESS payload — IDE prompt-card live updates only
-                # (dropped by DB persist since LogType != LOG).
-                progress_payload = LogPublisher.log_progress(
-                    component=self.component,
-                    level=wf_level,
-                    state=stage,
-                    message=log,
-                )
-                LogPublisher.publish(
-                    channel_id=self.log_events_id,
-                    payload=progress_payload,
-                )
-                # LOG payload — feeds workflow logs UI and persists to
-                # execution_log. LogDataDTO validation requires the IDs.
-                if self.execution_id and self.organization_id:
-                    log_payload = LogPublisher.log_workflow(
-                        stage=stage,
-                        message=log,
-                        level=wf_level,
-                        execution_id=self.execution_id,
-                        file_execution_id=self.file_execution_id or None,
-                        organization_id=self.organization_id,
-                    )
-                    LogPublisher.publish(
-                        channel_id=self.log_events_id,
-                        payload=log_payload,
-                    )
-            except Exception:
-                logger.debug(
-                    "Failed to publish progress log (non-fatal)",
-                    exc_info=True,
-                )
+        if not self.log_events_id:
+            return
+
+        wf_level = _SDK_TO_WF_LEVEL.get(level, "INFO")
+
+        # PROGRESS payload — IDE prompt-card live updates only. Dropped at
+        # the DB persist layer because LogPublisher.publish only stores
+        # payloads whose `type == "LOG"`.
+        try:
+            progress_payload = LogPublisher.log_progress(
+                component=self.component,
+                level=wf_level,
+                state=stage,
+                message=log,
+            )
+            LogPublisher.publish(
+                channel_id=self.log_events_id,
+                payload=progress_payload,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to publish progress log (non-fatal)",
+                exc_info=True,
+            )
+
+        # LOG payload — feeds workflow logs UI and persists to execution_log.
+        # LogDataDTO validation requires `execution_id` and `organization_id`;
+        # `file_execution_id` is optional.
+        if not (self.execution_id and self.organization_id):
+            return
+
+        try:
+            log_payload = LogPublisher.log_workflow(
+                stage=stage,
+                message=log,
+                level=wf_level,
+                execution_id=self.execution_id,
+                file_execution_id=self.file_execution_id or None,
+                organization_id=self.organization_id,
+            )
+            LogPublisher.publish(
+                channel_id=self.log_events_id,
+                payload=log_payload,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to publish workflow log (non-fatal)",
+                exc_info=True,
+            )
 
     def stream_error_and_exit(self, message: str, err: Exception | None = None) -> None:
         """Log error and raise SdkError.

--- a/workers/executor/executor_tool_shim.py
+++ b/workers/executor/executor_tool_shim.py
@@ -60,9 +60,9 @@ class ExecutorToolShim(StreamMixin):
         platform_api_key: str = "",
         log_events_id: str = "",
         component: dict[str, str] | None = None,
-        execution_id: str = "",
-        organization_id: str = "",
-        file_execution_id: str = "",
+        execution_id: str | None = None,
+        organization_id: str | None = None,
+        file_execution_id: str | None = None,
     ) -> None:
         """Initialize the shim.
 

--- a/workers/executor/executor_tool_shim.py
+++ b/workers/executor/executor_tool_shim.py
@@ -88,6 +88,11 @@ class ExecutorToolShim(StreamMixin):
         self.execution_id = execution_id
         self.organization_id = organization_id
         self.file_execution_id = file_execution_id
+        # Track whether we've already surfaced a publish failure on this
+        # shim so that a down broker is flagged loudly once instead of
+        # silently swallowing every subsequent log line at DEBUG.
+        self._progress_publish_failed = False
+        self._log_publish_failed = False
         # Initialize StreamMixin.  EXECUTION_BY_TOOL is not set in
         # the worker environment, so _exec_by_tool will be False.
         super().__init__(log_level=LogLevel.INFO)
@@ -177,9 +182,12 @@ class ExecutorToolShim(StreamMixin):
                 payload=progress_payload,
             )
         except Exception:
-            logger.debug(
+            first_failure = not self._progress_publish_failed
+            self._progress_publish_failed = True
+            logger.log(
+                logging.WARNING if first_failure else logging.DEBUG,
                 "Failed to publish progress log (non-fatal)",
-                exc_info=True,
+                exc_info=first_failure,
             )
 
         # LOG payload — feeds workflow logs UI and persists to execution_log.
@@ -202,9 +210,12 @@ class ExecutorToolShim(StreamMixin):
                 payload=log_payload,
             )
         except Exception:
-            logger.debug(
+            first_failure = not self._log_publish_failed
+            self._log_publish_failed = True
+            logger.log(
+                logging.WARNING if first_failure else logging.DEBUG,
                 "Failed to publish workflow log (non-fatal)",
-                exc_info=True,
+                exc_info=first_failure,
             )
 
     def stream_error_and_exit(self, message: str, err: Exception | None = None) -> None:

--- a/workers/executor/executor_tool_shim.py
+++ b/workers/executor/executor_tool_shim.py
@@ -160,8 +160,8 @@ class ExecutorToolShim(StreamMixin):
         if self.log_events_id:
             try:
                 wf_level = _SDK_TO_WF_LEVEL.get(level, "INFO")
-                # PROGRESS: drives the IDE prompt-card live progress pane.
-                # Filtered out at the DB persist layer (LogType != LOG).
+                # PROGRESS payload — IDE prompt-card live updates only
+                # (dropped by DB persist since LogType != LOG).
                 progress_payload = LogPublisher.log_progress(
                     component=self.component,
                     level=wf_level,
@@ -172,11 +172,8 @@ class ExecutorToolShim(StreamMixin):
                     channel_id=self.log_events_id,
                     payload=progress_payload,
                 )
-                # LOG: feeds the workflow execution logs UI and persists
-                # to the execution_log table. Requires the workflow IDs
-                # to pass LogDataDTO validation; skip silently when any
-                # are missing (e.g. older callsites that don't thread
-                # them through yet).
+                # LOG payload — feeds workflow logs UI and persists to
+                # execution_log. LogDataDTO validation requires the IDs.
                 if self.execution_id and self.organization_id:
                     log_payload = LogPublisher.log_workflow(
                         stage=stage,

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -127,13 +127,7 @@ class LegacyExecutor(BaseExecutor):
             # Stream error to FE so the user sees the failure in real-time
             if self._log_events_id:
                 try:
-                    shim = ExecutorToolShim(
-                        log_events_id=self._log_events_id,
-                        component=self._log_component,
-                        execution_id=self._execution_id,
-                        organization_id=self._organization_id,
-                        file_execution_id=self._file_execution_id,
-                    )
+                    shim = self._build_shim()
                     shim.stream_log(
                         f"Error: {exc.message or type(exc).__name__}",
                         level=LogLevel.ERROR,
@@ -141,6 +135,26 @@ class LegacyExecutor(BaseExecutor):
                 except Exception:
                     pass  # Best-effort — don't mask the original error
             return ExecutionResult.failure(error=exc.message)
+
+    def _build_shim(
+        self,
+        *,
+        platform_api_key: str = "",
+        component: dict[str, str] | None = None,
+    ) -> ExecutorToolShim:
+        """Construct an ``ExecutorToolShim`` pre-populated with the
+        log-streaming and workflow-attribution fields captured in
+        ``execute()``. Callers override ``platform_api_key`` and
+        ``component`` as needed; everything else is shared.
+        """
+        return ExecutorToolShim(
+            platform_api_key=platform_api_key,
+            log_events_id=self._log_events_id,
+            component=self._log_component if component is None else component,
+            execution_id=self._execution_id,
+            organization_id=self._organization_id,
+            file_execution_id=self._file_execution_id,
+        )
 
     # ------------------------------------------------------------------
     # Phase 2B — Extract handler
@@ -182,14 +196,7 @@ class LegacyExecutor(BaseExecutor):
         execution_data_dir: str | None = params.get(IKeys.EXECUTION_DATA_DIR)
 
         # Build adapter shim and X2Text
-        shim = ExecutorToolShim(
-            platform_api_key=platform_api_key,
-            log_events_id=self._log_events_id,
-            component=self._log_component,
-            execution_id=self._execution_id,
-            organization_id=self._organization_id,
-            file_execution_id=self._file_execution_id,
-        )
+        shim = self._build_shim(platform_api_key=platform_api_key)
         x2text = X2Text(
             tool=shim,
             adapter_instance_id=x2text_instance_id,
@@ -364,6 +371,8 @@ class LegacyExecutor(BaseExecutor):
             organization_id=context.organization_id,
             request_id=context.request_id,
             log_events_id=context.log_events_id,
+            execution_id=context.execution_id,
+            file_execution_id=context.file_execution_id,
             executor_params={
                 "llm_adapter_instance_id": llm_adapter_id,
                 "summarize_prompt": summarize_prompt,
@@ -439,6 +448,8 @@ class LegacyExecutor(BaseExecutor):
                 executor_params=extract_params,
                 request_id=context.request_id,
                 log_events_id=context.log_events_id,
+                execution_id=context.execution_id,
+                file_execution_id=context.file_execution_id,
             )
             extract_result = self._handle_extract(extract_ctx)
             if not extract_result.success:
@@ -466,6 +477,8 @@ class LegacyExecutor(BaseExecutor):
             executor_params=index_params,
             request_id=context.request_id,
             log_events_id=context.log_events_id,
+            execution_id=context.execution_id,
+            file_execution_id=context.file_execution_id,
         )
         index_result = self._handle_index(index_ctx)
         if not index_result.success:
@@ -531,13 +544,8 @@ class LegacyExecutor(BaseExecutor):
         extracted_text = ""
         index_metrics: dict = {}
 
-        shim = ExecutorToolShim(
+        shim = self._build_shim(
             platform_api_key=extract_params.get("platform_api_key", ""),
-            log_events_id=self._log_events_id,
-            component=self._log_component,
-            execution_id=self._execution_id,
-            organization_id=self._organization_id,
-            file_execution_id=self._file_execution_id,
         )
         step = 1
 
@@ -554,6 +562,8 @@ class LegacyExecutor(BaseExecutor):
                 executor_params=extract_params,
                 request_id=context.request_id,
                 log_events_id=context.log_events_id,
+                execution_id=context.execution_id,
+                file_execution_id=context.file_execution_id,
             )
             extract_result = self._handle_extract(extract_ctx)
             if not extract_result.success:
@@ -658,6 +668,8 @@ class LegacyExecutor(BaseExecutor):
             executor_params=answer_params,
             request_id=context.request_id,
             log_events_id=context.log_events_id,
+            execution_id=context.execution_id,
+            file_execution_id=context.file_execution_id,
         )
         if is_single_pass:
             return self._handle_single_pass_extraction(answer_ctx)
@@ -760,6 +772,8 @@ class LegacyExecutor(BaseExecutor):
                 organization_id=context.organization_id,
                 request_id=context.request_id,
                 log_events_id=context.log_events_id,
+                execution_id=context.execution_id,
+                file_execution_id=context.file_execution_id,
                 executor_params={
                     "llm_adapter_instance_id": llm_adapter_id,
                     "summarize_prompt": summarize_prompt,
@@ -855,6 +869,8 @@ class LegacyExecutor(BaseExecutor):
                     organization_id=context.organization_id,
                     request_id=context.request_id,
                     log_events_id=context.log_events_id,
+                    execution_id=context.execution_id,
+                    file_execution_id=context.file_execution_id,
                     executor_params={
                         "embedding_instance_id": embedding,
                         "vector_db_instance_id": vector_db,
@@ -969,14 +985,7 @@ class LegacyExecutor(BaseExecutor):
             usage_kwargs=usage_kwargs,
         )
 
-        shim = ExecutorToolShim(
-            platform_api_key=platform_api_key,
-            log_events_id=self._log_events_id,
-            component=self._log_component,
-            execution_id=self._execution_id,
-            organization_id=self._organization_id,
-            file_execution_id=self._file_execution_id,
-        )
+        shim = self._build_shim(platform_api_key=platform_api_key)
         fs_instance = FileUtils.get_fs_instance(execution_source=execution_source)
 
         logger.info(
@@ -1217,14 +1226,7 @@ class LegacyExecutor(BaseExecutor):
         process_text_fn = None
         enable_highlight = tool_settings.get(PSKeys.ENABLE_HIGHLIGHT, False)
         enable_word_confidence = tool_settings.get(PSKeys.ENABLE_WORD_CONFIDENCE, False)
-        pipeline_shim = ExecutorToolShim(
-            platform_api_key=platform_api_key,
-            log_events_id=self._log_events_id,
-            component=self._log_component,
-            execution_id=self._execution_id,
-            organization_id=self._organization_id,
-            file_execution_id=self._file_execution_id,
-        )
+        pipeline_shim = self._build_shim(platform_api_key=platform_api_key)
         if enable_highlight:
             from executor.executors.plugins import ExecutorPluginLoader
 
@@ -1497,13 +1499,9 @@ class LegacyExecutor(BaseExecutor):
             output.get(PSKeys.TYPE, "TEXT"),
         )
 
-        shim = ExecutorToolShim(
+        shim = self._build_shim(
             platform_api_key=platform_api_key,
-            log_events_id=self._log_events_id,
             component={**self._log_component, "prompt_key": prompt_name},
-            execution_id=self._execution_id,
-            organization_id=self._organization_id,
-            file_execution_id=self._file_execution_id,
         )
         shim.stream_log(f"Processing prompt: `{prompt_name}`")
 
@@ -2062,14 +2060,7 @@ class LegacyExecutor(BaseExecutor):
             f"Context:\n---------------\n{doc_context}\n-----------------\n\nSummary:"
         )
 
-        shim = ExecutorToolShim(
-            platform_api_key=platform_api_key,
-            log_events_id=self._log_events_id,
-            component=self._log_component,
-            execution_id=self._execution_id,
-            organization_id=self._organization_id,
-            file_execution_id=self._file_execution_id,
-        )
+        shim = self._build_shim(platform_api_key=platform_api_key)
         usage_kwargs = {
             "run_id": context.run_id,
             PSKeys.LLM_USAGE_REASON: PSKeys.SUMMARIZE,

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -1777,7 +1777,7 @@ class LegacyExecutor(BaseExecutor):
             )
             shim.stream_log(f"Table extraction completed for: `{prompt_name}`")
             logger.info("TABLE extraction completed: prompt=%s", prompt_name)
-            shim.stream_log(f"Completed prompt: {prompt_name}")
+            shim.stream_log(f"Completed prompt: `{prompt_name}`")
         else:
             structured_output[prompt_name] = ""
             error_msg = table_result.error or "unknown error"
@@ -1787,7 +1787,7 @@ class LegacyExecutor(BaseExecutor):
                 error_msg,
             )
             shim.stream_log(
-                f"Table extraction failed for {prompt_name}: {error_msg}",
+                f"Table extraction failed for `{prompt_name}`: {error_msg}",
                 level=LogLevel.ERROR,
             )
 
@@ -1843,7 +1843,7 @@ class LegacyExecutor(BaseExecutor):
         line_item_ctx._log_component = self._log_component
         line_item_ctx.log_events_id = self._log_events_id
 
-        shim.stream_log(f"Running line-item extraction for: {prompt_name}")
+        shim.stream_log(f"Running line-item extraction for: `{prompt_name}`")
         line_item_result = line_item_executor.execute(line_item_ctx)
 
         if line_item_result.success:
@@ -1856,9 +1856,9 @@ class LegacyExecutor(BaseExecutor):
             context_list = data.get("context")
             if context_list:
                 metadata[PSKeys.CONTEXT][prompt_name] = context_list
-            shim.stream_log(f"Line-item extraction completed for: {prompt_name}")
+            shim.stream_log(f"Line-item extraction completed for: `{prompt_name}`")
             logger.info("LINE_ITEM extraction completed: prompt=%s", prompt_name)
-            shim.stream_log(f"Completed prompt: {prompt_name}")
+            shim.stream_log(f"Completed prompt: `{prompt_name}`")
         else:
             structured_output[prompt_name] = ""
             error_msg = line_item_result.error or "unknown error"
@@ -1868,7 +1868,7 @@ class LegacyExecutor(BaseExecutor):
                 error_msg,
             )
             shim.stream_log(
-                f"Line-item extraction failed for {prompt_name}: {error_msg}",
+                f"Line-item extraction failed for `{prompt_name}`: {error_msg}",
                 level=LogLevel.ERROR,
             )
 

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -57,12 +57,13 @@ class LegacyExecutor(BaseExecutor):
         Operation.STRUCTURE_PIPELINE.value: "_handle_structure_pipeline",
     }
 
-    # Defaults for log streaming (overridden by execute()).
-    _log_events_id: str = ""
-    _log_component: dict[str, str] = {}
-    _execution_id: str = ""
-    _file_execution_id: str = ""
-    _organization_id: str = ""
+    def __init__(self) -> None:
+        # Per-request state — overwritten on every ``execute()`` call.
+        self._log_events_id: str = ""
+        self._log_component: dict[str, str] = {}
+        self._execution_id: str | None = None
+        self._file_execution_id: str | None = None
+        self._organization_id: str | None = None
 
     @property
     def name(self) -> str:
@@ -80,11 +81,21 @@ class LegacyExecutor(BaseExecutor):
             NotImplementedError: From stub handlers (until 2D–2H).
         """
         # Extract log streaming info (set by tasks.py for IDE sessions).
-        self._log_events_id: str = context.log_events_id or ""
-        self._log_component: dict[str, str] = getattr(context, "_log_component", {})
-        self._execution_id: str = context.execution_id or ""
-        self._file_execution_id: str = context.file_execution_id or ""
-        self._organization_id: str = context.organization_id or ""
+        self._log_events_id = context.log_events_id or ""
+        self._log_component = getattr(context, "_log_component", None) or {}
+        self._execution_id = context.execution_id
+        self._file_execution_id = context.file_execution_id
+        self._organization_id = context.organization_id
+        if (
+            context.execution_source == "tool"
+            and self._log_events_id
+            and not (self._execution_id and self._organization_id)
+        ):
+            logger.warning(
+                "Workflow IDs missing on tool context run_id=%s — tool-level "
+                "logs will reach the UI but won't persist to execution_log.",
+                context.run_id,
+            )
 
         handler_name = self._OPERATION_MAP.get(context.operation)
         if handler_name is None:

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -84,8 +84,8 @@ class LegacyExecutor(BaseExecutor):
         # Extract log streaming info (set by tasks.py for IDE sessions).
         self._log_events_id: str = context.log_events_id or ""
         self._log_component: dict[str, str] = getattr(context, "_log_component", {})
-        self._execution_id: str = getattr(context, "execution_id", "") or ""
-        self._file_execution_id: str = getattr(context, "file_execution_id", "") or ""
+        self._execution_id: str = context.execution_id or ""
+        self._file_execution_id: str = context.file_execution_id or ""
         self._organization_id: str = context.organization_id or ""
 
         handler_name = self._OPERATION_MAP.get(context.operation)
@@ -1753,6 +1753,9 @@ class LegacyExecutor(BaseExecutor):
             execution_source=execution_source,
             organization_id=context.organization_id,
             request_id=context.request_id,
+            log_events_id=self._log_events_id,
+            execution_id=self._execution_id,
+            file_execution_id=self._file_execution_id,
             executor_params={
                 "llm_adapter_instance_id": output.get(PSKeys.LLM, ""),
                 "table_settings": output.get(PSKeys.TABLE_SETTINGS, {}),
@@ -1764,7 +1767,6 @@ class LegacyExecutor(BaseExecutor):
             },
         )
         table_ctx._log_component = self._log_component
-        table_ctx.log_events_id = self._log_events_id
 
         shim.stream_log(f"Running table extraction for: `{prompt_name}`")
         table_result = table_executor.execute(table_ctx)
@@ -1827,6 +1829,9 @@ class LegacyExecutor(BaseExecutor):
             execution_source=prompt_run_args["execution_source"],
             organization_id=context.organization_id,
             request_id=context.request_id,
+            log_events_id=self._log_events_id,
+            execution_id=self._execution_id,
+            file_execution_id=self._file_execution_id,
             executor_params={
                 "llm_adapter_instance_id": output.get(PSKeys.LLM, ""),
                 "tool_settings": prompt_run_args["tool_settings"],
@@ -1841,7 +1846,6 @@ class LegacyExecutor(BaseExecutor):
             },
         )
         line_item_ctx._log_component = self._log_component
-        line_item_ctx.log_events_id = self._log_events_id
 
         shim.stream_log(f"Running line-item extraction for: `{prompt_name}`")
         line_item_result = line_item_executor.execute(line_item_ctx)

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -60,8 +60,6 @@ class LegacyExecutor(BaseExecutor):
     # Defaults for log streaming (overridden by execute()).
     _log_events_id: str = ""
     _log_component: dict[str, str] = {}
-    # Workflow IDs for persistent log attribution; empty outside of a
-    # workflow context (e.g. bare IDE runs that don't set them).
     _execution_id: str = ""
     _file_execution_id: str = ""
     _organization_id: str = ""

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -60,6 +60,11 @@ class LegacyExecutor(BaseExecutor):
     # Defaults for log streaming (overridden by execute()).
     _log_events_id: str = ""
     _log_component: dict[str, str] = {}
+    # Workflow IDs for persistent log attribution; empty outside of a
+    # workflow context (e.g. bare IDE runs that don't set them).
+    _execution_id: str = ""
+    _file_execution_id: str = ""
+    _organization_id: str = ""
 
     @property
     def name(self) -> str:
@@ -79,6 +84,9 @@ class LegacyExecutor(BaseExecutor):
         # Extract log streaming info (set by tasks.py for IDE sessions).
         self._log_events_id: str = context.log_events_id or ""
         self._log_component: dict[str, str] = getattr(context, "_log_component", {})
+        self._execution_id: str = getattr(context, "execution_id", "") or ""
+        self._file_execution_id: str = getattr(context, "file_execution_id", "") or ""
+        self._organization_id: str = context.organization_id or ""
 
         handler_name = self._OPERATION_MAP.get(context.operation)
         if handler_name is None:
@@ -124,6 +132,9 @@ class LegacyExecutor(BaseExecutor):
                     shim = ExecutorToolShim(
                         log_events_id=self._log_events_id,
                         component=self._log_component,
+                        execution_id=self._execution_id,
+                        organization_id=self._organization_id,
+                        file_execution_id=self._file_execution_id,
                     )
                     shim.stream_log(
                         f"Error: {exc.message or type(exc).__name__}",
@@ -177,6 +188,9 @@ class LegacyExecutor(BaseExecutor):
             platform_api_key=platform_api_key,
             log_events_id=self._log_events_id,
             component=self._log_component,
+            execution_id=self._execution_id,
+            organization_id=self._organization_id,
+            file_execution_id=self._file_execution_id,
         )
         x2text = X2Text(
             tool=shim,
@@ -523,6 +537,9 @@ class LegacyExecutor(BaseExecutor):
             platform_api_key=extract_params.get("platform_api_key", ""),
             log_events_id=self._log_events_id,
             component=self._log_component,
+            execution_id=self._execution_id,
+            organization_id=self._organization_id,
+            file_execution_id=self._file_execution_id,
         )
         step = 1
 
@@ -958,6 +975,9 @@ class LegacyExecutor(BaseExecutor):
             platform_api_key=platform_api_key,
             log_events_id=self._log_events_id,
             component=self._log_component,
+            execution_id=self._execution_id,
+            organization_id=self._organization_id,
+            file_execution_id=self._file_execution_id,
         )
         fs_instance = FileUtils.get_fs_instance(execution_source=execution_source)
 
@@ -1203,6 +1223,9 @@ class LegacyExecutor(BaseExecutor):
             platform_api_key=platform_api_key,
             log_events_id=self._log_events_id,
             component=self._log_component,
+            execution_id=self._execution_id,
+            organization_id=self._organization_id,
+            file_execution_id=self._file_execution_id,
         )
         if enable_highlight:
             from executor.executors.plugins import ExecutorPluginLoader
@@ -1371,7 +1394,7 @@ class LegacyExecutor(BaseExecutor):
         challenge_llm_id = tool_settings.get(PSKeys.CHALLENGE_LLM)
         if not challenge_llm_id:
             return
-        shim.stream_log(f"Running challenge for: {prompt_name}")
+        shim.stream_log(f"Running challenge for: `{prompt_name}`")
         challenge_llm = llm_cls(
             adapter_instance_id=challenge_llm_id,
             tool=shim,
@@ -1390,7 +1413,7 @@ class LegacyExecutor(BaseExecutor):
             metadata=metadata,
         )
         challenger.run()
-        shim.stream_log(f"Challenge verification completed for: {prompt_name}")
+        shim.stream_log(f"Challenge verification completed for: `{prompt_name}`")
         logger.info("Challenge completed: prompt=%s", prompt_name)
 
     @staticmethod
@@ -1412,7 +1435,7 @@ class LegacyExecutor(BaseExecutor):
         evaluator_cls = ExecutorPluginLoader.get("evaluation")
         if not evaluator_cls:
             return
-        shim.stream_log(f"Running evaluation for: {prompt_name}")
+        shim.stream_log(f"Running evaluation for: `{prompt_name}`")
         evaluator = evaluator_cls(
             query=output.get(PSKeys.COMBINED_PROMPT, ""),
             context="\n".join(context_list),
@@ -1480,8 +1503,11 @@ class LegacyExecutor(BaseExecutor):
             platform_api_key=platform_api_key,
             log_events_id=self._log_events_id,
             component={**self._log_component, "prompt_key": prompt_name},
+            execution_id=self._execution_id,
+            organization_id=self._organization_id,
+            file_execution_id=self._file_execution_id,
         )
-        shim.stream_log(f"Processing prompt: {prompt_name}")
+        shim.stream_log(f"Processing prompt: `{prompt_name}`")
 
         if variable_replacement_svc.is_variables_present(prompt_text=prompt_text):
             prompt_text = variable_replacement_svc.replace_variables_in_prompt(
@@ -1494,7 +1520,7 @@ class LegacyExecutor(BaseExecutor):
                 custom_data=custom_data,
                 is_ide=execution_source == "ide",
             )
-            shim.stream_log(f"Resolved template variables for: {prompt_name}")
+            shim.stream_log(f"Resolved template variables for: `{prompt_name}`")
 
         logger.info(
             "Executing prompt: tool_id=%s name=%s run_id=%s", tool_id, prompt_name, run_id
@@ -1574,7 +1600,9 @@ class LegacyExecutor(BaseExecutor):
                     adapter_instance_id=output[PSKeys.VECTOR_DB],
                     embedding=embedding,
                 )
-            shim.stream_log(f"Initialized LLM and retrieval adapters for: {prompt_name}")
+            shim.stream_log(
+                f"Initialized LLM and retrieval adapters for: `{prompt_name}`"
+            )
         except Exception as e:
             msg = f"Couldn't fetch adapter. {e}"
             logger.error(msg)
@@ -1588,7 +1616,7 @@ class LegacyExecutor(BaseExecutor):
             retrieval_strategy = output.get(PSKeys.RETRIEVAL_STRATEGY)
             valid_strategies = {s.value for s in RetrievalStrategy}
             if retrieval_strategy in valid_strategies:
-                shim.stream_log(f"Retrieving context for: {prompt_name}")
+                shim.stream_log(f"Retrieving context for: `{prompt_name}`")
                 logger.info(
                     "Performing retrieval: prompt=%s strategy=%s chunk_size=%d",
                     prompt_name,
@@ -1613,14 +1641,14 @@ class LegacyExecutor(BaseExecutor):
                     )
                 metadata[PSKeys.CONTEXT][prompt_name] = context_list
                 shim.stream_log(
-                    f"Retrieved {len(context_list)} context chunks for: {prompt_name}"
+                    f"Retrieved {len(context_list)} context chunks for: `{prompt_name}`"
                 )
                 logger.debug(
                     "Retrieved %d context chunks for prompt: %s",
                     len(context_list),
                     prompt_name,
                 )
-                shim.stream_log(f"Running LLM completion for: {prompt_name}")
+                shim.stream_log(f"Running LLM completion for: `{prompt_name}`")
                 answer = answer_prompt_svc.construct_and_run_prompt(
                     tool_settings=tool_settings,
                     output=output,
@@ -1652,7 +1680,7 @@ class LegacyExecutor(BaseExecutor):
                 tool_id=tool_id,
                 doc_name=doc_name,
             )
-            shim.stream_log(f"Applied type conversion for: {prompt_name}")
+            shim.stream_log(f"Applied type conversion for: `{prompt_name}`")
 
             self._run_challenge_if_enabled(
                 tool_settings=tool_settings,
@@ -1676,7 +1704,7 @@ class LegacyExecutor(BaseExecutor):
                 shim=shim,
                 prompt_name=prompt_name,
             )
-            shim.stream_log(f"Completed prompt: {prompt_name}")
+            shim.stream_log(f"Completed prompt: `{prompt_name}`")
 
             val = structured_output.get(prompt_name)
             if isinstance(val, str):
@@ -1738,7 +1766,7 @@ class LegacyExecutor(BaseExecutor):
         table_ctx._log_component = self._log_component
         table_ctx.log_events_id = self._log_events_id
 
-        shim.stream_log(f"Running table extraction for: {prompt_name}")
+        shim.stream_log(f"Running table extraction for: `{prompt_name}`")
         table_result = table_executor.execute(table_ctx)
 
         if table_result.success:
@@ -1747,7 +1775,7 @@ class LegacyExecutor(BaseExecutor):
             metrics.setdefault(prompt_name, {}).update(
                 {"table_extraction": table_metrics}
             )
-            shim.stream_log(f"Table extraction completed for: {prompt_name}")
+            shim.stream_log(f"Table extraction completed for: `{prompt_name}`")
             logger.info("TABLE extraction completed: prompt=%s", prompt_name)
             shim.stream_log(f"Completed prompt: {prompt_name}")
         else:
@@ -2036,6 +2064,9 @@ class LegacyExecutor(BaseExecutor):
             platform_api_key=platform_api_key,
             log_events_id=self._log_events_id,
             component=self._log_component,
+            execution_id=self._execution_id,
+            organization_id=self._organization_id,
+            file_execution_id=self._file_execution_id,
         )
         usage_kwargs = {
             "run_id": context.run_id,

--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from file_processing.worker import app
 from shared.enums.task_enums import TaskName
+from shared.infrastructure.context import StateStore
 
 from unstract.sdk1.constants import ToolEnv, UsageKwargs
 from unstract.sdk1.execution.context import ExecutionContext
@@ -257,6 +258,7 @@ def _execute_structure_tool_impl(params: dict) -> dict:
             dispatcher=dispatcher,
             shim=shim,
             file_execution_id=file_execution_id,
+            execution_id=execution_id,
             organization_id=organization_id,
             source_file_name=source_file_name,
             fs=fs,
@@ -388,6 +390,15 @@ def _execute_structure_tool_impl(params: dict) -> dict:
         execution_source="tool",
         organization_id=organization_id,
         request_id=file_execution_id,
+        # Thread the log channel so ExecutorToolShim.stream_log can publish
+        # tool-level progress to the workflow execution logs UI. Falls back
+        # to empty (no publish) when running outside a workflow context.
+        log_events_id=StateStore.get("LOG_EVENTS_ID") or "",
+        # Workflow IDs drive persistent attribution in the execution_log
+        # table — without them LogDataDTO validation drops tool-level
+        # messages even when WebSocket delivery succeeds.
+        execution_id=execution_id,
+        file_execution_id=file_execution_id,
         executor_params={
             "extract_params": extract_params,
             "index_template": index_template,
@@ -533,6 +544,7 @@ def _run_agentic_extraction(
     dispatcher: ExecutionDispatcher,
     shim: Any,
     file_execution_id: str,
+    execution_id: str,
     organization_id: str,
     source_file_name: str,
     fs: Any,
@@ -587,6 +599,9 @@ def _run_agentic_extraction(
         execution_source="tool",
         organization_id=organization_id,
         request_id=file_execution_id,
+        log_events_id=StateStore.get("LOG_EVENTS_ID") or "",
+        execution_id=execution_id,
+        file_execution_id=file_execution_id,
         executor_params={
             "document_id": file_execution_id,
             "document_text": document_text,

--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -236,7 +236,15 @@ def _execute_structure_tool_impl(params: dict) -> dict:
     # ---- Step 1: Setup ----
     from executor.executor_tool_shim import ExecutorToolShim
 
-    shim = ExecutorToolShim(platform_api_key=platform_service_api_key)
+    # Thread workflow IDs so pre-dispatch X2Text / platform helper logs reach
+    # the workflow logs UI (matches the pipeline/agentic dispatch contexts).
+    shim = ExecutorToolShim(
+        platform_api_key=platform_service_api_key,
+        log_events_id=StateStore.get("LOG_EVENTS_ID") or "",
+        execution_id=execution_id,
+        file_execution_id=file_execution_id,
+        organization_id=organization_id,
+    )
 
     platform_helper = _create_platform_helper(shim, file_execution_id)
     dispatcher = ExecutionDispatcher(celery_app=app)

--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -238,9 +238,16 @@ def _execute_structure_tool_impl(params: dict) -> dict:
 
     # Workflow IDs on the pre-dispatch shim let X2Text/platform helper logs
     # reach the workflow logs UI before the executor dispatch happens.
+    log_events_id = StateStore.get("LOG_EVENTS_ID") or ""
+    if not log_events_id:
+        logger.warning(
+            "LOG_EVENTS_ID missing from StateStore for execution_id=%s — "
+            "tool-level logs will not stream to the workflow logs UI.",
+            execution_id,
+        )
     shim = ExecutorToolShim(
         platform_api_key=platform_service_api_key,
-        log_events_id=StateStore.get("LOG_EVENTS_ID") or "",
+        log_events_id=log_events_id,
         execution_id=execution_id,
         file_execution_id=file_execution_id,
         organization_id=organization_id,

--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -236,8 +236,8 @@ def _execute_structure_tool_impl(params: dict) -> dict:
     # ---- Step 1: Setup ----
     from executor.executor_tool_shim import ExecutorToolShim
 
-    # Thread workflow IDs so pre-dispatch X2Text / platform helper logs reach
-    # the workflow logs UI (matches the pipeline/agentic dispatch contexts).
+    # Workflow IDs on the pre-dispatch shim let X2Text/platform helper logs
+    # reach the workflow logs UI before the executor dispatch happens.
     shim = ExecutorToolShim(
         platform_api_key=platform_service_api_key,
         log_events_id=StateStore.get("LOG_EVENTS_ID") or "",
@@ -398,13 +398,7 @@ def _execute_structure_tool_impl(params: dict) -> dict:
         execution_source="tool",
         organization_id=organization_id,
         request_id=file_execution_id,
-        # Thread the log channel so ExecutorToolShim.stream_log can publish
-        # tool-level progress to the workflow execution logs UI. Falls back
-        # to empty (no publish) when running outside a workflow context.
         log_events_id=StateStore.get("LOG_EVENTS_ID") or "",
-        # Workflow IDs drive persistent attribution in the execution_log
-        # table — without them LogDataDTO validation drops tool-level
-        # messages even when WebSocket delivery succeeds.
         execution_id=execution_id,
         file_execution_id=file_execution_id,
         executor_params={


### PR DESCRIPTION
## What

- Propagate `log_events_id` + workflow IDs (`execution_id`, `file_execution_id`, `organization_id`) through `ExecutionContext` → `LegacyExecutor` → every `ExecutorToolShim` so tool-level `stream_log` lines publish to the log broker.
- `ExecutorToolShim.stream_log` now dual-emits PROGRESS (IDE prompt-card live progress — unchanged) + LOG (feeds the workflow execution logs UI and persists to `execution_log` via the existing drain) when the workflow IDs are present.
- `LogModal` / pipeline `LogsModal` render log cells through the existing `CustomMarkdown` helper — backticked identifiers become inline-code pills, embedded newlines become line breaks. Prompt-key mentions in `legacy_executor` get backticks for consistency.

## Why

Two stacked gaps kept tool-level lines (`Processing prompt: X`, `Running LLM completion for: X`, lookup calls, etc.) out of the workflow execution logs UI and out of the `execution_log` table for API / workflow runs:

1. **Empty `log_events_id`** — `structure_tool_task` set `LOG_EVENTS_ID` in `StateStore` but never threaded it into the dispatched context. `ExecutorToolShim.stream_log` gated the publish on a truthy `self.log_events_id`, so every tool log was dropped before it hit the broker.
2. **Wrong payload shape** — even when the channel was set, the shim published via `LogPublisher.log_progress(...)` whose payload omits `execution_id` / `organization_id` / `file_execution_id`. `get_validated_log_data` (`log_utils.py`) requires those IDs and `LogType == LOG` for persistence, so tool lines were silently filtered at the Redis → DB drain.

With both gaps closed, tool-level lines now show up live in the UI and replay from the DB.

## How

- Extended `ExecutionContext` (`unstract/sdk1/.../execution/context.py`) with optional `execution_id` and `file_execution_id` fields, plus serialization.
- `structure_tool_task.py` pulls `LOG_EVENTS_ID` from `StateStore` and threads `execution_id` / `file_execution_id` into both pipeline and agentic context dicts.
- `LegacyExecutor.execute()` caches `_execution_id`, `_file_execution_id`, `_organization_id` from the context and passes them to every `ExecutorToolShim(...)` construction.
- `ExecutorToolShim.stream_log` keeps the existing PROGRESS publish (so IDE prompt cards continue to update) and, when workflow IDs are present, additionally publishes a `LogPublisher.log_workflow(...)` payload on the same channel for the workflow-logs consumer to persist + fan out.
- `LogModal.jsx` and pipelines `LogsModal.jsx` render log cells via the existing `CustomMarkdown` helper — no new dependency, just re-using the same renderer used elsewhere in the IDE.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. The new workflow IDs are optional (empty-string defaults) on the shim — when absent, behaviour is identical to before (PROGRESS-only emit). The PROGRESS publish path is unchanged so IDE prompt cards keep working. Markdown rendering is backward compatible with plain-text log lines since `CustomMarkdown` renders non-markdown input as plain text.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- N/A

## Related Issues or PRs

- Companion cloud-side backtick / multi-line log formatting changes on `feat/lookups-v2` (lookup plugin).

## Dependencies Versions

- None.

## Notes on Testing

- Run an API / workflow deployment and confirm `Processing prompt:`, `Running LLM completion for:` and similar tool-level events appear in the Logs modal.
- Query `unstract.execution_log` for the run and confirm tool-level rows persist alongside orchestration rows.
- Open an IDE / test run and confirm the prompt-card live progress pane still updates (PROGRESS path intact).
- Open the Logs modal on a recent run and confirm backticked identifiers render as inline-code pills and `\n` renders as line breaks.

## Screenshots
<img width="1719" height="871" alt="image" src="https://github.com/user-attachments/assets/41371e33-5b14-41df-8d31-8b578a2f4e3b" />

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
