### PR TITLE
UN-3358 [FIX] Drop cross-region S3 buckets from connector listing

### DIFF
--- a/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/minio/exceptions.py
@@ -8,20 +8,24 @@ from unstract.connectors.exceptions import ConnectorError
 class BucketProbeDisposition(Enum):
     """Action for a `list_objects_v2` probe failure, per S3 error code."""
 
-    DROP = "drop"  # Hide the bucket (no access, or bucket gone).
-    FAIL_OPEN = "fail_open"  # Region mismatch — keep bucket visible.
+    DROP = "drop"  # Hide the bucket (no access, bucket gone, or unreachable).
+    FAIL_OPEN = "fail_open"  # Keep the bucket visible despite the probe error.
     RETRY_FAIL_OPEN = "retry_fail_open"  # Throttled — retry once, then keep.
 
 
 # S3 `Error.Code` → probe disposition. Unlisted codes propagate.
 # `RequestTimeTooSkewed` is omitted deliberately: it's a system-wide clock
 # issue, not a bucket outcome — let it surface via `handle_s3fs_exception`.
+# `PermanentRedirect` / `IllegalLocationConstraintException` are dropped: the
+# connector is pinned to one `endpoint_url`, so cross-region buckets can't
+# be browsed through it regardless of IAM — listing them only surfaces a
+# confusing `[Errno 78]` on click.
 BUCKET_PROBE_DISPOSITION: dict[str, BucketProbeDisposition] = {
     "AccessDenied": BucketProbeDisposition.DROP,
     "AllAccessDisabled": BucketProbeDisposition.DROP,
     "NoSuchBucket": BucketProbeDisposition.DROP,
-    "PermanentRedirect": BucketProbeDisposition.FAIL_OPEN,
-    "IllegalLocationConstraintException": BucketProbeDisposition.FAIL_OPEN,
+    "PermanentRedirect": BucketProbeDisposition.DROP,
+    "IllegalLocationConstraintException": BucketProbeDisposition.DROP,
     "SlowDown": BucketProbeDisposition.RETRY_FAIL_OPEN,
     "Throttling": BucketProbeDisposition.RETRY_FAIL_OPEN,
     "ThrottlingException": BucketProbeDisposition.RETRY_FAIL_OPEN,

--- a/unstract/connectors/tests/filesystems/test_miniofs.py
+++ b/unstract/connectors/tests/filesystems/test_miniofs.py
@@ -116,6 +116,20 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
         ):
             self.assertFalse(asyncio.run(fs._is_bucket_accessible("other-region")))
 
+    def test_illegal_location_constraint_bucket_is_dropped(self) -> None:
+        # Companion to PermanentRedirect: same cross-region condition surfaced
+        # as a 400 instead of a 301. Guards against a future edit reverting
+        # only one of the two cross-region entries in BUCKET_PROBE_DISPOSITION.
+        fs = self._make_fs()
+        with patch.object(
+            fs,
+            "_call_s3",
+            new=AsyncMock(
+                side_effect=_translated_error("IllegalLocationConstraintException")
+            ),
+        ):
+            self.assertFalse(asyncio.run(fs._is_bucket_accessible("wrong-region")))
+
     def test_throttling_retries_then_fails_open(self) -> None:
         fs = self._make_fs()
 

--- a/unstract/connectors/tests/filesystems/test_miniofs.py
+++ b/unstract/connectors/tests/filesystems/test_miniofs.py
@@ -104,15 +104,17 @@ class TestAccessFilteredS3FileSystem(unittest.TestCase):
         ):
             self.assertFalse(asyncio.run(fs._is_bucket_accessible("deleted")))
 
-    def test_permanent_redirect_bucket_is_kept(self) -> None:
-        # Fail-open: region mismatch keeps the bucket listed.
+    def test_permanent_redirect_bucket_is_dropped(self) -> None:
+        # Connector pins one endpoint_url; cross-region buckets are unreachable
+        # via this connector regardless of IAM, so drop them rather than fail
+        # later with [Errno 78] on click.
         fs = self._make_fs()
         with patch.object(
             fs,
             "_call_s3",
             new=AsyncMock(side_effect=_translated_error("PermanentRedirect")),
         ):
-            self.assertTrue(asyncio.run(fs._is_bucket_accessible("other-region")))
+            self.assertFalse(asyncio.run(fs._is_bucket_accessible("other-region")))
 
     def test_throttling_retries_then_fails_open(self) -> None:
         fs = self._make_fs()


### PR DESCRIPTION
## What

- Reclassify `PermanentRedirect` and `IllegalLocationConstraintException` from `FAIL_OPEN` to `DROP` in `BUCKET_PROBE_DISPOSITION` (`unstract/connectors/.../filesystems/minio/exceptions.py`).
- Refresh the table comment and the `BucketProbeDisposition.FAIL_OPEN` docstring; the enum value itself is retained as a future extension point.
- Flip the unit test: `test_permanent_redirect_bucket_is_kept` → `test_permanent_redirect_bucket_is_dropped`.

## Why

After #1925, staging AWS-S3 still listed buckets the connector could not actually browse. Any bucket in a region different from the configured `endpoint_url` returned `PermanentRedirect` on the per-bucket probe, which the disposition table treated as `FAIL_OPEN` and kept visible. Clicking such a bucket then surfaced `[Errno 78] The bucket you are attempting to access must be addressed using the specified endpoint`. Local MinIO never reproduced this because it is single-region; only AWS-S3 with cross-region buckets in the account exercises the path.

`MinioFS` is pinned to a single `endpoint_url` and s3fs does not auto-redirect across regions, so cross-region buckets are structurally unreachable through this connector regardless of IAM — dropping them is strictly better UX than leaving the user a broken click target. The same conclusion applies under IRSA: credential source is orthogonal to region routing, so this fix covers both auth modes.

## How

The probe disposition table is the single point of control for `_AccessFilteredS3FileSystem._is_bucket_accessible`. Switching the two region-routing codes from `FAIL_OPEN` to `DROP` makes the filter hide cross-region buckets at listing time, so the failing click path is unreachable. `RETRY_FAIL_OPEN` (throttling), `AccessDenied`, `NoSuchBucket`, and unclassified-code propagation are untouched.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. The change is scoped to two S3 error codes inside the bucket-listing filter. Per-bucket browsing, write paths, credential-test path, and the other dispositions are unchanged. The only visible behavior change is that buckets returning `PermanentRedirect` / `IllegalLocationConstraintException` no longer appear in the connector root — which matches the documented expectation in `prompting/iam-s3-bucket/list-bucket-user/staging-test-setup.md`.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

-

## Related Issues or PRs

- Follow-up to #1925 (`UN-3358 [FIX] List only S3 buckets the connector credentials can browse`).

## Dependencies Versions

- None

## Notes on Testing

- Unit: `cd unstract/connectors && .venv/bin/python -m pytest tests/filesystems/test_miniofs.py::TestAccessFilteredS3FileSystem -v` — 13/13 pass, including the renamed `test_permanent_redirect_bucket_is_dropped`.
- mypy clean on both touched modules.
- Local MinIO regression (`prompting/iam-s3-bucket/list-bucket-user/test-setup.md`): denied bucket still hidden, allowed bucket still browsable — the `AccessDenied` path is untouched.
- Staging AWS-S3 verification (`prompting/iam-s3-bucket/list-bucket-user/staging-test-setup.md` step 5a): only `unstract-staging-iam-bucket` should appear in the connector root; the previously-leaking cross-region buckets are gone, and the `[Errno 78]` reproduction is no longer reachable from the UI.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).