### PR TITLE
UN-3479 [FIX] Stamp adapter_key alongside adapter_id_key on tool_instance PATCH

### DIFF
--- a/backend/tool_instance_v2/tool_instance_helper.py
+++ b/backend/tool_instance_v2/tool_instance_helper.py
@@ -97,26 +97,24 @@ class ToolInstanceHelper:
         """
         if adapter_key in metadata:
             adapter_value = metadata[adapter_key]
-            adapter_id = None
             if ToolInstanceHelper.is_uuid_format(adapter_value):
                 logger.debug(f"Adapter value '{adapter_value}' is already in UUID format")
                 adapter = AdapterInstance.objects.get(
                     id=adapter_value, adapter_type=adapter_type.value
                 )
-                adapter_id = str(adapter.id)
-                metadata_key_for_id = adapter_property.get(
-                    AdapterPropertyKey.ADAPTER_ID_KEY, AdapterPropertyKey.ADAPTER_ID
-                )
-                metadata[metadata_key_for_id] = adapter_id
             else:
                 adapter = AdapterProcessor.get_adapter_by_name_and_type(
                     adapter_type=adapter_type, adapter_name=adapter_value
                 )
-                adapter_id = str(adapter.id)
-                metadata_key_for_id = adapter_property.get(
-                    AdapterPropertyKey.ADAPTER_ID_KEY, AdapterPropertyKey.ADAPTER_ID
-                )
-                metadata[metadata_key_for_id] = adapter_id
+            adapter_id = str(adapter.id)
+            metadata_key_for_id = adapter_property.get(
+                AdapterPropertyKey.ADAPTER_ID_KEY, AdapterPropertyKey.ADAPTER_ID
+            )
+            # Keep adapter_key and adapter_id_key both canonical to the resolved
+            # target UUID; otherwise stale UUID-shaped values at adapter_key
+            # bypass the lazy migrator and fail schema enum validation later.
+            metadata[adapter_key] = adapter_id
+            metadata[metadata_key_for_id] = adapter_id
 
     @staticmethod
     def update_metadata_with_adapter_instances(


### PR DESCRIPTION
## Summary

- `ToolInstanceHelper.update_metadata_with_adapter_properties` resolved the adapter on PATCH but only wrote the target UUID to `metadata[adapter_id_key]`, leaving `metadata[adapter_key]` carrying whatever the PATCH sent — a name from `to_representation`, or a stale UUID from `create()` defaults / a prior clone iteration's deleted adapter.
- Schema enum validation runs against `adapter_key`, and `ensure_adapter_ids_in_metadata` short-circuits the lazy NAME→UUID migration whenever it sees any UUID-shaped value there. So a stale UUID at `adapter_key` survives PATCH and later trips workflow execution with:
  ```
  Error validating tool settings for 'Check_migration':
    '9e043be4-3aad-472f-a971-12432974691b' is not one of
    ['b6c1a736-3e1e-41cb-ab76-51eacf6709a5']
  ```
  (seen on staging after a cross-org clone with adapter churn).
- Fix: write the resolved UUID to **both** `metadata[adapter_key]` and `metadata[adapter_id_key]` so the invariant `metadata[adapter_key] == metadata[adapter_id_key] == <current org UUID>` holds after every save. Existing affected rows self-heal on the next PATCH (UI re-save, or rerun of the org-clone tool_instance phase).
- Also DRY'd the duplicated `metadata_key_for_id` lookup that existed in both branches.

## Test plan

- [ ] Manual: run org-migration clone end-to-end against an org whose target had prior adapter churn → workflow run succeeds (no `is not one of` error).
- [ ] Manual: edit a tool_instance via the UI (re-select LLM dropdown, save) → row's `metadata[adapter_key]` matches `metadata[adapter_id_key]`.
- [ ] Unit coverage to follow alongside the broader tool_instance test-rig (deferred per same convention as #1989).

🤖 Generated with [Claude Code](https://claude.com/claude-code)