### PR TITLE
UN-3393 [FEAT] Wire AuditSerializer subclasses through SanitizedSerializerMixin

### DIFF
--- a/backend/api_v2/serializers.py
+++ b/backend/api_v2/serializers.py
@@ -22,7 +22,7 @@ from rest_framework.serializers import (
     ValidationError,
 )
 from tags.serializers import TagParamsSerializer
-from utils.input_sanitizer import validate_name_field, validate_no_html_tags
+from utils.input_sanitizer import validate_name_field
 from utils.serializer.integrity_error_mixin import IntegrityErrorMixin
 from workflow_manager.endpoint_v2.models import WorkflowEndpoint
 from workflow_manager.workflow_v2.exceptions import ExecutionDoesNotExistError
@@ -65,11 +65,6 @@ class APIDeploymentSerializer(IntegrityErrorMixin, AuditSerializer):
 
     def validate_display_name(self, value: str) -> str:
         return validate_name_field(value, field_name="Display name")
-
-    def validate_description(self, value: str) -> str:
-        if value is None:
-            return value
-        return validate_no_html_tags(value, field_name="Description")
 
     def validate_workflow(self, workflow):
         """Validate that the workflow has properly configured source and destination endpoints."""

--- a/backend/api_v2/serializers.py
+++ b/backend/api_v2/serializers.py
@@ -29,7 +29,7 @@ from tenant_account_v2.sharing_helpers import (
     serialize_group_refs,
     serialize_owner_refs,
 )
-from utils.input_sanitizer import validate_name_field, validate_no_html_tags
+from utils.input_sanitizer import validate_name_field
 from utils.serializer.integrity_error_mixin import IntegrityErrorMixin
 from workflow_manager.endpoint_v2.models import WorkflowEndpoint
 from workflow_manager.workflow_v2.exceptions import ExecutionDoesNotExistError
@@ -83,11 +83,6 @@ class APIDeploymentSerializer(IntegrityErrorMixin, AuditSerializer):
 
     def validate_display_name(self, value: str) -> str:
         return validate_name_field(value, field_name="Display name")
-
-    def validate_description(self, value: str) -> str:
-        if value is None:
-            return value
-        return validate_no_html_tags(value, field_name="Description")
 
     def validate_workflow(self, workflow):
         """Validate that the workflow has properly configured source and destination endpoints."""

--- a/backend/backend/serializers.py
+++ b/backend/backend/serializers.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from rest_framework.serializers import ModelSerializer
+from utils.serializer import ModelSerializer
 
 from backend.constants import RequestKey
 

--- a/backend/notification_v2/serializers.py
+++ b/backend/notification_v2/serializers.py
@@ -1,11 +1,12 @@
 from rest_framework import serializers
 from utils.input_sanitizer import validate_name_field
+from utils.serializer import ModelSerializer
 
 from .enums import AuthorizationType, NotificationType, PlatformType
 from .models import Notification
 
 
-class NotificationSerializer(serializers.ModelSerializer):
+class NotificationSerializer(ModelSerializer):
     notification_type = serializers.ChoiceField(choices=NotificationType.choices())
     authorization_type = serializers.ChoiceField(choices=AuthorizationType.choices())
     platform = serializers.ChoiceField(choices=PlatformType.choices(), required=False)

--- a/backend/notification_v2/serializers.py
+++ b/backend/notification_v2/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from utils.input_sanitizer import validate_name_field
+from utils.serializer import ModelSerializer
 
 from .enums import AuthorizationType, NotificationType, PlatformType
 from .models import Notification
@@ -13,7 +14,7 @@ class NotificationSettingsSerializer(serializers.Serializer):
     club_interval_seconds = serializers.IntegerField(min_value=60, max_value=7200)
 
 
-class NotificationSerializer(serializers.ModelSerializer):
+class NotificationSerializer(ModelSerializer):
     notification_type = serializers.ChoiceField(choices=NotificationType.choices())
     authorization_type = serializers.ChoiceField(choices=AuthorizationType.choices())
     platform = serializers.ChoiceField(choices=PlatformType.choices(), required=False)

--- a/backend/prompt_studio/prompt_studio_core_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/serializers.py
@@ -86,8 +86,7 @@ class CustomToolSerializer(IntegrityErrorMixin, AuditSerializer):
     class Meta:
         model = CustomTool
         fields = "__all__"
