### PR TITLE
UN-3465 [FIX] Wrap set_user_organization in transaction.atomic

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -26,7 +26,10 @@ Create isolated worktrees for parallel development. Ends by providing commands t
    ```bash
    git fetch origin main
    mkdir -p "$(dirname "$WORKTREE_PATH")"
-   git worktree add -b "{branch}" "$WORKTREE_PATH" origin/main
+   # --no-track: do NOT set the new branch's upstream to origin/main.
+   # Without it, a later `git push -u origin {branch}` can be reported by
+   # the server as also fast-forwarding main, landing commits on main.
+   git worktree add --no-track -b "{branch}" "$WORKTREE_PATH" origin/main
    ```
 
 4. **Copy config files**

--- a/backend/account_v2/authentication_controller.py
+++ b/backend/account_v2/authentication_controller.py
@@ -101,8 +101,8 @@ class AuthenticationController:
             return self.auth_service.handle_authorization_callback(
                 request=request, backend=backend
             )
-        except Exception as ex:
-            logger.error(f"Error while handling authorization callback: {ex}")
+        except Exception:
+            logger.exception("Error while handling authorization callback")
             return redirect("/error")
 
     def user_organizations(self, request: Request) -> Any:

--- a/backend/account_v2/authentication_controller.py
+++ b/backend/account_v2/authentication_controller.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from django.conf import settings
 from django.contrib.auth import logout as django_logout
+from django.db import transaction
 from django.db.utils import IntegrityError
 from django.http import HttpRequest
 from django.middleware import csrf
@@ -163,6 +164,7 @@ class AuthenticationController:
 
         return response
 
+    @transaction.atomic
     def set_user_organization(self, request: Request, organization_id: str) -> Response:
         user: User = request.user
         new_organization = False


### PR DESCRIPTION
## What

- Wrap `AuthenticationController.set_user_organization` in `@transaction.atomic` so the new-org branch (org row + tenant member + frictionless onboarding hook + initial platform key) is a single all-or-nothing unit of work.
- Update the `/worktree` skill to use `git worktree add --no-track` so the new branch does not inherit `origin/main` as its upstream.

## Why

- `set_user_organization` creates an organization row and a tenant member, then calls into pluggable hooks (frictionless onboarding, initial platform key). Each step can fail for unrelated reasons. Without a transaction, a failure mid-flow leaves the organization row persisted with no follow-up bookkeeping completed.
- That partial state is self-perpetuating: the next login finds the organization already exists, takes the existing-org branch, and never re-runs the hooks. The user ends up logged in but in a workspace missing the state those hooks would have created — no automatic recovery path.
- Wrapping the method in atomic means a failure rolls back the org row along with the tenant member, so a retry sees a clean fresh-org path.
- Worktree skill: when `git worktree add -b <branch> $PATH origin/main` runs without `--no-track`, the new branch's upstream is set to `origin/main`. A subsequent `git push -u origin <branch>` is then susceptible to being interpreted by the server as also fast-forwarding `main`, depending on the remote's push config. `--no-track` removes the implicit link without any other behaviour change.

## How

- Add `from django.db import transaction` and `@transaction.atomic` to `set_user_organization` in `backend/account_v2/authentication_controller.py`.
- Add `--no-track` to the `git worktree add` invocation in `.claude/skills/worktree/SKILL.md` with an inline comment explaining the rationale.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- The atomic wrapper changes the failure semantics of two pre-existing exception handlers inside the wrapped scope:
  - `create_tenant_user` catches `IntegrityError` without a savepoint. The duplicate-user race path was already broken (caller does not null-check the return — `None` flowed into `set_organization_member_role` and crashed downstream). Under atomic, the same race produces a `TransactionManagementError` on commit instead of an `AttributeError` later. Both are 500s; net behaviour change is negligible.
  - `create_initial_platform_key` has a bare `except Exception` that has always silently swallowed errors, including `DuplicateData`. Under atomic, an underlying DB error inside `generate_platform_key` will surface as `TransactionManagementError` on commit instead of a silently broken org. Again, both pre/post are failure modes — the atomic version at least rolls back the org row.
- Both pre-existing patterns will be cleaned up in a follow-up (savepoint or propagate) — out of scope here.
- This only addresses DB state. External resources created inside the pluggable hooks (Auth0 org, etc.) are out of scope.
- Worktree skill change is doc-only and additive; it removes an implicit upstream link, no other behaviour change.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- [Django `transaction.atomic` docs](https://docs.djangoproject.com/en/stable/topics/db/transactions/#django.db.transaction.atomic)
- [`git worktree add --no-track`](https://git-scm.com/docs/git-worktree)

## Related Issues or PRs

- Cloud-side companion: Zipstack/unstract-cloud#1484
- Follow-up needed: clean up `create_tenant_user` IntegrityError handling and `create_initial_platform_key` bare except (savepoint or propagate).

## Dependencies Versions

- None.

## Notes on Testing

- Manual: trigger a failure inside one of the new-org hooks (e.g. misconfigured frictionless adapter); confirm no orphan row remains in `account_v2_organization` for the attempted org and a retry after fixing the upstream cause succeeds cleanly.
- Worktree skill: run the skill end-to-end; confirm the new worktree's branch has no upstream until an explicit `git push -u`.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).