### PR TITLE
UN-3318 [FIX] Allow apostrophes in Platform API Key name and description

### DIFF
--- a/backend/platform_api/serializers.py
+++ b/backend/platform_api/serializers.py
@@ -7,11 +7,12 @@ from backend.serializers import AuditSerializer
 from platform_api.models import PlatformApiKey
 
 # Alphanumeric, spaces, hyphens, underscores, periods, commas, colons,
-# parentheses, forward slashes. No HTML tags or angle brackets.
-SAFE_TEXT_PATTERN = re.compile(r"^[a-zA-Z0-9 \-_.,:()/]+$")
+# apostrophes, parentheses, forward slashes. No HTML tags or angle brackets.
+SAFE_TEXT_PATTERN = re.compile(r"^[a-zA-Z0-9 \-_.,:'()/]+$")
 SAFE_TEXT_ERROR = (
     "Only alphanumeric characters, spaces, hyphens, underscores, "
-    "periods, commas, colons, parentheses, and forward slashes are allowed."
+    "periods, commas, colons, apostrophes, parentheses, and forward slashes "
+    "are allowed."
 )
 
 

--- a/frontend/src/components/settings/platform-api-keys/PlatformApiKeys.jsx
+++ b/frontend/src/components/settings/platform-api-keys/PlatformApiKeys.jsx
@@ -32,9 +32,9 @@ import { SettingsLayout } from "../settings-layout/SettingsLayout.jsx";
 import "../platform/PlatformSettings.css";
 import "./PlatformApiKeys.css";
 
-const SAFE_TEXT_REGEX = /^[a-zA-Z0-9 \-_.,:()/]+$/;
+const SAFE_TEXT_REGEX = /^[a-zA-Z0-9 \-_.,:'()/]+$/;
 const SAFE_TEXT_MESSAGE =
-  "Only alphanumeric characters, spaces, hyphens, underscores, periods, commas, colons, parentheses, and forward slashes are allowed.";
+  "Only alphanumeric characters, spaces, hyphens, underscores, periods, commas, colons, apostrophes, parentheses, and forward slashes are allowed.";
 
 const PERMISSION_OPTIONS = [
   { value: "read_write", label: "Read/Write", color: "blue" },


### PR DESCRIPTION
## What

- Allow apostrophe (`'`) in the Platform API Key `name` and `description` fields on both frontend validation and backend serializer.

## Why

- The `SAFE_TEXT` allow-list regex introduced with #1860 rejected apostrophes, blocking valid names like `Chandru's key`.
- The code comment's stated intent was *"No HTML tags or angle brackets"* — apostrophe got swept up in the allow-list cut, not deliberately targeted.
- Apostrophe is XSS-irrelevant under React auto-escaping and Django ORM parameterization.

## How

- `backend/platform_api/serializers.py`: added `'` to `SAFE_TEXT_PATTERN` and updated `SAFE_TEXT_ERROR` message.
- `frontend/src/components/settings/platform-api-keys/PlatformApiKeys.jsx`: added `'` to `SAFE_TEXT_REGEX` and updated `SAFE_TEXT_MESSAGE`.
- Angle-bracket / HTML-tag rejection is preserved (the actual stated intent).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. Strictly widens the allow-list by one character.
- Downstream service-account email construction (`services._slugify_for_email`) already self-sanitizes via `re.sub(r"[^a-z0-9\-]", "", slug)`, so the email/username path is unaffected.
- DB uniqueness on `(name, organization)` is unchanged.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- N/A

## Related Issues or PRs

- #1860 (UN-3318 — original Platform API Key implementation that introduced `SAFE_TEXT_PATTERN`).

## Dependencies Versions

- None.

## Notes on Testing

- Create a Platform API Key with name `Chandru's key` and description `John's prod token` — both should now save.
- Verify HTML/angle-bracket input (`<script>`) is still rejected.
- Verify duplicate-name uniqueness still enforced.

## Screenshots

_N/A — text validation change only._

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).