### PR TITLE
[HOTFIX] Add IAM Role / Instance Profile auth mode to AWS Bedrock adapter

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
     from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
-
 from unstract.sdk1.adapters.constants import Common
 from unstract.sdk1.adapters.enums import AdapterTypes
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -525,11 +525,12 @@ class AWSBedrockLLMParameters(BaseChatCompletionParameters):
                 result_metadata["thinking"] = thinking_config
                 result_metadata["temperature"] = 1
 
-        # Create validation metadata excluding control fields
+        # Create validation metadata excluding control fields. `auth_type` is
+        # a UI-only selector that drives form rendering; LiteLLM never sees it.
         validation_metadata = {
             k: v
             for k, v in result_metadata.items()
-            if k not in ("enable_thinking", "budget_tokens", "thinking")
+            if k not in ("enable_thinking", "budget_tokens", "thinking", "auth_type")
         }
 
         validated = AWSBedrockLLMParameters(**validation_metadata).model_dump()
@@ -981,7 +982,12 @@ class AWSBedrockEmbeddingParameters(BaseEmbeddingParameters):
         ):
             adapter_metadata["aws_region_name"] = adapter_metadata["region_name"]
 
-        validated = AWSBedrockEmbeddingParameters(**adapter_metadata).model_dump()
+        # `auth_type` is a UI-only selector; strip before LiteLLM kwargs.
+        validation_metadata = {
+            k: v for k, v in adapter_metadata.items() if k != "auth_type"
+        }
+
+        validated = AWSBedrockEmbeddingParameters(**validation_metadata).model_dump()
 
         # Strip empty AWS access keys so boto3's default credential chain
         # takes over (instance profile / IRSA / AWS Profile / env vars).

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
+
 from unstract.sdk1.adapters.constants import Common
 from unstract.sdk1.adapters.enums import AdapterTypes
 
@@ -474,6 +475,71 @@ class VertexAILLMParameters(BaseChatCompletionParameters):
             return f"vertex_ai/{model}"
 
 
+# AWS Bedrock auth helpers: shared by LLM and Embedding param classes.
+# `auth_type` is a UI-only selector (Access Keys vs IAM Role / Instance
+# Profile) that drives form rendering. The backend translates the user's
+# choice into actual credential handling here so that both validate()
+# methods stay symmetric and a single bug fix applies to both paths.
+_BEDROCK_AWS_KEY_FIELDS: tuple[str, ...] = (
+    "aws_access_key_id",
+    "aws_secret_access_key",
+)
+_BEDROCK_VALID_AUTH_TYPES: frozenset[str | None] = frozenset(
+    {None, "access_keys", "iam_role"}
+)
+
+
+def _resolve_bedrock_aws_credentials(
+    adapter_metadata: dict[str, "Any"],
+    validated: dict[str, "Any"],
+) -> dict[str, "Any"]:
+    """Apply auth_type semantics to the validated LiteLLM kwargs.
+
+    Three cases:
+    - ``auth_type == "iam_role"``: drop access keys unconditionally so a
+      previously-saved adapter switched into IAM Role mode does not leak
+      stale long-lived credentials. boto3's default credential chain
+      (IRSA / instance profile / env vars / AWS Profile) takes over.
+    - ``auth_type == "access_keys"`` (explicit): require non-blank values.
+      A blank submission must surface as a clear error rather than
+      silently fall through to the default chain (which would hide the
+      mistake and authenticate with whatever ambient creds the host has).
+    - ``auth_type is None`` (legacy adapters created before this field
+      existed): lenient strip of empty/missing keys. Preserves backwards
+      compatibility for stored configurations.
+
+    Raises:
+        ValueError: on unknown ``auth_type`` (typo / non-UI client) or on
+            blank credentials when ``auth_type == "access_keys"``.
+    """
+    auth_type = adapter_metadata.get("auth_type")
+    if auth_type not in _BEDROCK_VALID_AUTH_TYPES:
+        raise ValueError(
+            f"Unknown auth_type {auth_type!r}; expected one of "
+            f"{sorted(t for t in _BEDROCK_VALID_AUTH_TYPES if t)!r} or absent."
+        )
+
+    if auth_type == "iam_role":
+        for key in _BEDROCK_AWS_KEY_FIELDS:
+            validated.pop(key, None)
+        return validated
+
+    if auth_type == "access_keys":
+        for key in _BEDROCK_AWS_KEY_FIELDS:
+            value = validated.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{key} is required when auth_type is 'access_keys'.")
+        return validated
+
+    # Legacy adapters with no auth_type: strip blanks silently to
+    # preserve the pre-PR behaviour where empty key fields fell through
+    # to boto3's default chain.
+    for key in _BEDROCK_AWS_KEY_FIELDS:
+        if not validated.get(key):
+            validated.pop(key, None)
+    return validated
+
+
 class AWSBedrockLLMParameters(BaseChatCompletionParameters):
     """See https://docs.litellm.ai/docs/providers/bedrock."""
 
