### PR TITLE
UN-3152 [FIX] Bedrock bearer token lost on LLM.complete() re-validation

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -674,11 +674,13 @@ def _resolve_bedrock_aws_credentials(
     if auth_type == "iam_role":
         _drop_bedrock_access_keys(validated)
         validated.pop(_BEDROCK_BEARER_TOKEN_FIELD, None)
+        validated.pop(_BEDROCK_LITELLM_BEARER_KWARG, None)
         return validated
 
     if auth_type == "access_keys":
         _require_bedrock_access_keys(validated)
         validated.pop(_BEDROCK_BEARER_TOKEN_FIELD, None)
+        validated.pop(_BEDROCK_LITELLM_BEARER_KWARG, None)
         return validated
 
     if auth_type == "bearer_token":
@@ -689,10 +691,16 @@ def _resolve_bedrock_aws_credentials(
     # No auth_type: strip blank access keys (boto3 chain takes over) and
     # drop any bearer token — bearer auth must be opted into explicitly
     # via auth_type='bearer_token' rather than promoted from this branch.
+    # A non-blank `api_key` is preserved here to support `LLM.complete()`'s
+    # re-validation pass, where bearer-mode kwargs round-trip without their
+    # original `auth_type`. A blank `api_key` (Pydantic's `None` default
+    # for an unset field) is dropped so LiteLLM doesn't see `api_key=None`.
     for key in _BEDROCK_AWS_KEY_FIELDS:
         if not validated.get(key):
             validated.pop(key, None)
     validated.pop(_BEDROCK_BEARER_TOKEN_FIELD, None)
+    if not validated.get(_BEDROCK_LITELLM_BEARER_KWARG):
+        validated.pop(_BEDROCK_LITELLM_BEARER_KWARG, None)
     return validated
 
 
@@ -703,6 +711,9 @@ class AWSBedrockLLMParameters(BaseChatCompletionParameters):
     aws_secret_access_key: str | None = None
     # AWS_BEARER_TOKEN_BEDROCK; resolver translates to LiteLLM's `api_key`.
     aws_bearer_token: str | None = None
+    # Declared so it survives `LLM.complete()`'s re-validation of self.kwargs;
+    # otherwise Pydantic would drop it as an unknown field.
+    api_key: str | None = None
     aws_region_name: str | None = None
     aws_profile_name: str | None = None  # For AWS SSO authentication
     model_id: str | None = None  # For Application Inference Profile (cost tracking)
@@ -1196,6 +1207,9 @@ class AWSBedrockEmbeddingParameters(BaseEmbeddingParameters):
     aws_secret_access_key: str | None = None
     # AWS_BEARER_TOKEN_BEDROCK; resolver translates to LiteLLM's `api_key`.
     aws_bearer_token: str | None = None
+    # Declared so it survives Pydantic re-validation if the kwargs ever round-
+    # trip through validate() (parity with the LLM param class).
+    api_key: str | None = None
     aws_region_name: str | None
 
     @staticmethod

--- a/unstract/sdk1/tests/test_bedrock_adapter.py
+++ b/unstract/sdk1/tests/test_bedrock_adapter.py
@@ -251,6 +251,30 @@ def test_llm_bearer_token_strips_surrounding_whitespace() -> None:
     assert out["api_key"] == "bedrock-key-abc"
 
 
+def test_llm_bearer_token_survives_revalidation() -> None:
+    """Bearer-mode kwargs must round-trip through a second validate() call.
+
+    ``LLM.complete()`` re-runs ``validate({**self.kwargs, **kwargs})`` on
+    every call. The second pass has no ``auth_type`` and no
+    ``aws_bearer_token`` (both stripped on the first pass), so the resolver
+    can't re-translate. ``api_key`` must survive Pydantic's
+    ``model_dump()`` on the round-trip — otherwise LiteLLM falls through
+    to SigV4 signing and 401s with "Unable to locate credentials".
+    """
+    first = AWSBedrockLLMParameters.validate(
+        {
+            "auth_type": "bearer_token",
+            "model": "anthropic.claude-3-haiku-20240307-v1:0",
+            "region_name": "us-east-1",
+            "aws_bearer_token": "bedrock-key-abc",
+        }
+    )
+    assert first["api_key"] == "bedrock-key-abc"
+
+    second = AWSBedrockLLMParameters.validate({**first, "max_tokens": 100})
+    assert second["api_key"] == "bedrock-key-abc"
+
+
 def test_llm_iam_role_drops_stale_bearer_token() -> None:
     out = AWSBedrockLLMParameters.validate(
         {
@@ -487,6 +511,22 @@ def test_embedding_bearer_token_strips_surrounding_whitespace() -> None:
         }
     )
     assert out["api_key"] == "bedrock-key-abc"
+
+
+def test_embedding_bearer_token_survives_revalidation() -> None:
+    """Defensive parity with the LLM round-trip test."""
+    first = AWSBedrockEmbeddingParameters.validate(
+        {
+            "auth_type": "bearer_token",
+            "model": "amazon.titan-embed-text-v2:0",
+            "region_name": "us-east-1",
+            "aws_bearer_token": "bedrock-key-abc",
+        }
+    )
+    assert first["api_key"] == "bedrock-key-abc"
+
+    second = AWSBedrockEmbeddingParameters.validate({**first})
+    assert second["api_key"] == "bedrock-key-abc"
 
 
 def test_embedding_iam_role_drops_stale_bearer_token() -> None:


### PR DESCRIPTION
## What

Fix a bug introduced by #1952 (bearer-token Bedrock auth) where the bearer token is silently dropped on `LLM.complete()`'s second `validate()` call, causing the UI "Test Connection" action to fail with `BedrockException Invalid Authentication - Unable to locate credentials` for any Bedrock LLM adapter configured with **Bedrock API Key (Bearer Token)** auth.

## Why

`LLM.complete()` re-runs `adapter.validate({**self.kwargs, **kwargs})` on every call (`unstract/sdk1/src/unstract/sdk1/llm.py:286`). The first pass translates `aws_bearer_token` → LiteLLM's `api_key` kwarg and pops both the bearer field and `auth_type`, so the second pass sees:

- `api_key` present (output of the first pass)
- no `aws_bearer_token` (popped)
- no `auth_type` (popped) → resolver falls into legacy mode

Pydantic's `model_dump()` only emits **declared** fields, and `api_key` was not declared on `AWSBedrockLLMParameters` — so the second pass silently dropped the token. LiteLLM then fell through to SigV4 signing, found no AWS credentials, and 401'd with `Unable to locate credentials` (the exact UI-visible symptom).

This was 100% reproducible in the UI: pick **Bedrock API Key (Bearer Token)** → paste a valid key → click **Test Connection** → fail.

## How

- Declare `api_key: str | None = None` on both `AWSBedrockLLMParameters` and `AWSBedrockEmbeddingParameters` so the field survives Pydantic's `model_dump()`. Embedding doesn't re-validate today, but the symmetric declaration defends against a future regression.
- Update `_resolve_bedrock_aws_credentials` to pop `api_key` in `iam_role` and `access_keys` modes (drops Pydantic's `None` default, plus any stale `api_key` from a previous bearer-mode kwargs dict). In legacy mode, pop a blank `api_key` while preserving a non-blank one — the round-trip case the LLM path needs.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

**No.** Validated against every non-bearer flow. Output kwargs are byte-identical to pre-fix:

| Mode | Pre-fix output keys | Post-fix output keys |
|---|---|---|
| `access_keys` | model, temp, n, timeout, max_tokens, max_retries, aws_access_key_id, aws_secret_access_key, aws_region_name, aws_profile_name, model_id | **identical** |
| `iam_role` | model, temp, n, timeout, max_tokens, max_retries, aws_region_name, aws_profile_name, model_id | **identical** |
| legacy (no `auth_type`) | model, temp, n, timeout, max_tokens, max_retries, aws_access_key_id, aws_secret_access_key, aws_region_name, aws_profile_name, model_id | **identical** |
| `bearer_token` | model, ..., api_key | **identical** + now actually survives `LLM.complete()` re-validate |

All 19 pre-existing access_keys / iam_role / legacy / stale-key tests still pass — they explicitly assert `"api_key" not in out` for non-bearer modes, so the resolver pop guarantees no regression.

## Database Migrations

None.

## Env Config

None.

## Relevant Docs

- LiteLLM Bedrock provider — bearer-token consumption: [docs.litellm.ai/docs/providers/bedrock](https://docs.litellm.ai/docs/providers/bedrock)

## Related Issues or PRs

- Follows #1952 (introduced the bearer-token feature and the bug it didn't surface in unit tests).

## Dependencies Versions

None changed.

## Notes on Testing

Run locally:

```sh
cd unstract/sdk1 && uv run pytest tests/test_bedrock_adapter.py -v
```

37 passed (35 pre-existing + 2 new round-trip regression tests):

- `test_llm_bearer_token_survives_revalidation` — pins the LLM bug fix; second `validate()` call must keep `api_key` intact.
- `test_embedding_bearer_token_survives_revalidation` — defensive parity for embedding.

End-to-end smoke check (manual):

- [ ] Rebuild Docker services that vendor `unstract/sdk1`.
- [ ] In the UI, create a Bedrock LLM adapter, switch **Authentication Type** to *Bedrock API Key (Bearer Token)*, paste a valid key, click **Test Connection** — should now succeed (was 401 before this fix).
- [ ] Repeat with `access_keys` and `iam_role` adapters to confirm no regression.

## Screenshots

The UI failure screenshots were attached to the bug report — re-testing them with this branch should show **Test Connection** passing instead of the `Unable to locate credentials` toast.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).