### PR TITLE
[HOTFIX] Bool-parse ENABLE_HIGHLIGHT_API_DEPLOYMENT env var (v0.161.4)

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -689,4 +689,6 @@ if missing_settings:
     )
     raise ValueError(ERROR_MESSAGE)
 
-ENABLE_HIGHLIGHT_API_DEPLOYMENT = os.environ.get("ENABLE_HIGHLIGHT_API_DEPLOYMENT", False)
+ENABLE_HIGHLIGHT_API_DEPLOYMENT = CommonUtils.str_to_bool(
+    os.environ.get("ENABLE_HIGHLIGHT_API_DEPLOYMENT", "False")
+)


### PR DESCRIPTION
## Summary
- Cherry-pick of #1937 onto a new `v0.161.4-hotfix` base branch (originally rebased on `v0.161.7` by mistake).
- Wraps `ENABLE_HIGHLIGHT_API_DEPLOYMENT` env var read in `CommonUtils.str_to_bool` so values like `"False"` / `"false"` / `"0"` are correctly evaluated as falsy.

## Why a new hotfix branch
The fix landed on `v0.161.7-hotfix` (PR #1937) but was supposed to be cut from `v0.161.4`. This PR re-targets the same change onto `v0.161.4-hotfix` for the correct release line.

## Original commit
- 18dc2303 [HOTFIX] Bool-parse ENABLE_HIGHLIGHT_API_DEPLOYMENT env var (#1937)

## Test plan
- [ ] Confirm `ENABLE_HIGHLIGHT_API_DEPLOYMENT="False"` evaluates to `False` in `backend/backend/settings/base.py`
- [ ] Verify cloud configuration plugin's `ConfigSpec.default` honors the falsy value
- [ ] CI green on `v0.161.4-hotfix` base

🤖 Generated with [Claude Code](https://claude.com/claude-code)