-        # Tool-level LLM context fields and stored LLM output;
-        # may legitimately contain XML/HTML-like markup.
+        # LLM-facing text legitimately contains XML-like markup.
         html_safe_fields = (
             "summarize_prompt",
             "preamble",

--- a/backend/prompt_studio/prompt_studio_core_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/serializers.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from utils.FileValidator import FileValidator
-from utils.input_sanitizer import validate_name_field, validate_no_html_tags
+from utils.input_sanitizer import validate_name_field
 from utils.serializer.integrity_error_mixin import IntegrityErrorMixin
 
 from backend.serializers import AuditSerializer
@@ -86,6 +86,14 @@ class CustomToolSerializer(IntegrityErrorMixin, AuditSerializer):
     class Meta:
         model = CustomTool
         fields = "__all__"
+        # Tool-level LLM context fields and stored LLM output;
+        # may legitimately contain XML/HTML-like markup.
+        html_safe_fields = (
+            "summarize_prompt",
+            "preamble",
+            "postamble",
+            "output",
+        )
 
     unique_error_message_map: dict[str, dict[str, str]] = {
         "unique_tool_name": {
@@ -98,11 +106,6 @@ class CustomToolSerializer(IntegrityErrorMixin, AuditSerializer):
 
     def validate_tool_name(self, value: str) -> str:
         return validate_name_field(value, field_name="Tool name")
-
-    def validate_description(self, value: str) -> str:
-        if value is None:
-            return value
-        return validate_no_html_tags(value, field_name="Description")
 
     def validate_summarize_llm_adapter(self, value):
         """Validate that the adapter type is LLM and is accessible to the user."""

--- a/backend/prompt_studio/prompt_studio_core_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/serializers.py
@@ -11,7 +11,7 @@ from tenant_account_v2.sharing_helpers import (
     serialize_owner_refs,
 )
 from utils.FileValidator import FileValidator
-from utils.input_sanitizer import validate_name_field, validate_no_html_tags
+from utils.input_sanitizer import validate_name_field
 from utils.serializer.integrity_error_mixin import IntegrityErrorMixin
 
 from backend.serializers import AuditSerializer
@@ -106,6 +106,14 @@ class CustomToolSerializer(IntegrityErrorMixin, AuditSerializer):
         extra_kwargs = {
             "shared_to_org": {"read_only": True},
         }
+        # Tool-level LLM context fields and stored LLM output;
+        # may legitimately contain XML/HTML-like markup.
+        html_safe_fields = (
+            "summarize_prompt",
+            "preamble",
+            "postamble",
+            "output",
+        )
 
     unique_error_message_map: dict[str, dict[str, str]] = {
         "unique_tool_name": {
@@ -118,11 +126,6 @@ class CustomToolSerializer(IntegrityErrorMixin, AuditSerializer):
 
     def validate_tool_name(self, value: str) -> str:
         return validate_name_field(value, field_name="Tool name")
-
-    def validate_description(self, value: str) -> str:
-        if value is None:
-            return value
-        return validate_no_html_tags(value, field_name="Description")
 
     def validate_summarize_llm_adapter(self, value):
         """Validate that the adapter type is LLM and is accessible to the user."""

--- a/backend/prompt_studio/prompt_studio_core_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/serializers.py
@@ -106,8 +106,7 @@ class CustomToolSerializer(IntegrityErrorMixin, AuditSerializer):
         extra_kwargs = {
             "shared_to_org": {"read_only": True},
         }
-        # Tool-level LLM context fields and stored LLM output;
-        # may legitimately contain XML/HTML-like markup.
+        # LLM-facing text legitimately contains XML-like markup.
         html_safe_fields = (
             "summarize_prompt",
             "preamble",

--- a/backend/prompt_studio/prompt_studio_output_manager_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_output_manager_v2/serializers.py
@@ -16,6 +16,13 @@ class PromptStudioOutputSerializer(AuditSerializer):
     class Meta:
         model = PromptStudioOutputManager
         fields = "__all__"
+        # Stored LLM response (`output`) and document chunks (`context`)
+        # routinely contain <thinking>, <context>, and other XML-like
+        # tags from the model. The serializer is mounted on a
+        # ModelViewSet with no class-level method restrictions, so writes
+        # routed through it (DRF admin / browsable API / any future write
+        # endpoint) must accept arbitrary text.
+        html_safe_fields = ("output", "context")
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/backend/prompt_studio/prompt_studio_output_manager_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_output_manager_v2/serializers.py
@@ -16,12 +16,7 @@ class PromptStudioOutputSerializer(AuditSerializer):
     class Meta:
         model = PromptStudioOutputManager
         fields = "__all__"
-        # Stored LLM response (`output`) and document chunks (`context`)
-        # routinely contain <thinking>, <context>, and other XML-like
-        # tags from the model. The serializer is mounted on a
-        # ModelViewSet with no class-level method restrictions, so writes
-        # routed through it (DRF admin / browsable API / any future write
-        # endpoint) must accept arbitrary text.
+        # LLM output/context legitimately contains XML-like tags.
         html_safe_fields = ("output", "context")
 
     def to_representation(self, instance):

--- a/backend/prompt_studio/prompt_studio_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_v2/serializers.py
@@ -26,6 +26,15 @@ class ToolStudioPromptSerializer(AuditSerializer):
     class Meta:
         model = ToolStudioPrompt
         fields = "__all__"
+        # LLM prompt text legitimately contains XML/HTML-like markup
+        # (e.g. <context>, <thinking>). `output` is the LLM response,
+        # which may include any text the model produced.
+        html_safe_fields = (
+            "prompt",
+            "assert_prompt",
+            "assertion_failure_prompt",
+            "output",
+        )
 
 
 class ToolStudioIndexSerializer(serializers.Serializer):

--- a/backend/prompt_studio/prompt_studio_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_v2/serializers.py
@@ -26,9 +26,7 @@ class ToolStudioPromptSerializer(AuditSerializer):
     class Meta:
         model = ToolStudioPrompt
         fields = "__all__"
-        # LLM prompt text legitimately contains XML/HTML-like markup
-        # (e.g. <context>, <thinking>). `output` is the LLM response,
-        # which may include any text the model produced.
+        # Prompts and LLM output legitimately contain XML-like markup.
         html_safe_fields = (
             "prompt",
             "assert_prompt",

--- a/backend/prompt_studio/prompt_studio_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_v2/serializers.py
@@ -29,9 +29,7 @@ class ToolStudioPromptSerializer(AuditSerializer):
         # View owns uniqueness (IntegrityError->DuplicateData on create); drop
         # the DRF auto-validator that 400s on re-save / PUT before the view runs.
         validators = []
-        # LLM prompt text legitimately contains XML/HTML-like markup
-        # (e.g. <context>, <thinking>). `output` is the LLM response,
-        # which may include any text the model produced.
+        # Prompts and LLM output legitimately contain XML-like markup.
         html_safe_fields = (
             "prompt",
             "assert_prompt",

--- a/backend/prompt_studio/prompt_studio_v2/serializers.py
+++ b/backend/prompt_studio/prompt_studio_v2/serializers.py
@@ -29,6 +29,15 @@ class ToolStudioPromptSerializer(AuditSerializer):
         # View owns uniqueness (IntegrityError->DuplicateData on create); drop
         # the DRF auto-validator that 400s on re-save / PUT before the view runs.
         validators = []
+        # LLM prompt text legitimately contains XML/HTML-like markup
+        # (e.g. <context>, <thinking>). `output` is the LLM response,
+        # which may include any text the model produced.
+        html_safe_fields = (
+            "prompt",
+            "assert_prompt",
+            "assertion_failure_prompt",
+            "output",
+        )
 
 
 class ToolStudioIndexSerializer(serializers.Serializer):

--- a/backend/tags/serializers.py
+++ b/backend/tags/serializers.py
@@ -3,11 +3,12 @@ import re
 
 from rest_framework import serializers
 from rest_framework.serializers import CharField, ValidationError
+from utils.serializer import ModelSerializer
 
 from tags.models import Tag
 
 
-class TagSerializer(serializers.ModelSerializer):
+class TagSerializer(ModelSerializer):
     class Meta:
         model = Tag
         fields = ["id", "name", "description"]

--- a/backend/utils/serializer/sanitization.py
+++ b/backend/utils/serializer/sanitization.py
@@ -36,9 +36,14 @@ class SanitizedSerializerMixin:
             if name in exempt or field.read_only:
                 continue
             if isinstance(field, drf.CharField):
+                # Prefer a user-visible label so errors read like
+                # "Prompt key must not contain..." instead of "prompt_key must...".
+                display_name = field.label or name.replace("_", " ").capitalize()
                 # partial binds the field name at iteration time, avoiding the
                 # late-binding closure trap of a bare lambda.
-                field.validators.append(partial(validate_no_html_tags, field_name=name))
+                field.validators.append(
+                    partial(validate_no_html_tags, field_name=display_name)
+                )
 
 
 class ModelSerializer(SanitizedSerializerMixin, drf.ModelSerializer):

--- a/backend/utils/tests/test_sanitized_serializer_mixin.py
+++ b/backend/utils/tests/test_sanitized_serializer_mixin.py
@@ -56,6 +56,17 @@ class TestSanitizedSerializerMixin:
         msg = str(s.errors["description"][0])
         assert "description" in msg.lower()
 
+    def test_error_message_uses_humanised_field_name(self):
+        """snake_case field names are surfaced as 'Snake case' in user-visible errors."""
+
+        class SnakeCaseSerializer(Serializer):
+            prompt_key = drf.CharField()
+
+        s = SnakeCaseSerializer(data={"prompt_key": "<h1>x</h1>"})
+        assert not s.is_valid()
+        msg = str(s.errors["prompt_key"][0])
+        assert msg.startswith("Prompt key ")
+
     def test_html_safe_fields_opts_out(self):
         s = WithOptOutSerializer(
             data={"name": "ok", "prompt": "<thinking>step 1</thinking>"}

--- a/backend/utils/tests/test_sanitized_serializer_mixin.py
+++ b/backend/utils/tests/test_sanitized_serializer_mixin.py
@@ -62,7 +62,7 @@ class TestSanitizedSerializerMixin:
         class SnakeCaseSerializer(Serializer):
             prompt_key = drf.CharField()
 
-        s = SnakeCaseSerializer(data={"prompt_key": "<h1>x</h1>"})
+        s = SnakeCaseSerializer(data={"prompt_key": "<script>x</script>"})
         assert not s.is_valid()
         msg = str(s.errors["prompt_key"][0])
         assert msg.startswith("Prompt key ")

--- a/backend/workflow_manager/workflow_v2/serializers.py
+++ b/backend/workflow_manager/workflow_v2/serializers.py
@@ -14,7 +14,7 @@ from rest_framework.serializers import (
 )
 from tool_instance_v2.serializers import ToolInstanceSerializer
 from tool_instance_v2.tool_instance_helper import ToolInstanceHelper
-from utils.input_sanitizer import validate_name_field, validate_no_html_tags
+from utils.input_sanitizer import validate_name_field
 from utils.serializer.integrity_error_mixin import IntegrityErrorMixin
 
 from backend.constants import RequestKey
@@ -49,11 +49,6 @@ class WorkflowSerializer(IntegrityErrorMixin, AuditSerializer):
 
     def validate_workflow_name(self, value: str) -> str:
         return validate_name_field(value, field_name="Workflow name")
-
-    def validate_description(self, value: str) -> str:
-        if value is None:
-            return value
-        return validate_no_html_tags(value, field_name="Description")
 
     def to_representation(self, instance: Workflow) -> dict[str, str]:
         representation: dict[str, str] = super().to_representation(instance)

--- a/backend/workflow_manager/workflow_v2/serializers.py
+++ b/backend/workflow_manager/workflow_v2/serializers.py
@@ -19,7 +19,7 @@ from tenant_account_v2.sharing_helpers import (
 )
 from tool_instance_v2.serializers import ToolInstanceSerializer
 from tool_instance_v2.tool_instance_helper import ToolInstanceHelper
-from utils.input_sanitizer import validate_name_field, validate_no_html_tags
+from utils.input_sanitizer import validate_name_field
 from utils.serializer.integrity_error_mixin import IntegrityErrorMixin
 
 from backend.constants import RequestKey
@@ -63,11 +63,6 @@ class WorkflowSerializer(IntegrityErrorMixin, AuditSerializer):
 
     def validate_workflow_name(self, value: str) -> str:
         return validate_name_field(value, field_name="Workflow name")
-
-    def validate_description(self, value: str) -> str:
-        if value is None:
-            return value
-        return validate_no_html_tags(value, field_name="Description")
 
     def to_representation(self, instance: Workflow) -> dict[str, str]:
         representation: dict[str, str] = super().to_representation(instance)

--- a/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
+++ b/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
@@ -205,6 +205,16 @@ function DocumentParser({
         return res;
       })
       .catch((err) => {
+        // Field-keyed DRF validation errors are surfaced inline on the
+        // prompt card; re-throw so the card's catch can render them.
+        const data = err?.response?.data;
+        const hasFieldError =
+          data?.type === "validation_error" &&
+          Array.isArray(data?.errors) &&
+          data.errors.some((e) => e?.attr);
+        if (hasFieldError) {
+          throw err;
+        }
         setAlertDetails(handleException(err, "Failed to update"));
       });
   };

--- a/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
+++ b/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
@@ -37,6 +37,19 @@ try {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+const getFieldErrors = (err) => {
+  const data = err?.response?.data;
+  if (data?.type !== "validation_error" || !Array.isArray(data?.errors)) {
+    return {};
+  }
+  return data.errors.reduce((acc, e) => {
+    if (e?.attr) {
+      acc[e.attr] = e.detail || "Invalid value";
+    }
+    return acc;
+  }, {});
+};
+
 function DocumentParser({
   addPromptInstance,
   scrollToBottom,
@@ -140,7 +153,12 @@ function DocumentParser({
     return `/api/v1/unstract/${sessionDetails?.orgId}/prompt-studio/prompt/${urlPath}`;
   };
 
-  const handleChangePromptCard = async (name, value, promptId) => {
+  const handleChangePromptCard = async (
+    name,
+    value,
+    promptId,
+    onFieldError,
+  ) => {
     const promptsAndNotes = details?.prompts || [];
 
     if (name === "prompt_key") {
@@ -205,17 +223,16 @@ function DocumentParser({
         return res;
       })
       .catch((err) => {
-        // Field-keyed DRF validation errors are surfaced inline on the
-        // prompt card; re-throw so the card's catch can render them.
-        const data = err?.response?.data;
-        const hasFieldError =
-          data?.type === "validation_error" &&
-          Array.isArray(data?.errors) &&
-          data.errors.some((e) => e?.attr);
-        if (hasFieldError) {
-          throw err;
+        // Inline rendering of field errors is opt-in: a caller that has no
+        // renderer for the offending field returns false and gets the alert,
+        // so a rejected value can never fail silently.
+        const fieldErrors = getFieldErrors(err);
+        const handledInline =
+          Object.keys(fieldErrors).length > 0 && onFieldError?.(fieldErrors);
+        if (!handledInline) {
+          setAlertDetails(handleException(err, "Failed to update"));
         }
-        setAlertDetails(handleException(err, "Failed to update"));
+        throw err;
       });
   };
 

--- a/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
+++ b/frontend/src/components/custom-tools/document-parser/DocumentParser.jsx
@@ -223,12 +223,10 @@ function DocumentParser({
         return res;
       })
       .catch((err) => {
-        // Inline rendering of field errors is opt-in: a caller that has no
-        // renderer for the offending field returns false and gets the alert,
-        // so a rejected value can never fail silently.
-        const fieldErrors = getFieldErrors(err);
-        const handledInline =
-          Object.keys(fieldErrors).length > 0 && onFieldError?.(fieldErrors);
+        // Reporting the rejection is opt-in: a caller that will not report it
+        // itself returns false and gets the alert, so a rejected value can
+        // never fail silently.
+        const handledInline = onFieldError?.(getFieldErrors(err));
         if (!handledInline) {
           setAlertDetails(handleException(err, "Failed to update"));
         }

--- a/frontend/src/components/custom-tools/editable-text/EditableText.css
+++ b/frontend/src/components/custom-tools/editable-text/EditableText.css
@@ -20,3 +20,9 @@
   font-weight: bold;
   font-size: 14px;
 }
+
+.editable-text-error-message {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+}

--- a/frontend/src/components/custom-tools/editable-text/EditableText.css
+++ b/frontend/src/components/custom-tools/editable-text/EditableText.css
@@ -20,3 +20,9 @@
   font-weight: bold;
   font-size: 13px;
 }
+
+.editable-text-error-message {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+}

--- a/frontend/src/components/custom-tools/editable-text/EditableText.jsx
+++ b/frontend/src/components/custom-tools/editable-text/EditableText.jsx
@@ -1,4 +1,4 @@
-import { Input } from "antd";
+import { Input, Typography } from "antd";
 import debounce from "lodash/debounce";
 import PropTypes from "prop-types";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -17,6 +17,7 @@ function EditableText({
   isTextarea,
   placeHolder,
   isCoverageLoading,
+  error,
 }) {
   const name = isTextarea ? "prompt" : "prompt_key";
   const [triggerHandleChange, setTriggerHandleChange] = useState(false);
@@ -94,24 +95,32 @@ function EditableText({
   }
 
   return (
-    <Input
-      className="width-100 input-header-text"
-      value={text}
-      onChange={handleTextChange}
-      placeholder="Enter Key"
-      name={name}
-      size="small"
-      style={{ backgroundColor: "transparent" }}
-      variant={`${!isEditing && !isHovered ? "borderless" : "outlined"}`}
-      autoSize={true}
-      onMouseOver={() => setIsHovered(true)}
-      onMouseOut={() => setIsHovered(false)}
-      onBlur={handleBlur}
-      onClick={() => setIsEditing(true)}
-      disabled={
-        isCoverageLoading || isSinglePassExtractLoading || isPublicSource
-      }
-    />
+    <>
+      <Input
+        className="width-100 input-header-text"
+        value={text}
+        onChange={handleTextChange}
+        placeholder="Enter Key"
+        name={name}
+        size="small"
+        style={{ backgroundColor: "transparent" }}
+        variant={`${!isEditing && !isHovered ? "borderless" : "outlined"}`}
+        autoSize={true}
+        onMouseOver={() => setIsHovered(true)}
+        onMouseOut={() => setIsHovered(false)}
+        onBlur={handleBlur}
+        onClick={() => setIsEditing(true)}
+        disabled={
+          isCoverageLoading || isSinglePassExtractLoading || isPublicSource
+        }
+        status={error ? "error" : undefined}
+      />
+      {error && (
+        <Typography.Text type="danger" className="editable-text-error-message">
+          {error}
+        </Typography.Text>
+      )}
+    </>
   );
 }
 
@@ -126,6 +135,7 @@ EditableText.propTypes = {
   isTextarea: PropTypes.bool,
   placeHolder: PropTypes.string,
   isCoverageLoading: PropTypes.bool.isRequired,
+  error: PropTypes.string,
 };
 
 export { EditableText };

--- a/frontend/src/components/custom-tools/editable-text/EditableText.jsx
+++ b/frontend/src/components/custom-tools/editable-text/EditableText.jsx
@@ -2,6 +2,7 @@ import debounce from "lodash/debounce";
 import PropTypes from "prop-types";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/shims/antd-inputs";
+import { Typography } from "@/components/ui/shims/antd-typography";
 
 import "./EditableText.css";
 import { useCustomToolStore } from "../../../store/custom-tool-store";
@@ -17,6 +18,7 @@ function EditableText({
   isTextarea,
   placeHolder,
   isCoverageLoading,
+  error,
 }) {
   const name = isTextarea ? "prompt" : "prompt_key";
   const [triggerHandleChange, setTriggerHandleChange] = useState(false);
@@ -94,24 +96,32 @@ function EditableText({
   }
 
   return (
-    <Input
-      className="width-100 input-header-text"
-      value={text}
-      onChange={handleTextChange}
-      placeholder="Enter Key"
-      name={name}
-      size="small"
-      style={{ backgroundColor: "transparent" }}
-      variant={`${!isEditing && !isHovered ? "borderless" : "outlined"}`}
-      autoSize={true}
-      onMouseOver={() => setIsHovered(true)}
-      onMouseOut={() => setIsHovered(false)}
-      onBlur={handleBlur}
-      onClick={() => setIsEditing(true)}
-      disabled={
-        isCoverageLoading || isSinglePassExtractLoading || isPublicSource
-      }
-    />
+    <>
+      <Input
+        className="width-100 input-header-text"
+        value={text}
+        onChange={handleTextChange}
+        placeholder="Enter Key"
+        name={name}
+        size="small"
+        style={{ backgroundColor: "transparent" }}
+        variant={`${!isEditing && !isHovered ? "borderless" : "outlined"}`}
+        autoSize={true}
+        onMouseOver={() => setIsHovered(true)}
+        onMouseOut={() => setIsHovered(false)}
+        onBlur={handleBlur}
+        onClick={() => setIsEditing(true)}
+        disabled={
+          isCoverageLoading || isSinglePassExtractLoading || isPublicSource
+        }
+        status={error ? "error" : undefined}
+      />
+      {error && (
+        <Typography.Text type="danger" className="editable-text-error-message">
+          {error}
+        </Typography.Text>
+      )}
+    </>
   );
 }
 
@@ -126,6 +136,7 @@ EditableText.propTypes = {
   isTextarea: PropTypes.bool,
   placeHolder: PropTypes.string,
   isCoverageLoading: PropTypes.bool.isRequired,
+  error: PropTypes.string,
 };
 
 export { EditableText };

--- a/frontend/src/components/custom-tools/editable-text/EditableText.jsx
+++ b/frontend/src/components/custom-tools/editable-text/EditableText.jsx
@@ -61,7 +61,7 @@ function EditableText({
     if (!triggerHandleChange) {
       return;
     }
-    handleChange(text, promptId, name, true, false);
+    handleChange(text, promptId, name, true, false).catch(() => {});
     setTriggerHandleChange(false);
   }, [triggerHandleChange]);
 

--- a/frontend/src/components/custom-tools/editable-text/EditableText.jsx
+++ b/frontend/src/components/custom-tools/editable-text/EditableText.jsx
@@ -27,6 +27,11 @@ function EditableText({
   const { isSinglePassExtractLoading, isPublicSource } = useCustomToolStore();
 
   useEffect(() => {
+    // A rejected edit rolls the stored value back; keep the typed text on
+    // screen so the user can correct it in place.
+    if (error) {
+      return;
+    }
     setText(defaultText);
   }, [defaultText]);
 

--- a/frontend/src/components/custom-tools/prompt-card/Header.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/Header.jsx
@@ -92,6 +92,7 @@ function Header({
   handleSpsLoading,
   enforceType,
   isAgenticTableReady = true,
+  promptKeyError,
 }) {
   const {
     selectedDoc,
@@ -335,6 +336,7 @@ function Header({
           handleChange={handleChange}
           placeHolder={updatePlaceHolder}
           isCoverageLoading={isCoverageLoading}
+          error={promptKeyError}
         />
       </Col>
       <Col span={12} className="display-flex-right">
@@ -493,6 +495,7 @@ Header.propTypes = {
   handleSpsLoading: PropTypes.func.isRequired,
   enforceType: PropTypes.string,
   isAgenticTableReady: PropTypes.bool,
+  promptKeyError: PropTypes.string,
 };
 
 export { Header };

--- a/frontend/src/components/custom-tools/prompt-card/Header.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/Header.jsx
@@ -97,6 +97,7 @@ function Header({
   handleSpsLoading,
   enforceType,
   isAgenticTableReady = true,
+  promptKeyError,
 }) {
   const {
     selectedDoc,
@@ -384,6 +385,7 @@ function Header({
           handleChange={handleChange}
           placeHolder={updatePlaceHolder}
           isCoverageLoading={isCoverageLoading}
+          error={promptKeyError}
         />
       </Col>
       <Col span={12} className="display-flex-right">
@@ -563,6 +565,7 @@ Header.propTypes = {
   handleSpsLoading: PropTypes.func.isRequired,
   enforceType: PropTypes.string,
   isAgenticTableReady: PropTypes.bool,
+  promptKeyError: PropTypes.string,
 };
 
 export { Header };

--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -53,6 +53,7 @@ const PromptCard = memo(
     const [promptKey, setPromptKey] = useState("");
     const [promptText, setPromptText] = useState("");
     const [selectedLlmProfileId, setSelectedLlmProfileId] = useState(null);
+    const [fieldErrors, setFieldErrors] = useState({});
 
     const [isCoverageLoading, setIsCoverageLoading] = useState(false);
     const [openOutputForDoc, setOpenOutputForDoc] = useState(false);
@@ -157,6 +158,14 @@ const PromptCard = memo(
       const updatedPromptDetailsState = { ...promptDetailsState };
       updatedPromptDetailsState[name] = value;
 
+      // New attempt — drop any prior inline error for this field.
+      setFieldErrors((prev) => {
+        if (!(name in prev)) return prev;
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      });
+
       handleUpdateStatus(
         isUpdateStatus,
         promptId,
@@ -178,9 +187,26 @@ const PromptCard = memo(
             setUpdateStatus,
           );
         })
-        .catch(() => {
+        .catch((err) => {
           handleUpdateStatus(isUpdateStatus, promptId, null, setUpdateStatus);
-          setPromptDetailsState(prevPromptDetailsState);
+          const data = err?.response?.data;
+          const fieldErrorMap = {};
+          if (
+            data?.type === "validation_error" &&
+            Array.isArray(data?.errors)
+          ) {
+            data.errors.forEach((e) => {
+              if (e?.attr) {
+                fieldErrorMap[e.attr] = e.detail || "Invalid value";
+              }
+            });
+          }
+          if (Object.keys(fieldErrorMap).length > 0) {
+            // Keep the typed value so user can fix in place; show inline error.
+            setFieldErrors((prev) => ({ ...prev, ...fieldErrorMap }));
+          } else {
+            setPromptDetailsState(prevPromptDetailsState);
+          }
         })
         .finally(() => {
           if (isUpdateStatus) {
@@ -381,6 +407,7 @@ const PromptCard = memo(
           coverageCountData={coverageCountData}
           isChallenge={isChallenge}
           handleSelectHighlight={handleSelectHighlight}
+          fieldErrors={fieldErrors}
         />
         <OutputForDocModal
           open={openOutputForDoc}

--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -217,12 +217,15 @@ const PromptCard = memo(
             setUpdateStatus,
           );
         })
-        .catch(() => {
+        .catch((err) => {
           handleUpdateStatus(isUpdateStatus, promptId, null, setUpdateStatus);
           if (!handledInline) {
             // Roll back only the field that failed, for the same reason.
             setPromptDetailsState((prev) => ({ ...prev, [name]: prevValue }));
           }
+          // Callers keeping their own copy of the value (Header's webhook and
+          // toggle state) roll back off this rejection.
+          throw err;
         })
         .finally(() => {
           if (isUpdateStatus) {
@@ -235,11 +238,12 @@ const PromptCard = memo(
 
     const handleSelectDefaultLLM = (llmProfileId) => {
       setSelectedLlmProfileId(llmProfileId);
+      // Error already surfaced by handleChange; no local copy to roll back.
       handleChange(
         llmProfileId,
         promptDetailsState?.prompt_id,
         "profile_manager",
-      );
+      ).catch(() => {});
     };
 
     const addCoordsToFlattened = (coords, flattened) => {
@@ -321,7 +325,12 @@ const PromptCard = memo(
         setAlertDetails({ type: "error", content: block.reason });
         return;
       }
-      handleChange(value, promptDetailsState?.prompt_id, "enforce_type", true);
+      handleChange(
+        value,
+        promptDetailsState?.prompt_id,
+        "enforce_type",
+        true,
+      ).catch(() => {});
     };
 
     const handleSpsLoading = (docId, isLoadingStatus) => {

--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -53,6 +53,7 @@ const PromptCard = memo(
     const [promptKey, setPromptKey] = useState("");
     const [promptText, setPromptText] = useState("");
     const [selectedLlmProfileId, setSelectedLlmProfileId] = useState(null);
+    const [fieldErrors, setFieldErrors] = useState({});
 
     const [isCoverageLoading, setIsCoverageLoading] = useState(false);
     const [openOutputForDoc, setOpenOutputForDoc] = useState(false);
@@ -165,6 +166,14 @@ const PromptCard = memo(
        */
       const prevValue = promptDetailsState?.[name];
 
+      // New attempt — drop any prior inline error for this field.
+      setFieldErrors((prev) => {
+        if (!(name in prev)) return prev;
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      });
+
       handleUpdateStatus(
         isUpdateStatus,
         promptId,
@@ -186,10 +195,24 @@ const PromptCard = memo(
             setUpdateStatus,
           );
         })
-        .catch(() => {
+        .catch((err) => {
           handleUpdateStatus(isUpdateStatus, promptId, null, setUpdateStatus);
-          // Roll back only the field that failed, for the same reason.
-          setPromptDetailsState((prev) => ({ ...prev, [name]: prevValue }));
+          const data = err?.response?.data;
+          const fieldErrorMap = {};
+          if (data?.type === "validation_error" && Array.isArray(data?.errors)) {
+            data.errors.forEach((e) => {
+              if (e?.attr) {
+                fieldErrorMap[e.attr] = e.detail || "Invalid value";
+              }
+            });
+          }
+          if (Object.keys(fieldErrorMap).length > 0) {
+            // Keep the typed value so user can fix in place; show inline error.
+            setFieldErrors((prev) => ({ ...prev, ...fieldErrorMap }));
+          } else {
+            // Roll back only the field that failed, for the same reason.
+            setPromptDetailsState((prev) => ({ ...prev, [name]: prevValue }));
+          }
         })
         .finally(() => {
           if (isUpdateStatus) {
@@ -390,6 +413,7 @@ const PromptCard = memo(
           coverageCountData={coverageCountData}
           isChallenge={isChallenge}
           handleSelectHighlight={handleSelectHighlight}
+          fieldErrors={fieldErrors}
         />
         <OutputForDocModal
           open={openOutputForDoc}

--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 import {
   PROMPT_RUN_API_STATUSES,
@@ -58,6 +58,10 @@ const PromptCard = memo(
     const [promptText, setPromptText] = useState("");
     const [selectedLlmProfileId, setSelectedLlmProfileId] = useState(null);
     const [fieldErrors, setFieldErrors] = useState({});
+    // Per-field attempt counter. The key input is debounced, not disabled
+    // while saving, so a slow rejection can land after a newer attempt has
+    // already been accepted; only the latest attempt may touch state.
+    const attemptGen = useRef({});
 
     const [isCoverageLoading, setIsCoverageLoading] = useState(false);
     const [openOutputForDoc, setOpenOutputForDoc] = useState(false);
@@ -170,13 +174,20 @@ const PromptCard = memo(
        */
       const prevValue = promptDetailsState?.[name];
 
+      const generation = (attemptGen.current[name] =
+        (attemptGen.current[name] || 0) + 1);
+      const isLatestAttempt = () => attemptGen.current[name] === generation;
+
+      const clearFieldError = () =>
+        setFieldErrors((prev) => {
+          if (!(name in prev)) return prev;
+          const next = { ...prev };
+          delete next[name];
+          return next;
+        });
+
       // New attempt — drop any prior inline error for this field.
-      setFieldErrors((prev) => {
-        if (!(name in prev)) return prev;
-        const next = { ...prev };
-        delete next[name];
-        return next;
-      });
+      clearFieldError();
 
       handleUpdateStatus(
         isUpdateStatus,
@@ -186,20 +197,19 @@ const PromptCard = memo(
       );
       setPromptDetailsState((prev) => ({ ...prev, [name]: value }));
 
-      let handledInline = false;
-      const showInlineErrors = (fieldErrors) => {
-        const renderable = Object.entries(fieldErrors).filter(([attr]) =>
+      // Collected here but applied in the rejection handler, so the inline
+      // error and the rollback below always land in the same render.
+      let inlineErrors = null;
+      const showInlineErrors = (errors) => {
+        const renderable = Object.entries(errors).filter(([attr]) =>
           RENDERABLE_FIELD_ERRORS.has(attr),
         );
-        if (!renderable.length) {
+        // A superseded attempt cannot render its error, so it must not claim
+        // the field either — the caller falls back to the global alert.
+        if (!renderable.length || !isLatestAttempt()) {
           return false;
         }
-        // Keep the typed value so user can fix in place; show inline error.
-        setFieldErrors((prev) => ({
-          ...prev,
-          ...Object.fromEntries(renderable),
-        }));
-        handledInline = true;
+        inlineErrors = Object.fromEntries(renderable);
         return true;
       };
 
@@ -210,6 +220,9 @@ const PromptCard = memo(
             prev[promptId] = data;
             return prev;
           });
+          if (isLatestAttempt()) {
+            clearFieldError();
+          }
           handleUpdateStatus(
             isUpdateStatus,
             promptId,
@@ -219,9 +232,14 @@ const PromptCard = memo(
         })
         .catch((err) => {
           handleUpdateStatus(isUpdateStatus, promptId, null, setUpdateStatus);
-          if (!handledInline) {
-            // Roll back only the field that failed, for the same reason.
+          if (isLatestAttempt()) {
+            // Roll the field back to the stored value even when the rejected
+            // text stays in the input: outputs, highlights and confidence are
+            // keyed off prompt_key and have to track the server.
             setPromptDetailsState((prev) => ({ ...prev, [name]: prevValue }));
+            if (inlineErrors) {
+              setFieldErrors((prev) => ({ ...prev, ...inlineErrors }));
+            }
           }
           // Callers keeping their own copy of the value (Header's webhook and
           // toggle state) roll back off this rejection.

--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -27,6 +27,10 @@ try {
 const useEnforceTypeSwitchGate =
   useEnforceTypeSwitchGatePlugin || (() => () => null);
 
+// Fields with an inline error renderer on the card. Anything else falls back
+// to the global alert, so widening the sanitizer cannot silence a rejection.
+const RENDERABLE_FIELD_ERRORS = new Set(["prompt_key"]);
+
 const PromptCard = memo(
   ({
     promptDetails,
@@ -181,7 +185,25 @@ const PromptCard = memo(
         setUpdateStatus,
       );
       setPromptDetailsState((prev) => ({ ...prev, [name]: value }));
-      return handleChangePromptCard(name, value, promptId)
+
+      let handledInline = false;
+      const showInlineErrors = (fieldErrors) => {
+        const renderable = Object.entries(fieldErrors).filter(([attr]) =>
+          RENDERABLE_FIELD_ERRORS.has(attr),
+        );
+        if (!renderable.length) {
+          return false;
+        }
+        // Keep the typed value so user can fix in place; show inline error.
+        setFieldErrors((prev) => ({
+          ...prev,
+          ...Object.fromEntries(renderable),
+        }));
+        handledInline = true;
+        return true;
+      };
+
+      return handleChangePromptCard(name, value, promptId, showInlineErrors)
         .then((res) => {
           const data = res?.data;
           setUpdatedPromptsCopy((prev) => {
@@ -195,21 +217,9 @@ const PromptCard = memo(
             setUpdateStatus,
           );
         })
-        .catch((err) => {
+        .catch(() => {
           handleUpdateStatus(isUpdateStatus, promptId, null, setUpdateStatus);
-          const data = err?.response?.data;
-          const fieldErrorMap = {};
-          if (data?.type === "validation_error" && Array.isArray(data?.errors)) {
-            data.errors.forEach((e) => {
-              if (e?.attr) {
-                fieldErrorMap[e.attr] = e.detail || "Invalid value";
-              }
-            });
-          }
-          if (Object.keys(fieldErrorMap).length > 0) {
-            // Keep the typed value so user can fix in place; show inline error.
-            setFieldErrors((prev) => ({ ...prev, ...fieldErrorMap }));
-          } else {
+          if (!handledInline) {
             // Roll back only the field that failed, for the same reason.
             setPromptDetailsState((prev) => ({ ...prev, [name]: prevValue }));
           }

--- a/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCard.jsx
@@ -200,20 +200,26 @@ const PromptCard = memo(
       // Collected here but applied in the rejection handler, so the inline
       // error and the rollback below always land in the same render.
       let inlineErrors = null;
-      const showInlineErrors = (errors) => {
+      const reportFieldError = (errors) => {
+        // A superseded attempt reports nothing: the newer one owns the field
+        // and surfaces its own outcome, so an alert here would contradict the
+        // value the user can see was accepted.
+        if (!isLatestAttempt()) {
+          return true;
+        }
         const renderable = Object.entries(errors).filter(([attr]) =>
           RENDERABLE_FIELD_ERRORS.has(attr),
         );
-        // A superseded attempt cannot render its error, so it must not claim
-        // the field either — the caller falls back to the global alert.
-        if (!renderable.length || !isLatestAttempt()) {
+        // Nothing renderable — the caller falls back to the global alert so a
+        // rejected value can never fail silently.
+        if (!renderable.length) {
           return false;
         }
         inlineErrors = Object.fromEntries(renderable);
         return true;
       };
 
-      return handleChangePromptCard(name, value, promptId, showInlineErrors)
+      return handleChangePromptCard(name, value, promptId, reportFieldError)
         .then((res) => {
           const data = res?.data;
           setUpdatedPromptsCopy((prev) => {

--- a/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
@@ -74,6 +74,7 @@ function PromptCardItems({
   coverageCountData,
   isChallenge,
   handleSelectHighlight,
+  fieldErrors,
 }) {
   const {
     llmProfiles,
@@ -231,6 +232,7 @@ function PromptCardItems({
             handleSpsLoading={handleSpsLoading}
             enforceType={enforceType}
             isAgenticTableReady={isAgenticTableReady}
+            promptKeyError={fieldErrors?.prompt_key}
           />
         </Space>
       </div>
@@ -369,6 +371,7 @@ function PromptCardItems({
 }
 
 PromptCardItems.propTypes = {
+  fieldErrors: PropTypes.object,
   promptDetails: PropTypes.object.isRequired,
   enforceTypeList: PropTypes.array,
   allTableSettings: PropTypes.array,

--- a/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
@@ -70,6 +70,7 @@ function PromptCardItems({
   coverageCountData,
   isChallenge,
   handleSelectHighlight,
+  fieldErrors,
 }) {
   const {
     llmProfiles,
@@ -191,6 +192,7 @@ function PromptCardItems({
             handleSpsLoading={handleSpsLoading}
             enforceType={enforceType}
             isAgenticTableReady={isAgenticTableReady}
+            promptKeyError={fieldErrors?.prompt_key}
           />
         </Space>
       </div>
@@ -333,6 +335,7 @@ function PromptCardItems({
 }
 
 PromptCardItems.propTypes = {
+  fieldErrors: PropTypes.object,
   promptDetails: PropTypes.object.isRequired,
   enforceTypeList: PropTypes.array,
   allTableSettings: PropTypes.array,


### PR DESCRIPTION
## What

- Builds on #1965 (foundation PR) by routing every `AuditSerializer` subclass through `SanitizedSerializerMixin`. ~18 write-path serializers now auto-reject HTML/JS-shaped input on every writable `CharField` / `TextField`.
- Affected (transitively): `WorkflowSerializer`, `CustomToolSerializer`, `APIDeploymentSerializer`, `APIKeySerializer`, `ConnectorInstanceSerializer`, `BaseAdapterSerializer`, `PlatformKeySerializer`, `PlatformApiKey{Create,Update}Serializer`, `PipelineSerializer`, `ToolInstanceSerializer`, `ToolStudioPromptSerializer`, `PromptStudioOutputSerializer`, `ProfileManagerSerializer`, `IndexManagerSerializer`, `PromptStudioRegistry{,Info}Serializer`, `PromptStudioDocumentManagerSerializer`.
- Adds `Meta.html_safe_fields` opt-outs on the two serializers that legitimately carry LLM markup:
  - `ToolStudioPromptSerializer` → `prompt`, `assert_prompt`, `assertion_failure_prompt`, `output`.
  - `CustomToolSerializer` → `summarize_prompt`, `preamble`, `postamble`, `output`.
- Removes the three redundant `validate_description` methods (in `api_v2.APIDeploymentSerializer`, `workflow_v2.WorkflowSerializer`, `prompt_studio_core_v2.CustomToolSerializer`) — the mixin now covers them.

## Why

- The foundation PR (#1965) added `SanitizedSerializerMixin` and pre-mixed `ModelSerializer` / `Serializer` / `HyperlinkedModelSerializer` under `utils.serializer` but did not wire any production serializer through them. This PR is the smallest, highest-leverage wiring step: changing **one** parent class (`AuditSerializer`) closes the input-validation gap on the majority of write-path entities.
- `validate_<name>` methods (which use `validate_name_field`) are kept because they also strip whitespace and reject empty values — behaviour the mixin doesn't duplicate. Only the `validate_description` methods (which just call `validate_no_html_tags`) are removed.
- Free-form LLM prompt / output fields (`prompt`, `output`, `summarize_prompt`, etc.) legitimately contain `<context>` / `<thinking>` / arbitrary model output. They're explicitly opted out via `Meta.html_safe_fields`.

## How

- `backend/backend/serializers.py`: `AuditSerializer` now inherits `utils.serializer.ModelSerializer` instead of `rest_framework.serializers.ModelSerializer`. `create` / `update` semantics unchanged.
- Per-serializer `Meta.html_safe_fields` declarations on the two LLM-bearing serializers (Prompt Studio).
- Three `validate_description` removals + `validate_no_html_tags` import drop from the affected modules.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- **Functional:** The 8 serializers that were already hand-wired (in the in-flight fix) continue to behave identically. The 14 manual `validate_<field>` methods still exist — the mixin's validator is appended to the field's `validators` list, so the same rejection is enforced either way. Removing only the redundant `validate_description` methods avoids double-validation noise but doesn't change any acceptance outcome.
- **New rejections:** `AuditSerializer` subclasses that were *not* previously sanitised now auto-reject HTML in their `CharField` / `TextField` (e.g. `ConnectorInstance.connector_name`, `PlatformKey.key_name`, `Pipeline.pipeline_name`, `AdapterInstance.adapter_name`, etc.). Per the May 2026 US-prod scan (see KB `Obsidian Vault/zipstuff/UN-3393-input-validation/05-prod-baseline.md`), zero legitimate user content uses `<…>` in these columns — every match was pentest leftover. Migration risk: ~zero.
- **LLM fields explicitly opted out:** `prompt`, `assert_prompt`, `assertion_failure_prompt`, `output`, `summarize_prompt`, `preamble`, `postamble` are listed in `Meta.html_safe_fields` so they continue to accept arbitrary text.
- **Direct DRF-base-class users:** Serializers that inherit directly from `serializers.ModelSerializer` / `serializers.Serializer` / `serializers.HyperlinkedModelSerializer` (i.e. not via `AuditSerializer`) are **not** touched by this PR. They remain unchanged. A follow-up sweep will convert them; their absence here means write paths through them retain pre-PR behaviour.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- KB: `Obsidian Vault/zipstuff/UN-3393-input-validation/`.
- ADR 0003 (`adr/0003-base-mixin-default-on-opt-out.md`) — opt-out semantics.

## Related Issues or PRs

- Jira: UN-3393.
- Stacked on: #1965 (foundation).
- Follow-up: a separate PR that converts the remaining ~20 direct DRF-base-class users (`tags/serializers.py`, `scheduler/serializer.py`, `tenant_account_v2/serializer.py`, `pipeline_v2/serializers/{internal,update,sharing,execute}.py`, response-only and list serializers across the codebase, …).
- Follow-up: cover `backend/pluggable_apps/` (lives in the `unstract-cloud` repo; separate PR there).

## Dependencies Versions

- None.

## Notes on Testing

Local tests in the OSS worktree (cloud-deps not installed, so `manage.py check` is unavailable here — CI runs the full suite):

```bash
cd backend && uv run pytest utils/tests/ -q
```

→ 85 passed (50 from foundation + 35 pre-existing utils tests).

Manual sanity:

```bash
cd backend && uv run python -c "from utils.serializer import ModelSerializer; from backend.serializers import AuditSerializer; assert issubclass(AuditSerializer, ModelSerializer); print('ok')"
```

## Screenshots

n/a (no UI change)

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).