### PR TITLE
UN-3431 [FIX] Restore log_events_id on tool-run dispatch and persist without UI subscriber

### DIFF
--- a/workers/executor/executor_tool_shim.py
+++ b/workers/executor/executor_tool_shim.py
@@ -93,6 +93,9 @@ class ExecutorToolShim(StreamMixin):
         # silently swallowing every subsequent log line at DEBUG.
         self._progress_publish_failed = False
         self._log_publish_failed = False
+        # Adapters whose name+model has already been surfaced to the UI;
+        # later mentions skip repeating the model line.
+        self._adapters_logged: set[str] = set()
         # Initialize StreamMixin.  EXECUTION_BY_TOOL is not set in
         # the worker environment, so _exec_by_tool will be False.
         super().__init__(log_level=LogLevel.INFO)
@@ -229,3 +232,26 @@ class ExecutorToolShim(StreamMixin):
         """
         logger.error(message)
         raise SdkError(message, actual_err=err)
+
+    def log_adapter_once(
+        self,
+        kind: str,
+        adapter_id: str,
+        adapter: Any,
+    ) -> None:
+        """Surface adapter identity to the UI on first use only.
+
+        ``kind`` is the human label ("LLM", "Embedding", "Vector DB").
+        ``adapter`` is an SDK instance — read only for non-sensitive
+        identity (model name or adapter display name); ``adapter_id``
+        is the dedup key. Subsequent calls for the same id are no-ops.
+        """
+        if not adapter_id or adapter_id in self._adapters_logged:
+            return
+        self._adapters_logged.add(adapter_id)
+        get_model = getattr(adapter, "get_model_name", None)
+        if callable(get_model):
+            label = get_model() or adapter_id
+        else:
+            label = getattr(adapter, "_adapter_name", "") or adapter_id
+        self.stream_log(f"Using {kind}: `{label}`")

--- a/workers/executor/executor_tool_shim.py
+++ b/workers/executor/executor_tool_shim.py
@@ -161,41 +161,36 @@ class ExecutorToolShim(StreamMixin):
         if _levels.index(level) < _levels.index(self.log_level):
             return
 
-        # Publish progress to frontend via the log consumer queue.
-        if not self.log_events_id:
-            return
-
         wf_level = _SDK_TO_WF_LEVEL.get(level, "INFO")
 
-        # PROGRESS payload — IDE prompt-card live updates only. Dropped at
-        # the DB persist layer because LogPublisher.publish only stores
-        # payloads whose `type == "LOG"`.
-        try:
-            progress_payload = LogPublisher.log_progress(
-                component=self.component,
-                level=wf_level,
-                state=stage,
-                message=log,
-            )
-            LogPublisher.publish(
-                channel_id=self.log_events_id,
-                payload=progress_payload,
-            )
-        except Exception:
-            first_failure = not self._progress_publish_failed
-            self._progress_publish_failed = True
-            logger.log(
-                logging.WARNING if first_failure else logging.DEBUG,
-                "Failed to publish progress log (non-fatal)",
-                exc_info=first_failure,
-            )
+        # PROGRESS payload routes via the websocket room; skip when absent.
+        if self.log_events_id:
+            try:
+                progress_payload = LogPublisher.log_progress(
+                    component=self.component,
+                    level=wf_level,
+                    state=stage,
+                    message=log,
+                )
+                LogPublisher.publish(
+                    channel_id=self.log_events_id,
+                    payload=progress_payload,
+                )
+            except Exception:
+                first_failure = not self._progress_publish_failed
+                self._progress_publish_failed = True
+                logger.log(
+                    logging.WARNING if first_failure else logging.DEBUG,
+                    "Failed to publish progress log (non-fatal)",
+                    exc_info=first_failure,
+                )
 
-        # LOG payload — feeds workflow logs UI and persists to execution_log.
-        # LogDataDTO validation requires `execution_id` and `organization_id`;
-        # `file_execution_id` is optional.
+        # LOG payload persists to execution_log; falls back to execution_id
+        # as the routing channel so it survives without a websocket subscriber.
         if not (self.execution_id and self.organization_id):
             return
 
+        log_channel = self.log_events_id or self.execution_id
         try:
             log_payload = LogPublisher.log_workflow(
                 stage=stage,
@@ -206,7 +201,7 @@ class ExecutorToolShim(StreamMixin):
                 organization_id=self.organization_id,
             )
             LogPublisher.publish(
-                channel_id=self.log_events_id,
+                channel_id=log_channel,
                 payload=log_payload,
             )
         except Exception:

--- a/workers/executor/executors/index.py
+++ b/workers/executor/executors/index.py
@@ -155,7 +155,6 @@ class Index:
         ):
             return doc_id
 
-        self.tool.stream_log("Indexing file...")
         full_text = [
             {
                 "section": "full",
@@ -171,7 +170,6 @@ class Index:
     def _trigger_indexing(self, vector_db: Any, documents: list) -> None:
         import openai
 
-        self.tool.stream_log("Adding nodes to vector db...")
         try:
             vector_db.index_document(
                 documents,

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -13,6 +13,7 @@ from typing import Any
 from executor.executor_tool_shim import ExecutorToolShim
 from executor.executors.constants import ExecutionSource
 from executor.executors.constants import IndexingConstants as IKeys
+from executor.executors.constants import PromptServiceConstants as PSKeys
 from executor.executors.dto import (
     ChunkingConfig,
     FileInfo,
@@ -242,15 +243,15 @@ class LegacyExecutor(BaseExecutor):
             Path(file_path).name,
             context.run_id,
         )
-        shim.stream_log("Initializing text extractor...")
-        shim.stream_log(f"Using text extractor: {type(x2text.x2text_instance).__name__}")
-
+        extractor_name = type(x2text.x2text_instance).__name__
         try:
-            shim.stream_log("Extracting text from document...")
+            shim.stream_log(
+                f"Extracting text using `{extractor_name}`"
+                + (" (with highlight)" if enable_highlight else "")
+            )
             if enable_highlight and isinstance(
                 x2text.x2text_instance, (LLMWhisperer, LLMWhispererV2)
             ):
-                shim.stream_log("Extracting text with highlight support enabled...")
                 process_response: TextExtractionResult = x2text.process(
                     input_file_path=file_path,
                     output_file_path=output_file_path,
@@ -301,7 +302,6 @@ class LegacyExecutor(BaseExecutor):
                 process_response.extraction_metadata
                 and process_response.extraction_metadata.line_metadata
             ):
-                shim.stream_log("Saving extraction metadata...")
                 result_data["highlight_metadata"] = (
                     process_response.extraction_metadata.line_metadata
                 )
@@ -605,12 +605,23 @@ class LegacyExecutor(BaseExecutor):
         shim = self._build_shim(
             platform_api_key=extract_params.get("platform_api_key", ""),
         )
+
+        # One-shot run-config line — non-sensitive flags only; adapter
+        # identities are emitted inline on first use with full model info.
+        tool_settings = answer_params.get(PSKeys.TOOL_SETTINGS, {})
+        outputs = answer_params.get(PSKeys.OUTPUTS, [])
+        shim.stream_log(
+            f"Run config: prompts={len(outputs)} | "
+            f"single_pass={'on' if is_single_pass else 'off'} | "
+            f"summarize={'on' if is_summarization else 'off'} | "
+            f"challenge="
+            f"{'on' if tool_settings.get(PSKeys.ENABLE_CHALLENGE) else 'off'}"
+        )
         step = 1
 
         try:
             # ---- Step 1: Extract ----
             if not skip_extraction:
-                shim.stream_log(f"Pipeline step {step}: Extracting text from document...")
                 step += 1
                 extract_ctx = ExecutionContext(
                     executor_name=context.executor_name,
@@ -632,7 +643,6 @@ class LegacyExecutor(BaseExecutor):
 
             # ---- Step 2: Summarize (if enabled) ----
             if is_summarization:
-                shim.stream_log(f"Pipeline step {step}: Summarizing extracted text...")
                 step += 1
                 summarize_result = self._run_pipeline_summarize(
                     context=context,
@@ -648,9 +658,6 @@ class LegacyExecutor(BaseExecutor):
                 answer_params["file_path"] = input_file_path
             elif not is_single_pass:
                 # ---- Step 3: Index per output with dedup ----
-                shim.stream_log(
-                    f"Pipeline step {step}: Indexing document into vector store..."
-                )
                 step += 1
                 index_metrics = self._run_pipeline_index(
                     context=context,
@@ -693,7 +700,9 @@ class LegacyExecutor(BaseExecutor):
             index_metrics=index_metrics,
         )
 
-        shim.stream_log("Pipeline completed successfully")
+        output_map = structured_output.get(PSKeys.OUTPUT, {}) or {}
+        answered = sum(1 for v in output_map.values() if v not in (None, "", [], {}))
+        shim.stream_log(f"Pipeline completed: {answered}/{len(outputs)} prompts answered")
         out_metadata = {
             k: v
             for k, v in (answer_result.metadata or {}).items()
@@ -728,12 +737,9 @@ class LegacyExecutor(BaseExecutor):
                 output["chunk-size"] = 0
                 output["chunk-overlap"] = 0
             operation = Operation.SINGLE_PASS_EXTRACTION.value
-            mode_label = "single pass"
         else:
             operation = Operation.ANSWER_PROMPT.value
-            mode_label = "prompt"
 
-        shim.stream_log(f"Pipeline step {step}: Running {mode_label} execution...")
         answer_ctx = ExecutionContext(
             executor_name=context.executor_name,
             operation=operation,
@@ -1075,8 +1081,6 @@ class LegacyExecutor(BaseExecutor):
             Path(file_path).name,
             context.run_id,
         )
-        shim.stream_log("Initializing indexing pipeline...")
-
         # Skip indexing when chunk_size is 0 — no vector operations needed.
         # ChunkingConfig raises ValueError for 0, so handle before DTO.
         if chunk_size == 0:
@@ -1117,7 +1121,6 @@ class LegacyExecutor(BaseExecutor):
             )
             doc_id = index.generate_index_key(file_info=file_info, fs=fs_instance)
             logger.debug("Generated index key: doc_id=%s", doc_id)
-            shim.stream_log("Checking document index status...")
 
             embedding = embedding_compat(
                 adapter_instance_id=embedding_instance_id,
@@ -1129,7 +1132,8 @@ class LegacyExecutor(BaseExecutor):
                 adapter_instance_id=vector_db_instance_id,
                 embedding=embedding,
             )
-            shim.stream_log("Initialized embedding and vector DB adapters")
+            shim.log_adapter_once("Embedding", embedding_instance_id, embedding)
+            shim.log_adapter_once("Vector DB", vector_db_instance_id, vector_db)
 
             doc_id_found = index.is_document_indexed(
                 doc_id=doc_id, embedding=embedding, vector_db=vector_db
@@ -1150,11 +1154,9 @@ class LegacyExecutor(BaseExecutor):
                 )
                 return ExecutionResult(success=True, data={IKeys.DOC_ID: doc_id})
 
-            if doc_id_found and reindex:
-                shim.stream_log("Document already indexed, re-indexing...")
-            else:
-                shim.stream_log("Indexing document for the first time...")
-            shim.stream_log("Indexing document into vector store...")
+            shim.stream_log(
+                "Re-indexing document" if doc_id_found else "Indexing document"
+            )
             index.perform_indexing(
                 vector_db=vector_db,
                 doc_id=doc_id,
@@ -1689,7 +1691,8 @@ class LegacyExecutor(BaseExecutor):
             retrieval_strategy = output.get(PSKeys.RETRIEVAL_STRATEGY)
             valid_strategies = {s.value for s in RetrievalStrategy}
             if retrieval_strategy in valid_strategies:
-                shim.stream_log(f"Retrieving context for: `{prompt_name}`")
+                if chunk_size > 0:
+                    shim.stream_log(f"Retrieving context for: `{prompt_name}`")
                 logger.info(
                     "Performing retrieval: prompt=%s strategy=%s chunk_size=%d",
                     prompt_name,
@@ -1713,9 +1716,11 @@ class LegacyExecutor(BaseExecutor):
                         context_retrieval_metrics=context_retrieval_metrics,
                     )
                 metadata[PSKeys.CONTEXT][prompt_name] = context_list
-                shim.stream_log(
-                    f"Retrieved {len(context_list)} context chunks for: `{prompt_name}`"
-                )
+                if chunk_size > 0:
+                    shim.stream_log(
+                        f"Retrieved {len(context_list)} chunks via RAG "
+                        f"for `{prompt_name}`"
+                    )
                 logger.debug(
                     "Retrieved %d context chunks for prompt: %s",
                     len(context_list),
@@ -1861,6 +1866,11 @@ class LegacyExecutor(BaseExecutor):
                     adapter_instance_id=output[PSKeys.VECTOR_DB],
                     embedding=embedding,
                 )
+            shim.log_adapter_once("LLM", output[PSKeys.LLM], llm)
+            if embedding is not None:
+                shim.log_adapter_once("Embedding", output[PSKeys.EMBEDDING], embedding)
+            if vector_db is not None:
+                shim.log_adapter_once("Vector DB", output[PSKeys.VECTOR_DB], vector_db)
             shim.stream_log(
                 f"Initialized LLM and retrieval adapters for: `{prompt_name}`"
             )
@@ -2274,7 +2284,6 @@ class LegacyExecutor(BaseExecutor):
 
         _, _, _, _, llm_cls, _, _ = self._get_prompt_deps()
 
-        shim.stream_log("Initializing LLM for summarization...")
         llm: Any = None
         try:
             llm = llm_cls(
@@ -2286,7 +2295,9 @@ class LegacyExecutor(BaseExecutor):
                 AnswerPromptService as answer_prompt_svc,
             )
 
-            shim.stream_log("Running document summarization...")
+            shim.stream_log(
+                f"Summarizing extracted text using LLM: `{llm.get_model_name()}`"
+            )
             summary = answer_prompt_svc.run_completion(llm=llm, prompt=prompt)
             records = list(llm.flush_pending_usage())
             logger.info("Summarization completed: run_id=%s", context.run_id)

--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -459,6 +459,7 @@ def _execute_structure_tool_impl(params: dict) -> dict:
             execution_source="tool",
             organization_id=organization_id,
             request_id=file_execution_id,
+            log_events_id=log_events_id,
             execution_id=execution_id,
             file_execution_id=file_execution_id,
             executor_params=agentic_params,
@@ -490,6 +491,7 @@ def _execute_structure_tool_impl(params: dict) -> dict:
             execution_source="tool",
             organization_id=organization_id,
             request_id=file_execution_id,
+            log_events_id=log_events_id,
             execution_id=execution_id,
             file_execution_id=file_execution_id,
             executor_params={


### PR DESCRIPTION
## What

- `workers/file_processing/structure_tool_task.py`: thread `log_events_id` into the `agentic_table` and `structure_pipeline` `ExecutionContext` dispatches.
- `workers/executor/executor_tool_shim.py`: gate only the PROGRESS publish on `log_events_id`; the LOG payload now falls back to `execution_id` as the routing channel.

## Why

- During the agentic_table refactor (#1914), both new dispatch sites stopped passing `log_events_id`. Tool-run logs ("Pipeline step 1: …", "Processing prompt: about", etc.) never reached the workflow execution logs UI for any run that went through `structure_pipeline` — that is the dominant code path.
- `ExecutorToolShim.stream_log` additionally short-circuited at `if not self.log_events_id: return` before the LOG-payload publish, so even contexts that have valid `execution_id` + `organization_id` but no websocket subscriber (API deployments) silently dropped their `execution_log` rows.

## How

- Restore the `log_events_id=log_events_id` kwarg on the two regressed `ExecutionContext` constructions; the third dispatch (`agentic_extraction`) already had it.
- In `ExecutorToolShim.stream_log`, move the PROGRESS branch behind a truthy `log_events_id` check and use `self.log_events_id or self.execution_id` as the LOG channel so persistence works without a UI subscriber. Mirrors backend `WorkflowLog` channel-fallback behaviour.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No regression risk. PROGRESS publishing behaviour is unchanged for IDE / workflow UI runs (still keyed on `log_events_id`). LOG persistence only gains coverage — when `log_events_id` was present, the LOG already used it as channel; when it was absent, the code previously returned and now publishes via `execution_id` instead.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- N/A.

## Related Issues or PRs

- UN-3431
- Regression introduced by #1914 (agentic_table executor refactor).
- Original tool-run log streaming feature: #1927.
- Pairs with the cloud-side fix that threads workflow IDs into plugin tool shims: `Zipstack/unstract-cloud#1491`.

## Dependencies Versions

- None.

## Notes on Testing

Built `unstract/worker-unified:test` from this branch (with the cloud plugin fix overlaid) and recreated all v2 workers locally. Smoke tests to run:

- [ ] Run a structure_pipeline workflow (single prompt, RAG path) via the workflow UI — TOOL_RUN-stage rows should now appear in `unstract.execution_log` and stream live in the workflow logs panel.
- [ ] Run the same workflow as an API deployment (no websocket subscriber) — TOOL_RUN rows should still persist to `execution_log`.
- [ ] Run a Single-Pass Extraction workflow — `Reading document context...`, `Running single-pass extraction with N fields...` lines should appear (covered jointly by this PR + the cloud plugin PR).
- [ ] Run a table / line-item / agentic-table prompt — corresponding extraction lines should appear.
- [ ] Bare IDE run from Prompt Studio — PROGRESS spinner should still update on the prompt card; nothing extra in `execution_log` (unchanged).

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).