### PR TITLE
[FIX] Strip deprecated sampling params for Claude Opus 4.7

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -17,11 +17,13 @@ from unstract.sdk1.adapters.enums import AdapterTypes
 logger = logging.getLogger(__name__)
 
 # Anthropic models that have deprecated sampling parameters (`temperature`,
-# `top_p`, `top_k`). The patterns are substring-matched against the model id
-# after lowercasing and normalizing `.` / `_` to `-`, so a single entry covers:
+# `top_p`, `top_k`). The patterns are regex-searched against the model id
+# after lowercasing and normalizing `.` / `_` to `-`. The match is anchored at
+# the trailing edge so that unrelated future ids (`claude-opus-4-70`,
+# `claude-opus-4-75`, `claude-opus-4-7verbose`) do not match. A single entry
+# covers every encoding of the id we have observed:
 #   - Native Anthropic              `claude-opus-4-7`, `anthropic/claude-opus-4-7`
 #   - Bedrock foundation model      `anthropic.claude-opus-4-7-<date>-v1:0`
-#   - Bedrock route prefixes        `converse/...`, `invoke/...`
 #   - Bedrock cross-region profile  `us.anthropic.claude-opus-4-7-...`,
 #                                   `eu.`, `apac.`, `global.` variants
 #   - Bedrock foundation-model ARN  `arn:aws:bedrock:<region>::foundation-model/
@@ -30,15 +32,17 @@ logger = logging.getLogger(__name__)
 #                                    inference-profile/us.anthropic.claude-opus-4-7-...`
 #   - Vertex AI                     `vertex_ai/claude-opus-4-7@<date>`
 #   - Azure AI Foundry              deployments whose name embeds `claude-opus-4-7`
+# Leading text (route prefixes like `converse/`, `invoke/`, `bedrock/`) passes
+# through because the regex is anchored only at the trailing edge.
 # Add new entries here when Anthropic deprecates sampling on more models.
-# Patterns are anchored at the trailing edge: the version digit must be
-# followed by end-of-string or one of `-:@/v`, so unrelated future ids like
-# `claude-opus-4-70`, `claude-opus-4-75` do not match. The allowed delimiters
-# cover the date suffix (`-20260101-v1:0`), Vertex `@<date>`, ARN paths, and
-# the `v1:0` version tag.
-# See https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+# Trailing anchor allows: end-of-string, or one of `-`/`:`/`@`/`/` (the
+# delimiters used in date suffixes, ARN paths, Vertex `@<date>`, and the
+# `v1:0` tag), or `v` followed by a digit (the version-tag start). A bare
+# `v` is intentionally rejected so alpha continuations like `4-7verbose` do
+# not silently match.
+# See https://docs.claude.com/en/about-claude/models/whats-new-claude-4-7
 _SAMPLING_DEPRECATED_MODEL_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"claude-opus-4-7(?=$|[-:@/v])"),
+    re.compile(r"claude-opus-4-7(?=$|[-:@/]|v\d)"),
 )
 _DEPRECATED_SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
 # Fields whose value can carry a model id. `model` is universal; `model_id` is
@@ -55,10 +59,12 @@ def _has_deprecated_sampling_params(model: str | None) -> bool:
     Claude Opus 4.7; sending any of them yields a 400 from Anthropic and from
     the providers that proxy it (Bedrock, Azure AI Foundry, Vertex AI).
 
