### PR TITLE
UN-3318 [FIX] Stop noisy admin entries in resource sharing (auto-share + share dropdown)

### DIFF
--- a/backend/backend/serializers.py
+++ b/backend/backend/serializers.py
@@ -11,15 +11,7 @@ class AuditSerializer(ModelSerializer):
         if request:
             validated_data[RequestKey.CREATED_BY] = request.user
             validated_data[RequestKey.MODIFIED_BY] = request.user
-        instance = super().create(validated_data)
-
-        # Auto-add key owner as co-owner for resources created via API key
-        if request and hasattr(request, "platform_api_key"):
-            platform_api_key = request.platform_api_key
-            if hasattr(instance, "shared_users") and platform_api_key.created_by:
-                instance.shared_users.add(platform_api_key.created_by)
-
-        return instance
+        return super().create(validated_data)
 
     def update(self, instance: Any, validated_data: dict[str, Any]) -> Any:
         if self.context.get(RequestKey.REQUEST):

--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -2729,30 +2729,6 @@ class PromptStudioHelper:
             organization=organization,
         )
 
-        # When a service account creates a tool, add the API key owner
-        # as a shared user so they can see it in the UI.
-        if getattr(user, "is_service_account", False):
-            from platform_api.models import PlatformApiKey
-
-            try:
-                key = PlatformApiKey.objects.get(api_user=user)
-                if key.created_by:
-                    tool.shared_users.add(key.created_by)
-                else:
-                    logger.warning(
-                        "PlatformApiKey for service account %s has no "
-                        "created_by while creating tool %s",
-                        user.id,
-                        tool.tool_id,
-                    )
-            except PlatformApiKey.DoesNotExist:
-                logger.warning(
-                    "No PlatformApiKey found for service account %s "
-                    "while creating tool %s",
-                    user.id,
-                    tool.tool_id,
-                )
-
         return tool
 
     @staticmethod

--- a/backend/tenant_account_v2/serializer.py
+++ b/backend/tenant_account_v2/serializer.py
@@ -29,10 +29,21 @@ class UserInviteResponseSerializer(serializers.Serializer):
 class OrganizationMemberSerializer(serializers.ModelSerializer):
     email = serializers.CharField(source="user.email", read_only=True)
     id = serializers.CharField(source="user.id", read_only=True)
+    is_admin = serializers.SerializerMethodField()
 
     class Meta:
         model = OrganizationMember
-        fields = ("id", "email", "role")
+        fields = ("id", "email", "role", "is_admin")
+
+    def get_is_admin(self, obj: OrganizationMember) -> bool:
+        # Admin determination is auth-plugin specific (OSS "admin" vs Auth0
+        # "unstract_admin"); defer to the same check used for access control.
+        auth_controller = self.context.get("auth_controller")
+        if auth_controller is None:
+            from account_v2.authentication_controller import AuthenticationController
+
+            auth_controller = AuthenticationController()
+        return auth_controller.is_admin_by_role(obj.role)
 
 
 class LimitedUserEmailListSerializer(serializers.ListSerializer):

--- a/backend/tenant_account_v2/users_view.py
+++ b/backend/tenant_account_v2/users_view.py
@@ -177,7 +177,9 @@ class OrganizationUserViewSet(viewsets.ViewSet):
             members: list[OrganizationMember] = (
                 auth_controller.get_organization_members_by_org_id()
             )
-            serialized_members = OrganizationMemberSerializer(members, many=True).data
+            serialized_members = OrganizationMemberSerializer(
+                members, many=True, context={"auth_controller": auth_controller}
+            ).data
             return Response(
                 status=status.HTTP_200_OK,
                 data={"message": "success", "members": serialized_members},

--- a/frontend/src/components/custom-tools/header/Header.jsx
+++ b/frontend/src/components/custom-tools/header/Header.jsx
@@ -181,6 +181,7 @@ function Header({
           users.map((user) => ({
             id: user?.id,
             email: user?.email,
+            is_admin: user?.is_admin,
           })),
         );
         return users;

--- a/frontend/src/components/custom-tools/list-of-tools/ListOfTools.jsx
+++ b/frontend/src/components/custom-tools/list-of-tools/ListOfTools.jsx
@@ -308,6 +308,7 @@ function ListOfTools({ segmentOptions, segmentValue, onSegmentChange }) {
           users.map((user) => ({
             id: user?.id,
             email: user?.email,
+            is_admin: user?.is_admin,
           })),
         );
       })

