### PR TITLE
perf: skip unnecessary shared user queries

### DIFF
--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -346,7 +346,7 @@ class AdapterInstanceViewSet(ModelViewSet):
         response = super().partial_update(request, *args, **kwargs)
 
         # Send email notifications to newly shared users
-        if response.status_code == 200 and shared_users_updated:
+        if response.status_code == 200 and shared_users_updated and bool(notification_plugin):
             try:
                 adapter.refresh_from_db()
                 new_shared_users = set(adapter.shared_users.all())

--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -346,7 +346,11 @@ class AdapterInstanceViewSet(ModelViewSet):
         response = super().partial_update(request, *args, **kwargs)
 
         # Send email notifications to newly shared users
-        if response.status_code == 200 and shared_users_updated and bool(notification_plugin):
+        if (
+            response.status_code == 200
+            and shared_users_updated
+            and bool(notification_plugin)
+        ):
             try:
                 adapter.refresh_from_db()
                 new_shared_users = set(adapter.shared_users.all())

--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -294,16 +294,17 @@ class AdapterInstanceViewSet(ModelViewSet):
     def partial_update(
         self, request: Request, *args: tuple[Any], **kwargs: dict[str, Any]
     ) -> Response:
-        # Store current shared users before update (for email notifications)
         adapter = self.get_object()
-        current_shared_users = set(adapter.shared_users.all())
+        shared_users_updated = AdapterKeys.SHARED_USERS in request.data
+        current_shared_users = set()
 
-        if AdapterKeys.SHARED_USERS in request.data:
+        if shared_users_updated:
+            current_shared_users = set(adapter.shared_users.all())
             # find the deleted users
             shared_users = {
                 int(user_id) for user_id in request.data.get("shared_users", {})
             }
-            current_users = {user.id for user in adapter.shared_users.all()}
+            current_users = {user.id for user in current_shared_users}
             removed_users = current_users.difference(shared_users)
 
             # if removed user use this adapter as default
@@ -345,7 +346,7 @@ class AdapterInstanceViewSet(ModelViewSet):
         response = super().partial_update(request, *args, **kwargs)
 
         # Send email notifications to newly shared users
-        if response.status_code == 200 and AdapterKeys.SHARED_USERS in request.data:
+        if response.status_code == 200 and shared_users_updated:
             try:
                 adapter.refresh_from_db()
                 new_shared_users = set(adapter.shared_users.all())

--- a/backend/api_v2/api_deployment_views.py
+++ b/backend/api_v2/api_deployment_views.py
@@ -373,7 +373,10 @@ class APIDeploymentViewSet(viewsets.ModelViewSet):
         """Override partial_update to handle sharing notifications."""
         # Get current instance and shared users
         instance = self.get_object()
-        current_shared_users = set(instance.shared_users.all())
+        shared_users_updated = "shared_users" in request.data
+        current_shared_users = set()
+        if shared_users_updated:
+            current_shared_users = set(instance.shared_users.all())
 
         # Perform the update
         response = super().partial_update(request, *args, **kwargs)
@@ -381,7 +384,7 @@ class APIDeploymentViewSet(viewsets.ModelViewSet):
         # If successful and shared_users changed, send notifications
         if (
             response.status_code == 200
-            and "shared_users" in request.data
+            and shared_users_updated
             and notification_plugin
         ):
             try:

--- a/backend/api_v2/api_deployment_views.py
+++ b/backend/api_v2/api_deployment_views.py
@@ -382,11 +382,7 @@ class APIDeploymentViewSet(viewsets.ModelViewSet):
         response = super().partial_update(request, *args, **kwargs)
 
         # If successful and shared_users changed, send notifications
-        if (
-            response.status_code == 200
-            and shared_users_updated
-            and notification_plugin
-        ):
+        if response.status_code == 200 and shared_users_updated and notification_plugin:
             try:
                 instance.refresh_from_db()
                 new_shared_users = set(instance.shared_users.all())