-    The check normalizes case and `.`/`_` separators to `-`, then substring-
-    matches against the patterns. This catches every format that embeds the
-    model id (foundation model ids, cross-region profiles, foundation-model
-    ARNs, inference-profile ARNs, Vertex `@`-suffixed ids).
+    The check normalizes case and `.`/`_` separators to `-`, then regex-
+    searches against the patterns with a trailing-edge boundary, so
+    `claude-opus-4-70` and `claude-opus-4-7verbose` do not match. This
+    catches every format that embeds the model id (foundation model ids,
+    cross-region profiles, foundation-model ARNs, inference-profile ARNs,
+    Vertex `@`-suffixed ids).
 
     It does NOT catch:
     - Bedrock Application Inference Profile ARNs (e.g.
@@ -76,18 +82,41 @@ def _has_deprecated_sampling_params(model: str | None) -> bool:
 
 
 def _strip_deprecated_sampling_params(validated: dict[str, "Any"]) -> dict[str, "Any"]:
-    """Drop sampling params for models that reject them (e.g. Claude Opus 4.7).
+    """Return a copy of `validated` with deprecated sampling params removed.
 
-    Pydantic's `model_dump()` re-emits the default `temperature=0.1` even when
-    the caller never set one, so the field must be popped after validation to
-    keep it off the wire. Checks both `model` and `model_id` so Bedrock callers
-    routing through an Application Inference Profile are covered when the
-    standard model id only appears in `model_id`.
+    The input dict is not mutated. Returns a shallow copy so callers can rely
+    on `before is not after` and follow the file's copy-then-mutate style.
+
+    `temperature` is the load-bearing case: `BaseChatCompletionParameters`
+    declares `temperature: float | None = Field(default=0.1)`, so Pydantic's
+    `model_dump()` re-emits the default even when the caller never set one.
+    `top_p` and `top_k` are not declared fields and are normally dropped by
+    Pydantic, but the strip defends against caller-supplied values flowing
+    through `**adapter_metadata`.
+
+    Checks both `model` and `model_id` so Bedrock callers routing through an
+    Application Inference Profile are covered when the standard model id only
+    appears in `model_id`.
+
+    Contract change: the returned dict may not contain a `temperature` key.
+    Consumers must read via `.get("temperature")`, not `dict["temperature"]`.
     """
-    if any(_has_deprecated_sampling_params(validated.get(f)) for f in _MODEL_ID_FIELDS):
+    result = dict(validated)
+    if any(_has_deprecated_sampling_params(result.get(f)) for f in _MODEL_ID_FIELDS):
         for param in _DEPRECATED_SAMPLING_PARAMS:
-            validated.pop(param, None)
-    return validated
+            result.pop(param, None)
+    elif any(p in result for p in _DEPRECATED_SAMPLING_PARAMS):
+        # Sampling params present but no model id field matched a deprecation
+        # pattern. This is the only failure mode for an opaque Bedrock AIP ARN
+        # or an Azure Foundry deployment whose name omits the model id; without
+        # this breadcrumb the strip-skipped state is indistinguishable from
+        # "never attempted" when debugging the resulting 400 from upstream.
+        logger.debug(
+            "Sampling-param strip skipped; no model id field matched a "
+            "deprecation pattern. Model ids: %s",
+            {f: result.get(f) for f in _MODEL_ID_FIELDS if result.get(f)},
+        )
+    return result
 
 
 def register_adapters(adapters: dict[str, dict[str, "Any"]], adapter_type: str) -> None:
@@ -1021,9 +1050,6 @@ class AzureAIFoundryLLMParameters(BaseChatCompletionParameters):
         )
 
         validated = AzureAIFoundryLLMParameters(**adapter_metadata).model_dump()
-        # Azure AI Foundry proxies Anthropic models that reject sampling params
-        # (e.g. Claude Opus 4.7); detection relies on the deployment name
-        # embedding the model id.
         return _strip_deprecated_sampling_params(validated)
 
     @staticmethod

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -2,6 +2,7 @@ import glob
 import inspect
 import logging
 import os
+import re
 from abc import ABC, abstractmethod
 from importlib import import_module
 from typing import TYPE_CHECKING
@@ -30,8 +31,15 @@ logger = logging.getLogger(__name__)
 #   - Vertex AI                     `vertex_ai/claude-opus-4-7@<date>`
 #   - Azure AI Foundry              deployments whose name embeds `claude-opus-4-7`
 # Add new entries here when Anthropic deprecates sampling on more models.
+# Patterns are anchored at the trailing edge: the version digit must be
+# followed by end-of-string or one of `-:@/v`, so unrelated future ids like
+# `claude-opus-4-70`, `claude-opus-4-75` do not match. The allowed delimiters
+# cover the date suffix (`-20260101-v1:0`), Vertex `@<date>`, ARN paths, and
+# the `v1:0` version tag.
 # See https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
-_SAMPLING_DEPRECATED_MODEL_PATTERNS: tuple[str, ...] = ("claude-opus-4-7",)
+_SAMPLING_DEPRECATED_MODEL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"claude-opus-4-7(?=$|[-:@/v])"),
+)
 _DEPRECATED_SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
 # Fields whose value can carry a model id. `model` is universal; `model_id` is
 # Bedrock's separate ARN field used for Application Inference Profile cost
@@ -64,7 +72,7 @@ def _has_deprecated_sampling_params(model: str | None) -> bool:
     if not model:
         return False
     normalized = model.lower().replace(".", "-").replace("_", "-")
-    return any(pat in normalized for pat in _SAMPLING_DEPRECATED_MODEL_PATTERNS)
+    return any(rx.search(normalized) for rx in _SAMPLING_DEPRECATED_MODEL_PATTERNS)
 
 
 def _strip_deprecated_sampling_params(validated: dict[str, "Any"]) -> dict[str, "Any"]:
@@ -528,7 +536,7 @@ class VertexAILLMParameters(BaseChatCompletionParameters):
         if "thinking" in result_metadata:
             validated_data["thinking"] = result_metadata["thinking"]
 
-        return validated_data
+        return _strip_deprecated_sampling_params(validated_data)
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -15,6 +15,72 @@ from unstract.sdk1.adapters.enums import AdapterTypes
 
 logger = logging.getLogger(__name__)
 
+# Anthropic models that have deprecated sampling parameters (`temperature`,
+# `top_p`, `top_k`). The patterns are substring-matched against the model id
+# after lowercasing and normalizing `.` / `_` to `-`, so a single entry covers:
+#   - Native Anthropic              `claude-opus-4-7`, `anthropic/claude-opus-4-7`
+#   - Bedrock foundation model      `anthropic.claude-opus-4-7-<date>-v1:0`
+#   - Bedrock route prefixes        `converse/...`, `invoke/...`
+#   - Bedrock cross-region profile  `us.anthropic.claude-opus-4-7-...`,
+#                                   `eu.`, `apac.`, `global.` variants
+#   - Bedrock foundation-model ARN  `arn:aws:bedrock:<region>::foundation-model/
+#                                    anthropic.claude-opus-4-7-...`
+#   - Bedrock inference-profile ARN `arn:aws:bedrock:<region>:<account>:
+#                                    inference-profile/us.anthropic.claude-opus-4-7-...`
+#   - Vertex AI                     `vertex_ai/claude-opus-4-7@<date>`
+#   - Azure AI Foundry              deployments whose name embeds `claude-opus-4-7`
+# Add new entries here when Anthropic deprecates sampling on more models.
+# See https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+_SAMPLING_DEPRECATED_MODEL_PATTERNS: tuple[str, ...] = ("claude-opus-4-7",)
+_DEPRECATED_SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
+# Fields whose value can carry a model id. `model` is universal; `model_id` is
+# Bedrock's separate ARN field used for Application Inference Profile cost
+# tracking — when callers route through an AIP, the standard model id often
+# only appears here, not in `model`.
+_MODEL_ID_FIELDS: tuple[str, ...] = ("model", "model_id")
+
+
+def _has_deprecated_sampling_params(model: str | None) -> bool:
+    """Return True when the model rejects sampling parameters.
+
+    Anthropic deprecated `temperature`, `top_p`, and `top_k` starting with
+    Claude Opus 4.7; sending any of them yields a 400 from Anthropic and from
+    the providers that proxy it (Bedrock, Azure AI Foundry, Vertex AI).
+
+    The check normalizes case and `.`/`_` separators to `-`, then substring-
+    matches against the patterns. This catches every format that embeds the
+    model id (foundation model ids, cross-region profiles, foundation-model
+    ARNs, inference-profile ARNs, Vertex `@`-suffixed ids).
+
+    It does NOT catch:
+    - Bedrock Application Inference Profile ARNs (e.g.
+      `arn:aws:bedrock:...:application-inference-profile/abcd1234`), whose
+      tail is an opaque profile id — the underlying model is not recoverable
+      from the string. Pass the AIP ARN in `model_id` and keep the standard
+      model id in `model`, or the strip won't fire.
+    - Azure AI Foundry deployment names that omit the model id; rename the
+      deployment to include `claude-opus-4-7` so detection works.
+    """
+    if not model:
+        return False
+    normalized = model.lower().replace(".", "-").replace("_", "-")
+    return any(pat in normalized for pat in _SAMPLING_DEPRECATED_MODEL_PATTERNS)
+
+
+def _strip_deprecated_sampling_params(validated: dict[str, "Any"]) -> dict[str, "Any"]:
+    """Drop sampling params for models that reject them (e.g. Claude Opus 4.7).
+
+    Pydantic's `model_dump()` re-emits the default `temperature=0.1` even when
+    the caller never set one, so the field must be popped after validation to
+    keep it off the wire. Checks both `model` and `model_id` so Bedrock callers
+    routing through an Application Inference Profile are covered when the
+    standard model id only appears in `model_id`.
+    """
+    if any(_has_deprecated_sampling_params(validated.get(f)) for f in _MODEL_ID_FIELDS):
+        for param in _DEPRECATED_SAMPLING_PARAMS:
+            validated.pop(param, None)
+    return validated
+
 
 def register_adapters(adapters: dict[str, dict[str, "Any"]], adapter_type: str) -> None:
     """Register all SDK v1 adapters of given type.
@@ -646,7 +712,8 @@ class AWSBedrockLLMParameters(BaseChatCompletionParameters):
         # Keys mode requires non-blank values, legacy (no auth_type) is
         # lenient. Reads auth_type from result_metadata since validation_
         # metadata strips it before Pydantic.
-        return _resolve_bedrock_aws_credentials(result_metadata, validated)
+        validated = _resolve_bedrock_aws_credentials(result_metadata, validated)
+        return _strip_deprecated_sampling_params(validated)
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:
@@ -735,7 +802,7 @@ class AnthropicLLMParameters(BaseChatCompletionParameters):
         if enable_extended_context:
             validated["extra_headers"] = {"anthropic-beta": "context-1m-2025-08-07"}
 
-        return validated
+        return _strip_deprecated_sampling_params(validated)
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:
@@ -945,7 +1012,11 @@ class AzureAIFoundryLLMParameters(BaseChatCompletionParameters):
             adapter_metadata
         )
 
