### PR TITLE
UN-2946 [MISC] Fix empty Default tab in Prompt Studio Combined Output

### DIFF
--- a/backend/prompt_studio/prompt_studio_output_manager_v2/output_manager_helper.py
+++ b/backend/prompt_studio/prompt_studio_output_manager_v2/output_manager_helper.py
@@ -323,8 +323,10 @@ class OutputManagerHelper:
                 .order_by("prompt_id", "profile_manager_id", "-modified_at")
                 .distinct("prompt_id", "profile_manager_id")
             )
+            # ``prompt_id_id`` is the raw FK column; ``prompt_id`` returns the
+            # related ToolStudioPrompt instance (FK field shadows the PK name).
             outputs_index = {
-                (str(o.prompt_id), str(o.profile_manager_id)): o for o in outputs
+                (str(o.prompt_id_id), str(o.profile_manager_id)): o for o in outputs
             }
 
         enrichment_by_key: dict[str, Any] = {}


### PR DESCRIPTION
## What

- Fix the empty Default tab in Prompt Studio Combined Output.

## Why

- The `DISTINCT-ON` refactor in `fetch_default_output_response` (commit `993ae95d1`, merged via PR #1929) built `outputs_index` with `str(o.prompt_id)`.
- On `PromptStudioOutputManager` the FK field is named `prompt_id`, which shadows the related model's PK column — so `o.prompt_id` returns the **`ToolStudioPrompt` instance**, not a UUID. `str()` on the instance produces `"ToolStudioPrompt object (<uuid>)"`, never matches the canonical-UUID lookup key, and every prompt resolves to `""` → Default tab renders empty.
- Confirmed against staging DB (tool `da2b94a4-6f0d-4919-8fcf-6ee160d32ff1`, doc `cb966b88-…`): the row for prompt `skills` on the tool's default profile has 59 chars of output, but the Default tab payload returns `{skills: "", summary: ""}`. Matches the user's screenshot exactly.

## How

- One-line change: `str(o.prompt_id)` → `str(o.prompt_id_id)` in the `outputs_index` dict comprehension. `prompt_id_id` is the raw FK column.
- Side benefit: drops the implicit N+1 from lazy-loading the related `ToolStudioPrompt` per row, restoring the perf intent of the original commit.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. The fix only corrects a buggy dict key in the Default tab path. Profile-named tabs use a different endpoint (`list` with `profile_manager=` filter) and are unaffected. SinglePass Extraction mode is unaffected — its data path is keyed off `defaultLlmProfile` rather than `fetch_default_output_response`.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- N/A.

## Related Issues or PRs

- Regression introduced by PR #1929 (lookups V2 OSS bridge), specifically commit `993ae95d1` `[PERF] Push Combined Output queries into SQL`.

## Dependencies Versions

- None.

## Notes on Testing

- Run a multi-profile Prompt Studio execution on a tool where each prompt has a pinned `profile_manager_id` (or none, falling back to the tool's default LLM profile).
- Open Combined Output → Default tab → expect the values from each prompt's pinned profile (or the default LLM profile fallback).
- Profile-named tabs should continue to show their per-profile values.
- SinglePass Extraction mode: toggle on, verify combined output still renders correctly.

## Screenshots

- See attached staging screenshot (Akshaya.pdf Combined Output → Default tab shows `{skills: "", summary: ""}` before fix).

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).