--- a/backend/connector_v2/views.py
+++ b/backend/connector_v2/views.py
@@ -204,13 +204,16 @@ class ConnectorInstanceViewSet(viewsets.ModelViewSet):
     def partial_update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Override to handle sharing notifications."""
         instance = self.get_object()
-        current_shared_users = set(instance.shared_users.all())
+        shared_users_updated = "shared_users" in request.data
+        current_shared_users = set()
+        if shared_users_updated:
+            current_shared_users = set(instance.shared_users.all())
 
         response = super().partial_update(request, *args, **kwargs)
 
         if (
             response.status_code == 200
-            and "shared_users" in request.data
+            and shared_users_updated
             and bool(notification_plugin)
         ):
             try:

--- a/backend/pipeline_v2/views.py
+++ b/backend/pipeline_v2/views.py
@@ -143,13 +143,16 @@ class PipelineViewSet(viewsets.ModelViewSet):
     def partial_update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Override to handle sharing notifications."""
         instance = self.get_object()
-        current_shared_users = set(instance.shared_users.all())
+        shared_users_updated = "shared_users" in request.data
+        current_shared_users = set()
+        if shared_users_updated:
+            current_shared_users = set(instance.shared_users.all())
 
         response = super().partial_update(request, *args, **kwargs)
 
         if (
             response.status_code == 200
-            and "shared_users" in request.data
+            and shared_users_updated
             and notification_plugin
         ):
             try:

--- a/backend/pipeline_v2/views.py
+++ b/backend/pipeline_v2/views.py
@@ -150,11 +150,7 @@ class PipelineViewSet(viewsets.ModelViewSet):
 
         response = super().partial_update(request, *args, **kwargs)
 
-        if (
-            response.status_code == 200
-            and shared_users_updated
-            and notification_plugin
-        ):
+        if response.status_code == 200 and shared_users_updated and notification_plugin:
             try:
                 instance.refresh_from_db()
                 new_shared_users = set(instance.shared_users.all())

--- a/backend/prompt_studio/prompt_studio_core_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/views.py
@@ -266,15 +266,17 @@ class PromptStudioCoreView(viewsets.ModelViewSet):
     def partial_update(
         self, request: Request, *args: tuple[Any], **kwargs: dict[str, Any]
     ) -> Response:
-        # Store current shared users before update for email notifications
         custom_tool = self.get_object()
-        current_shared_users = set(custom_tool.shared_users.all())
+        shared_users_updated = "shared_users" in request.data
+        current_shared_users = set()
+        if shared_users_updated:
+            current_shared_users = set(custom_tool.shared_users.all())
 
         # Perform the update
         response = super().partial_update(request, *args, **kwargs)
 
         # Send email notifications to newly shared users
-        if response.status_code == 200 and "shared_users" in request.data:
+        if response.status_code == 200 and shared_users_updated:
             from plugins import get_plugin
 
             notification_plugin = get_plugin("notification")

--- a/backend/utils/tests/test_shared_user_query_optimizations.py
+++ b/backend/utils/tests/test_shared_user_query_optimizations.py
@@ -31,15 +31,15 @@ def test_workflow_partial_update_skips_shared_user_lookup_without_share_changes(
     workflow.shared_users.all.assert_not_called()
 
 
-def test_adapter_partial_update_reuses_pre_update_shared_users() -> None:
+def test_adapter_partial_update_queries_shared_users_once_without_notification_plugin() -> None:
+    # When notification_plugin is absent (the common test-env case), the post-update
+    # comparison block is skipped entirely. Only one pre-update snapshot query should
+    # be made — the old code made two (snapshot + duplicate ID extraction).
     view = AdapterInstanceViewSet()
     shared_user_1 = SimpleNamespace(id=1)
     shared_user_2 = SimpleNamespace(id=2)
     adapter = MagicMock(adapter_type="LLM", adapter_name="Adapter", id=1)
-    adapter.shared_users.all.side_effect = [
-        [shared_user_1, shared_user_2],
-        [shared_user_1, shared_user_2],
-    ]
+    adapter.shared_users.all.return_value = [shared_user_1, shared_user_2]
     request = SimpleNamespace(
         data={"shared_users": ["1", "2"]},
         user=MagicMock(),
@@ -53,8 +53,10 @@ def test_adapter_partial_update_reuses_pre_update_shared_users() -> None:
             autospec=True,
             return_value=Response(status=status.HTTP_200_OK),
         ),
+        patch("adapter_processor_v2.views.notification_plugin", None),
     ):
         response = view.partial_update(request)
 
     assert response.status_code == status.HTTP_200_OK
-    assert adapter.shared_users.all.call_count == 2
+    # Pre-update snapshot only — the duplicate ID-extraction query is gone.
+    assert adapter.shared_users.all.call_count == 1

