### PR TITLE
[MISC] Handle reasoning models in OpenAI-compatible LLM adapter

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -346,11 +346,42 @@ class OpenAILLMParameters(BaseChatCompletionParameters):
             return f"openai/{model}"
 
 
+# Anchored to the start or a path separator and to the trailing edge so that
+# look-alike ids (e.g. `gpt-50`) do not match.
+_REASONING_MODEL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?:^|/)gpt-5(?=$|[-.])"),
+    re.compile(r"(?:^|/)o[1-9](?=$|[-.])"),
+)
+
+
+def _is_reasoning_model(model: str | None) -> bool:
+    """Return True when the model id matches a known OpenAI reasoning family."""
+    if not model:
+        return False
+    normalized = model.lower().replace("_", "-")
+    return any(rx.search(normalized) for rx in _REASONING_MODEL_PATTERNS)
+
+
+def _apply_reasoning_param_compat(validated: dict[str, "Any"]) -> None:
+    """Reshape sampling params in place for OpenAI reasoning models.
+
+    Reasoning models reject `temperature` != 1 and require
+    `max_completion_tokens` over `max_tokens`. litellm applies this for
+    providers it has model metadata for; the generic OpenAI-compatible
+    provider has none, so the adapter handles it.
+    """
+    validated.pop("temperature", None)
+    max_tokens = validated.pop("max_tokens", None)
+    if max_tokens is not None:
+        validated["max_completion_tokens"] = max_tokens
+
+
 class OpenAICompatibleLLMParameters(BaseChatCompletionParameters):
     """See https://docs.litellm.ai/docs/providers/openai_compatible/."""
 
     api_key: str | None = None
     api_base: str
+    reasoning_effort: str | None = None
 
     @staticmethod
     def validate(adapter_metadata: dict[str, "Any"]) -> dict[str, "Any"]:
@@ -360,7 +391,38 @@ class OpenAICompatibleLLMParameters(BaseChatCompletionParameters):
         api_key = adapter_metadata.get("api_key")
         if isinstance(api_key, str) and not api_key.strip():
             adapter_metadata["api_key"] = None
-        return OpenAICompatibleLLMParameters(**adapter_metadata).model_dump()
+
+        # `reasoning_effort` applies only when reasoning is explicitly enabled.
+        enable_reasoning = adapter_metadata.get("enable_reasoning", False)
+        if not enable_reasoning and adapter_metadata.get("reasoning_effort"):
+            enable_reasoning = True
+
+        result_metadata = adapter_metadata.copy()
+        if enable_reasoning:
+            result_metadata["reasoning_effort"] = adapter_metadata.get(
+                "reasoning_effort", "medium"
+            )
+
+        exclude_fields = {"enable_reasoning"}
+        if not enable_reasoning:
+            exclude_fields.add("reasoning_effort")
+        validation_metadata = {
+            k: v for k, v in result_metadata.items() if k not in exclude_fields
+        }
+
+        validated = OpenAICompatibleLLMParameters(**validation_metadata).model_dump()
+
+        if enable_reasoning:
+            validated["reasoning_effort"] = result_metadata["reasoning_effort"]
+        else:
+            validated.pop("reasoning_effort", None)
+
+        # Apply param compatibility for recognized reasoning models, or when
+        # reasoning is explicitly enabled (covers non-standard model names).
+        if enable_reasoning or _is_reasoning_model(validated.get("model")):
+            _apply_reasoning_param_compat(validated)
+
+        return validated
 
     @staticmethod
     def validate_model(adapter_metadata: dict[str, "Any"]) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/custom_openai.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/custom_openai.json
@@ -55,6 +55,53 @@
       "title": "Timeout",
       "default": 900,
       "description": "Timeout in seconds."
+    },
+    "enable_reasoning": {
+      "type": "boolean",
+      "title": "Enable Reasoning",
+      "default": false,
+      "description": "Allow the model to apply extra reasoning for complex tasks. Recognized reasoning models (gpt-5, o-series) are handled automatically; enable this only to tune the reasoning effort, or for reasoning models served under a non-standard name."
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "enable_reasoning": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "reasoning_effort": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "default": "medium",
+            "title": "Reasoning Effort",
+            "description": "Sets the Reasoning Strength when Reasoning Effort is enabled"
+          }
+        },
+        "required": [
+          "reasoning_effort"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "enable_reasoning": {
+            "const": false
+          }
+        }
+      },
+      "then": {
+        "properties": {}
+      }
+    }
+  ]
 }

--- a/unstract/sdk1/tests/test_openai_compatible_adapter.py
+++ b/unstract/sdk1/tests/test_openai_compatible_adapter.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from importlib import import_module
 from unittest.mock import MagicMock, patch
 
+import pytest
 from unstract.sdk1.adapters.base1 import OpenAICompatibleLLMParameters
 from unstract.sdk1.adapters.constants import Common
 from unstract.sdk1.adapters.llm1 import adapters
@@ -97,7 +98,7 @@ def test_openai_compatible_validate_default_keeps_temperature_and_max_tokens() -
         }
     )
 
-    assert validated["temperature"] == 0.1
+    assert validated["temperature"] == pytest.approx(0.1)
     assert validated["max_tokens"] == 4096
     assert "max_completion_tokens" not in validated
     assert "reasoning_effort" not in validated
