### PR TITLE
UN-3479 [FIX] Admin bypass on raw access helpers missed by #1989

### DIFF
--- a/backend/prompt_studio/permission.py
+++ b/backend/prompt_studio/permission.py
@@ -16,5 +16,4 @@ class PromptAcesssToUser(permissions.BasePermission):
             return True
         if obj.tool_id.shared_users.filter(pk=request.user.pk).exists():
             return True
-        # Org admins implicitly have access to every tool in the org.
         return OrganizationMemberService.is_user_organization_admin(request.user)

--- a/backend/prompt_studio/permission.py
+++ b/backend/prompt_studio/permission.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework import permissions
 from rest_framework.request import Request
 from rest_framework.views import APIView
+from tenant_account_v2.organization_member_service import OrganizationMemberService
 
 
 class PromptAcesssToUser(permissions.BasePermission):
@@ -11,11 +12,9 @@ class PromptAcesssToUser(permissions.BasePermission):
     def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
         if getattr(request.user, "is_service_account", False):
             return True
-        return (
-            True
-            if (
-                obj.tool_id.created_by == request.user
-                or obj.tool_id.shared_users.filter(pk=request.user.pk).exists()
-            )
-            else False
-        )
+        if obj.tool_id.created_by == request.user:
+            return True
+        if obj.tool_id.shared_users.filter(pk=request.user.pk).exists():
+            return True
+        # Org admins implicitly have access to every tool in the org.
+        return OrganizationMemberService.is_user_organization_admin(request.user)

--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -16,6 +16,7 @@ from django.db.models.manager import BaseManager
 from plugins import get_plugin
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
+from tenant_account_v2.organization_member_service import OrganizationMemberService
 from utils.file_storage.constants import FileStorageKeys
 from utils.file_storage.helpers.prompt_studio_file_helper import PromptStudioFileHelper
 from utils.local_context import StateStore
@@ -190,6 +191,11 @@ class PromptStudioHelper:
         profile_manager_owner = profile_manager.created_by
         if profile_manager_owner is None:
             # No owner on this profile manager — skip ownership validation
+            return
+
+        # Org admins implicitly have access to every adapter in the org,
+        # matching AdapterInstance.objects.for_user semantics.
+        if OrganizationMemberService.is_user_organization_admin(profile_manager_owner):
             return
 
         is_llm_owned = (

--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -190,11 +190,8 @@ class PromptStudioHelper:
         """
         profile_manager_owner = profile_manager.created_by
         if profile_manager_owner is None:
-            # No owner on this profile manager — skip ownership validation
             return
 
-        # Org admins implicitly have access to every adapter in the org,
-        # matching AdapterInstance.objects.for_user semantics.
         if OrganizationMemberService.is_user_organization_admin(profile_manager_owner):
             return
 

--- a/backend/tool_instance_v2/tool_instance_helper.py
+++ b/backend/tool_instance_v2/tool_instance_helper.py
@@ -483,8 +483,6 @@ class ToolInstanceHelper:
         adapter_ids: set[str],
     ) -> None:
         adapter_instances = AdapterInstance.objects.filter(id__in=adapter_ids).all()
-        # Org admins implicitly have access to every adapter in the org,
-        # matching AdapterInstance.objects.for_user semantics.
         is_admin = OrganizationMemberService.is_user_organization_admin(user)
 
         for adapter_instance in adapter_instances:
@@ -526,7 +524,6 @@ class ToolInstanceHelper:
         Raises:
             PermissionDenied: If user doesn't have access to the tool
         """
-        # Org admins implicitly have access to every tool in the org.
         is_admin = OrganizationMemberService.is_user_organization_admin(user)
 
         # Try to find the tool in PromptStudioRegistry first

--- a/backend/tool_instance_v2/tool_instance_helper.py
+++ b/backend/tool_instance_v2/tool_instance_helper.py
@@ -10,6 +10,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError as DjangoValidationError
 from jsonschema.exceptions import ValidationError as JSONValidationError
 from prompt_studio.prompt_studio_registry_v2.models import PromptStudioRegistry
+from tenant_account_v2.organization_member_service import OrganizationMemberService
 from workflow_manager.workflow_v2.constants import WorkflowKey
 
 from tool_instance_v2.constants import JsonSchemaKey
@@ -482,6 +483,9 @@ class ToolInstanceHelper:
         adapter_ids: set[str],
     ) -> None:
         adapter_instances = AdapterInstance.objects.filter(id__in=adapter_ids).all()
+        # Org admins implicitly have access to every adapter in the org,
+        # matching AdapterInstance.objects.for_user semantics.
+        is_admin = OrganizationMemberService.is_user_organization_admin(user)
 
         for adapter_instance in adapter_instances:
             if not adapter_instance.is_usable:
@@ -494,7 +498,8 @@ class ToolInstanceHelper:
                 raise PermissionDenied(error_msg)
 
             if not (
-                adapter_instance.shared_to_org
+                is_admin
+                or adapter_instance.shared_to_org
                 or adapter_instance.created_by == user
                 or adapter_instance.shared_users.filter(pk=user.pk).exists()
             ):