--- a/backend/utils/tests/test_shared_user_query_optimizations.py
+++ b/backend/utils/tests/test_shared_user_query_optimizations.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from rest_framework import status, viewsets
+from rest_framework.response import Response
+
+from adapter_processor_v2.views import AdapterInstanceViewSet
+from workflow_manager.workflow_v2.views import WorkflowViewSet
+
+
+def test_workflow_partial_update_skips_shared_user_lookup_without_share_changes() -> None:
+    view = WorkflowViewSet()
+    workflow = MagicMock()
+    workflow.shared_users.all.side_effect = AssertionError(
+        "shared_users should not be queried for non-sharing updates"
+    )
+    request = SimpleNamespace(data={"workflow_name": "renamed"}, user=MagicMock())
+
+    with (
+        patch.object(WorkflowViewSet, "get_object", return_value=workflow),
+        patch.object(
+            viewsets.ModelViewSet,
+            "partial_update",
+            autospec=True,
+            return_value=Response(status=status.HTTP_200_OK),
+        ),
+    ):
+        response = view.partial_update(request)
+
+    assert response.status_code == status.HTTP_200_OK
+    workflow.shared_users.all.assert_not_called()
+
+
+def test_adapter_partial_update_reuses_pre_update_shared_users() -> None:
+    view = AdapterInstanceViewSet()
+    shared_user_1 = SimpleNamespace(id=1)
+    shared_user_2 = SimpleNamespace(id=2)
+    adapter = MagicMock(adapter_type="LLM", adapter_name="Adapter", id=1)
+    adapter.shared_users.all.side_effect = [
+        [shared_user_1, shared_user_2],
+        [shared_user_1, shared_user_2],
+    ]
+    request = SimpleNamespace(
+        data={"shared_users": ["1", "2"]},
+        user=MagicMock(),
+    )
+
+    with (
+        patch.object(AdapterInstanceViewSet, "get_object", return_value=adapter),
+        patch.object(
+            viewsets.ModelViewSet,
+            "partial_update",
+            autospec=True,
+            return_value=Response(status=status.HTTP_200_OK),
+        ),
+    ):
+        response = view.partial_update(request)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert adapter.shared_users.all.call_count == 2

--- a/backend/workflow_manager/workflow_v2/views.py
+++ b/backend/workflow_manager/workflow_v2/views.py
@@ -140,9 +140,12 @@ class WorkflowViewSet(viewsets.ModelViewSet):
         """Override partial_update to handle sharing notifications."""
         # Get the workflow instance before update
         workflow = self.get_object()
+        shared_users_updated = "shared_users" in request.data
 
-        # Store current shared users for comparison
-        current_shared_users = set(workflow.shared_users.all())
+        # Store current shared users for comparison only when sharing changes.
+        current_shared_users = set()
+        if shared_users_updated:
+            current_shared_users = set(workflow.shared_users.all())
 
         # Perform the standard partial update
         response = super().partial_update(request, *args, **kwargs)
@@ -150,7 +153,7 @@ class WorkflowViewSet(viewsets.ModelViewSet):
         # If update was successful and shared_users field was modified
         if (
             response.status_code == 200
-            and "shared_users" in request.data
+            and shared_users_updated
             and bool(notification_plugin)
         ):
             try:


### PR DESCRIPTION
## Summary
- skip `shared_users` lookups in shareable resource `partial_update` handlers unless the request actually updates sharing
- reuse the adapter pre-update `shared_users` snapshot instead of querying the same M2M relation twice before the update
- add regression tests for the non-sharing update path and the adapter query reuse path

## Why
This was the highest-impact, lowest-effort performance win from the audit: these endpoints were paying for M2M reads on every partial update, even when the request changed unrelated fields, and adapters were issuing the same pre-update query twice.

## Validation
- `python3 -m py_compile backend/adapter_processor_v2/views.py backend/workflow_manager/workflow_v2/views.py backend/pipeline_v2/views.py backend/connector_v2/views.py backend/prompt_studio/prompt_studio_core_v2/views.py backend/api_v2/api_deployment_views.py backend/utils/tests/test_shared_user_query_optimizations.py`
- `uv run ...` local lint/test execution is currently blocked by repository `uv.lock` parse errors (`banks` wheel version mismatch and ambiguous `office365-rest-python-client` source)