### PR TITLE
[MISC] Show alert with execution-logs link on workflow run

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,11 @@
-import { Button, ConfigProvider, notification, Typography, theme } from "antd";
+import { Button, ConfigProvider, notification, theme } from "antd";
 import axios from "axios";
 import { useEffect } from "react";
 import { HelmetProvider } from "react-helmet-async";
 import { BrowserRouter } from "react-router-dom";
 import { GenericLoader } from "./components/generic-loader/GenericLoader";
 import CustomMarkdown from "./components/helpers/custom-markdown/CustomMarkdown.jsx";
+import { NotificationIdLine } from "./components/notification/NotificationIdLine.jsx";
 import { PageTitle } from "./components/widgets/page-title/PageTitle.jsx";
 import { THEME } from "./helpers/GetStaticData.js";
 import { attachRequestIdInterceptor } from "./helpers/requestId.js";
@@ -63,20 +64,22 @@ function App() {
 
     const showRequestId =
       alertDetails?.type === "error" && alertDetails?.requestId;
+    const showExecutionId = Boolean(alertDetails?.executionId);
     const description = (
       <>
         <CustomMarkdown text={alertDetails?.content} />
+        {showExecutionId && (
+          <NotificationIdLine
+            label="Execution ID"
+            value={alertDetails?.executionId}
+            stacked
+          />
+        )}
         {showRequestId && (
-          <div className="notification-request-id">
-            <Typography.Text type="secondary">Request ID:</Typography.Text>{" "}
-            <Typography.Text
-              code
-              copyable={{ text: alertDetails?.requestId }}
-              className="notification-request-id__value"
-            >
-              {alertDetails?.requestId}
-            </Typography.Text>
-          </div>
+          <NotificationIdLine
+            label="Request ID"
+            value={alertDetails?.requestId}
+          />
         )}
       </>
     );
@@ -90,8 +93,14 @@ function App() {
       key: alertDetails?.key,
     });
 
