### PR TITLE
UN-3493 [FEAT] Support ui:order in adapter schemas; lift Bedrock auth fields

### DIFF
--- a/frontend/src/layouts/rjsf-form-layout/RjsfFormLayout.jsx
+++ b/frontend/src/layouts/rjsf-form-layout/RjsfFormLayout.jsx
@@ -44,6 +44,8 @@ function RjsfFormLayout({
     const rest = { ...schema };
     delete rest.title;
     delete rest.description;
+    // ui:order is a uiSchema directive, not a JSON Schema keyword.
+    delete rest["ui:order"];
     return rest;
   }, [schema]);
 
@@ -78,12 +80,14 @@ function RjsfFormLayout({
     [],
   );
 
-  const uiSchema = useMemo(
-    () => ({
-      "ui:classNames": "my-rjsf-form",
-    }),
-    [formData],
-  );
+  const uiSchema = useMemo(() => {
+    const base = { "ui:classNames": "my-rjsf-form" };
+    // Let a schema control field order, including dependency-injected fields.
+    if (Array.isArray(schema?.["ui:order"])) {
+      base["ui:order"] = schema["ui:order"];
+    }
+    return base;
+  }, [schema]);
 
   const removeBlankDefault = useCallback((schema) => {
     if (schema?.properties && schema?.required) {

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/bedrock.json
@@ -1,6 +1,18 @@
 {
   "title": "Bedrock LLM",
   "type": "object",
+  "ui:order": [
+    "adapter_name",
+    "model",
+    "model_id",
+    "auth_type",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_bearer_token",
+    "aws_profile_name",
+    "region_name",
+    "*"
+  ],
   "required": [
     "region_name",
     "model",


### PR DESCRIPTION
## What

- Adds optional `ui:order` support to adapter JSON schemas (read by `RjsfFormLayout`) and uses it in `bedrock.json` to lift the AWS auth fields up near the top of the form.

## Why

- Bedrock's credential inputs (`aws_access_key_id`, `aws_secret_access_key`, `aws_bearer_token`) live under `dependencies.auth_type.oneOf`. RJSF renders dependency-injected fields *after* all static properties, so they always landed at the bottom of the form — regardless of where the `auth_type` dropdown sat. Every other LLM adapter shows auth near the top (2nd/3rd field); Bedrock was the odd one out.

## How

- `RjsfFormLayout.jsx`: read an optional `ui:order` from the incoming schema, strip it from the validated JSON Schema (it's a uiSchema directive, not a JSON Schema keyword), and pass it through to RJSF's `uiSchema`. The `ui:order` wildcard `"*"` lets the dependency-injected credential fields slot into an explicit position.
- `bedrock.json`: add `ui:order` placing `auth_type` and its credential fields right after the model fields, with a trailing `"*"` for everything else.
- Mechanism is generic — any adapter schema can now declare `ui:order`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. `ui:order` handling is opt-in: schemas without it are unaffected (the `uiSchema` only adds the key when the schema provides an array). No field defaults, validation, or submitted data change — only render order. Only `bedrock.json` opts in.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- [RJSF uiSchema ui:order](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema/#order)

## Related Issues or PRs

- Follow-up to #1996 (AWS Bedrock Guardrails support / auth-field reorder). JIRA: UN-3493.

## Dependencies Versions

- None changed.

## Notes on Testing

- Verified in the Add/Edit Bedrock adapter form: auth credential fields now render directly under the Authentication Type dropdown instead of at the bottom. Other adapter forms render unchanged.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