@@ -539,14 +605,11 @@ class AWSBedrockLLMParameters(BaseChatCompletionParameters):
         if enable_thinking and "thinking" in result_metadata:
             validated["thinking"] = result_metadata["thinking"]
 
-        # Strip empty AWS access keys so boto3's default credential chain
-        # takes over (instance profile / IRSA / AWS Profile / env vars).
-        # Mirrors the pattern in the S3/MinIO connector.
-        for key in ("aws_access_key_id", "aws_secret_access_key"):
-            if not validated.get(key):
-                validated.pop(key, None)
-
-        return validated
+        # Apply Bedrock auth semantics: IAM Role mode drops keys, Access
+        # Keys mode requires non-blank values, legacy (no auth_type) is
+        # lenient. Reads auth_type from result_metadata since validation_
+        # metadata strips it before Pydantic.
+        return _resolve_bedrock_aws_credentials(result_metadata, validated)
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:
@@ -967,10 +1030,11 @@ class VertexAIEmbeddingParameters(BaseEmbeddingParameters):
 class AWSBedrockEmbeddingParameters(BaseEmbeddingParameters):
     """See https://docs.litellm.ai/docs/providers/bedrock."""
 
+    # Region is still mandatory — credentials are the only fields that
+    # may be absent (IAM Role / Instance Profile mode).
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
-    aws_region_name: str | None = None
-    aws_profile_name: str | None = None  # For AWS SSO authentication
+    aws_region_name: str | None
 
     @staticmethod
     def validate(adapter_metadata: dict[str, "Any"]) -> dict[str, "Any"]:
@@ -989,14 +1053,9 @@ class AWSBedrockEmbeddingParameters(BaseEmbeddingParameters):
 
         validated = AWSBedrockEmbeddingParameters(**validation_metadata).model_dump()
 
-        # Strip empty AWS access keys so boto3's default credential chain
-        # takes over (instance profile / IRSA / AWS Profile / env vars).
-        # Mirrors the pattern in the S3/MinIO connector.
-        for key in ("aws_access_key_id", "aws_secret_access_key"):
-            if not validated.get(key):
-                validated.pop(key, None)
-
-        return validated
+        # Apply Bedrock auth semantics: IAM Role drops keys, Access Keys
+        # requires non-blank values, legacy (no auth_type) is lenient.
+        return _resolve_bedrock_aws_credentials(adapter_metadata, validated)
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -538,6 +538,13 @@ class AWSBedrockLLMParameters(BaseChatCompletionParameters):
         if enable_thinking and "thinking" in result_metadata:
             validated["thinking"] = result_metadata["thinking"]
 
+        # Strip empty AWS access keys so boto3's default credential chain
+        # takes over (instance profile / IRSA / AWS Profile / env vars).
+        # Mirrors the pattern in the S3/MinIO connector.
+        for key in ("aws_access_key_id", "aws_secret_access_key"):
+            if not validated.get(key):
+                validated.pop(key, None)
+
         return validated
 
     @staticmethod
@@ -959,9 +966,10 @@ class VertexAIEmbeddingParameters(BaseEmbeddingParameters):
 class AWSBedrockEmbeddingParameters(BaseEmbeddingParameters):
     """See https://docs.litellm.ai/docs/providers/bedrock."""
 
-    aws_access_key_id: str | None
-    aws_secret_access_key: str | None
-    aws_region_name: str | None
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
+    aws_region_name: str | None = None
+    aws_profile_name: str | None = None  # For AWS SSO authentication
 
     @staticmethod
     def validate(adapter_metadata: dict[str, "Any"]) -> dict[str, "Any"]:
