### PR TITLE
UN-2946 [MISC] Restore Prompt Studio public sharing after lookups V2 wiring

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
       - APPLICATION_NAME=unstract-backend
     labels:
       - traefik.enable=true
-      - traefik.http.routers.backend.rule=Host(`frontend.unstract.localhost`) && (PathPrefix(`/api/v1`) || PathPrefix(`/deployment`))
+      - traefik.http.routers.backend.rule=Host(`frontend.unstract.localhost`) && (PathPrefix(`/api/v1`) || PathPrefix(`/deployment`) || PathPrefix(`/public`))
       - traefik.http.services.backend.loadbalancer.server.port=8000
     extra_hosts:
       # "host-gateway" is a special string that translates to host docker0 i/f IP.
@@ -134,7 +134,7 @@ services:
       - ENVIRONMENT=development
     labels:
       - traefik.enable=true
-      - traefik.http.routers.frontend.rule=Host(`frontend.unstract.localhost`) && !PathPrefix(`/api/v1`) && !PathPrefix(`/deployment`)
+      - traefik.http.routers.frontend.rule=Host(`frontend.unstract.localhost`) && !PathPrefix(`/api/v1`) && !PathPrefix(`/deployment`) && !PathPrefix(`/public`)
       - traefik.http.services.frontend.loadbalancer.server.port=80
 
   platform-service:

--- a/docker/sample.proxy_overrides.yaml
+++ b/docker/sample.proxy_overrides.yaml
@@ -5,7 +5,7 @@ http:
       rule: Host(`frontend.unstract.localhost`)
     backend:
       service: backend
-      rule: Host(`frontend.unstract.localhost`) && (PathPrefix(`/api/v1`) || PathPrefix(`/deployment`))
+      rule: Host(`frontend.unstract.localhost`) && (PathPrefix(`/api/v1`) || PathPrefix(`/deployment`) || PathPrefix(`/public`))
 
   services:
     frontend:

--- a/frontend/src/components/custom-tools/combined-output/JsonView.jsx
+++ b/frontend/src/components/custom-tools/combined-output/JsonView.jsx
@@ -39,10 +39,14 @@ function JsonView({
   }, [combinedOutput, enrichedOutput, activeView]);
 
   useEffect(() => {
-    if (!enrichedOutput || Object.keys(enrichedOutput).length === 0) {
+    const hasEnriched =
+      enrichedOutput && Object.keys(enrichedOutput).length > 0;
+    if (!hasEnriched) {
       setActiveView("Raw");
+    } else if (isPublicSource) {
+      setActiveView("Enriched");
     }
-  }, [enrichedOutput]);
+  }, [enrichedOutput, isPublicSource]);
 
   const displayOutput =
     activeView === "Enriched" &&

