### PR TITLE
UN-3479 [FIX] Provide service-account access to resources for org-migration via python client

### DIFF
--- a/backend/adapter_processor_v2/models.py
+++ b/backend/adapter_processor_v2/models.py
@@ -35,7 +35,7 @@ class AdapterInstanceModelManager(DefaultOrganizationManagerMixin, BaseModelMana
 
     def for_user(self, user: User) -> QuerySet[Any]:
         if getattr(user, "is_service_account", False):
-            return self.all()
+            return self.get_queryset().filter(is_friction_less=False)
 
         return (
             self.get_queryset()

--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -153,15 +153,13 @@ class AdapterInstanceViewSet(ModelViewSet):
         return [IsOwner()]
 
     def get_queryset(self) -> QuerySet | None:
+        queryset = AdapterInstance.objects.for_user(self.request.user)
         if filter_args := FilterHelper.build_filter_args(
             self.request,
             constant.ADAPTER_TYPE,
+            constant.ADAPTER_NAME,
         ):
-            queryset = AdapterInstance.objects.for_user(self.request.user).filter(
-                **filter_args
-            )
-        else:
-            queryset = AdapterInstance.objects.for_user(self.request.user)
+            queryset = queryset.filter(**filter_args)
         return queryset
 
     def get_serializer_class(

--- a/backend/api_v2/api_deployment_views.py
+++ b/backend/api_v2/api_deployment_views.py
@@ -260,6 +260,11 @@ class APIDeploymentViewSet(viewsets.ModelViewSet):
         if search:
             queryset = queryset.filter(display_name__icontains=search)
 
+        # Exact-match api_name filter for migration SDK's get-or-create flow.
+        api_name = self.request.query_params.get("api_name")
+        if api_name:
+            queryset = queryset.filter(api_name=api_name)
+
         return queryset
 
     def get_serializer_class(self) -> serializers.Serializer:

--- a/backend/connector_v2/serializers.py
+++ b/backend/connector_v2/serializers.py
@@ -29,7 +29,13 @@ class ConnectorInstanceSerializer(AuditSerializer):
     class Meta:
         model = ConnectorInstance
         fields = "__all__"
-        extra_kwargs = {"connector_name": {"required": False}}
+        # connector_mode is overridden in to_representation from the catalog,
+        # so any client-supplied value is silently discarded — mark it read_only
+        # to make that explicit (and to keep DRF OPTIONS schema honest).
+        extra_kwargs = {
+            "connector_name": {"required": False},
+            "connector_mode": {"read_only": True},
+        }
 
     def validate_connector_name(self, value: str) -> str:
         return validate_name_field(value, field_name="Connector name")

--- a/backend/connector_v2/views.py
+++ b/backend/connector_v2/views.py
@@ -51,6 +51,7 @@ class ConnectorInstanceViewSet(viewsets.ModelViewSet):
             RequestKey.WORKFLOW,
             RequestKey.CREATED_BY,
             CIKey.CONNECTOR_TYPE,
+            CIKey.CONNECTOR_NAME,
         )
         if filter_args:
             queryset = queryset.filter(**filter_args)

--- a/backend/permissions/permission.py
+++ b/backend/permissions/permission.py
@@ -83,6 +83,8 @@ class IsFrictionLessAdapter(permissions.BasePermission):
     ) -> bool:
         if obj.is_friction_less:
             return False
+        if _is_service_account(request):
+            return True
 
         return True if obj.created_by == request.user else False
 

--- a/backend/pipeline_v2/views.py
+++ b/backend/pipeline_v2/views.py
@@ -77,6 +77,11 @@ class PipelineViewSet(viewsets.ModelViewSet):
         if search:
             queryset = queryset.filter(pipeline_name__icontains=search)
 
+        # Exact-match name filter for migration SDK's get-or-create flow.
+        pipeline_name = self.request.query_params.get(PK.PIPELINE_NAME)
+        if pipeline_name:
+            queryset = queryset.filter(pipeline_name=pipeline_name)
+
         # Apply default ordering: last_run_time desc (nulls last), then created_at desc
         # This ensures pipelines with recent runs appear first, never-run pipelines at end
         queryset = queryset.order_by(

--- a/backend/prompt_studio/permission.py
+++ b/backend/prompt_studio/permission.py
@@ -9,6 +9,8 @@ class PromptAcesssToUser(permissions.BasePermission):
     """Is the crud to Prompt/Notes allowed to user."""
 
     def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+        if getattr(request.user, "is_service_account", False):
+            return True
         return (
             True
             if (

--- a/backend/prompt_studio/prompt_studio_registry_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/views.py
@@ -27,6 +27,7 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
         filterArgs = FilterHelper.build_filter_args(
             self.request,
             PromptStudioRegistryKeys.PROMPT_REGISTRY_ID,
+            "custom_tool",
         )
         queryset = None
         if filterArgs:

--- a/backend/tags/urls.py
+++ b/backend/tags/urls.py
@@ -5,12 +5,15 @@ from tags.views import TagViewSet
 tag_list = TagViewSet.as_view(
     {
         "get": TagViewSet.list.__name__,
+        "post": TagViewSet.create.__name__,
     }
 )
 
 tag_detail = TagViewSet.as_view(
     {
         "get": TagViewSet.retrieve.__name__,
+        "patch": TagViewSet.partial_update.__name__,
+        "delete": TagViewSet.destroy.__name__,
     }
 )
 

--- a/backend/tags/views.py
+++ b/backend/tags/views.py
@@ -20,6 +20,7 @@ class TagViewSet(viewsets.ModelViewSet):
     pagination_class = CustomPagination
     ordering_fields = ["created_at"]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filterset_fields = ["name"]
 
     def get_queryset(self):
         """Retrieve the base queryset for the Tag model, allowing additional

--- a/backend/tool_instance_v2/views.py
+++ b/backend/tool_instance_v2/views.py
@@ -94,8 +94,17 @@ class ToolInstanceViewSet(viewsets.ModelViewSet):
             RequestKey.WORKFLOW,
         )
 
-        accessible_workflows = Workflow.objects.for_user(self.request.user)
-        queryset = ToolInstance.objects.filter(workflow__in=accessible_workflows)
+        # Service accounts (Platform API key holders) need org-wide
+        # tool-instance visibility scoped via the workflows they can
+        # access — otherwise the migration SDK can't enumerate
+        # ToolInstance rows it didn't create. Regular users keep the
+        # original per-creator scope so shared-workflow access does NOT
+        # silently broaden their tool-instance visibility.
+        if getattr(self.request.user, "is_service_account", False):
+            accessible_workflows = Workflow.objects.for_user(self.request.user)
+            queryset = ToolInstance.objects.filter(workflow__in=accessible_workflows)
+        else:
+            queryset = ToolInstance.objects.filter(created_by=self.request.user)
         if filter_args:
             queryset = queryset.filter(**filter_args)
         return queryset

--- a/backend/tool_instance_v2/views.py
+++ b/backend/tool_instance_v2/views.py
@@ -13,6 +13,7 @@ from rest_framework.versioning import URLPathVersioning
 from utils.filtering import FilterHelper
 from utils.user_session import UserSessionUtils
 from workflow_manager.workflow_v2.constants import WorkflowKey
+from workflow_manager.workflow_v2.models.workflow import Workflow
 
 from backend.constants import RequestKey
 from tool_instance_v2.constants import ToolInstanceErrors, ToolKey
@@ -92,12 +93,11 @@ class ToolInstanceViewSet(viewsets.ModelViewSet):
             RequestKey.CREATED_BY,
             RequestKey.WORKFLOW,
         )
+
+        accessible_workflows = Workflow.objects.for_user(self.request.user)
+        queryset = ToolInstance.objects.filter(workflow__in=accessible_workflows)
         if filter_args:
-            queryset = ToolInstance.objects.filter(
-                created_by=self.request.user, **filter_args
-            )
-        else:
-            queryset = ToolInstance.objects.filter(created_by=self.request.user)
+            queryset = queryset.filter(**filter_args)
         return queryset
 
     def get_serializer_class(self) -> serializers.Serializer:

--- a/backend/workflow_manager/workflow_v2/views.py
+++ b/backend/workflow_manager/workflow_v2/views.py
@@ -83,6 +83,7 @@ class WorkflowViewSet(viewsets.ModelViewSet):
             RequestKey.PROJECT,
             WorkflowKey.WF_OWNER,
             WorkflowKey.WF_IS_ACTIVE,
+            WorkflowKey.WF_NAME,
         )
         # Use for_user method to include shared workflows
         queryset = (


### PR DESCRIPTION
## What

Platform API gaps surfaced while building the org-to-org data-migration SDK (companion: `Zipstack/unstract-python-client#15`). Backend-only; no UI changes.

- **Service-account access** for adapters, prompts, tool instances (`0648934ac`):
  - `AdapterInstanceModelManager.for_user` filters `is_friction_less=True` out of the service-account queryset (frictionless onboarding adapters never migrate).
  - `IsFrictionLessAdapter` short-circuits to allow service accounts on non-frictionless adapters.
  - `PromptAcesssToUser` passes service accounts through (Prompt Studio access via Platform API key).
  - `tool_instance_v2.views.get_queryset` routes through `Workflow.for_user` so service accounts see workflow-scoped tool instances.
- **`?adapter_name=` filter** on adapter list (`c05dc0561`) via `FilterHelper.build_filter_args`.
- **Tag POST/PATCH/DELETE** exposed in `tags/urls.py` (`5af6baac1`).
- **`?name=` filter** on connector + tag list (`5e02e99d5`).
- **`connector_mode` read-only** in `ConnectorInstanceSerializer` (`9b1d6c526`) — server-derived, must not be settable from client.
- **`?workflow_name=` filter** on workflow list (`34e9db70a`).
- **`?custom_tool=` filter** on `PromptStudioRegistry` list (`4538894f1`).
- **`?pipeline_name=` / `?api_name=` filters** on pipeline + api-deployment list (`f53959e98`).

## Why

The SDK migrates resources by `list (filter by name) → adopt-if-exists or POST` against the target org. Without these the service-account-issued Platform API key either 403s on non-owned rows or can't filter by name. Tag CRUD was previously read-only — the SDK needs to create tags on the target. `connector_mode` being writable is a latent bug (server-derived) and was tightened while touching the serializer.

Tracked in **UN-3479**.

## How

- All viewset filters are additive query-param branches inside `get_queryset()`, exact-match, behind explicit param presence checks. Existing flows (no param) are unchanged.
- Permission widenings are gated on `_is_service_account(user)` — regular user flows continue to hit the existing `IsOwner` / `IsOwnerOrSharedUser` / `IsOwnerOrSharedUserOrSharedToOrg` checks.
- Tag CRUD routes follow the same DRF pattern as other v2 viewsets; no new permission class.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. Changes are strictly additive for end users:
- Filter params are opt-in — omitting them returns the same queryset as before.
- Permission short-circuits only fire when `is_service_account=True`; regular user authorisation is untouched.
- `connector_mode` becoming read-only matches what the backend already enforces in `perform_create` — there is no caller in the OSS or cloud frontends that sets it.

## Database Migrations

None.

## Env Config

None.

## Relevant Docs

- JIRA: [UN-3479](https://zipstack.atlassian.net/browse/UN-3479)
- KB (internal): `~/Documents/Obsidian Vault/zipstuff/org-data-migration/`

## Related Issues or PRs

- Companion SDK PR: `Zipstack/unstract-python-client#15` (`feat/org-migration`).

## Dependencies Versions

None.

## Notes on Testing

- Local end-to-end smoke via the SDK against the docker stack (`org_Q4qgjLWIbaJlfSts` → `org_migration_target`): adapters, connectors, tags, custom tools, workflows, tool instances, workflow endpoints, 12 ETL/TASK pipelines, 3 API deployments — all create on first run, adopt idempotently on re-run. Auto-provisioned keys verified 1:1 on target.
- Reviewers can repro with `unstract-migrate migrate --source-url ... --source-org ... --target-url ... --target-org ...` (Platform API keys via env: `UNSTRACT_MIGRATION_SOURCE_KEY` / `UNSTRACT_MIGRATION_TARGET_KEY`).
- Backend unit coverage for the service-account permission branches is queued as a follow-up before un-drafting.

## Screenshots

N/A — backend-only.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).


[UN-3479]: https://zipstack.atlassian.net/browse/UN-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