-        return AzureAIFoundryLLMParameters(**adapter_metadata).model_dump()
+        validated = AzureAIFoundryLLMParameters(**adapter_metadata).model_dump()
+        # Azure AI Foundry proxies Anthropic models that reject sampling params
+        # (e.g. Claude Opus 4.7); detection relies on the deployment name
+        # embedding the model id.
+        return _strip_deprecated_sampling_params(validated)
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -50,6 +50,21 @@ _DEPRECATED_SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
 # tracking — when callers route through an AIP, the standard model id often
 # only appears here, not in `model`.
 _MODEL_ID_FIELDS: tuple[str, ...] = ("model", "model_id")
+# Substring of a Bedrock Application Inference Profile ARN; the rest of the
+# ARN is an opaque profile id so the underlying foundation model id is not
+# recoverable from the string. Used only to narrow the debug-breadcrumb path
+# on the strip's no-match branch.
+_OPAQUE_AIP_ARN_MARKER: str = "application-inference-profile"
+
+
+def _looks_like_opaque_aip_arn(value: str | None) -> bool:
+    """Return True when the value looks like a Bedrock AIP ARN.
+
+    Bedrock AIP ARNs do not carry the underlying foundation-model id in the
+    string, so the sampling-strip detector cannot decide whether the call is
+    bound for Claude Opus 4.7.
+    """
+    return bool(value) and _OPAQUE_AIP_ARN_MARKER in value
 
 
 def _has_deprecated_sampling_params(model: str | None) -> bool:
