### PR TITLE
[MISC] Fix zero cost tracking for OpenAI-compatible adapter

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -6,6 +6,7 @@ import re
 from abc import ABC, abstractmethod
 from importlib import import_module
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from typing import Any
@@ -372,6 +373,13 @@ def _is_openai_reasoning_model(model: str) -> bool:
     return bool(_OPENAI_REASONING_MODEL_PATTERN.match(model.lower()))
 
 
+def _is_openai_api_endpoint(api_base: str | None) -> bool:
+    """Return True when api_base points at OpenAI's own API host."""
+    if not api_base:
+        return False
+    return (urlparse(api_base).hostname or "").lower() == "api.openai.com"
+
+
 class OpenAICompatibleLLMParameters(BaseChatCompletionParameters):
     """See https://docs.litellm.ai/docs/providers/openai_compatible/."""
 
@@ -462,6 +470,14 @@ class OpenAICompatibleLLMParameters(BaseChatCompletionParameters):
             validated.pop("reasoning_effort", None)
         else:
             validated.pop("reasoning_effort", None)
+
+        # The custom_openai/ prefix has no entry in the cost price map. Strip
+        # it only for OpenAI's own endpoint; other gateways price the same
+        # model name differently, so leave their cost unresolved.
+        if _is_openai_api_endpoint(validated.get("api_base")):
+            validated["cost_model"] = validated["model"][
+                len(_CUSTOM_OPENAI_PROVIDER_PREFIX) :
+            ]
 
         return validated
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -374,10 +374,13 @@ def _is_openai_reasoning_model(model: str) -> bool:
 
 
 def _is_openai_api_endpoint(api_base: str | None) -> bool:
-    """Return True when api_base points at OpenAI's own API host."""
+    """Return True when api_base points at OpenAI's own HTTPS API host."""
     if not api_base:
         return False
-    return (urlparse(api_base).hostname or "").lower() == "api.openai.com"
+    parsed = urlparse(api_base)
+    return (
+        parsed.scheme == "https" and (parsed.hostname or "").lower() == "api.openai.com"
+    )
 
 
 class OpenAICompatibleLLMParameters(BaseChatCompletionParameters):

--- a/unstract/sdk1/tests/test_openai_compatible_adapter.py
+++ b/unstract/sdk1/tests/test_openai_compatible_adapter.py
@@ -303,6 +303,43 @@ def test_openai_compatible_validate_no_reasoning_unchanged() -> None:
     assert "reasoning_effort" not in validated
 
 
+def test_openai_compatible_validate_sets_cost_model_for_openai_endpoint() -> None:
+    # On OpenAI's endpoint, cost_model drops the prefix so pricing resolves.
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://api.openai.com/v1",
+            "api_key": "test-key",
+            "model": "gpt-4o",
+        }
+    )
+
+    assert validated["model"] == "custom_openai/gpt-4o"
+    assert validated["cost_model"] == "gpt-4o"
+
+
+def test_openai_compatible_validate_cost_model_keeps_openai_subprefix() -> None:
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://api.openai.com/v1",
+            "model": "custom_openai/openai/gpt-4o",
+        }
+    )
+
+    assert validated["cost_model"] == "openai/gpt-4o"
+
+
+def test_openai_compatible_validate_no_cost_model_for_other_gateway() -> None:
+    # Non-OpenAI gateways price the same name differently; leave it unresolved.
+    validated = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://gateway.example.com/v1",
+            "model": "gpt-4o",
+        }
+    )
+
+    assert "cost_model" not in validated
+
+
 def test_openai_compatible_adapter_uses_distinct_description_and_icon() -> None:
     metadata = OpenAICompatibleLLMAdapter.get_metadata()
 

--- a/unstract/sdk1/tests/test_openai_compatible_adapter.py
+++ b/unstract/sdk1/tests/test_openai_compatible_adapter.py
@@ -340,6 +340,19 @@ def test_openai_compatible_validate_no_cost_model_for_other_gateway() -> None:
     assert "cost_model" not in validated
 
 
+def test_openai_compatible_validate_cost_model_stable_on_revalidation() -> None:
+    # validate() may run on its own previous output; cost_model must survive.
+    first = OpenAICompatibleLLMParameters.validate(
+        {
+            "api_base": "https://api.openai.com/v1",
+            "model": "gpt-4o",
+        }
+    )
+    second = OpenAICompatibleLLMParameters.validate(first)
+
+    assert second["cost_model"] == "gpt-4o"
+
+
 def test_openai_compatible_adapter_uses_distinct_description_and_icon() -> None:
     metadata = OpenAICompatibleLLMAdapter.get_metadata()
 


### PR DESCRIPTION
## What

LLM usage recorded by the OpenAI-compatible (`custom_openai`) adapter always has `cost_in_dollars = 0`.

## Why

`validate_model` prefixes the model with `custom_openai/`. `_record_usage` prices via `litellm.cost_per_token(model="custom_openai/...")`, but `custom_openai` is a generic passthrough provider with **no entry in LiteLLM's price map** — the lookup fails and cost falls back to `0`.

## How

Mirror the Azure adapter's existing `cost_model` mechanism (`model` = routing identity, `cost_model` = pricing identity):

- When `api_base` points at OpenAI's own HTTPS API host, set `cost_model` to the bare model name (prefix stripped). LiteLLM's price map then resolves real OpenAI rates.
- For any other endpoint, `cost_model` is left unset. Non-OpenAI gateways (vLLM, self-hosted, third-party resellers) serve same-named models at different — or no — market prices, so guessing OpenAI rates would be confidently wrong. Cost stays `0` (honest "unresolved"), unchanged from today.

`cost_model` is popped in `LLM.__init__` and never reaches `litellm.completion()`, so routing is unaffected.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. The change only adds a `cost_model` key on the OpenAI-endpoint path; `cost_model` is consumed solely by cost lookup and never sent to `litellm.completion()`. All other endpoints behave exactly as before (cost `0`). Routing, request params, and reasoning handling are untouched.

## Related Issues or PRs

Follow-up to #1983 (OpenAI gpt-5 / o-series support in the openai-compatible adapter).


## Notes on Testing

4 new cases in `test_openai_compatible_adapter.py`: `cost_model` set for the OpenAI endpoint, `openai/` sub-prefix preserved, `cost_model` absent for other gateways, and `cost_model` stable across `validate()` re-validation. Full suite: 22 tests pass.

## Screenshots
<img width="368" height="525" alt="image" src="https://github.com/user-attachments/assets/aaa479cb-6d1c-4a54-9d6f-fb81738c4465" />

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
