### PR TITLE
UN-3436 [FIX] Reroute system-bucket worker IO to fsspec-cached FileSystem and shorten rate-limit stale cutoff

### DIFF
--- a/backend/api_v2/rate_limit_constants.py
+++ b/backend/api_v2/rate_limit_constants.py
@@ -74,7 +74,16 @@ class RateLimitDefaults:
     DEFAULT_GLOBAL_LIMIT = 100  # Concurrent requests system-wide
 
     # TTL and timing
-    DEFAULT_TTL_HOURS = 6  # Hours to keep execution in ZSET
+    # DEFAULT_TTL_HOURS is the Redis key TTL — controls when the whole ZSET
+    # is garbage-collected after the org becomes inactive.
+    # DEFAULT_STALE_ENTRY_HOURS is the per-entry cutoff — entries older than
+    # this are removed on every check_and_acquire/get_current_usage call.
+    # The two are split because a leaked entry (worker OOM/SIGKILL before
+    # release_slot fires) shouldn't tie up a slot for the full key TTL.
+    # Override via API_DEPLOYMENT_RATE_LIMIT_TTL_HOURS and
+    # API_DEPLOYMENT_RATE_LIMIT_STALE_ENTRY_HOURS Django settings.
+    DEFAULT_TTL_HOURS = 6  # Hours before the ZSET key itself expires
+    DEFAULT_STALE_ENTRY_HOURS = 1  # Per-entry cutoff for stale releases
     DEFAULT_CACHE_TTL_SECONDS = 600  # 10 minutes cache for org limits
 
     # Lock timeouts

--- a/backend/api_v2/rate_limiter.py
+++ b/backend/api_v2/rate_limiter.py
@@ -27,7 +27,7 @@ class APIDeploymentRateLimiter:
 
     @classmethod
     def _get_ttl_seconds(cls) -> int:
