### PR TITLE
fix: correct decorator order in prompt-service so auth_required is enforced

### DIFF
--- a/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
+++ b/prompt-service/src/unstract/prompt_service/controllers/answer_prompt.py
@@ -34,8 +34,8 @@ from unstract.sdk1.vector_db import VectorDB
 answer_prompt_bp = Blueprint("answer-prompt", __name__)
 
 
-@AuthHelper.auth_required
 @answer_prompt_bp.route("/answer-prompt", methods=["POST"])
+@AuthHelper.auth_required
 def prompt_processor() -> Any:
     platform_key = AuthHelper.get_token_from_auth_header(request)
     payload: dict[Any, Any] = request.json

--- a/prompt-service/src/unstract/prompt_service/controllers/extraction.py
+++ b/prompt-service/src/unstract/prompt_service/controllers/extraction.py
@@ -18,8 +18,8 @@ REQUIRED_FIELDS = [
 ]
 
 
-@AuthHelper.auth_required
 @extraction_bp.route("/extract", methods=["POST"])
+@AuthHelper.auth_required
 def extract() -> Any:
     platform_key = AuthHelper.get_token_from_auth_header(request)
     payload: dict[Any, Any] = request.json

--- a/prompt-service/src/unstract/prompt_service/controllers/indexing.py
+++ b/prompt-service/src/unstract/prompt_service/controllers/indexing.py
@@ -32,8 +32,8 @@ REQUIRED_FIELDS = [
 ]
 
 
-@AuthHelper.auth_required
 @indexing_bp.route("/index", methods=["POST"])
+@AuthHelper.auth_required
 def index() -> Any:
     """Endpoint for indexing documents into the vector database.
 


### PR DESCRIPTION
## What

Swaps the `@auth_required` / `@route` decorator order in three `prompt-service` controllers
so that Flask registers the **authenticated wrapper**, not the raw handler function.


## Why

Python applies stacked decorators bottom-up. The previous order placed `@auth_required`
on top:

```python
# Before (buggy)
@AuthHelper.auth_required      # applied 2nd — only updates the module-level name
@extraction_bp.route("/extract", methods=["POST"])   # applied 1st — Flask stores raw fn
def extract():
```

Flask finalises its URL map at import time when `@route` is applied. `@auth_required` is
applied afterward, updating only the module-level variable — the URL map already holds the
raw function. As a result, the auth wrapper is never invoked on any incoming request.

Correct order (route first, then auth):

```python
# After (fixed)
@extraction_bp.route("/extract", methods=["POST"])
@AuthHelper.auth_required
def extract():
```

## How

| File | Change |
|------|--------|
| `controllers/extraction.py` | swap decorator order |
| `controllers/indexing.py` | swap decorator order |
| `controllers/answer_prompt.py` | swap decorator order |

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No. The same auth logic is applied — this fix makes it actually run for the first time.
No behavioural changes beyond enforcing the token check that was already implemented.

## Database Migrations

N/A

## Env Config

N/A

## Relevant Docs

N/A

## Related Issues or PRs

N/A

## Dependencies Versions

N/A

## Notes on Testing

```bash
# Before fix: missing Authorization header returns 400/500 (handler-internal error)
# After fix:
curl -s -o /dev/null -w "%{http_code}" \
  -X POST http://localhost:3003/answer-prompt \
  -H 'Content-Type: application/json' -d '{}'
# Expected: 401
```

`platform-service` and `x2text-service` in this repo already use the correct order
(`@route` above auth). This change brings `prompt-service` in line with the same pattern.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).