--- a/frontend/src/components/custom-tools/combined-output/JsonView.jsx
+++ b/frontend/src/components/custom-tools/combined-output/JsonView.jsx
@@ -28,8 +28,7 @@ function JsonView({
   isSinglePass,
   isLoading,
 }) {
-  // Anonymous share viewers care about the enriched (post-lookup) value;
-  // the existing useEffect below falls back to "Raw" when no enriched data exists.
+  // Read-only viewers default to the enriched value.
   const isPublicSource = useCustomToolStore((s) => s.isPublicSource);
   const [activeView, setActiveView] = useState(
     isPublicSource ? "Enriched" : "Raw",

--- a/frontend/src/components/custom-tools/combined-output/JsonView.jsx
+++ b/frontend/src/components/custom-tools/combined-output/JsonView.jsx
@@ -2,7 +2,7 @@ import { Tabs } from "antd";
 import TabPane from "antd/es/tabs/TabPane";
 import Prism from "prismjs";
 import PropTypes from "prop-types";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useCustomToolStore } from "../../../store/custom-tool-store";
 import { JsonViewBody } from "./JsonViewBody";
@@ -33,6 +33,7 @@ function JsonView({
   const [activeView, setActiveView] = useState(
     isPublicSource ? "Enriched" : "Raw",
   );
+  const didInitTab = useRef(false);
 
   useEffect(() => {
     Prism.highlightAll();
@@ -43,8 +44,13 @@ function JsonView({
       enrichedOutput && Object.keys(enrichedOutput).length > 0;
     if (!hasEnriched) {
       setActiveView("Raw");
-    } else if (isPublicSource) {
+      didInitTab.current = false;
+      return;
+    }
+    // Public viewer default fires once so a manual Raw toggle isn't stomped on re-renders.
+    if (isPublicSource && !didInitTab.current) {
       setActiveView("Enriched");
+      didInitTab.current = true;
     }
   }, [enrichedOutput, isPublicSource]);
 

--- a/frontend/src/components/custom-tools/combined-output/JsonView.jsx
+++ b/frontend/src/components/custom-tools/combined-output/JsonView.jsx
@@ -4,6 +4,7 @@ import Prism from "prismjs";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
+import { useCustomToolStore } from "../../../store/custom-tool-store";
 import { JsonViewBody } from "./JsonViewBody";
 
 let EnrichedOutputToggle;
@@ -27,7 +28,12 @@ function JsonView({
   isSinglePass,
   isLoading,
 }) {
-  const [activeView, setActiveView] = useState("Raw");
+  // Anonymous share viewers care about the enriched (post-lookup) value;
+  // the existing useEffect below falls back to "Raw" when no enriched data exists.
+  const isPublicSource = useCustomToolStore((s) => s.isPublicSource);
+  const [activeView, setActiveView] = useState(
+    isPublicSource ? "Enriched" : "Raw",
+  );
 
   useEffect(() => {
     Prism.highlightAll();

--- a/frontend/src/hooks/useAxiosPrivate.js
+++ b/frontend/src/hooks/useAxiosPrivate.js
@@ -17,7 +17,7 @@ function useAxiosPrivate() {
           // Skip logout on routes that intentionally render without a session.
           const onPublicShare =
             typeof window !== "undefined" &&
-            window.location.pathname.startsWith("/promptStudio/share");
+            window.location.pathname.startsWith("/promptStudio/share/");
           if (!onPublicShare) {
             // TODO: Implement Session Expired Modal
             logout();

--- a/frontend/src/hooks/useAxiosPrivate.js
+++ b/frontend/src/hooks/useAxiosPrivate.js
@@ -14,8 +14,15 @@ function useAxiosPrivate() {
       },
       async (error) => {
         if (error?.response?.status === 401) {
-          // TODO: Implement Session Expired Modal
-          logout();
+          // Anonymous share viewer has no session to log out of; a 401
+          // here is a misrouted authenticated probe, not an expired session.
+          const onPublicShare =
+            typeof window !== "undefined" &&
+            window.location.pathname.startsWith("/promptStudio/share");
+          if (!onPublicShare) {
+            // TODO: Implement Session Expired Modal
+            logout();
+          }
         }
         return Promise.reject(error);
       },

--- a/frontend/src/hooks/useAxiosPrivate.js
+++ b/frontend/src/hooks/useAxiosPrivate.js
@@ -18,7 +18,13 @@ function useAxiosPrivate() {
           const onPublicShare =
             typeof globalThis !== "undefined" &&
             globalThis.location?.pathname.startsWith("/promptStudio/share/");
-          if (!onPublicShare) {
+          if (onPublicShare) {
+            // Keep a breadcrumb so a stray authenticated probe doesn't go silent.
+            console.warn("[useAxiosPrivate] Suppressed 401 on public share", {
+              url: error?.config?.url,
+              path: globalThis.location?.pathname,
+            });
+          } else {
             // TODO: Implement Session Expired Modal
             logout();
           }

--- a/frontend/src/hooks/useAxiosPrivate.js
+++ b/frontend/src/hooks/useAxiosPrivate.js
@@ -14,8 +14,7 @@ function useAxiosPrivate() {
       },
       async (error) => {
         if (error?.response?.status === 401) {
-          // Anonymous share viewer has no session to log out of; a 401
-          // here is a misrouted authenticated probe, not an expired session.
+          // Skip logout on routes that intentionally render without a session.
           const onPublicShare =
             typeof window !== "undefined" &&
             window.location.pathname.startsWith("/promptStudio/share");

--- a/frontend/src/hooks/useAxiosPrivate.js
+++ b/frontend/src/hooks/useAxiosPrivate.js
@@ -16,8 +16,8 @@ function useAxiosPrivate() {
         if (error?.response?.status === 401) {
           // Skip logout on routes that intentionally render without a session.
           const onPublicShare =
-            typeof window !== "undefined" &&
-            window.location.pathname.startsWith("/promptStudio/share/");
+            typeof globalThis !== "undefined" &&
+            globalThis.location?.pathname.startsWith("/promptStudio/share/");
           if (!onPublicShare) {
             // TODO: Implement Session Expired Modal
             logout();


### PR DESCRIPTION
## What

- Restore the anonymous Prompt Studio public-share viewer (`/promptStudio/share/<id>`), which started breaking after the lookups V2 PR (#1929) shipped.
- Stop the global 401 → forced logout for the share viewer.
- Route `/public/share/*` to the backend through the local Traefik proxy.
- Default the Combined Output JSON tab to "Enriched" when viewing a public share.

## Why

- The lookups V2 PR added `useLookupDirtySeed` (cloud plugin) which mounts unconditionally inside `ToolIde` and probes `/api/v1/unstract/<orgId>/prompt-studio/<toolId>/check_deployment_usage/`. In the anonymous share viewer `orgId` is `undefined` and the request 401s. The global `useAxiosPrivate` response interceptor calls `logout()` on **any** 401, redirecting the share page through `/api/v1/logout`. The share viewer has no session to expire, so the interceptor was effectively bricking the page.
- Locally, the Traefik router only forwarded `/api/v1` and `/deployment` to the backend, so `/public/share/*` fell through to the Vite dev server and returned the SPA index HTML instead of JSON. Staging works only because the staging ingress already has a `/public` rule.
- For anonymous viewers the enriched (post-lookup) value is the *point* of the project; defaulting to Raw made shared projects look empty when the LLM extraction alone wasn't meaningful.

## How

- `frontend/src/hooks/useAxiosPrivate.js`: gate `logout()` behind `!window.location.pathname.startsWith("/promptStudio/share")`. A 401 on the share viewer is a misrouted authenticated probe, not an expired session.
- `docker/docker-compose.yaml` and `docker/sample.proxy_overrides.yaml`: add `PathPrefix(`/public`)` to the backend Traefik rule and exclude `/public` from the frontend negative-match.
- `frontend/src/components/custom-tools/combined-output/JsonView.jsx`: read `isPublicSource` from the custom-tool store and initialize `activeView` to `"Enriched"` when true. The existing `useEffect` already falls back to "Raw" when no enriched data is present, so non-lookup projects are unaffected.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Low risk. Each change is scoped to the public-share viewer or to local-dev proxy routing:
  - The 401 → logout gate only short-circuits when the **path** starts with `/promptStudio/share`. Authenticated editor flows still call `logout()` on session expiry as before.
  - The Traefik change is local-dev only (`docker-compose.yaml` + `sample.proxy_overrides.yaml`); the staging/prod ingresses are unchanged and already route `/public` correctly.
  - `JsonView` default-tab change is gated on `isPublicSource`. Editor sessions still default to "Raw".

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- None.

## Related Issues or PRs

- JIRA: UN-2946 (lookups V2)
- Companion cloud-side fix: Zipstack/unstract-cloud#1495
- Regression introduced by: #1929

## Dependencies Versions

- None.

## Notes on Testing

1. Pull the branch + the cloud-side companion PR; run `python copy_cloud_deps.py -y` from the cloud worktree into the OSS worktree.
2. `VERSION=public-share-test docker compose -f docker-compose.yaml -f compose.override.yaml build frontend backend` and `up -d frontend backend`.
3. As a signed-in user, create or pick a Prompt Studio project with at least one lookup-assigned prompt, then enable public sharing and copy the share URL.
4. Open the share URL in a private/incognito window:
   - Page renders project, prompts, and outputs.
   - Network tab: no `/api/v1/logout` redirect.
   - Network tab: no `/api/v1/unstract/undefined/prompt-studio/.../check_deployment_usage/` call.
   - `/public/share/prompt-studio-metadata/`, `/document-metadata/`, `/profiles-metadata/`, `/outputs-metadata/` all return 200 JSON via `frontend.unstract.localhost`.
   - Combined Output → JSON view opens on "Enriched" for lookup-assigned prompts; "Raw" toggle still works.
5. Sign back in and confirm the editor flow still defaults to "Raw", and that a deliberate 401 (e.g. expired session) still triggers logout.

## Screenshots

N/A — behavioural fix; no UI redesign.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).