### PR TITLE
[MISC] Create platform key before onboarding step at signup

### DIFF
--- a/backend/account_v2/authentication_controller.py
+++ b/backend/account_v2/authentication_controller.py
@@ -199,14 +199,14 @@ class AuthenticationController:
                 organization=organization, user=user
             )
 
-            # Guarantee an active platform key exists before any flaky side
-            # effect (HTTP onboarding) that could abort the flow and leave an
-            # orphan org. Idempotent — safe on every login.
-            self.authentication_helper.create_initial_platform_key(
-                user=user, organization=organization
-            )
-
             if new_organization:
+                # Run the pure-DB platform-key write before the HTTP onboarding
+                # step, so a failure there cannot leave the org without a key
+                # (the org row is already committed and won't be re-entered).
+                self.authentication_helper.create_initial_platform_key(
+                    user=user, organization=organization
+                )
+
                 try:
                     self.auth_service.frictionless_onboarding(
                         organization=organization, user=user

--- a/backend/account_v2/authentication_controller.py
+++ b/backend/account_v2/authentication_controller.py
@@ -199,6 +199,13 @@ class AuthenticationController:
                 organization=organization, user=user
             )
 
+            # Guarantee an active platform key exists before any flaky side
+            # effect (HTTP onboarding) that could abort the flow and leave an
+            # orphan org. Idempotent — safe on every login.
+            self.authentication_helper.create_initial_platform_key(
+                user=user, organization=organization
+            )
+
             if new_organization:
                 try:
                     self.auth_service.frictionless_onboarding(
@@ -207,9 +214,6 @@ class AuthenticationController:
                 except MethodNotImplemented:
                     logger.info("frictionless_onboarding not implemented")
 
-                self.authentication_helper.create_initial_platform_key(
-                    user=user, organization=organization
-                )
                 logger.info(
                     f"New organization created with Id {organization_id}",
                 )

--- a/backend/account_v2/authentication_controller.py
+++ b/backend/account_v2/authentication_controller.py
@@ -200,9 +200,6 @@ class AuthenticationController:
             )
 
             if new_organization:
-                # Run the pure-DB platform-key write before the HTTP onboarding
-                # step, so a failure there cannot leave the org without a key
-                # (the org row is already committed and won't be re-entered).
                 self.authentication_helper.create_initial_platform_key(
                     user=user, organization=organization
                 )

--- a/backend/account_v2/authentication_helper.py
+++ b/backend/account_v2/authentication_helper.py
@@ -5,7 +5,7 @@ from platform_settings_v2.platform_auth_service import PlatformAuthenticationSer
 from tenant_account_v2.organization_member_service import OrganizationMemberService
 
 from account_v2.dto import MemberData
-from account_v2.models import Organization, User
+from account_v2.models import Organization, PlatformKey, User
 from account_v2.user import UserService
 
 logger = logging.getLogger(__name__)
@@ -55,36 +55,22 @@ class AuthenticationHelper:
         return user
 
     def create_initial_platform_key(self, user: User, organization: Organization) -> None:
-        """Create an initial platform key for the given user and organization.
+        """Ensure the organization has an initial active platform key.
 
-        This method generates a new platform key with the specified parameters
-        and saves it to the database. The generated key is set as active and
-        assigned the name "Key #1". The key is associated with the provided
-        user and organization.
-
-        Parameters:
-            user (User): The user for whom the platform key is being created.
-            organization (Organization):
-                The organization to which the platform key belongs.
-
-        Raises:
-            Exception: If an error occurs while generating the platform key.
-
-        Returns:
-            None
+        Idempotent: no-op if the org already has any platform key. Safe to
+        call on every login as a self-heal for orgs whose creation flow
+        aborted before the platform-key write.
         """
-        try:
-            PlatformAuthenticationService.generate_platform_key(
-                is_active=True,
-                key_name="Key #1",
-                user=user,
-                organization=organization,
-            )
-        except Exception:
-            logger.error(
-                "Failed to create default platform key for "
-                f"organization {organization.organization_id}"
-            )
+        # Respect prior admin deactivation; avoid the (key_name, organization)
+        # unique-constraint collision on "Key #1".
+        if PlatformKey.objects.filter(organization=organization).exists():
+            return
+        PlatformAuthenticationService.generate_platform_key(
+            is_active=True,
+            key_name="Key #1",
+            user=user,
+            organization=organization,
+        )
 
     @staticmethod
     def remove_users_from_organization_by_pks(

--- a/backend/account_v2/authentication_helper.py
+++ b/backend/account_v2/authentication_helper.py
@@ -58,15 +58,22 @@ class AuthenticationHelper:
         """Create the first active platform key for a freshly created org.
 
         Intended to run once, during the new-organization branch of signup.