@@ -973,7 +981,16 @@ class AWSBedrockEmbeddingParameters(BaseEmbeddingParameters):
         ):
             adapter_metadata["aws_region_name"] = adapter_metadata["region_name"]
 
-        return AWSBedrockEmbeddingParameters(**adapter_metadata).model_dump()
+        validated = AWSBedrockEmbeddingParameters(**adapter_metadata).model_dump()
+
+        # Strip empty AWS access keys so boto3's default credential chain
+        # takes over (instance profile / IRSA / AWS Profile / env vars).
+        # Mirrors the pattern in the S3/MinIO connector.
+        for key in ("aws_access_key_id", "aws_secret_access_key"):
+            if not validated.get(key):
+                validated.pop(key, None)
+
+        return validated
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/bedrock.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/bedrock.json
@@ -2,9 +2,7 @@
     "title": "Bedrock Embeddings",
     "type": "object",
     "required": [
-      "aws_secret_access_key",
       "region_name",
-      "aws_access_key_id",
       "model",
       "adapter_name"
     ],
@@ -24,19 +22,24 @@
       "aws_access_key_id": {
         "type": "string",
         "title": "AWS Access Key ID",
-        "description": "Provide your AWS Access Key ID",
+        "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
         "format": "password"
       },
       "aws_secret_access_key": {
         "type": "string",
         "title": "AWS Secret Access Key",
-        "description": "Provide your AWS Secret Access Key",
+        "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
         "format": "password"
       },
       "region_name": {
         "type": "string",
         "title": "AWS Region name",
         "description": "Provide the AWS Region name where the service is running. Eg. us-east-1"
+      },
+      "aws_profile_name": {
+        "type": "string",
+        "title": "AWS Profile Name",
+        "description": "AWS SSO profile name for authentication. Use this instead of access keys when using AWS SSO. Example: dev-profile"
       },
       "max_retries": {
         "type": "number",

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/bedrock.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/bedrock.json
@@ -19,18 +19,6 @@
         "default": "amazon.titan-embed-text-v2:0",
         "description": "Model name. Refer to [Bedrock's documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) for the list of available models."
       },