@@ -145,7 +146,7 @@ def test_openai_compatible_validate_non_reasoning_model_unaffected() -> None:
         }
     )
 
-    assert validated["temperature"] == 0.1
+    assert validated["temperature"] == pytest.approx(0.1)
     assert validated["max_tokens"] == 4096
     assert "max_completion_tokens" not in validated
 

--- a/unstract/sdk1/tests/test_openai_compatible_adapter.py
+++ b/unstract/sdk1/tests/test_openai_compatible_adapter.py
@@ -85,6 +85,88 @@ def test_openai_compatible_schema_is_loadable() -> None:
     assert "ERNIE" not in schema["properties"]["model"]["description"]
     assert "qianfan" not in schema["properties"]["api_base"]["description"].lower()
     assert "default" not in schema["properties"]["api_base"]
+    assert schema["properties"]["enable_reasoning"]["default"] is False
+
+
+def test_openai_compatible_validate_default_keeps_temperature_and_max_tokens() -> None:
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://gateway.example.com/v1",
+            "model": "gateway-model",
+            "max_tokens": 4096,
+        }
+    )
+
+    assert validated["temperature"] == 0.1
+    assert validated["max_tokens"] == 4096
+    assert "max_completion_tokens" not in validated
+    assert "reasoning_effort" not in validated
+
+
+def test_openai_compatible_validate_autodetects_reasoning_model() -> None:
+    """gpt-5 must work without the user enabling the Reasoning toggle."""
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://api.openai.com/v1",
+            "api_key": "test-key",
+            "model": "gpt-5",
+            "temperature": 0.1,
+            "max_tokens": 4096,
+        }
+    )
+
+    assert "temperature" not in validated
+    assert "max_tokens" not in validated
+    assert validated["max_completion_tokens"] == 4096
+    # reasoning_effort stays opt-in
+    assert "reasoning_effort" not in validated
+
+
+def test_openai_compatible_validate_autodetects_o_series_with_prefix() -> None:
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://api.openai.com/v1",
+            "model": "custom_openai/openai/o3-mini",
+            "max_tokens": 1024,
+        }
+    )
+
+    assert "temperature" not in validated
+    assert validated["max_completion_tokens"] == 1024
+
+
+def test_openai_compatible_validate_non_reasoning_model_unaffected() -> None:
+    """A look-alike name (gpt-50) must not trigger the reasoning transforms."""
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://gateway.example.com/v1",
+            "model": "gpt-50-turbo",
+            "max_tokens": 4096,
+        }
+    )
+
+    assert validated["temperature"] == 0.1
+    assert validated["max_tokens"] == 4096
+    assert "max_completion_tokens" not in validated
+
+
+def test_openai_compatible_validate_reasoning_toggle_overrides_unknown_name() -> None:
+    """The toggle still fixes params for reasoning models with odd names."""
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://gateway.example.com/v1",
+            "model": "gateway-reasoner",
+            "temperature": 0.1,
+            "max_tokens": 4096,
+            "enable_reasoning": True,
+            "reasoning_effort": "high",
+        }
+    )
+
+    assert "temperature" not in validated
+    assert validated["reasoning_effort"] == "high"
+    assert validated["max_completion_tokens"] == 4096
+    assert "enable_reasoning" not in validated
 
 
 def test_openai_compatible_adapter_uses_distinct_description_and_icon() -> None:


### PR DESCRIPTION
## What

The OpenAI-compatible LLM adapter now supports reasoning models (gpt-5, o-series). It detects them by model name and reshapes sampling params, and adds an `Enable Reasoning` toggle for `reasoning_effort` tuning.

## Why

Testing the OpenAI-compatible adapter against a reasoning model failed with provider 400s: `temperature` != 1 rejected, and `max_tokens` not supported (`max_completion_tokens` required). litellm auto-corrects these for providers it has model metadata for (`openai/`, `azure/`), but the generic `custom_openai` provider has none, so the params were sent verbatim and rejected.

## How

- `base1.py`: added `_is_reasoning_model()` (name-based detection, anchored regex to avoid look-alike ids) and `_apply_reasoning_param_compat()` which drops `temperature` and renames `max_tokens` → `max_completion_tokens`. `OpenAICompatibleLLMParameters.validate()` applies this for recognized reasoning models, or when reasoning is explicitly enabled.
- `custom_openai.json`: added `enable_reasoning` toggle + conditional `reasoning_effort`, mirroring the OpenAI adapter schema.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. Non-reasoning OpenAI-compatible models are unaffected — `temperature` and `max_tokens` flow through unchanged as before. The param reshaping is gated to recognized reasoning model names or the explicit toggle.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

- None

## Related Issues or PRs

- Follow-up to #1895 (Add a dedicated OpenAI-compatible LLM adapter)

## Dependencies Versions

- None

## Notes on Testing

- Unit tests added in `test_openai_compatible_adapter.py`: auto-detect of reasoning models, look-alike name rejection, prefixed model ids, toggle override for non-standard names.
- Run: `cd unstract/sdk1 && uv run pytest tests/test_openai_compatible_adapter.py`

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)