### PR TITLE
[HOTFIX] Honor ENABLE_HIGHLIGHT_API_DEPLOYMENT env var on on-prem

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -689,4 +689,6 @@ if missing_settings:
     )
     raise ValueError(ERROR_MESSAGE)
 
-ENABLE_HIGHLIGHT_API_DEPLOYMENT = os.environ.get("ENABLE_HIGHLIGHT_API_DEPLOYMENT", False)
+ENABLE_HIGHLIGHT_API_DEPLOYMENT = CommonUtils.str_to_bool(
+    os.environ.get("ENABLE_HIGHLIGHT_API_DEPLOYMENT", "False")
+)


### PR DESCRIPTION
## Summary
- Hotfix on top of `v0.161.4`. Pairs with cloud hotfix Zipstack/unstract-cloud#1467.
- Wraps `ENABLE_HIGHLIGHT_API_DEPLOYMENT` env-var read in `backend/backend/settings/base.py` with `CommonUtils.str_to_bool(...)` so values like `False` / `false` / `0` actually evaluate falsy. Previously `os.environ.get(...)` returned the raw string, so any non-empty value (including `"False"`) was truthy in Python and bypassed the gate.
- The setting is consumed as the `ConfigSpec.default` in `unstract-cloud/backend/plugins/configuration/cloud_config.py`. `Configuration.get_value_by_organization(...)` returns this default when no per-org row exists, so the bool fix takes effect on cloud and on-prem builds where the configuration plugin is loaded.

## Why this is the only OSS change
- The on-prem regression fix (loading the configuration plugin in on-prem images so the registry knows the key) is cloud-only and ships in Zipstack/unstract-cloud#1467.
- This OSS PR is intentionally minimal — only the bool parsing.

## Test plan
- [ ] On-prem (with cloud PR #1467 merged & on-prem image rebuilt): set `ENABLE_HIGHLIGHT_API_DEPLOYMENT=true`, run an API deployment (sync + polled), confirm `highlight_data` and `extracted_text` are present in the response metadata.
- [ ] On-prem: set `ENABLE_HIGHLIGHT_API_DEPLOYMENT=False`, confirm both keys are stripped (this is the case the bool fix unblocks).
- [ ] Cloud: with no per-org `Configuration` row and env=`true`, confirm fleet-wide default keeps highlight data.
- [ ] Cloud: with no per-org row and env=`False`, confirm fleet-wide default strips both keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)