--- a/frontend/src/components/tool-settings/tool-settings/ToolSettings.jsx
+++ b/frontend/src/components/tool-settings/tool-settings/ToolSettings.jsx
@@ -172,6 +172,7 @@ function ToolSettings({ type }) {
           users.map((user) => ({
             id: user?.id,
             email: user?.email,
+            is_admin: user?.is_admin,
           })),
         );
       })

--- a/frontend/src/components/widgets/share-permission/SharePermission.jsx
+++ b/frontend/src/components/widgets/share-permission/SharePermission.jsx
@@ -16,6 +16,7 @@ import {
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 
+import { useSessionStore } from "../../../store/session-store";
 import { SpinnerLoader } from "../spinner-loader/SpinnerLoader";
 
 function SharePermission({
@@ -28,31 +29,48 @@ function SharePermission({
   onApply,
   isSharableToOrg = false,
 }) {
+  const { sessionDetails } = useSessionStore();
+  const currentUserId = sessionDetails?.userId?.toString();
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [shareWithEveryone, setShareWithEveryone] = useState(false);
 
   useEffect(() => {
     if (permissionEdit && adapter && adapter?.shared_users) {
-      // If permissionEdit is true, and adapter is available,
-      // set the selectedUsers to the IDs of shared users
+      const creatorId = (
+        adapter?.created_by?.id ?? adapter?.created_by
+      )?.toString();
       const users = allUsers.filter((user) => {
-        if (adapter?.created_by?.id !== undefined) {
-          return isSharableToOrg
-            ? !selectedUsers.includes(user?.id?.toString())
-            : user?.id !== adapter?.created_by?.id?.toString() &&
-                !selectedUsers.includes(user?.id?.toString());
-        } else {
-          return isSharableToOrg
-            ? !selectedUsers.includes(user?.id?.toString())
-            : user?.id !== adapter?.created_by?.toString() &&
-                !selectedUsers.includes(user?.id?.toString());
+        const userId = user?.id?.toString();
+        // Already-selected users shouldn't reappear as options
+        if (selectedUsers.includes(userId)) {
+          return false;
         }
+        // Can't share a resource with yourself
+        if (userId === currentUserId) {
+          return false;
+        }
+        // Admins already have access to everything — sharing is a no-op
+        if (user?.is_admin) {
+          return false;
+        }
+        // The creator already owns it, unless we're sharing org-wide
+        if (!isSharableToOrg && userId === creatorId) {
+          return false;
+        }
+        return true;
       });
       setFilteredUsers(users);
       setShareWithEveryone(adapter?.shared_to_org || false);
     }
-  }, [permissionEdit, adapter, allUsers, selectedUsers]);
+  }, [
+    permissionEdit,
+    adapter,
+    allUsers,
+    selectedUsers,
+    currentUserId,
+    isSharableToOrg,
+  ]);
 
   useEffect(() => {
     if (adapter?.shared_users) {

--- a/frontend/src/components/widgets/share-permission/SharePermission.jsx
+++ b/frontend/src/components/widgets/share-permission/SharePermission.jsx
@@ -30,7 +30,7 @@ function SharePermission({
   isSharableToOrg = false,
 }) {
   const { sessionDetails } = useSessionStore();
-  const currentUserId = sessionDetails?.userId?.toString();
+  const currentUserId = sessionDetails?.id?.toString();
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [shareWithEveryone, setShareWithEveryone] = useState(false);
@@ -98,25 +98,30 @@ function SharePermission({
     setShareWithEveryone(checked);
   };
 
+  // Admins have org-wide access, so they aren't listed as explicit shares.
+  // This also hides legacy admin rows created before the auto-share removal.
+  const sharedUsersToDisplay = selectedUsers
+    .map((userId) => {
+      const user = allUsers.find((u) =>
+        u?.id !== undefined
+          ? u?.id.toString() === userId.toString()
+          : u?.toString() === userId.toString(),
+      );
+      return {
+        id: user?.id,
+        email: user?.email,
+        is_admin: user?.is_admin,
+      };
+    })
+    .filter((user) => !user.is_admin);
+
   let sharedWithContent;
   if (shareWithEveryone) {
     sharedWithContent = <Typography.Text>Shared with everyone</Typography.Text>;
-  } else if (selectedUsers.length > 0) {
+  } else if (sharedUsersToDisplay.length > 0) {
     sharedWithContent = (
       <List
-        dataSource={selectedUsers.map((userId) => {
-          const user = allUsers.find((u) => {
-            if (u?.id !== undefined) {
-              return u?.id.toString() === userId.toString();
-            } else {
-              return u?.toString() === userId.toString();
-            }
-          });
-          return {
-            id: user?.id,
-            email: user?.email,
-          };
-        })}
+        dataSource={sharedUsersToDisplay}
         renderItem={(item) => (
           <List.Item
             extra={

--- a/frontend/src/hooks/useShareModal.js
+++ b/frontend/src/hooks/useShareModal.js
@@ -42,16 +42,19 @@ function useShareModal({
         userList = responseData.map((user) => ({
           id: user.id,
           email: user.email,
+          is_admin: user.is_admin,
         }));
       } else if (responseData?.members && Array.isArray(responseData.members)) {
         userList = responseData.members.map((member) => ({
           id: member.id,
           email: member.email,
+          is_admin: member.is_admin,
         }));
       } else if (responseData?.users && Array.isArray(responseData.users)) {
         userList = responseData.users.map((user) => ({
           id: user.id,
           email: user.email,
+          is_admin: user.is_admin,
         }));
       }
 


### PR DESCRIPTION
## What

Two related cleanups so admin access stops adding noise to the sharing UI:

1. **Stop auto-sharing platform-key-created resources with the admin.** Resources created via a platform API key are no longer auto-added to the key owner's `shared_users` list.
2. **Hide the current user and admins from the "Share Users" dropdown.** You can't meaningfully share with yourself, and admins already have access to everything — so neither should appear as a share target.

## Why

- Org admins already see every resource via the `for_user` admin bypass (manager returns all org rows when `is_user_organization_admin`), so a `shared_users` entry for an admin grants **no** extra access — it only adds noise to the "Shared with" list and the share dropdown.
- Offering admins as share targets is also misleading and would create **stale grants** that survive a later role demotion. Keeping admin access purely role-driven avoids that drift.
- Sharing a resource with yourself is meaningless.

## How

- `backend/backend/serializers.py`: dropped the `request.platform_api_key` block in `AuditSerializer.create`.
- `backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py`: dropped the `is_service_account` branch that added the key owner to a new tool's `shared_users`.
- `backend/tenant_account_v2/serializer.py`: `OrganizationMemberSerializer` now returns an `is_admin` flag computed via `is_admin_by_role`, so the frontend doesn't hardcode role strings (works for OSS `"admin"` and Auth0 `"unstract_admin"`). View passes the existing `auth_controller` via serializer context.
- `frontend/.../SharePermission.jsx`: dropdown candidate list excludes the current user (`sessionDetails.userId`) and admins (`is_admin`), in addition to the existing creator/selected exclusions.
- Threaded `is_admin` through the share-user fetch sites (`ListOfTools`, `Header`, `ToolSettings`, `useShareModal`).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. Admins retain full visibility/access to all org resources through the `for_user` admin bypass and the `_is_organization_admin` allow in object-level permission classes — independent of `shared_users`. Non-admins never saw platform-key-created resources before (creator is the service account). The dropdown change only removes options that were no-ops (self, admins); frontends that don't yet pass `is_admin` simply retain prior behavior (graceful degradation).

## Database Migrations

- None. Go-forward behavior only; existing rows are intentionally left untouched.

## Env Config

- None.

## Notes on Testing

- Create a resource (adapter / Prompt Studio project) via a platform API key, then open the share dialog as an admin → "Shared with" shows no auto-added admin. Verified live on a dev namespace: project created via platform key has `shared_users: []`.
- Open the "Share Users" dropdown → the current user and admin members are not listed as options. Non-admin members still appear.
- Confirm admins still see/manage all resources normally.

## Related Issues or PRs

- Follow-up to #1860 (UN-3318 Platform API key implementation), which introduced the admin auto-share.

## Notes

- The cloud Lookups feature reuses this share widget via a plugin in `unstract-cloud`; a matching one-line `is_admin` mapping there is tracked as a separate cloud PR.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