@@ -521,11 +526,16 @@ class ToolInstanceHelper:
         Raises:
             PermissionDenied: If user doesn't have access to the tool
         """
+        # Org admins implicitly have access to every tool in the org.
+        is_admin = OrganizationMemberService.is_user_organization_admin(user)
+
         # Try to find the tool in PromptStudioRegistry first
         try:
             prompt_registry_tool = PromptStudioRegistry.objects.get(pk=tool_uid)
             if (
-                prompt_registry_tool.shared_to_org
+                is_admin
+                or prompt_registry_tool.created_by == user
+                or prompt_registry_tool.shared_to_org
                 or prompt_registry_tool.shared_users.filter(pk=user.pk).exists()
             ):
                 return
@@ -543,7 +553,9 @@ class ToolInstanceHelper:
             try:
                 agentic_registry_tool = AgenticStudioRegistry.objects.get(pk=tool_uid)
                 if (
-                    agentic_registry_tool.shared_to_org
+                    is_admin
+                    or agentic_registry_tool.created_by == user
+                    or agentic_registry_tool.shared_to_org
                     or agentic_registry_tool.shared_users.filter(pk=user.pk).exists()
                 ):
                     return

--- a/backend/workflow_manager/workflow_v2/permissions.py
+++ b/backend/workflow_manager/workflow_v2/permissions.py
@@ -1,5 +1,6 @@
 from django.shortcuts import get_object_or_404
 from rest_framework.permissions import BasePermission
+from tenant_account_v2.organization_member_service import OrganizationMemberService
 
 from workflow_manager.workflow_v2.models.workflow import Workflow
 
@@ -35,11 +36,12 @@ class IsWorkflowOwnerOrShared(BasePermission):
         workflow = request._workflow_cache
         user = request.user
 
-        # Check access: owner OR shared user OR shared to organization
+        # Check access: owner OR shared user OR shared to organization OR org admin
         has_access = (
             workflow.created_by == user
             or user in workflow.shared_users.all()
             or (workflow.shared_to_org and workflow.organization == user.organization)
+            or OrganizationMemberService.is_user_organization_admin(user)
         )
 
         return has_access

--- a/backend/workflow_manager/workflow_v2/permissions.py
+++ b/backend/workflow_manager/workflow_v2/permissions.py
@@ -36,7 +36,6 @@ class IsWorkflowOwnerOrShared(BasePermission):
         workflow = request._workflow_cache
         user = request.user
 
-        # Check access: owner OR shared user OR shared to organization OR org admin
         has_access = (
             workflow.created_by == user
             or user in workflow.shared_users.all()


### PR DESCRIPTION
## What

Adds the org-admin bypass to five access-control sites that the sweep in #1989 did not touch:

- `PromptStudioHelper.validate_profile_manager_owner_access` — short-circuit when the profile owner is an org admin.
- `ToolInstanceHelper.validate_adapter_access` — admit org admins on the request user.
- `ToolInstanceHelper.validate_tool_access` — admit org admins; also adds the missing `created_by == user` branch so creators are not denied their own registry tool.
- `prompt_studio.permission.PromptAcesssToUser` — admit org admins.
- `workflow_v2.permissions.IsWorkflowOwnerOrShared` — admit org admins.

## Why

The org-admin bypass was missed for a few auth related checks

## How

Each site now consults `OrganizationMemberService.is_user_organization_admin(...)`:

- For the profile-manager validator the admin check is against the **profile owner**, matching `AdapterInstance.objects.for_user` semantics (admins implicitly hold every adapter).
- For the other four sites the check is against the **request user**, matching `IsOwnerOrSharedUserOrSharedToOrg` in `backend/permissions/permission.py`.

`validate_tool_access` was also missing a `created_by == user` branch — added so creators are not denied their own registry tool (separate latent bug surfaced during the sweep).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No regressions expected. Every change only **widens** the permission set (admin bypass is added as an additional `or` branch). Non-admin behaviour and the existing owner / shared-user / shared-to-org branches are unchanged. The `created_by == user` branch added in `validate_tool_access` only adds access for tool creators — never removes.

## Database Migrations

None.

## Env Config

None.

## Relevant Docs

-

## Related Issues or PRs

- Follow-up to #1989 (`UN-3479 [FEAT] Org admin override on resources + ProfileManager sharing`).

## Dependencies Versions

-

## Notes on Testing

Manual reproduction against staging:
1. As an admin in an org where another member created a non-shared X2Text/LLM/Vector/Embedding adapter, select that adapter on a profile.
2. Run Prompt Studio indexing. Previously 403; now succeeds.
3. As an admin, GET/PATCH/DELETE a teammate-owned `ToolInstance` / workflow whose access funnels through `IsWorkflowOwnerOrShared` or `PromptAcesssToUser`. Previously 403; now allowed.
4. Non-admin negative cases unchanged: a non-admin without sharing still gets 403.

Existing test `tests/test_build_index_payload.py` patches out `validate_profile_manager_owner_access`, so no unit-test surface is impacted.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).