### PR TITLE
[HOTFIX] Bool-parse ENABLE_HIGHLIGHT_API_DEPLOYMENT env var

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -690,4 +690,6 @@ if missing_settings:
     )
     raise ValueError(ERROR_MESSAGE)
 
-ENABLE_HIGHLIGHT_API_DEPLOYMENT = os.environ.get("ENABLE_HIGHLIGHT_API_DEPLOYMENT", False)
+ENABLE_HIGHLIGHT_API_DEPLOYMENT = CommonUtils.str_to_bool(
+    os.environ.get("ENABLE_HIGHLIGHT_API_DEPLOYMENT", "False")
+)


### PR DESCRIPTION
## Summary
- Hotfix on top of `v0.161.7`. Pairs with cloud hotfix Zipstack/unstract-cloud (will be opened against `v0.158.5-hotfix`).
- Wraps `ENABLE_HIGHLIGHT_API_DEPLOYMENT` env-var read in `backend/backend/settings/base.py` with `CommonUtils.str_to_bool(...)` so values like `False` / `false` / `0` actually evaluate falsy. Previously `os.environ.get(...)` returned the raw string, so any non-empty value (including `"False"`) was truthy in Python and bypassed the gate.
- The setting is consumed as the `ConfigSpec.default` in `unstract-cloud/backend/plugins/configuration/cloud_config.py`. `Configuration.get_value_by_organization(...)` returns this default when no per-org row exists, so the bool fix takes effect on cloud and on-prem builds where the configuration plugin is loaded.

## Why a new PR (replacing #1933)
- The earlier PR was based on `v0.161.4-hotfix`. Releasing that would have collided with already-tagged `v0.161.5/.6/.7`.
- This PR is rebased onto `v0.161.7` so the next free tag on the v0.161.x line — `v0.161.8` — can ship cleanly. Customer also picks up the security/stability fixes that landed in v0.161.5/.6/.7 (SQL identifier sanitization, OrgFilterBackend, axios pin, SIGTERM worker fix).

## Test plan
- [ ] On-prem (with paired cloud hotfix merged & on-prem image rebuilt from this `oss-branch`): set `ENABLE_HIGHLIGHT_API_DEPLOYMENT=true`, run an API deployment (sync + polled), confirm `highlight_data` and `extracted_text` are present.
- [ ] On-prem: set `ENABLE_HIGHLIGHT_API_DEPLOYMENT=False`, confirm both keys are stripped (this is the case the bool fix unblocks).
- [ ] Cloud: with no per-org `Configuration` row and env=`true`, confirm fleet-wide default keeps highlight data.
- [ ] Cloud: with no per-org row and env=`False`, confirm fleet-wide default strips both keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)