### PR TITLE
UN-3463 [FEAT] Add Invitations tab to Manage Users page

### DIFF
--- a/backend/account_v2/dto.py
+++ b/backend/account_v2/dto.py
@@ -124,10 +124,12 @@ class MemberInvitation:
     Attributes:
         id (str): The unique identifier for the invitation.
         email (str): The user email.
-        roles (List[str]): The roles assigned to the invitee.
+        roles (List[str]): Human-readable role names assigned to the invitee.
         created_at (Optional[str]): The timestamp when the invitation
             was created.
         expires_at (Optional[str]): The timestamp when the invitation expires.
+        inviter_name (Optional[str]): Display name of the user who sent the
+            invitation, when available from the auth provider.
     """
 
     id: str
@@ -135,6 +137,7 @@ class MemberInvitation:
     roles: list[str]
     created_at: str | None = None
     expires_at: str | None = None
+    inviter_name: str | None = None
 
 
 @dataclass

--- a/backend/tenant_account_v2/serializer.py
+++ b/backend/tenant_account_v2/serializer.py
@@ -135,8 +135,10 @@ class GetRolesResponseSerializer(serializers.Serializer):
 class ListInvitationsResponseSerializer(serializers.Serializer):
     id = serializers.CharField()
     email = serializers.CharField()
+    roles = serializers.ListField(child=serializers.CharField(), default=list)
     created_at = serializers.CharField()
     expires_at = serializers.CharField()
+    inviter_name = serializers.CharField(allow_null=True, required=False)
 
     def to_representation(self, instance: Any) -> OrderedDict[str, Any]:
         data: OrderedDict[str, Any] = super().to_representation(instance)

--- a/backend/tenant_account_v2/tests/test_invitation_serializer.py
+++ b/backend/tenant_account_v2/tests/test_invitation_serializer.py
@@ -1,0 +1,38 @@
+from account_v2.dto import MemberInvitation
+
+from tenant_account_v2.serializer import ListInvitationsResponseSerializer
+
+
+class TestListInvitationsResponseSerializer:
+    def test_serializes_all_fields(self):
+        invitation = MemberInvitation(
+            id="inv_1",
+            email="alice@example.com",
+            roles=["unstract_admin", "unstract_user"],
+            created_at="2026-05-01T10:00:00Z",
+            expires_at="2026-05-08T10:00:00Z",
+            inviter_name="Bob Smith",
+        )
+
+        data = ListInvitationsResponseSerializer(invitation).data
+
+        assert data["id"] == "inv_1"
+        assert data["email"] == "alice@example.com"
+        assert data["roles"] == ["unstract_admin", "unstract_user"]
+        assert data["created_at"] == "2026-05-01T10:00:00Z"
+        assert data["expires_at"] == "2026-05-08T10:00:00Z"
+        assert data["inviter_name"] == "Bob Smith"
+
+    def test_inviter_name_optional(self):
+        invitation = MemberInvitation(
+            id="inv_2",
+            email="carol@example.com",
+            roles=[],
+            created_at="2026-05-01T10:00:00Z",
+            expires_at="2026-05-08T10:00:00Z",
+        )
+
+        data = ListInvitationsResponseSerializer(invitation).data
+
+        assert data["roles"] == []
+        assert data["inviter_name"] is None

--- a/frontend/src/components/settings/users/Users.css
+++ b/frontend/src/components/settings/users/Users.css
@@ -8,6 +8,14 @@
   overflow-y: auto;
 }
 
+.user-tabs {
+  padding: 0 15px;
+}
+
+.user-tabs .ant-tabs-nav {
+  margin-bottom: 0;
+}
+
 .user-reload-button {
   font-size: 16px;
 }

--- a/frontend/src/components/settings/users/Users.jsx
+++ b/frontend/src/components/settings/users/Users.jsx
@@ -5,11 +5,21 @@ import {
   PlusOutlined,
   ReloadOutlined,
 } from "@ant-design/icons";
-import { Button, Dropdown, Modal, Space, Table, Typography } from "antd";
-import { useEffect, useState } from "react";
+import {
+  Button,
+  Dropdown,
+  Modal,
+  Space,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+} from "antd";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./Users.css";
 
+import { formattedDateTime } from "../../../helpers/GetStaticData.js";
 import { useAxiosPrivate } from "../../../hooks/useAxiosPrivate";
 import { useExceptionHandler } from "../../../hooks/useExceptionHandler.jsx";
 import usePostHogEvents from "../../../hooks/usePostHogEvents.js";
@@ -20,6 +30,9 @@ import { CustomButton } from "../../widgets/custom-button/CustomButton.jsx";
 import { SpinnerLoader } from "../../widgets/spinner-loader/SpinnerLoader.jsx";
 import { TopBar } from "../../widgets/top-bar/TopBar.jsx";
 
+const MEMBERS_TAB = "members";
+const INVITATIONS_TAB = "invitations";
+
 function Users() {
   const axiosPrivate = useAxiosPrivate();
   const { sessionDetails } = useSessionStore();
@@ -28,12 +41,19 @@ function Users() {
   const { setPostHogCustomEvent } = usePostHogEvents();
 
   const [userList, setUserList] = useState([]);
-  const [filteredUserList, setFilteredUserList] = useState(userList);
+  const [filteredUserList, setFilteredUserList] = useState([]);
+  const [invitationList, setInvitationList] = useState([]);
+  const [filteredInvitationList, setFilteredInvitationList] = useState([]);
   const { setAlertDetails } = useAlertStore();
   const [open, setOpen] = useState(false);
   const [confirmLoading, setConfirmLoading] = useState(false);
   const [selectedUserEmail, setSelectedUserEmail] = useState();
+  const [selectedInvitation, setSelectedInvitation] = useState();
+  const [invitationDeleteOpen, setInvitationDeleteOpen] = useState(false);
+  const [invitationDeleteLoading, setInvitationDeleteLoading] = useState(false);
   const [isTableLoading, setIsTableLoading] = useState(false);
+  const [isInvitationsLoading, setIsInvitationsLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState(MEMBERS_TAB);
 
   const { Text } = Typography;
 
@@ -43,6 +63,12 @@ function Users() {
   const removeUser = (emailToRemove) => {
     const newUserList = userList.filter((user) => user.email !== emailToRemove);
     setUserList(newUserList);
+  };
+
+  const removeInvitation = (idToRemove) => {
+    setInvitationList((prev) =>
+      prev.filter((invitation) => invitation.id !== idToRemove),
+    );
   };
 
   const handleDelete = async () => {
@@ -57,7 +83,7 @@ function Users() {
     };
     setConfirmLoading(true);
     axiosPrivate(requestOptions)
-      .then((res) => {
+      .then(() => {
         setConfirmLoading(false);
         setOpen(false);
         removeUser(selectedUserEmail.email);
@@ -71,6 +97,40 @@ function Users() {
 
   const handleCancel = () => {
     setOpen(false);
+  };
+
+  const handleInvitationDeleteCancel = () => {
+    setInvitationDeleteOpen(false);
+  };
+
+  const handleInvitationDelete = async () => {
+    if (!selectedInvitation?.id) {
+      return;
+    }
+    const requestOptions = {
+      method: "DELETE",
+      url: `/api/v1/unstract/${sessionDetails?.orgId}/invitation/${selectedInvitation.id}/`,
+      headers: {
+        "X-CSRFToken": sessionDetails?.csrfToken,
+        "Content-Type": "application/json",
+      },
+    };
+    setInvitationDeleteLoading(true);
+    axiosPrivate(requestOptions)
+      .then(() => {
+        removeInvitation(selectedInvitation.id);
+        setAlertDetails({
+          type: "success",
+          content: "Invitation revoked",
+        });
+      })
+      .catch((err) => {
+        setAlertDetails(handleException(err, "Failed to revoke invitation"));
+      })
+      .finally(() => {
+        setInvitationDeleteLoading(false);
+        setInvitationDeleteOpen(false);
+      });
   };
 
   const getAllUsers = async () => {
@@ -93,6 +153,33 @@ function Users() {
       setAlertDetails(handleException(err, "Failed to load"));
     } finally {
       setIsTableLoading(false);
+    }
+  };
+
+  const getAllInvitations = async () => {
+    try {
+      setIsInvitationsLoading(true);
+      const requestOptions = {
+        method: "GET",
+        url: `/api/v1/unstract/${sessionDetails?.orgId}/invitation/`,
+      };
+      const response = await axiosPrivate(requestOptions);
+      const invitations = response?.data?.members || [];
+      setInvitationList(
+        invitations.map((invitation) => ({
+          key: invitation.id,
+          id: invitation.id,
+          email: invitation.email,
+          roles: invitation.roles || [],
+          inviter_name: invitation.inviter_name,
+          created_at: invitation.created_at,
+          expires_at: invitation.expires_at,
+        })),
+      );
+    } catch (err) {
+      setAlertDetails(handleException(err, "Failed to load invitations"));
+    } finally {
+      setIsInvitationsLoading(false);
     }
   };
 
@@ -175,6 +262,81 @@ function Users() {
       ? [...baseColumns, actionColumn]
       : baseColumns;
 
+  const formatRoleLabel = (name) =>
+    typeof name === "string"
+      ? name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+      : name;
+
+  const isExpired = (expiresAt) => {
+    if (!expiresAt) {
+      return false;
+    }
+    const expiry = new Date(expiresAt).getTime();
+    return Number.isFinite(expiry) && expiry < Date.now();
+  };
+
+  const invitationColumns = [
+    {
+      title: "Email",
+      dataIndex: "email",
+    },
+    {
+      title: "Role",
+      dataIndex: "roles",
+      render: (roles) => {
+        if (!roles?.length) {
+          return "-";
+        }
+        return (
+          <Space size={4} wrap>
+            {roles.map((role) => (
+              <Tag key={role}>{formatRoleLabel(role)}</Tag>
+            ))}
+          </Space>
+        );
+      },
+    },
+    {
+      title: "Invited By",
+      dataIndex: "inviter_name",
+      render: (value) => value || "-",
+    },
+    {
+      title: "Invited On",
+      dataIndex: "created_at",
+      render: (value) => formattedDateTime(value) || "-",
+    },
+    {
+      title: "Expires On",
+      dataIndex: "expires_at",
+      render: (value) => formattedDateTime(value) || "-",
+    },
+    {
+      title: "Status",
+      dataIndex: "expires_at",
+      render: (value) =>
+        isExpired(value) ? (
+          <Tag color="red">Expired</Tag>
+        ) : (
+          <Tag color="gold">Pending</Tag>
+        ),
+    },
+    {
+      title: "Actions",
+      align: "center",
+      render: (_, record) => (
+        <Button
+          type="text"
+          icon={<DeleteOutlined />}
+          onClick={() => {
+            setSelectedInvitation(record);
+            setInvitationDeleteOpen(true);
+          }}
+        />
+      ),
+    },
+  ];
+
   const handleInviteUsers = () => {
     navigate(`/${sessionDetails?.orgName}/users/invite`);
 
@@ -186,21 +348,90 @@ function Users() {
       // If an error occurs while setting custom posthog event, ignore it and continue
     }
   };
+
+  const handleReload = () => {
+    if (activeTab === INVITATIONS_TAB) {
+      getAllInvitations();
+    } else {
+      getAllUsers();
+    }
+  };
+
   useEffect(() => {
     getAllUsers();
+    getAllInvitations();
   }, []);
 
   useEffect(() => {
     setFilteredUserList(userList);
   }, [userList]);
 
+  useEffect(() => {
+    setFilteredInvitationList(invitationList);
+  }, [invitationList]);
+
+  const isInvitationsTab = activeTab === INVITATIONS_TAB;
+  const searchData = isInvitationsTab ? invitationList : userList;
+  const setFilteredData = isInvitationsTab
+    ? setFilteredInvitationList
+    : setFilteredUserList;
+
+  const tabItems = useMemo(
+    () => [
+      {
+        key: MEMBERS_TAB,
+        label: `Members (${userList.length})`,
+        children: (
+          <div className="user-table">
+            <Table
+              columns={columns}
+              dataSource={filteredUserList}
+              size="small"
+              loading={{
+                indicator: <SpinnerLoader />,
+                spinning: isTableLoading,
+              }}
+            />
+          </div>
+        ),
+      },
+      {
+        key: INVITATIONS_TAB,
+        label: `Invitations (${invitationList.length})`,
+        children: (
+          <div className="user-table">
+            <Table
+              columns={invitationColumns}
+              dataSource={filteredInvitationList}
+              size="small"
+              loading={{
+                indicator: <SpinnerLoader />,
+                spinning: isInvitationsLoading,
+              }}
+            />
+          </div>
+        ),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      filteredUserList,
+      filteredInvitationList,
+      isTableLoading,
+      isInvitationsLoading,
+      userList.length,
+      invitationList.length,
+      columns,
+    ],
+  );
+
   return (
     <>
       <TopBar
         enableSearch={true}
         title="Manage Users"
-        searchData={userList}
-        setFilteredUserList={setFilteredUserList}
+        searchData={searchData}
+        setFilteredUserList={setFilteredData}
       >
         {!sessionDetails?.provider && (
           <CustomButton
@@ -214,23 +445,18 @@ function Users() {
         <Button
           shape="circle"
           icon={<ReloadOutlined />}
-          onClick={getAllUsers}
+          onClick={handleReload}
           className="user-reload-button"
         />
       </TopBar>
       <div className="user-bg-col">
         <IslandLayout>
-          <div className="user-table">
-            <Table
-              columns={columns}
-              dataSource={filteredUserList}
-              size="small"
-              loading={{
-                indicator: <SpinnerLoader />,
-                spinning: isTableLoading,
-              }}
-            />
-          </div>
+          <Tabs
+            activeKey={activeTab}
+            onChange={setActiveTab}
+            items={tabItems}
+            className="user-tabs"
+          />
         </IslandLayout>
       </div>
       <Modal
@@ -244,6 +470,22 @@ function Users() {
       >
         <Typography>Are you sure you want to delete user id</Typography>
         <Text strong>{selectedUserEmail?.email}</Text>
+      </Modal>
+      <Modal
+        title="Revoke Invitation"
+        open={invitationDeleteOpen}
+        onOk={handleInvitationDelete}
+        confirmLoading={invitationDeleteLoading}
+        onCancel={handleInvitationDeleteCancel}
+        okText="Revoke"
+        okButtonProps={{ danger: true }}
+        centered
+        className="delete-user-modal"
+      >
+        <Typography>
+          Are you sure you want to revoke the invitation for
+        </Typography>
+        <Text strong>{selectedInvitation?.email}</Text>
       </Modal>
     </>
   );


### PR DESCRIPTION
## What

- Convert the **Manage Users** page (`/users`) into a tabbed view: **Members** + **Invitations**.
- The Invitations tab lists pending invites with columns: **Email**, **Role**, **Invited By**, **Invited On**, **Expires On**, **Status** (Pending / Expired tag), and **Actions** (revoke).
- Revoke flow uses the existing `DELETE /api/v1/unstract/{orgId}/invitation/{id}/` endpoint with a confirmation modal.
- Expose two new fields on `ListInvitationsResponseSerializer`:
  - `roles: list[str]` — human-readable role names (was already present on the underlying DTO; now surfaced through the API)
  - `inviter_name: str | None` — display name of the user who sent the invitation
- Add `inviter_name: str \| None = None` to the shared `MemberInvitation` dataclass.

## Why

- Parent ticket UN-265: "The invited user details tab is missing in User Settings Page." Admins currently have no way to see pending invitations, who they were sent by, when they expire, or whether they've gone stale. They also can't revoke a stale invite from the UI.

## How

- `Users.jsx` is reworked around antd `Tabs` instead of a single table. Search and reload buttons now act on the active tab. Member list logic and revoke-user flow are untouched — only an additional tab + state for invitations.
- New unit tests for `ListInvitationsResponseSerializer` verify that the new fields are surfaced and that `inviter_name` correctly serializes as `null` when absent.
- All UI strings/columns gracefully handle missing values (`"-"`) so the page renders fine before the companion cloud-side change lands.

## Can this PR break any existing features?

No. Changes are additive:
- Serializer fields are added, never removed — existing API consumers ignore unknown fields.
- DTO additions default to `None` / `[]` — existing callers/constructors continue to work.
- The Members tab data path and revoke-user flow are unchanged.
- Frontend renders fine when `inviter_name` is `null` or `roles` is empty.

## Database Migrations

None.

## Env Config

None.

## Related Issues or PRs

- Parent: UN-265
- Sub-task: UN-3463
- Companion cloud-side change: UN-3464 (Auth0 plugin) plumbs `inviter_name` from Auth0 and resolves role IDs to names. This PR ships safely without that one — fields just return `null` / `[]` until cloud lands.

## Dependencies Versions

None.

## Notes on Testing

Backend unit tests (2 passing locally):
```bash
cd backend
pytest tenant_account_v2/tests/test_invitation_serializer.py -v
```

Manual UI test plan:
- [ ] Visit `/{org}/users` as an admin — page renders with **Members** tab active by default.
- [ ] Switch to **Invitations** tab — pending invitations load from `GET /invitation/`.
- [ ] Tab labels show counts: `Members (N)` and `Invitations (M)`.
- [ ] Invitation rows show email, role tags, inviter name (or `-`), invited/expires dates, and a Pending / Expired tag.
- [ ] Search bar filters the active tab's data.
- [ ] Reload button refreshes the active tab.
- [ ] Click delete icon on an invitation → "Revoke Invitation" modal → confirm → row disappears + success alert.
- [ ] Non-admins still hit the existing `RequireAdmin` gate.

## Screenshots

_To be added once running locally._

## Checklist

- [x] I have added an appropriate PR title and description
- [x] I have read and understood the Contribution Guidelines
- [x] My code follows the style guidelines of this project
- [x] I have solved all the sonar issues
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings