### PR TITLE
[MISC] Remove broken is_default fallback in get_adapter_by_name_and_type

### DIFF
--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -256,7 +256,7 @@ class AdapterProcessor:
     @staticmethod
     def get_adapter_by_name_and_type(
         adapter_type: AdapterTypes,
-        adapter_name: str | None = None,
+        adapter_name: str,
     ) -> AdapterInstance:
         """Get the adapter instance by its name and type.
 
@@ -270,20 +270,19 @@ class AdapterProcessor:
         Raises:
         - AdapterNotFound: If the adapter is not found.
         """
+        if not adapter_name:
+            raise AdapterNotFound(
+                f"adapter_name is required to look up an adapter of type "
+                f"'{adapter_type.value}'"
+            )
         try:
-            if adapter_name:
-                adapter: AdapterInstance = AdapterInstance.objects.get(
-                    adapter_name=adapter_name, adapter_type=adapter_type.value
-                )
-            else:
-                adapter = AdapterInstance.objects.get(
-                    adapter_type=adapter_type.value, is_default=True
-                )
+            adapter: AdapterInstance = AdapterInstance.objects.get(
+                adapter_name=adapter_name, adapter_type=adapter_type.value
+            )
         except AdapterInstance.DoesNotExist:
             error_msg = (
-                f"Couldn't find adapter with name '{adapter_name}' and type '{adapter_type.value}'"
-                if adapter_name
-                else f"Couldn't find default adapter with type '{adapter_type.value}'"
+                f"Couldn't find adapter with name '{adapter_name}' "
+                f"and type '{adapter_type.value}'"
             )
             logger.error(error_msg)
             raise AdapterNotFound(error_msg)

--- a/backend/tool_instance_v2/tool_instance_helper.py
+++ b/backend/tool_instance_v2/tool_instance_helper.py
@@ -97,8 +97,6 @@ class ToolInstanceHelper:
         """
         if adapter_key in metadata:
             adapter_value = metadata[adapter_key]
-            # Skip empty/None — nothing to resolve, and the backend has no
-            # default-adapter fallback for an unnamed slot.
             if not adapter_value:
                 return
             if ToolInstanceHelper.is_uuid_format(adapter_value):

--- a/backend/tool_instance_v2/tool_instance_helper.py
+++ b/backend/tool_instance_v2/tool_instance_helper.py
@@ -97,6 +97,10 @@ class ToolInstanceHelper:
         """
         if adapter_key in metadata:
             adapter_value = metadata[adapter_key]
+            # Skip empty/None — nothing to resolve, and the backend has no
+            # default-adapter fallback for an unnamed slot.
+            if not adapter_value:
+                return
             if ToolInstanceHelper.is_uuid_format(adapter_value):
                 logger.debug(f"Adapter value '{adapter_value}' is already in UUID format")
                 adapter = AdapterInstance.objects.get(


### PR DESCRIPTION
## Summary

- `AdapterInstance` has **no `is_default` field** (never defined in any migration), yet `AdapterProcessor.get_adapter_by_name_and_type` falls back to `AdapterInstance.objects.get(adapter_type=..., is_default=True)` when `adapter_name` is falsy. Django raises `FieldError` → HTTP 500.
- Surfaced via the customer's org-clone script: a `text_extractor` tool_instance whose source metadata holds an empty/None `x2text_adapter` slot is PATCHed to the target, the helper passes `adapter_name=""` into `get_adapter_by_name_and_type`, and the dead `else` branch trips.
- The dead branch has been there since 2024 (commit 8a081fa2a) — it predates the `UserDefaultAdapter` model that actually owns default-adapter semantics today.

## Changes

- `backend/adapter_processor_v2/adapter_processor.py` — drop the broken `else: is_default=True`. `adapter_name` is now required; raises `AdapterNotFound` if missing.
- `backend/tool_instance_v2/tool_instance_helper.py` — in `update_metadata_with_adapter_properties`, short-circuit when `adapter_value` is empty/None. Nothing to resolve, and the backend has no default-adapter fallback for an unnamed slot.

## Regression analysis

All 3 in-tree callers of `get_adapter_by_name_and_type` already pass a truthy `adapter_name`:

| Caller | Pre-guard |
|---|---|
| `tool_instance_helper.py:_migrate_adapter_keys_for_type` | `metadata[adapter_key] and not is_uuid_format(...)` ✅ |
| `tool_instance_v2/serializers.py:to_representation` | `adapter_value and not is_uuid_format(adapter_value)` ✅ |
| `tool_instance_helper.py:update_metadata_with_adapter_properties` | none → now skipped early in this PR ✅ |

No external/plugin caller in `unstract-cloud` invokes this method without a name.
No migration ever created an `is_default` column, so no data-shape concern.
Default-adapter semantics remain owned by `UserDefaultAdapter` + `AdapterProcessor.get_default_adapters` — untouched.

## Traceback (customer)

```
django.core.exceptions.FieldError: Cannot resolve keyword 'is_default' into field.
Choices are: adapter_id, adapter_metadata, ..., user_default_x2text_adapter
  File "adapter_processor_v2/adapter_processor.py", line 279, in get_adapter_by_name_and_type
    adapter = AdapterInstance.objects.get(
                  adapter_type=adapter_type.value, is_default=True
              )
```

## Test plan

- [ ] Unit-style: call `update_metadata_with_adapter_properties` with metadata containing `{x2text_adapter: ""}` — verifies early-return, no DB hit.
- [ ] Unit-style: `get_adapter_by_name_and_type(LLM, adapter_name="")` raises `AdapterNotFound` (not `FieldError`).
- [ ] Manual: rerun the org-clone for the customer org against a workflow whose source `text_extractor` has an unbound adapter slot — PATCH should now 200 (or skip cleanly) instead of 500.
- [ ] Sanity: existing tool_instance PATCH with named adapters still resolves names → UUIDs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)