-        """Get TTL in seconds from hours setting."""
+        """Get Redis key TTL in seconds from hours setting."""
         ttl_hours = getattr(
             settings,
             "API_DEPLOYMENT_RATE_LIMIT_TTL_HOURS",
@@ -36,9 +36,29 @@ class APIDeploymentRateLimiter:
         return ttl_hours * 3600
 
     @classmethod
+    def _get_stale_entry_seconds(cls) -> int:
+        """Get per-entry stale cutoff in seconds.
+
+        Shorter than the key TTL so a leaked entry (worker OOM/SIGKILL
+        before the release path fires) frees its slot within hours rather
+        than the full key TTL.
+        """
+        stale_hours = getattr(
+            settings,
+            "API_DEPLOYMENT_RATE_LIMIT_STALE_ENTRY_HOURS",
+            RateLimitDefaults.DEFAULT_STALE_ENTRY_HOURS,
+        )
+        return stale_hours * 3600
+
+    @classmethod
     def _get_cutoff_timestamp(cls) -> float:
-        """Get timestamp cutoff for removing stale entries."""
-        return time.time() - cls._get_ttl_seconds()
+        """Get timestamp cutoff for removing stale entries.
+
+        Uses the stale-entry cutoff (not the key TTL) so leaks caused by
+        non-graceful worker termination are reaped without waiting for the
+        whole ZSET key to expire.
+        """
+        return time.time() - cls._get_stale_entry_seconds()
 
     @classmethod
     def _cleanup_expired_entries(cls, key: str) -> None:

--- a/workers/shared/workflow/connectors/utils.py
+++ b/workers/shared/workflow/connectors/utils.py
@@ -9,26 +9,70 @@ from typing import Any
 
 from unstract.connectors.connectorkit import Connectorkit
 from unstract.connectors.filesystems.unstract_file_system import UnstractFileSystem
+from unstract.filesystem import FileStorageType, FileSystem
 
 logger = logging.getLogger(__name__)
 
 
+# Connector IDs that resolve to the system-internal MinIO bucket. These are
+# the same bucket the workers already reach via FileSystem(...) — going
+# through connectorkit makes us load MinioFS, which used to opt out of
+# fsspec's instance cache and leak boto3 sessions under load. We short-circuit
+# them to the cached FileSystem path instead.
+_SYSTEM_INTERNAL_CONNECTOR_IDS = {
+    "pcs|b8cd25cd-4452-4d54-bd5e-e7d71459b702",  # UnstractCloudStorage
+}
+
+
+class _SystemFileStorageAdapter(UnstractFileSystem):
+    """UnstractFileSystem-shaped wrapper around the cached FileSystem path.
+
+    Returned in place of a connector instance for system-internal storage,
+    so call sites that do `connector.get_fsspec_fs()` keep working without
+    loading the leaky MinioFS code path.
+    """
+
+    def __init__(self, storage_type: FileStorageType):
+        super().__init__("SystemFileStorage")
+        self._file_storage = FileSystem(storage_type).get_file_storage()
+
+    def get_fsspec_fs(self) -> Any:
+        return self._file_storage.fs
+
+    def test_credentials(self) -> bool:
+        return True
+
+
 def get_connector_instance(
-    connector_id: str, settings: dict[str, Any]
+    connector_id: str,
+    settings: dict[str, Any],
+    storage_type: FileStorageType = FileStorageType.WORKFLOW_EXECUTION,
 ) -> UnstractFileSystem:
     """Get a filesystem connector instance.
+
+    For system-internal connector IDs (e.g., UnstractCloudStorage), returns
+    an adapter backed by the cached FileSystem instance instead of loading
+    the connector class. For all other connector IDs, behaves as before.
 
     Args:
         connector_id: Connector ID (e.g., "google_cloud_storage|uuid")
         settings: Connector settings/credentials
+        storage_type: Which system storage role to use when short-circuiting
 
     Returns:
-        UnstractFileSystem: Instantiated connector
+        UnstractFileSystem: Instantiated connector or system adapter
 
     Raises:
         ValueError: If connector not found or instantiation fails
     """
     try:
+        if connector_id in _SYSTEM_INTERNAL_CONNECTOR_IDS:
+            logger.debug(
+                f"Routing system-internal connector {connector_id} through "
+                f"FileSystem({storage_type.value})"
+            )
+            return _SystemFileStorageAdapter(storage_type)
+
         # Use Connectorkit to get connector class
         connectorkit = Connectorkit()
         connector_class = connectorkit.get_connector_class_by_connector_id(connector_id)


### PR DESCRIPTION
## What

- Workers route the UnstractCloudStorage (UCS, `pcs|b8cd25cd-...`) connector ID through the cached `unstract.filesystem.FileSystem` path instead of loading `MinioFS` via connectorkit.
- Rate-limit ZSET gets a separate stale-entry cutoff (default 1h) split from the existing 6h Redis key TTL.

Companion cloud PR: https://github.com/Zipstack/unstract-cloud/pull/1468 (executor capacity / config bump for the integration env load test).

## Why

Sustained API-deployment load tests against the integration env plateaued at ~u250 with two compounding failures:

1. Executor pods accumulated boto3 sessions and OOM'd. Workers were loading `UnstractCloudStorage` (a system-bucket connector that inherits `MinioFS`) per workflow execution; `MinioFS` opts out of fsspec's instance cache, so each instantiation produced a fresh boto3 session that urllib3's idle reaper could not keep up with under load. Prompt-service already reaches the same bucket via the SDK1 fsspec-cached path (`FileSystem(...).get_file_storage()`), so workers should too.
2. Rate-limit ZSET filled with stale entries. `_release_api_deployment_rate_limit` only fires from `update_execution_status(COMPLETED|ERROR|STOPPED)`. Worker OOM/SIGKILL/timeout never reaches that line, so the entry sat for the full 6h key TTL, causing false 429s, locust retry storm, and more MinIO connection churn.

Round 3 (after a manual Redis flush) confirmed the same workers held u300 cleanly, so both failure modes are real.

## How

**`workers/shared/workflow/connectors/utils.py`**
- New `_SYSTEM_INTERNAL_CONNECTOR_IDS` set listing the UCS connector ID.
- `_SystemFileStorageAdapter` is a thin `UnstractFileSystem` wrapper around `FileSystem(storage_type).get_file_storage()` exposing `get_fsspec_fs()` and `test_credentials()`.
- `get_connector_instance` short-circuits on a system ID and otherwise falls back to the existing connectorkit path. User S3/MinIO/GCS connectors are unchanged.

**`backend/api_v2/rate_limit_constants.py` + `backend/api_v2/rate_limiter.py`**
- New `DEFAULT_STALE_ENTRY_HOURS = 1` constant alongside the existing `DEFAULT_TTL_HOURS = 6`.
- `_get_stale_entry_seconds()` reads `API_DEPLOYMENT_RATE_LIMIT_STALE_ENTRY_HOURS` setting (override-able).
- `_get_cutoff_timestamp()` now uses the stale cutoff (not the key TTL) so leaked entries reap within an hour rather than six. `pipe.expire(org_key, ttl_seconds)` continues to use the full 6h key TTL.

The connector layer (`unstract/connectors/.../filesystems/minio/minio.py` and the UCS subclass) is intentionally **not** touched. Workers no longer reach for it for the system bucket; user-configured S3/MinIO connectors keep their existing behavior including `skip_instance_cache=True`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Worker call sites that resolved a UCS-typed connector via `get_connector_instance` now get a `FileStorage`-backed adapter instead of a `MinioFS` instance. The fsspec object exposed by `get_fsspec_fs()` is `S3FileSystem` in both cases, so any code that opens/reads/writes via fsspec is unaffected. The adapter implements `get_fsspec_fs()` and `test_credentials()` only; MinioFS-specific helpers (`extract_metadata_file_hash`, `extract_modified_date`, `is_dir_by_metadata`, `get_connector_root_dir`, ...) are not implemented because the only call site (`source.py:_get_fs_connector` -> `list_files_from_file_connector`, FILESYSTEM source) is not exercised with the UCS id in current product flows.
- The destination-side path (`WorkerConnectorService._get_destination_connector` -> `ConnectorOperations.get_fs_connector`) is a separate code path that this PR does not touch. If the UCS id ever flows through it, it will still load `MinioFS`. This was deliberate scope-limiting; flagged for follow-up if observed in profiling.
- Rate-limit cutoff change is opt-in via setting; default lowers stale window from 6h to 1h. Active executions (less than 1h elapsed) are unaffected. Workflows running longer than 1h would be released early — current integration test profiles cap at ~10 min so this is fine; worth confirming with prod traffic patterns before promotion.

## Database Migrations

- None.

## Env Config

- `API_DEPLOYMENT_RATE_LIMIT_STALE_ENTRY_HOURS` (new, optional, default 1) — per-entry cutoff in hours for stale ZSET releases.
- `API_DEPLOYMENT_RATE_LIMIT_TTL_HOURS` (existing, optional, default 6) — Redis key TTL in hours.

## Relevant Docs

- N/A.

## Related Issues or PRs

- Cloud companion: https://github.com/Zipstack/unstract-cloud/pull/1468
- Jira: UN-3436

## Dependencies Versions

- None.

## Notes on Testing

- Integration env Round 4: ramp 80->300 with no Redis flush mid-run. Pre-fix executor pods sat at 11–12.7 GB RSS by stage 4; post-fix expectation is to plateau. `manage.py get_org_rate_limit org_qijtoAkJNhznYhNt` should drop to 0 within seconds of locust shutdown at every stage.
- Unit-level: existing connectorkit tests still pass (system ID set is empty for non-cloud OSS deployments, so behavior is identical there).
- Trace check: `_SystemFileStorageAdapter.get_fsspec_fs()` returns `FileStorageHelper.file_storage_init(...)`'s result, which is a plain `fsspec.filesystem(protocol, **storage_config)` call. fsspec's instance cache is in effect (no `skip_instance_cache` is passed), confirming we hit the same cached `S3FileSystem` instance prompt-service uses.

## Screenshots

N/A.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).