@@ -105,15 +120,18 @@ def _strip_deprecated_sampling_params(validated: dict[str, "Any"]) -> dict[str, 
     if any(_has_deprecated_sampling_params(result.get(f)) for f in _MODEL_ID_FIELDS):
         for param in _DEPRECATED_SAMPLING_PARAMS:
             result.pop(param, None)
-    elif any(p in result for p in _DEPRECATED_SAMPLING_PARAMS):
-        # Sampling params present but no model id field matched a deprecation
-        # pattern. This is the only failure mode for an opaque Bedrock AIP ARN
-        # or an Azure Foundry deployment whose name omits the model id; without
-        # this breadcrumb the strip-skipped state is indistinguishable from
-        # "never attempted" when debugging the resulting 400 from upstream.
+    elif any(_looks_like_opaque_aip_arn(result.get(f)) for f in _MODEL_ID_FIELDS):
+        # An opaque Bedrock AIP ARN reached us with no Anthropic model id in
+        # any field. If the underlying foundation model is Opus 4.7+, the
+        # upstream call will 400 on `temperature is deprecated`; this debug
+        # log makes the strip-skipped state distinguishable from a
+        # never-attempted strip when debugging the resulting 400. The guard
+        # is intentionally narrow — the broader "any sampling param present"
+        # form fires for every routine call because Pydantic's `model_dump`
+        # always re-emits the default `temperature=0.1`.
         logger.debug(
-            "Sampling-param strip skipped; no model id field matched a "
-            "deprecation pattern. Model ids: %s",
+            "Sampling-param strip skipped for opaque Bedrock AIP ARN; no "
+            "model id field matched a deprecation pattern. Model ids: %s",
             {f: result.get(f) for f in _MODEL_ID_FIELDS if result.get(f)},
         )
     return result

--- a/unstract/sdk1/tests/test_sampling_strip.py
+++ b/unstract/sdk1/tests/test_sampling_strip.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any
 
 import pytest
+
 from unstract.sdk1.adapters.base1 import (
     _DEPRECATED_SAMPLING_PARAMS,
     AnthropicLLMParameters,
@@ -155,8 +156,10 @@ def test_strip_via_model_field_when_model_id_is_opaque_aip_arn() -> None:
 def test_strip_skipped_when_both_fields_opaque_and_logs_debug(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Documented limitation: with no model id in any field, the strip is
-    a no-op and emits a debug breadcrumb so the upstream 400 is traceable.
+    """Documented limitation: opaque-only state must emit a breadcrumb.
+
+    With no model id in any field, the strip is a no-op; the debug log makes
+    the upstream 400 traceable.
     """
     inp = {
         "model": "bedrock/arn:aws:bedrock:us-east-1:0:application-inference-profile/abcd",
@@ -174,8 +177,9 @@ def test_strip_skipped_when_both_fields_opaque_and_logs_debug(
 def test_strip_does_not_log_when_no_sampling_params_present(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The breadcrumb only fires when sampling params are present, so the
-    common 'no temperature, no match' path stays quiet.
+    """The breadcrumb only fires when sampling params are present.
+
+    The common "no temperature, no match" path stays quiet.
     """
     inp = {"model": "gpt-4o"}
     with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
@@ -231,9 +235,10 @@ ADAPTER_CASES: list[tuple[str, type, dict[str, Any]]] = [
 def test_validate_strips_temperature_for_opus_4_7(
     name: str, cls: type, extra: dict[str, Any]
 ) -> None:
-    """Every adapter that proxies Anthropic must drop temperature on its
-    return path. The Vertex AI gap (commit 5a4ea27f shipped without it,
-    fixed in 7fb66f15) is exactly the regression this locks in.
+    """Every adapter that proxies Anthropic must drop temperature on return.
+
+    The Vertex AI gap (commit 5a4ea27f shipped without it, fixed in 7fb66f15)
+    is exactly the regression this locks in.
     """
     model = {
         "anthropic": "claude-opus-4-7",

--- a/unstract/sdk1/tests/test_sampling_strip.py
+++ b/unstract/sdk1/tests/test_sampling_strip.py
@@ -177,11 +177,32 @@ def test_strip_skipped_when_both_fields_opaque_and_logs_debug(
 def test_strip_does_not_log_when_no_sampling_params_present(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The breadcrumb only fires when sampling params are present.
+    """The breadcrumb stays quiet on the common no-op path.
 
-    The common "no temperature, no match" path stays quiet.
+    No model id field looks opaque, so the strip-skipped state is not worth
+    a debug breadcrumb.
     """
     inp = {"model": "gpt-4o"}
+    with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
+        _strip_deprecated_sampling_params(inp)
+    assert not any(
+        "Sampling-param strip skipped" in rec.message for rec in caplog.records
+    )
+
+
+def test_strip_does_not_log_when_sampling_params_present_but_model_not_opaque(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-deprecated models with default `temperature` must not emit noise.
+
+    `BaseChatCompletionParameters` declares `temperature: float | None =
+    Field(default=0.1)`, so every adapter's `validate()` returns a dict that
+    carries `temperature`. If the breadcrumb keyed off "any sampling param
+    present" it would fire for every routine call to `claude-3-5-sonnet`,
+    `claude-opus-4-6`, `gpt-4o`, etc. — pure log noise. The guard must
+    instead key off an opaque-looking model id field.
+    """
+    inp = {"model": "claude-3-5-sonnet-20241022", "temperature": 0.1}
     with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
         _strip_deprecated_sampling_params(inp)
     assert not any(

--- a/unstract/sdk1/tests/test_sampling_strip.py
+++ b/unstract/sdk1/tests/test_sampling_strip.py
@@ -167,7 +167,8 @@ def test_strip_skipped_when_both_fields_opaque_and_logs_debug(
     }
     with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
         out = _strip_deprecated_sampling_params(inp)
-    assert out["temperature"] == 0.5  # not stripped (documented limitation)
+    # Documented limitation: not stripped when no field carries the model id.
+    assert out["temperature"] == pytest.approx(0.5)
     assert any(
         "Sampling-param strip skipped" in rec.message for rec in caplog.records
     ), "expected debug breadcrumb when strip is a no-op"
@@ -191,7 +192,7 @@ def test_strip_does_not_log_when_no_sampling_params_present(
 def test_strip_retains_temperature_for_non_deprecated_models() -> None:
     inp = {"model": "claude-3-5-sonnet-20241022", "temperature": 0.5}
     out = _strip_deprecated_sampling_params(inp)
-    assert out["temperature"] == 0.5
+    assert out["temperature"] == pytest.approx(0.5)
 
 
 # ── adapter wiring (regression guard for the Vertex AI gap) ─────────────────
@@ -270,9 +271,9 @@ def test_validate_retains_temperature_for_opus_4_6(
         "azure_ai_foundry": "claude-opus-4-6",
     }[name]
     result = cls.validate({"model": model, "temperature": 0.5, **extra})
-    assert result["temperature"] == 0.5
+    assert result["temperature"] == pytest.approx(0.5)
 
 
 def test_vertex_validate_retains_temperature_for_gemini() -> None:
     result = VertexAILLMParameters.validate(_vertex_metadata("gemini-2.0-flash"))
-    assert result["temperature"] == 0.5
+    assert result["temperature"] == pytest.approx(0.5)

--- a/unstract/sdk1/tests/test_sampling_strip.py
+++ b/unstract/sdk1/tests/test_sampling_strip.py
@@ -14,11 +14,11 @@ from typing import Any
 
 import pytest
 from unstract.sdk1.adapters.base1 import (
+    _DEPRECATED_SAMPLING_PARAMS,
     AnthropicLLMParameters,
     AWSBedrockLLMParameters,
     AzureAIFoundryLLMParameters,
     VertexAILLMParameters,
-    _DEPRECATED_SAMPLING_PARAMS,
     _has_deprecated_sampling_params,
     _strip_deprecated_sampling_params,
 )
@@ -156,7 +156,8 @@ def test_strip_skipped_when_both_fields_opaque_and_logs_debug(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Documented limitation: with no model id in any field, the strip is
-    a no-op and emits a debug breadcrumb so the upstream 400 is traceable."""
+    a no-op and emits a debug breadcrumb so the upstream 400 is traceable.
+    """
     inp = {
         "model": "bedrock/arn:aws:bedrock:us-east-1:0:application-inference-profile/abcd",
         "model_id": "arn:aws:bedrock:us-east-1:0:application-inference-profile/efgh",
@@ -165,16 +166,17 @@ def test_strip_skipped_when_both_fields_opaque_and_logs_debug(
     with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
         out = _strip_deprecated_sampling_params(inp)
     assert out["temperature"] == 0.5  # not stripped (documented limitation)
-    assert any("Sampling-param strip skipped" in rec.message for rec in caplog.records), (
-        "expected debug breadcrumb when strip is a no-op"
-    )
+    assert any(
+        "Sampling-param strip skipped" in rec.message for rec in caplog.records
+    ), "expected debug breadcrumb when strip is a no-op"
 
 
 def test_strip_does_not_log_when_no_sampling_params_present(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The breadcrumb only fires when sampling params are present, so the
-    common 'no temperature, no match' path stays quiet."""
+    common 'no temperature, no match' path stays quiet.
+    """
     inp = {"model": "gpt-4o"}
     with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
         _strip_deprecated_sampling_params(inp)
@@ -231,7 +233,8 @@ def test_validate_strips_temperature_for_opus_4_7(
 ) -> None:
     """Every adapter that proxies Anthropic must drop temperature on its
     return path. The Vertex AI gap (commit 5a4ea27f shipped without it,
-    fixed in 7fb66f15) is exactly the regression this locks in."""
+    fixed in 7fb66f15) is exactly the regression this locks in.
+    """
     model = {
         "anthropic": "claude-opus-4-7",
         "bedrock": "anthropic.claude-opus-4-7-20260101-v1:0",

--- a/unstract/sdk1/tests/test_sampling_strip.py
+++ b/unstract/sdk1/tests/test_sampling_strip.py
@@ -1,0 +1,271 @@
+"""Tests for Claude Opus 4.7 sampling-parameter strip.
+
+Pins the detection regex and the four-adapter wiring against the failure
+modes that surfaced in PR #1934 review:
+- prefix collisions (`claude-opus-4-70`, `-75`, `4-7verbose`)
+- Bedrock Application Inference Profile ARN fallback via `model_id`
+- mutate-and-return regression (input dict must be preserved)
+- silent skip with sampling params present must emit a debug breadcrumb
+- every adapter calls the strip on its return path
+"""
+
+import logging
+from typing import Any
+
+import pytest
+from unstract.sdk1.adapters.base1 import (
+    AnthropicLLMParameters,
+    AWSBedrockLLMParameters,
+    AzureAIFoundryLLMParameters,
+    VertexAILLMParameters,
+    _DEPRECATED_SAMPLING_PARAMS,
+    _has_deprecated_sampling_params,
+    _strip_deprecated_sampling_params,
+)
+
+# ── detection: positives ────────────────────────────────────────────────────
+
+OPUS_47_POSITIVES: list[str] = [
+    # Native Anthropic
+    "claude-opus-4-7",
+    "anthropic/claude-opus-4-7",
+    "Claude-Opus-4-7",  # case
+    # Bedrock foundation model id with date stamp
+    "anthropic.claude-opus-4-7-20260101-v1:0",
+    "bedrock/anthropic.claude-opus-4-7-20260101-v1:0",
+    # Bedrock route prefixes pass through the trailing-edge anchor
+    "bedrock/converse/anthropic.claude-opus-4-7-20260101-v1:0",
+    "bedrock/invoke/anthropic.claude-opus-4-7-20260101-v1:0",
+    # Bedrock cross-region inference profiles
+    "us.anthropic.claude-opus-4-7-20260101-v1:0",
+    "bedrock/us.anthropic.claude-opus-4-7-20260101-v1:0",
+    "bedrock/eu.anthropic.claude-opus-4-7-20260101-v1:0",
+    "bedrock/apac.anthropic.claude-opus-4-7-20260101-v1:0",
+    "bedrock/global.anthropic.claude-opus-4-7-20260101-v1:0",
+    # Bedrock foundation-model ARN
+    "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-7-20260101-v1:0",
+    # Bedrock inference-profile ARN (cross-region)
+    "arn:aws:bedrock:us-east-1:000000000000:inference-profile/us.anthropic.claude-opus-4-7-20260101-v1:0",
+    # Vertex AI
+    "vertex_ai/claude-opus-4-7@20260101",
+    "vertex_ai/claude-opus-4-7",
+    # Azure AI Foundry deployments embedding the model id
+    "azure_ai/claude-opus-4-7",
+    "azure_ai/claude-opus-4-7-prod",
+    "azure_ai/my-claude-opus-4-7-deployment",
+    # Separator variants — Anthropic uses dashes, but the normalize step
+    # collapses `.` and `_` so dot/underscore forms still match
+    "claude.opus.4.7",
+    "claude_opus_4_7",
+    # Version tag accepted only as `v\d` after the trailing edge
+    "claude-opus-4-7v1",
+    "claude-opus-4-7v9",
+]
+
+
+@pytest.mark.parametrize("model", OPUS_47_POSITIVES)
+def test_has_deprecated_sampling_params_positive(model: str) -> None:
+    assert _has_deprecated_sampling_params(model)
+
+
+# ── detection: negatives ────────────────────────────────────────────────────
+
+NEGATIVES: list[str | None] = [
+    # Adjacent Claude model families that retain temperature
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-4-7",
+    "claude-haiku-4-5",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    # Non-Anthropic providers
+    "gpt-4o",
+    "gemini-2.0-flash",
+    "mistral-large-latest",
+    # Prefix collisions — lock the trailing-edge anchor against future
+    # versions whose id starts with `claude-opus-4-7` but is unrelated.
+    "claude-opus-4-70",
+    "claude-opus-4-75",
+    "claude-opus-4-79",
+    "anthropic/claude-opus-4-70",
+    "bedrock/anthropic.claude-opus-4-71-20260101-v1:0",
+    # Bare-`v` alpha continuations must NOT match (HIGH line 41 fix).
+    "claude-opus-4-7verbose",
+    "claude-opus-4-7vnext",
+    "claude-opus-4-7variant",
+    # Opaque Bedrock Application Inference Profile ARN — model id is not
+    # recoverable from the string. Strip-detection is expected to skip;
+    # callers must keep the standard id in `model` or `model_id`.
+    "arn:aws:bedrock:us-east-1:000000000000:application-inference-profile/abcd1234efgh",
+    # Empty / missing
+    None,
+    "",
+]
+
+
+@pytest.mark.parametrize("model", NEGATIVES)
+def test_has_deprecated_sampling_params_negative(model: str | None) -> None:
+    assert not _has_deprecated_sampling_params(model)
+
+
+# ── strip contract ──────────────────────────────────────────────────────────
+
+
+def test_strip_returns_copy_without_mutating_input() -> None:
+    inp: dict[str, Any] = {"model": "claude-opus-4-7", "temperature": 0.5}
+    out = _strip_deprecated_sampling_params(inp)
+    assert out is not inp
+    assert inp == {"model": "claude-opus-4-7", "temperature": 0.5}
+    assert "temperature" not in out
+
+
+def test_strip_removes_all_three_sampling_params() -> None:
+    inp = {
+        "model": "claude-opus-4-7",
+        "temperature": 0.5,
+        "top_p": 0.9,
+        "top_k": 40,
+    }
+    out = _strip_deprecated_sampling_params(inp)
+    for param in _DEPRECATED_SAMPLING_PARAMS:
+        assert param not in out, f"{param} should be stripped"
+
+
+def test_strip_via_model_id_field_when_model_is_opaque_aip_arn() -> None:
+    """Bedrock AIP fallback: opaque ARN in `model`, real id in `model_id`."""
+    inp = {
+        "model": "bedrock/arn:aws:bedrock:us-east-1:0:application-inference-profile/abcd",
+        "model_id": "anthropic.claude-opus-4-7-20260101-v1:0",
+        "temperature": 0.5,
+    }
+    out = _strip_deprecated_sampling_params(inp)
+    assert "temperature" not in out
+
+
+def test_strip_via_model_field_when_model_id_is_opaque_aip_arn() -> None:
+    """Bedrock AIP fallback: standard id in `model`, opaque ARN in `model_id`."""
+    inp = {
+        "model": "bedrock/anthropic.claude-opus-4-7-20260101-v1:0",
+        "model_id": "arn:aws:bedrock:us-east-1:0:application-inference-profile/abcd",
+        "temperature": 0.5,
+    }
+    out = _strip_deprecated_sampling_params(inp)
+    assert "temperature" not in out
+
+
+def test_strip_skipped_when_both_fields_opaque_and_logs_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Documented limitation: with no model id in any field, the strip is
+    a no-op and emits a debug breadcrumb so the upstream 400 is traceable."""
+    inp = {
+        "model": "bedrock/arn:aws:bedrock:us-east-1:0:application-inference-profile/abcd",
+        "model_id": "arn:aws:bedrock:us-east-1:0:application-inference-profile/efgh",
+        "temperature": 0.5,
+    }
+    with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
+        out = _strip_deprecated_sampling_params(inp)
+    assert out["temperature"] == 0.5  # not stripped (documented limitation)
+    assert any("Sampling-param strip skipped" in rec.message for rec in caplog.records), (
+        "expected debug breadcrumb when strip is a no-op"
+    )
+
+
+def test_strip_does_not_log_when_no_sampling_params_present(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The breadcrumb only fires when sampling params are present, so the
+    common 'no temperature, no match' path stays quiet."""
+    inp = {"model": "gpt-4o"}
+    with caplog.at_level(logging.DEBUG, logger="unstract.sdk1.adapters.base1"):
+        _strip_deprecated_sampling_params(inp)
+    assert not any(
+        "Sampling-param strip skipped" in rec.message for rec in caplog.records
+    )
+
+
+def test_strip_retains_temperature_for_non_deprecated_models() -> None:
+    inp = {"model": "claude-3-5-sonnet-20241022", "temperature": 0.5}
+    out = _strip_deprecated_sampling_params(inp)
+    assert out["temperature"] == 0.5
+
+
+# ── adapter wiring (regression guard for the Vertex AI gap) ─────────────────
+
+
+def _vertex_metadata(model: str, temperature: float = 0.5) -> dict[str, Any]:
+    return {
+        "model": model,
+        "vertex_credentials": "{}",
+        "vertex_project": "p",
+        "safety_settings": {},
+        "temperature": temperature,
+    }
+
+
+ADAPTER_CASES: list[tuple[str, type, dict[str, Any]]] = [
+    (
+        "anthropic",
+        AnthropicLLMParameters,
+        {"api_key": "k"},
+    ),
+    (
+        "bedrock",
+        AWSBedrockLLMParameters,
+        {"aws_region_name": "us-east-1"},
+    ),
+    (
+        "azure_ai_foundry",
+        AzureAIFoundryLLMParameters,
+        {"api_key": "k", "api_base": "https://x.inference.ai.azure.com"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name,cls,extra",
+    ADAPTER_CASES,
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_validate_strips_temperature_for_opus_4_7(
+    name: str, cls: type, extra: dict[str, Any]
+) -> None:
+    """Every adapter that proxies Anthropic must drop temperature on its
+    return path. The Vertex AI gap (commit 5a4ea27f shipped without it,
+    fixed in 7fb66f15) is exactly the regression this locks in."""
+    model = {
+        "anthropic": "claude-opus-4-7",
+        "bedrock": "anthropic.claude-opus-4-7-20260101-v1:0",
+        "azure_ai_foundry": "claude-opus-4-7",
+    }[name]
+    result = cls.validate({"model": model, "temperature": 0.5, **extra})
+    for param in _DEPRECATED_SAMPLING_PARAMS:
+        assert param not in result, f"{name}: {param} should be stripped"
+
+
+def test_vertex_validate_strips_temperature_for_opus_4_7() -> None:
+    result = VertexAILLMParameters.validate(_vertex_metadata("claude-opus-4-7@20260101"))
+    for param in _DEPRECATED_SAMPLING_PARAMS:
+        assert param not in result, f"vertex: {param} should be stripped"
+
+
+@pytest.mark.parametrize(
+    "name,cls,extra",
+    ADAPTER_CASES,
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_validate_retains_temperature_for_opus_4_6(
+    name: str, cls: type, extra: dict[str, Any]
+) -> None:
+    """Non-deprecated Claude models must keep temperature intact."""
+    model = {
+        "anthropic": "claude-opus-4-6",
+        "bedrock": "anthropic.claude-opus-4-6-20251022-v1:0",
+        "azure_ai_foundry": "claude-opus-4-6",
+    }[name]
+    result = cls.validate({"model": model, "temperature": 0.5, **extra})
+    assert result["temperature"] == 0.5
+
+
+def test_vertex_validate_retains_temperature_for_gemini() -> None:
+    result = VertexAILLMParameters.validate(_vertex_metadata("gemini-2.0-flash"))
+    assert result["temperature"] == 0.5

--- a/unstract/sdk1/tests/test_sampling_strip.py
+++ b/unstract/sdk1/tests/test_sampling_strip.py
@@ -13,7 +13,6 @@ import logging
 from typing import Any
 
 import pytest
-
 from unstract.sdk1.adapters.base1 import (
     _DEPRECATED_SAMPLING_PARAMS,
     AnthropicLLMParameters,


### PR DESCRIPTION
## What

- Add `_has_deprecated_sampling_params(model)` and `_strip_deprecated_sampling_params(validated)` helpers in `unstract/sdk1/.../adapters/base1.py`. The helpers substring-match the model id against `claude-opus-4-7` (case-insensitive, with `.` / `_` normalized to `-`) and pop `temperature` / `top_p` / `top_k` from the validated metadata when matched.
- Wire the strip step into `AnthropicLLMParameters.validate()`, `AWSBedrockLLMParameters.validate()`, and `AzureAIFoundryLLMParameters.validate()`.
- The strip inspects both `model` and `model_id`, so Bedrock callers routing through an Application Inference Profile (AIP) are covered when the standard model id appears in either field.

## Why

Anthropic deprecated `temperature`, `top_p`, and `top_k` starting with Claude Opus 4.7. Sending any of them now returns a 400 from Anthropic and from every provider that proxies it (Bedrock, Azure AI Foundry, Vertex AI). The Azure AI Foundry path is what surfaced first in the connector test:

```
Error from LLM adapter 'azure_ai': Azure_aiException -
{"type":"error","error":{"type":"invalid_request_error",
"message":"`temperature` is deprecated for this model."}, ...}
```

Pydantic's `model_dump()` on `BaseChatCompletionParameters` re-emits the default `temperature=0.1` even when the caller never set one, so we cannot rely on "don't pass it" — we have to actively pop it after validation.

Reference: <https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7>

## How

`base1.py`:

- New module-level pattern table `_SAMPLING_DEPRECATED_MODEL_PATTERNS = ("claude-opus-4-7",)` and `_DEPRECATED_SAMPLING_PARAMS = ("temperature", "top_p", "top_k")`. The pattern table is the single point of extension — if Anthropic deprecates sampling on more models later, we add an entry here.
- `_has_deprecated_sampling_params` lowercases the input and normalizes `.` and `_` separators to `-` before substring-matching, which covers every encoding of the id we found:
  - Native Anthropic: `claude-opus-4-7`, `anthropic/claude-opus-4-7`
  - Bedrock foundation model id: `anthropic.claude-opus-4-7-<date>-v1:0`, with optional `bedrock/converse/...` / `bedrock/invoke/...` route prefixes
  - Bedrock cross-region inference profiles: `us.`, `eu.`, `apac.`, `global.` variants
  - Bedrock foundation-model and inference-profile ARNs that embed the model id
  - Vertex AI: `vertex_ai/claude-opus-4-7@<date>`
  - Azure AI Foundry deployments whose name embeds the model id
- `_strip_deprecated_sampling_params` checks both `model` and `model_id` (Bedrock's separate AIP ARN field) and pops the three sampling params if either one matches.

`AnthropicLLMParameters.validate()`, `AWSBedrockLLMParameters.validate()`, `AzureAIFoundryLLMParameters.validate()` — return `_strip_deprecated_sampling_params(validated)` instead of `validated`.

### Coverage gap (documented in helper docstring)

Two cases the string-based detector cannot cover:

1. Bedrock Application Inference Profile ARNs whose tail is opaque, e.g. `arn:aws:bedrock:...:application-inference-profile/abcd1234`. The string carries no model id. Mitigation: callers should keep the standard model id in either `model` or `model_id`. If both fields hold opaque ARNs, the strip won't fire.
2. Azure AI Foundry deployments whose name does not embed `claude-opus-4-7`. Mitigation: rename the deployment to include the model id, or — if this becomes common — add an explicit UI flag.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No.

- The strip only fires when the model id matches `claude-opus-4-7` after normalization. Every other Anthropic / Bedrock / Azure AI Foundry model retains its `temperature` / `top_p` / `top_k` exactly as before — verified by direct `validate()` calls against `claude-3-5-sonnet`, `claude-opus-4-6`, `claude-sonnet-4-7`, `gpt-4o`, etc.
- `top_p` / `top_k` are not declared fields on the parameter classes today, so Pydantic was already dropping them silently for non-deprecated models. The defensive pop on the validated dict is a no-op for them in the normal path.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- [What's new in Claude Opus 4.7 — Anthropic](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7) — sampling parameters removed; `thinking.budget_tokens` also removed (out of scope here).
- [Claude Opus 4.7 — Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html)
- [LiteLLM Bedrock — Application Inference Profile usage](https://github.com/BerriAI/litellm/discussions/8905)

## Related Issues or PRs

- N/A — surfaced from the Azure AI Foundry connector test failure for an "azure opus 4.7" deployment.

## Dependencies Versions

- None.

## Notes on Testing

- Helper coverage matrix executed against 24 known Opus 4.7 id formats (native, Bedrock foundation, route-prefixed, cross-region profiles, foundation-model ARN, inference-profile ARN, Vertex `@`-suffixed, Azure deployments, mixed case, dot/underscore separators). All match. Negatives — `claude-opus-4-6`, `claude-sonnet-4-7`, `claude-haiku-4-5`, `gpt-4o`, `gemini-2.0-flash`, opaque AIP ARN, `None`, empty string — all correctly do not match.
- AIP fallback: confirmed strip via `model` when standard id is in `model` and AIP ARN is in `model_id`; confirmed strip via `model_id` when AIP ARN is in `model` and standard id is in `model_id`; confirmed limitation when both fields hold opaque ARNs.
- Adapter end-to-end: `AnthropicLLMParameters.validate()`, `AWSBedrockLLMParameters.validate()`, `AzureAIFoundryLLMParameters.validate()` — temperature stripped for Opus 4.7 inputs, retained for older Claude / non-Claude inputs.
- `pytest tests/ --ignore=tests/file_storage --ignore=tests/patches`: 221 pass. (The unrelated import error in `tests/patches/test_litellm_cohere_timeout.py` is pre-existing on `main`.)
- `ruff format --check` clean on the modified file.

## Screenshots

N/A — backend SDK change.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).