-    const logMessage = showRequestId
-      ? `${alertDetails.content}\nRequest ID: \`${alertDetails.requestId}\``
+    const logSuffix = [
+      showExecutionId && `Execution ID: \`${alertDetails.executionId}\``,
+      showRequestId && `Request ID: \`${alertDetails.requestId}\``,
+    ]
+      .filter(Boolean)
+      .join("\n");
+    const logMessage = logSuffix
+      ? `${alertDetails.content}\n${logSuffix}`
       : alertDetails.content;
 
     pushLogMessages([

--- a/frontend/src/components/agency/agency/Agency.jsx
+++ b/frontend/src/components/agency/agency/Agency.jsx
@@ -778,6 +778,16 @@ function Agency() {
       const execIdValue = initialRes?.data?.execution_id;
 
       setExecutionId(execIdValue);
+      if (execIdValue && !isStepExecution) {
+        // Live progress on this page is stale; point users at the logs page.
+        setAlertDetails({
+          type: "info",
+          title: "Workflow run started",
+          content: `[View logs](/logs/WF/${execIdValue}) to track progress`,
+          executionId: execIdValue,
+          duration: 0,
+        });
+      }
       body["execution_id"] = execIdValue;
       if (isStepExecution) {
         body["execution_action"] = wfExecutionTypes[executionAction];

--- a/frontend/src/components/logging/detailed-logs/DetailedLogs.jsx
+++ b/frontend/src/components/logging/detailed-logs/DetailedLogs.jsx
@@ -1,5 +1,4 @@
 import {
-  ArrowLeftOutlined,
   CalendarOutlined,
   ClockCircleOutlined,
   CloseCircleFilled,
@@ -24,12 +23,11 @@ import {
 } from "antd";
 import PropTypes from "prop-types";
 import { useEffect, useRef, useState } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import { useAxiosPrivate } from "../../../hooks/useAxiosPrivate";
 import { useExceptionHandler } from "../../../hooks/useExceptionHandler";
 import { useAlertStore } from "../../../store/alert-store";
-import { useSessionStore } from "../../../store/session-store";
 import "./DetailedLogs.css";
 import {
   formattedDateTime,
@@ -93,12 +91,8 @@ const DetailedLogs = () => {
   const axiosPrivate = useAxiosPrivate();
   const { setAlertDetails } = useAlertStore();
   const handleException = useExceptionHandler();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const { sessionDetails } = useSessionStore();
   const { getUrl } = useRequestUrl();
   const copyToClipboard = useCopyToClipboard();
-  const cameFromDashboard = location.state?.from === "dashboard";
 
   const [executionDetails, setExecutionDetails] = useState();
   const [executionFiles, setExecutionFiles] = useState();
@@ -460,18 +454,6 @@ const DetailedLogs = () => {
     <div className="detailed-logs-container">
       <div className="detailed-logs-header">
         <Typography.Title className="logs-title" level={4}>
-          <Button
-            type="text"
-            shape="circle"
-            icon={<ArrowLeftOutlined />}
-            onClick={() =>
-              navigate(
-                cameFromDashboard
-                  ? `/${sessionDetails?.orgName}/dashboard`
-                  : `/${sessionDetails?.orgName}/logs`,
-              )
-            }
-          />
           {type} Execution ID {id}
           <Button
             className="copy-btn-outlined"

--- a/frontend/src/components/logging/execution-logs/ExecutionLogs.jsx
+++ b/frontend/src/components/logging/execution-logs/ExecutionLogs.jsx
@@ -16,6 +16,7 @@ import {
   formattedDateTimeWithSeconds,
 } from "../../../helpers/GetStaticData";
 import { useAxiosPrivate } from "../../../hooks/useAxiosPrivate";
+import { useBackNavigation } from "../../../hooks/useBackNavigation";
 import { useExceptionHandler } from "../../../hooks/useExceptionHandler";
 import useRequestUrl from "../../../hooks/useRequestUrl";
 import { useAlertStore } from "../../../store/alert-store";
@@ -49,19 +50,9 @@ function ExecutionLogs() {
   const autoRefreshIntervalRef = useRef(null);
   const currentPath = location.pathname !== `/${sessionDetails?.orgName}/logs`;
 
-  // Compute back route - use location state if available, otherwise default to logs listing
-  const backRoute = id
-    ? location.state?.from || `/${sessionDetails?.orgName}/logs`
-    : null;
-
-  // Scroll-restoration wins; otherwise preserve caller's upstream UI state.
-  const backRouteState =
-    id && location.state?.scrollToCardId
-      ? {
-          scrollToCardId: location.state.scrollToCardId,
-          cardExpanded: location.state.cardExpanded,
-        }
-      : location.state?.backRouteState || null;
+  const handleNavigateBack = useBackNavigation(
+    `/${sessionDetails?.orgName}/logs`,
+  );
 
   const items = [
     {
@@ -220,8 +211,7 @@ function ExecutionLogs() {
         title={"Execution Logs"}
         customButtons={logTabs}
         enableSearch={false}
-        previousRoute={backRoute}
-        previousRouteState={backRouteState}
+        onNavigateBack={id ? handleNavigateBack : undefined}
       />
       <div className="file-log-layout">
         {id ? (

--- a/frontend/src/components/metrics-dashboard/RecentActivity.jsx
+++ b/frontend/src/components/metrics-dashboard/RecentActivity.jsx
@@ -84,7 +84,7 @@ function RecentActivity({ data, loading }) {
     }
     const typeConfig = TYPE_CONFIG[item.type] || TYPE_CONFIG.workflow;
     navigate(`/${orgName}/logs/${typeConfig.logType}/${item.execution_id}`, {
-      state: { from: "dashboard" },
+      state: { from: `/${orgName}/dashboard` },
     });
   };
 

--- a/frontend/src/components/notification/NotificationIdLine.jsx
+++ b/frontend/src/components/notification/NotificationIdLine.jsx
@@ -1,0 +1,31 @@
+import { Typography } from "antd";
+import PropTypes from "prop-types";
+
+function NotificationIdLine({ label, value, stacked = false }) {
+  if (!value) {
+    return null;
+  }
+  const className = stacked
+    ? "notification-id-line notification-id-line--stacked"
+    : "notification-id-line";
+  return (
+    <div className={className}>
+      <Typography.Text type="secondary">{label}:</Typography.Text>
+      <Typography.Text
+        code
+        copyable={{ text: value }}
+        className="notification-id-line__value"
+      >
+        {value}
+      </Typography.Text>
+    </div>
+  );
+}
+
+NotificationIdLine.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  stacked: PropTypes.bool,
+};
+
+export { NotificationIdLine };

--- a/frontend/src/hooks/useBackNavigation.js
+++ b/frontend/src/hooks/useBackNavigation.js
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+/*
+  Generic back-navigation for pages reached from multiple callsites.
+
+  Priority:
+   1. location.state.from   — explicit hint from the linking page (also
+      reinjects scrollToCardId / backRouteState so list pages can restore
+      scroll position on return).
+   2. navigate(-1)          — SPA history exists; pop one entry. Covers
+      callsites that didn't set state (e.g. markdown links in alerts).
+   3. fallbackPath          — deep link / refresh with no history.
+*/
+function useBackNavigation(fallbackPath, fallbackState = null) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return useCallback(() => {
+    const explicitFrom = location.state?.from;
+    if (explicitFrom) {
+      const restoredState = location.state?.scrollToCardId
+        ? {
+            scrollToCardId: location.state.scrollToCardId,
+            cardExpanded: location.state.cardExpanded,
+          }
+        : location.state?.backRouteState || null;
+      navigate(explicitFrom, { state: restoredState });
+      return;
+    }
+    if (location.key !== "default") {
+      navigate(-1);
+      return;
+    }
+    if (fallbackPath) {
+      navigate(fallbackPath, { state: fallbackState });
+    }
+  }, [location.key, location.state, navigate, fallbackPath, fallbackState]);
+}
+
+export { useBackNavigation };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -252,12 +252,12 @@ body {
   z-index: 2000;
 }
 
-.notification-request-id,
-.notification-request-id__value {
+.notification-id-line,
+.notification-id-line__value {
   font-size: 12px;
 }
 
-.notification-request-id {
+.notification-id-line {
   margin-top: 8px;
   display: flex;
   align-items: center;
@@ -265,6 +265,12 @@ body {
   gap: 4px;
 }
 
-.notification-request-id__value {
+.notification-id-line--stacked {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.notification-id-line__value {
   word-break: break-all;
 }

--- a/frontend/src/store/alert-store.js
+++ b/frontend/src/store/alert-store.js
@@ -14,6 +14,7 @@ const STORE_VARIABLES = {
     duration: DEFAULT_DURATION,
     key: null,
     requestId: null,
+    executionId: null,
   },
 };
 

--- a/workers/log_consumer/tasks.py
+++ b/workers/log_consumer/tasks.py
@@ -3,6 +3,7 @@
 This module contains Celery tasks for processing execution logs.
 """
 
+import json
 import os
 from typing import Any
 from urllib.parse import quote
@@ -107,7 +108,10 @@ def logs_consumer(**kwargs: Any) -> None:
 
     # Emit WebSocket event directly through Socket.IO (via Redis broker)
     try:
-        payload = {"data": log_message}
+        # Coerce UUID/datetime/etc. to JSON-safe primitives — Socket.IO's
+        # serializer is stdlib json and chokes on non-primitive types.
+        safe_message = json.loads(json.dumps(log_message, default=str))
+        payload = {"data": safe_message}
         sio.emit(event, data=payload, room=room)
         logger.debug(f"WebSocket event emitted successfully for room {room}")
     except Exception as e:


### PR DESCRIPTION
## What

- When a workflow is triggered from the Agency page, show a sticky info notification with a `View logs` link that opens the logs page filtered to the just-started execution. Browser back returns to the workflow page via SPA history.
- Surface the `Execution ID` as a stacked, copyable code value below the message — same widget already used for the `Request ID` on error alerts (#1955).
- Extract a shared `NotificationIdLine` component used by both `Execution ID` (info / workflow-run) and `Request ID` (error). Generalise the related CSS class from `.notification-request-id` to `.notification-id-line` (with a `--stacked` modifier).

## Why

- The old WebSocket-based progress updates that used to drive the Agency page are stale and no longer fire — clicking Run Workflow leaves the UI silent. Rather than reviving the WS path, point the user at the existing logs page where the same execution can be tracked.
- Reusing the existing copyable-UUID widget keeps notification UI consistent across info and error toasts and avoids duplicating the JSX/CSS.

## How

- `Agency.jsx#handleInitialExecution`: after the first `handleWfExecutionApi` call returns an `execution_id`, fire `setAlertDetails` with `type: "info"`, `content` containing a markdown link `[View logs](/logs/WF/${execId})`, and the new `executionId` field. `duration: 0` makes it sticky. Skipped for step-execution since stepping stays on-page.
  - `CustomMarkdown` already rewrites internal `[text](/path)` into a react-router `<Link>` and auto-prefixes the org name, so the `View logs` link participates in SPA history (browser back works).
- `alert-store.js`: adds `executionId: null` to the default alert shape (additive, optional).
- `App.jsx`: replaces the inline `Request ID` JSX with `<NotificationIdLine label value [stacked] />`; renders both `Execution ID` (when set) and `Request ID` (when set on error) using the same component. Log-panel suffix is built once from whichever ids are present.
- `NotificationIdLine.jsx`: tiny new component — secondary label + `Typography.Text code copyable={{ text: value }}`, with an optional `stacked` variant (label above the value) for the workflow-run case.
- `index.css`: renames `.notification-request-id` → `.notification-id-line`, adds `.notification-id-line--stacked` (`flex-direction: column`, `align-items: flex-start`).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- Low risk. The `Request ID` line renders through the same component with identical props, so the existing error-alert layout/styling carries over 1:1 (CSS rules were renamed, not changed). The new `executionId` field is additive on `alertDetails`; alerts that don't set it are unaffected. The Agency.jsx alert only fires when an `execution_id` is returned and we're not in step-execution mode.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- N/A.

## Related Issues or PRs

- Builds on #1955 (request-ID notification widget).

## Dependencies Versions

- No new dependencies.

## Notes on Testing

- Open a workflow, click Run Workflow → info notification appears with title `Workflow run started`, body `View logs to track progress` (link), followed by a stacked `Execution ID:` label and a copyable code-styled UUID.
- Click the `View logs` link → navigates to `/{orgName}/logs/WF/{executionId}`. Press the browser back button → returns to the workflow page.
- Click the copy icon on the Execution ID → UUID is copied to clipboard.
- Trigger any failing API call (existing path) → error notification still renders the `Request ID` line inline as before; layout and class names map cleanly to the renamed CSS.
- Step-execution (Step Forward/Back) → no Execution-ID notification fires, prior behaviour preserved.
- Verify the bottom Logs & Notifications panel row for the workflow-run alert appends `Execution ID: \`<uuid>\`` on its own line.

## Screenshots
<img width="2243" height="981" alt="image" src="https://github.com/user-attachments/assets/524c4f0d-f0bb-4260-8dac-8ac68e4cc0fd" />

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).