-        Failures are propagated — a signup without a platform key is a
-        broken account, better surfaced at signup than 404'd later.
+        Failures are logged but not propagated — a transient DB issue here
+        shouldn't block the user from completing signup; the missing key
+        can be recreated from settings later.
         """
-        PlatformAuthenticationService.generate_platform_key(
-            is_active=True,
-            key_name="Key #1",
-            user=user,
-            organization=organization,
-        )
+        try:
+            PlatformAuthenticationService.generate_platform_key(
+                is_active=True,
+                key_name="Key #1",
+                user=user,
+                organization=organization,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to create default platform key for "
+                f"organization {organization.organization_id}"
+            )
 
     @staticmethod
     def remove_users_from_organization_by_pks(

--- a/backend/account_v2/authentication_helper.py
+++ b/backend/account_v2/authentication_helper.py
@@ -55,13 +55,6 @@ class AuthenticationHelper:
         return user
 
     def create_initial_platform_key(self, user: User, organization: Organization) -> None:
-        """Create the first active platform key for a freshly created org.
-
-        Intended to run once, during the new-organization branch of signup.
-        Failures are logged but not propagated — a transient DB issue here
-        shouldn't block the user from completing signup; the missing key
-        can be recreated from settings later.
-        """
         try:
             PlatformAuthenticationService.generate_platform_key(
                 is_active=True,

--- a/backend/account_v2/authentication_helper.py
+++ b/backend/account_v2/authentication_helper.py
@@ -5,7 +5,7 @@ from platform_settings_v2.platform_auth_service import PlatformAuthenticationSer
 from tenant_account_v2.organization_member_service import OrganizationMemberService
 
 from account_v2.dto import MemberData
-from account_v2.models import Organization, PlatformKey, User
+from account_v2.models import Organization, User
 from account_v2.user import UserService
 
 logger = logging.getLogger(__name__)
@@ -55,16 +55,12 @@ class AuthenticationHelper:
         return user
 
     def create_initial_platform_key(self, user: User, organization: Organization) -> None:
-        """Ensure the organization has an initial active platform key.
+        """Create the first active platform key for a freshly created org.
 
-        Idempotent: no-op if the org already has any platform key. Safe to
-        call on every login as a self-heal for orgs whose creation flow
-        aborted before the platform-key write.
+        Intended to run once, during the new-organization branch of signup.
+        Failures are propagated — a signup without a platform key is a
+        broken account, better surfaced at signup than 404'd later.
         """
-        # Respect prior admin deactivation; avoid the (key_name, organization)
-        # unique-constraint collision on "Key #1".
-        if PlatformKey.objects.filter(organization=organization).exists():
-            return
         PlatformAuthenticationService.generate_platform_key(
             is_active=True,
             key_name="Key #1",


### PR DESCRIPTION
## What

- Move `create_initial_platform_key` ahead of `frictionless_onboarding` in `set_user_organization` (still gated on `new_organization=True`), so the platform-key write runs before the HTTP onboarding step.
- Keep failures non-fatal: `AuthenticationHelper.create_initial_platform_key` still swallows exceptions so signup completes, but now logs with `logger.exception` so the traceback is preserved.

## Why

- The new-org branch of `set_user_organization` runs the org-row commit, then `frictionless_onboarding` (an HTTP call to LLMW), then `create_initial_platform_key`. Only `MethodNotImplemented` is caught around the HTTP call — any other exception (LLMW 4xx/5xx, missing onboarding template files, etc.) propagates out, so the platform-key write never happens.
- Because the atomic wrap was reverted in UN-3476, the org row is already committed when that exception fires. The next login sees `new_organization=False` and skips the entire branch — including the platform-key write — permanently. The first internal call to `get_active_platform_key` then 404s with `ActiveKeyNotFound`.
- Reordering the two calls means a flaky LLMW can no longer strand the org without a platform key.

## How

- `authentication_controller.py`: call `create_initial_platform_key` immediately after `create_tenant_user`, before `frictionless_onboarding`, inside the existing `if new_organization:` branch.
- `authentication_helper.py`: kept the failure-swallowing behaviour so signup is not blocked on a transient DB issue, but replaced `logger.error` with `logger.exception` to preserve the traceback for triage.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Low risk. Behaviour for existing orgs (`new_organization=False`) is unchanged. For new orgs the only change is ordering: the platform-key DB write now happens before the HTTP onboarding step.
- Signup remains non-fatal on platform-key creation failure — same observable behaviour as before, just with a real traceback in logs now.
- Does **not** retroactively heal existing orphan orgs that were created before this fix and never got a platform key — that's a separate one-off data fix if needed.

## Database Migrations

- None.

## Env Config

- None.

## Notes on Testing

- Manual: sign up a fresh account; verify a `platform_key` row exists for the new org immediately after `POST /api/auth/set_organization/{id}` returns, and that internal endpoints (workflow execution, `InternalPlatformKeyView`) succeed without `ActiveKeyNotFound`.
- Regression: simulate a `frictionless_onboarding` failure (e.g. LLMW unreachable) and confirm the platform key is still present afterwards — the signup response will still surface the onboarding error, but the account is no longer permanently broken.

## Related Issues or PRs

- Follow-up to UN-3465 (#1954) and UN-3476 (#1977) — moves the platform-key DB write ahead of the HTTP onboarding side effect.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)