### PR TITLE
UN-3476 [FIX] Revert atomic wrap on set_user_organization

### DIFF
--- a/backend/account_v2/authentication_controller.py
+++ b/backend/account_v2/authentication_controller.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from django.conf import settings
 from django.contrib.auth import logout as django_logout
-from django.db import transaction
 from django.db.utils import IntegrityError
 from django.http import HttpRequest
 from django.middleware import csrf
@@ -164,7 +163,6 @@ class AuthenticationController:
 
         return response
 
-    @transaction.atomic
     def set_user_organization(self, request: Request, organization_id: str) -> Response:
         user: User = request.user
         new_organization = False


### PR DESCRIPTION
## What

Revert of the `@transaction.atomic` wrap on `AuthenticationController.set_user_organization` introduced in PR #1954 (`8b29fea02`). Two-line diff: drop the decorator and its import.

## Why

PR #1954 caused a regression. Since `2026-05-19 09:47 UTC`, every new signup on globe.unstract.com received a broken free-trial X2Text adapter (401 "Access denied due to invalid subscription key" on first OCR).

Mechanism:

- `set_user_organization` inserts the org row, then makes an HTTP call to the LLM Whisperer portal (`/onboarding-setup/`) to provision the X2Text adapter's subscription key.
- The portal is a separate Django service on a separate DB session (PgBouncer). Under PostgreSQL READ COMMITTED, it cannot see the org row while it's still uncommitted in the calling transaction.
- Portal returns 400 -> caller silently writes an empty `unstract_key` -> every subsequent OCR call gets 401.

Removing the atomic wrap restores the pre-#1954 behaviour: the org INSERT commits before the portal call runs, so the portal can see it.

### Why only the X2Text adapter breaks

The other three frictionless adapters (LLM, Vector DB, Embedding) are pure-local INSERTs from pre-baked env config, executed in the same DB session that holds the uncommitted org row - they read their own writes. Only X2Text crosses a process boundary to a service with an independent DB session, so only X2Text trips on the uncommitted-row visibility.

### Scope

Revert only. The silent-swallow in `create_subscription_and_retrieve_key` (which turns the portal 400 into an empty key written to the adapter row) is pre-existing brittleness and intentionally **not** addressed here - separate follow-up.

Stranded orgs from the regression window (2002, 2003, 2004, 2006, 2007, 2008, 2009) are recoverable via the existing `setup_frictionless_onboarding` mgmt command.

## Can this PR break any existing features?

No. It restores the exact pre-#1954 behaviour of `set_user_organization`. The original orphan-org-on-portal-failure edge case PR #1954 was trying to address comes back, but that was tolerated for years pre-#1954 and is much rarer than the regression it caused.

## Database Migrations

None.

## Env Config

None.

## Related Issues or PRs

- Jira: UN-3476
- Reverts the runtime effect of #1954.

## Notes on Testing

- [ ] New signup with fresh user on dev namespace -> all 4 free-trial adapters created; first OCR works.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).