### PR TITLE
UN-3458 [MISC] Add dormant v2 PR template for spec compliance

### DIFF
--- a/.github/pull_request_template_v2.md
+++ b/.github/pull_request_template_v2.md
@@ -1,0 +1,128 @@
+# Context
+
+### Spec PR
+<!-- Link to the merged spec repo PR that authorizes this work. This PR is blocked until the spec PR is merged. -->
+Zipstack/unstract-review-context#____
+
+### Summary
+<!-- One paragraph describing what this implementation delivers. -->
+
+### Implementation Ticket
+<!-- Link to the originating Jira ticket. -->
+
+---
+
+# Implementation Plan
+
+## Exit Criteria (Definition of Done)
+<!-- What conditions must be true for this PR to be considered complete? -->
+
+- [ ] All CI checks pass
+- [ ] Acceptance criteria from spec PR verified
+- [ ] Documentation updated (if applicable)
+- [ ] No regressions introduced
+
+## Implementation Constraints
+<!-- Are there any constraint exceptions being requested? If none, state "No exceptions requested." -->
+
+## Sequencing & Dependencies
+<!-- Which PRs or branches must merge before this? Which PRs does this block? -->
+
+- Depends on: #____
+- Blocks: #____
+
+## Verification Plan
+<!-- How is the correctness of this implementation validated? -->
+
+- [ ] Unit tests added/updated
+- [ ] Integration tests covering: ...
+- [ ] Performance tests (if applicable): ...
+- [ ] Manual verification steps: ...
+
+## Rollout Strategy
+<!-- How does this change reach production safely? -->
+
+- [ ] Feature flag: `flag_name`
+- [ ] Migration required: [ ] reversible [ ] irreversible
+- [ ] Canary / staged rollout plan: ...
+- [ ] Monitoring / alerting in place for: ...
+
+---
+
+# Testing Evidence
+
+## Test Results
+<!-- Paste or link CI output, coverage reports, or manual test evidence. -->
+
+## Risk Assessment
+<!-- What could go wrong with this change? How is that risk mitigated? -->
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+|      |            |        |            |
+
+---
+
+<!-- ================================================================== -->
+<!-- BELOW THIS LINE IS AGENT-GENERATED. DO NOT EDIT.                   -->
+<!-- The reviewer agent compiles this section automatically by          -->
+<!-- cross-checking the PR diff against Spec Compliance artifacts in    -->
+<!-- the spec repo (unstract-review-context).                          -->
+<!-- ================================================================== -->
+
+# Spec Compliance Report
+
+## Verdict
+<!-- PASS / CONFLICT DETECTED — escalated to @org/architects -->
+
+## Spec PR Linkage
+<!-- Verified: spec PR merged / Missing / Mismatched -->
+
+## Compliance Checks
+
+### Product Requirements
+
+#### Acceptance Criteria
+<!-- Does the implementation satisfy the defined business behavior? -->
+
+#### Scope Definition
+<!-- Does the implementation stay within defined scope boundaries? -->
+
+#### Non-Functional Requirements
+<!-- Does the code meet performance, availability, and resource contracts? -->
+
+#### Dependencies
+<!-- Are all dependencies used in this PR present in the approved registry? -->
+
+#### Assumptions & Constraints
+<!-- Does the code violate any active assumptions or constraints? -->
+
+### Specification
+
+#### Architecture Decision Records (ADRs)
+<!-- Does the code conform to active architectural decisions? -->
+
+#### API / Interface Contracts
+<!-- Do request/response schemas match the approved contracts? -->
+
+#### Data Model & State Ownership
+<!-- Does the code respect entity ownership and state transition rules? -->
+
+#### Failure Modes & Resilience
+<!-- Are required resilience patterns (retries, timeouts, circuit breakers) present? -->
+
+#### Security Considerations
+<!-- Are trust boundaries, auth mechanisms, and privilege models respected? -->
+
+#### Implementation Constraints
+<!-- Does the code avoid forbidden patterns and follow required patterns? -->
+
+## Conflicts (if any)
+
+| # | Artifact | File:Line | Violation | Severity |
+|---|----------|-----------|-----------|----------|
+|   |          |           |           |          |
+
+## Recommendation
+<!-- Resolve conflicts before re-requesting review. If any conflict requires -->
+<!-- amending a Spec artifact, raise a new spec PR first.                    -->


### PR DESCRIPTION
## What

- Adds `.github/pull_request_template_v2.md` alongside the existing `pull_request_template.md`.
- Source: framework template at [Zipstack/review-context-framework — `code_repo/.github/pull_request_template.md`](https://github.com/Zipstack/review-context-framework/blob/main/code_repo/.github/pull_request_template.md), with `<product>` → `unstract` substituted on lines 5 and 70.
- Existing `pull_request_template.md` untouched.

## Why

- Part of Review Context Framework adoption tracked in Epic **UN-3459**.
- Once the spec repo ([Zipstack/unstract-review-context](https://github.com/Zipstack/unstract-review-context)) and the reviewer agent are wired up (downstream tasks under UN-3459), this v2 template will replace the current "What/Why/How" form to drive spec-compliance checks at PR review time.
- Parking the file now (dormant) lets us merge the artifact independently from activation, without disrupting current reviewers.

## How

- Net-new file: `.github/pull_request_template_v2.md`.
- GitHub only auto-applies the exact filename `pull_request_template.md` — any other filename (including `pull_request_template_v2.md`) is **ignored**. So this file is completely dormant; PR authors will see zero behavior change.
- Activation later (separate PR) will be a rename:
  ```
  git mv .github/pull_request_template.md    .github/pull_request_template_v1.md.bak
  git mv .github/pull_request_template_v2.md .github/pull_request_template.md
  ```

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- **No.** GitHub's PR template auto-application logic only reads the file named `pull_request_template.md`. The added `pull_request_template_v2.md` is invisible to that logic — it sits in `.github/` as an unused file. No code paths, CI workflows, or reviewer flows depend on it.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- [Zipstack/review-context-framework](https://github.com/Zipstack/review-context-framework) — `README.md`, `WAR_OF_THE_CONTEXTS.md`, `DORA.md`
- Spec repo: [Zipstack/unstract-review-context](https://github.com/Zipstack/unstract-review-context)

## Related Issues or PRs

- Jira sub-task: **UN-3458** (this PR delivers it)
- Parent task: **UN-3457**
- Epic: **UN-3459** (Review Context Framework adoption)
- Sibling PR in `Zipstack/unstract-cloud`: https://github.com/Zipstack/unstract-cloud/pull/1490

## Dependencies Versions

- None.

## Notes on Testing

- Verified file is byte-identical to the framework source apart from the two `<product>` → `unstract` substitutions on lines 5 and 70.
- Verified the existing `pull_request_template.md` is unchanged.
- No runtime behavior to test — the file is dormant per GitHub's auto-template rules.

## Screenshots

N/A (no UI changes).

## Checklist

- [x] I have added an appropriate PR title and description
- [x] I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/)
- [x] My code follows the style guidelines of this project — N/A (template/config file, no code)
- [x] I have solved all the sonar issues — N/A (no Sonar-applicable code)
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas — N/A
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works — N/A (no behavior change)
- [x] New and existing unit tests pass locally with my changes — N/A
- [x] Any dependent changes have been merged and published in downstream modules — N/A
- [x] I have checked my code and corrected any misspellings