-      "aws_access_key_id": {
-        "type": "string",
-        "title": "AWS Access Key ID",
-        "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
-        "format": "password"
-      },
-      "aws_secret_access_key": {
-        "type": "string",
-        "title": "AWS Secret Access Key",
-        "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
-        "format": "password"
-      },
       "region_name": {
         "type": "string",
         "title": "AWS Region name",
@@ -56,6 +44,60 @@
         "title": "Timeout",
         "default": 900,
         "description": "Timeout in seconds"
+      },
+      "auth_type": {
+        "type": "string",
+        "title": "Authentication Type",
+        "enum": [
+          "access_keys",
+          "iam_role"
+        ],
+        "enumNames": [
+          "Access Keys",
+          "IAM Role / Instance Profile (on-prem AWS only)"
+        ],
+        "default": "access_keys",
+        "description": "Choose **Access Keys** for any deployment (provide your AWS Access Key ID and Secret). Choose **IAM Role / Instance Profile** only when Unstract is hosted on AWS infrastructure that already has ambient credentials — for example EKS pods with IRSA, ECS tasks with a task role, or EC2 instances with an instance profile. The on-prem option requires no further input; boto3 picks up the host's identity automatically."
+      }
+    },
+    "dependencies": {
+      "auth_type": {
+        "oneOf": [
+          {
+            "properties": {
+              "auth_type": {
+                "enum": [
+                  "access_keys"
+                ]
+              },
+              "aws_access_key_id": {
+                "type": "string",
+                "title": "AWS Access Key ID",
+                "description": "Provide your AWS Access Key ID.",
+                "format": "password"
+              },
+              "aws_secret_access_key": {
+                "type": "string",
+                "title": "AWS Secret Access Key",
+                "description": "Provide your AWS Secret Access Key.",
+                "format": "password"
+              }
+            },
+            "required": [
+              "aws_access_key_id",
+              "aws_secret_access_key"
+            ]
+          },
+          {
+            "properties": {
+              "auth_type": {
+                "enum": [
+                  "iam_role"
+                ]
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/bedrock.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/bedrock.json
@@ -24,11 +24,6 @@
         "title": "AWS Region name",
         "description": "Provide the AWS Region name where the service is running. Eg. us-east-1"
       },
-      "aws_profile_name": {
-        "type": "string",
-        "title": "AWS Profile Name",
-        "description": "AWS SSO profile name for authentication. Use this instead of access keys when using AWS SSO. Example: dev-profile"
-      },
       "max_retries": {
         "type": "number",
         "minimum": 0,

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
@@ -22,13 +22,13 @@
     "aws_access_key_id": {
       "type": "string",
       "title": "AWS Access Key ID",
-      "description": "Provide your AWS Access Key ID. Leave empty if using AWS Profile or IAM role.",
+      "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
       "format": "password"
     },
     "aws_secret_access_key": {
       "type": "string",
       "title": "AWS Secret Access Key",
-      "description": "Provide your AWS Secret Access Key. Leave empty if using AWS Profile or IAM role.",
+      "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
       "format": "password"
     },
     "region_name": {

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
@@ -19,18 +19,6 @@
       "default": "amazon.titan-text-express-v1",
       "description": "Model name. Refer to [Bedrock's documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) for the list of available models."
     },
-    "aws_access_key_id": {
-      "type": "string",
-      "title": "AWS Access Key ID",
-      "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
-      "format": "password"
-    },
-    "aws_secret_access_key": {
-      "type": "string",
-      "title": "AWS Secret Access Key",
-      "description": "Leave blank to use the host's IAM role / instance profile / IRSA, or AWS Profile.",
-      "format": "password"
-    },
     "region_name": {
       "type": "string",
       "title": "AWS Region Name",
@@ -75,6 +63,60 @@
       "title": "Enable Extended Thinking",
       "default": false,
       "description": "Enhance reasoning for complex tasks with step-by-step transparency. Available only for Claude 3.7 Sonnet."
+    },
+    "auth_type": {
+      "type": "string",
+      "title": "Authentication Type",
+      "enum": [
+        "access_keys",
+        "iam_role"
+      ],
+      "enumNames": [
+        "Access Keys",
+        "IAM Role / Instance Profile (on-prem AWS only)"
+      ],
+      "default": "access_keys",
+      "description": "Choose **Access Keys** for any deployment (provide your AWS Access Key ID and Secret). Choose **IAM Role / Instance Profile** only when Unstract is hosted on AWS infrastructure that already has ambient credentials — for example EKS pods with IRSA, ECS tasks with a task role, or EC2 instances with an instance profile. The on-prem option requires no further input; boto3 picks up the host's identity automatically."
+    }
+  },
+  "dependencies": {
+    "auth_type": {
+      "oneOf": [
+        {
+          "properties": {
+            "auth_type": {
+              "enum": [
+                "access_keys"
+              ]
+            },
+            "aws_access_key_id": {
+              "type": "string",
+              "title": "AWS Access Key ID",
+              "description": "Provide your AWS Access Key ID.",
+              "format": "password"
+            },
+            "aws_secret_access_key": {
+              "type": "string",
+              "title": "AWS Secret Access Key",
+              "description": "Provide your AWS Secret Access Key.",
+              "format": "password"
+            }
+          },
+          "required": [
+            "aws_access_key_id",
+            "aws_secret_access_key"
+          ]
+        },
+        {
+          "properties": {
+            "auth_type": {
+              "enum": [
+                "iam_role"
+              ]
+            }
+          }
+        }
+      ]
     }
   },
   "allOf": [

--- a/unstract/sdk1/tests/test_bedrock_adapter.py
+++ b/unstract/sdk1/tests/test_bedrock_adapter.py
@@ -6,7 +6,6 @@ configurations stored before auth_type existed.
 """
 
 import pytest
-
 from unstract.sdk1.adapters.base1 import (
     AWSBedrockEmbeddingParameters,
     AWSBedrockLLMParameters,

--- a/unstract/sdk1/tests/test_bedrock_adapter.py
+++ b/unstract/sdk1/tests/test_bedrock_adapter.py
@@ -1,0 +1,247 @@
+"""Unit tests for the AWS Bedrock LLM and embedding adapters.
+
+Covers the auth_type selector behaviour added alongside the IAM Role /
+Instance Profile mode, plus backwards compatibility for legacy adapter
+configurations stored before auth_type existed.
+"""
+
+import pytest
+
+from unstract.sdk1.adapters.base1 import (
+    AWSBedrockEmbeddingParameters,
+    AWSBedrockLLMParameters,
+)
+
+# ── LLM: validate auth_type semantics ────────────────────────────────────────
+
+
+def test_llm_legacy_no_auth_type_keeps_keys() -> None:
+    """Legacy adapters without auth_type must keep working unchanged."""
+    out = AWSBedrockLLMParameters.validate(
+        {
+            "model": "anthropic.claude-3-haiku-20240307-v1:0",
+            "region_name": "us-east-1",
+            "aws_access_key_id": "AKIAFAKE",
+            "aws_secret_access_key": "secret",
+        }
+    )
+    assert out["aws_access_key_id"] == "AKIAFAKE"
+    assert out["aws_secret_access_key"] == "secret"
+    assert out["aws_region_name"] == "us-east-1"
+    assert "auth_type" not in out
+
+
+def test_llm_access_keys_mode_keeps_keys_and_strips_auth_type() -> None:
+    out = AWSBedrockLLMParameters.validate(
+        {
+            "auth_type": "access_keys",
+            "model": "anthropic.claude-3-haiku-20240307-v1:0",
+            "region_name": "us-east-1",
+            "aws_access_key_id": "AKIAFAKE",
+            "aws_secret_access_key": "secret",
+        }
+    )
+    assert out["aws_access_key_id"] == "AKIAFAKE"
+    assert out["aws_secret_access_key"] == "secret"
+    assert "auth_type" not in out
+
+
+def test_llm_iam_role_mode_drops_keys_even_when_present() -> None:
+    """IAM Role mode unconditionally drops access keys.
+
+    A saved adapter switched into IAM mode must not silently leak the
+    previously stored long-lived credentials.
+    """
+    out = AWSBedrockLLMParameters.validate(
+        {
+            "auth_type": "iam_role",
+            "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "region_name": "us-east-1",
+            "aws_access_key_id": "STALE_KEY",
+            "aws_secret_access_key": "STALE_SECRET",
+        }
+    )
+    assert "aws_access_key_id" not in out
+    assert "aws_secret_access_key" not in out
+    assert out["aws_region_name"] == "us-east-1"
+    assert "auth_type" not in out
+
+
+def test_llm_iam_role_mode_with_no_keys() -> None:
+    out = AWSBedrockLLMParameters.validate(
+        {
+            "auth_type": "iam_role",
+            "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "region_name": "us-east-1",
+        }
+    )
+    assert "aws_access_key_id" not in out
+    assert "aws_secret_access_key" not in out
+
+
+def test_llm_access_keys_mode_blank_keys_raises() -> None:
+    """Blank values must surface a clear error.
+
+    Falling through to boto3's default chain would hide the user's
+    misconfiguration and authenticate with whatever ambient creds the
+    host happens to have.
+    """
+    with pytest.raises(ValueError, match="aws_access_key_id is required"):
+        AWSBedrockLLMParameters.validate(
+            {
+                "auth_type": "access_keys",
+                "model": "anthropic.claude-3-haiku-20240307-v1:0",
+                "region_name": "us-east-1",
+                "aws_access_key_id": "",
+                "aws_secret_access_key": "",
+            }
+        )
+
+
+def test_llm_access_keys_mode_whitespace_keys_raises() -> None:
+    with pytest.raises(ValueError, match="aws_secret_access_key is required"):
+        AWSBedrockLLMParameters.validate(
+            {
+                "auth_type": "access_keys",
+                "model": "anthropic.claude-3-haiku-20240307-v1:0",
+                "region_name": "us-east-1",
+                "aws_access_key_id": "AKIAFAKE",
+                "aws_secret_access_key": "   ",
+            }
+        )
+
+
+def test_llm_unknown_auth_type_raises() -> None:
+    """A typo or non-UI client must not silently fall through."""
+    with pytest.raises(ValueError, match="Unknown auth_type"):
+        AWSBedrockLLMParameters.validate(
+            {
+                "auth_type": "access_key",  # typo: missing 's'
+                "model": "anthropic.claude-3-haiku-20240307-v1:0",
+                "region_name": "us-east-1",
+                "aws_access_key_id": "AKIAFAKE",
+                "aws_secret_access_key": "secret",
+            }
+        )
+
+
+def test_llm_other_params_preserved_through_strip() -> None:
+    """Non-credential params survive the auth-type handling.
+
+    model_id, aws_profile_name, region, and thinking config must pass
+    through both the strip and the resolver unchanged.
+    """
+    out = AWSBedrockLLMParameters.validate(
+        {
+            "auth_type": "iam_role",
+            "model": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            "region_name": "us-east-1",
+            "aws_profile_name": "dev-profile",
+            "model_id": (
+                "arn:aws:bedrock:us-east-1:1234:application-inference-profile/abc"
+            ),
+            "enable_thinking": True,
+            "budget_tokens": 4096,
+        }
+    )
+    assert out["aws_profile_name"] == "dev-profile"
+    assert out["aws_region_name"] == "us-east-1"
+    assert out["model_id"].endswith("application-inference-profile/abc")
+    assert out["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+
+
+# ── Embedding: same auth_type matrix ─────────────────────────────────────────
+
+
+def test_embedding_legacy_no_auth_type_keeps_keys() -> None:
+    out = AWSBedrockEmbeddingParameters.validate(
+        {
+            "model": "amazon.titan-embed-text-v2:0",
+            "region_name": "us-east-1",
+            "aws_access_key_id": "AKIAFAKE",
+            "aws_secret_access_key": "secret",
+        }
+    )
+    assert out["aws_access_key_id"] == "AKIAFAKE"
+    assert out["aws_secret_access_key"] == "secret"
+    assert "auth_type" not in out
+
+
+def test_embedding_access_keys_mode_keeps_keys() -> None:
+    out = AWSBedrockEmbeddingParameters.validate(
+        {
+            "auth_type": "access_keys",
+            "model": "amazon.titan-embed-text-v2:0",
+            "region_name": "us-east-1",
+            "aws_access_key_id": "AKIAFAKE",
+            "aws_secret_access_key": "secret",
+        }
+    )
+    assert out["aws_access_key_id"] == "AKIAFAKE"
+    assert out["aws_secret_access_key"] == "secret"
+    assert "auth_type" not in out
+
+
+def test_embedding_iam_role_mode_drops_stale_keys() -> None:
+    """Embedding-side parity with the LLM stale-key fix."""
+    out = AWSBedrockEmbeddingParameters.validate(
+        {
+            "auth_type": "iam_role",
+            "model": "amazon.titan-embed-text-v2:0",
+            "region_name": "us-east-1",
+            "aws_access_key_id": "STALE_KEY",
+            "aws_secret_access_key": "STALE_SECRET",
+        }
+    )
+    assert "aws_access_key_id" not in out
+    assert "aws_secret_access_key" not in out
+    assert out["aws_region_name"] == "us-east-1"
+
+
+def test_embedding_iam_role_mode_with_no_keys() -> None:
+    out = AWSBedrockEmbeddingParameters.validate(
+        {
+            "auth_type": "iam_role",
+            "model": "amazon.titan-embed-text-v2:0",
+            "region_name": "us-east-1",
+        }
+    )
+    assert "aws_access_key_id" not in out
+    assert "aws_secret_access_key" not in out
+
+
+def test_embedding_access_keys_mode_blank_keys_raises() -> None:
+    with pytest.raises(ValueError, match="aws_access_key_id is required"):
+        AWSBedrockEmbeddingParameters.validate(
+            {
+                "auth_type": "access_keys",
+                "model": "amazon.titan-embed-text-v2:0",
+                "region_name": "us-east-1",
+                "aws_access_key_id": "",
+                "aws_secret_access_key": "",
+            }
+        )
+
+
+def test_embedding_unknown_auth_type_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown auth_type"):
+        AWSBedrockEmbeddingParameters.validate(
+            {
+                "auth_type": "iamrole",  # typo
+                "model": "amazon.titan-embed-text-v2:0",
+                "region_name": "us-east-1",
+            }
+        )
+
+
+def test_embedding_region_required_when_absent() -> None:
+    """aws_region_name is still mandatory even though credentials are not."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AWSBedrockEmbeddingParameters.validate(
+            {
+                "auth_type": "iam_role",
+                "model": "amazon.titan-embed-text-v2:0",
+            }
+        )


### PR DESCRIPTION
## What

Adds an **Authentication Type** selector to the AWS Bedrock LLM and embedding adapter forms with two options:

- **Access Keys** (default): existing flow — provide `aws_access_key_id` and `aws_secret_access_key`
- **IAM Role / Instance Profile (on-prem AWS only)**: no fields; relies on `boto3`'s default credential chain

When the IAM Role mode is selected, the form-only `auth_type` field is stripped before LiteLLM validation, and any empty access keys are dropped from the validated kwargs so `boto3` falls through to its default credential chain (IRSA on EKS, task role on ECS, instance profile on EC2, AWS Profile, env vars).

## Why

Customers running Unstract on AWS infrastructure (specifically EKS with IRSA) cannot — and don't want to — paste long-lived AWS access keys into the adapter form. The pod's service account already has a federated identity that `boto3` can use to call Bedrock; the adapter form just needs to accept blank credentials so the ambient identity takes over.

The S3/MinIO connector at `unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py` already implements this idiom for S3:

```python
if key and secret:
    creds["key"] = key
    creds["secret"] = secret
```

This PR applies the same pattern to the Bedrock adapter, with the addition of an explicit `auth_type` selector to make the user's choice clear in the UI.

## How

### `unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json`

Adds an `auth_type` enum with two options (`access_keys` default, `iam_role`) and a `dependencies/oneOf` block that:

- Renders `aws_access_key_id` + `aws_secret_access_key` (both required) when `auth_type == access_keys`
- Renders nothing extra when `auth_type == iam_role`

The selector's description explicitly notes the IRSA / instance-profile mode is for AWS-hosted Unstract deployments only.

### `unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/bedrock.json`

Same restructure. Drops `aws_access_key_id` and `aws_secret_access_key` from top-level `required`. Adds `aws_profile_name` for parity with the LLM form.

### `unstract/sdk1/src/unstract/sdk1/adapters/base1.py`

In both `AWSBedrockLLMParameters.validate()` and `AWSBedrockEmbeddingParameters.validate()`:

- Strip the form-only `auth_type` field from validation metadata before Pydantic dump
- Strip empty `aws_access_key_id` / `aws_secret_access_key` from the validated kwargs so `boto3`'s default chain takes over (mirrors the S3/MinIO connector idiom)

`AWSBedrockEmbeddingParameters` fields gain explicit `None` defaults so the access-key fields are truly optional in either mode (parity with `AWSBedrockLLMParameters` which already had this from earlier work).

## Can this PR break any existing features?

No. Backward-compatible across every scenario:

| Scenario | Behavior |
|---|---|
| Existing adapter with access keys filled in (no `auth_type` field stored) | `auth_type` defaults to `access_keys`; keys forwarded to `boto3` unchanged |
| New adapter, **Access Keys** mode | Keys forwarded to `boto3` |
| New adapter, **IAM Role** mode | No keys submitted; empty values stripped → `boto3` default credential chain takes over |
| Existing adapter with `aws_profile_name` set | Forwarded unchanged (not part of `auth_type`) |
| Bedrock `enable_thinking` / `model_id` (Application Inference Profile) | Unchanged — these continue to work in both auth modes |

End-to-end verified against real AWS Bedrock during development:

- `aws_role_name=arn:...:role/BedrockInvokeRole` with bootstrap creds in env: `STS:AssumeRole` succeeds, `Bedrock InvokeModel` succeeds with temp creds (token usage returned).
- `auth_type=iam_role` with no keys + ambient creds in env: `boto3` default chain picks up the env vars; Bedrock call signs and routes correctly.

## Relevant Docs

- LiteLLM Bedrock provider parameters: https://docs.litellm.ai/docs/providers/bedrock
- AWS IRSA (IAM roles for EKS service accounts): https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
- Pattern reference: `unstract/connectors/src/unstract/connectors/filesystems/minio/minio.py`