### PR TITLE
Deprecate classifier and text_extractor tools in UI, disable runner b…

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -187,6 +187,8 @@ services:
     image: unstract/runner:${VERSION}
     container_name: unstract-runner
     restart: unless-stopped
+    profiles:
+      - legacy-runner
     ports:
       - 5002:5002
     env_file:

--- a/frontend/src/components/agency/tool-info-card/ToolInfoCard.css
+++ b/frontend/src/components/agency/tool-info-card/ToolInfoCard.css
@@ -30,3 +30,8 @@
   grid-auto-flow: column;
   justify-self: end;
 }
+
+.toolinfo-card-deprecated {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/agency/tool-info-card/ToolInfoCard.jsx
+++ b/frontend/src/components/agency/tool-info-card/ToolInfoCard.jsx
@@ -1,4 +1,4 @@
-import { Card, Col, Row, Typography } from "antd";
+import { Card, Col, Row, Tag, Tooltip, Typography } from "antd";
 import PropTypes from "prop-types";
 import { useDrag } from "react-dnd";
 
@@ -6,13 +6,19 @@ import "./ToolInfoCard.css";
 import { ToolIcon } from "../tool-icon/ToolIcon";
 
 function ToolInfoCard({ toolInfo }) {
+  const isDeprecated = toolInfo?.deprecated;
+
   const [, ref] = useDrag({
     type: "STEP",
     item: { function_name: toolInfo?.function_name },
+    canDrag: !isDeprecated,
   });
 
   return (
-    <Card className="toolinfo-card" ref={ref}>
+    <Card
+      className={`toolinfo-card${isDeprecated ? " toolinfo-card-deprecated" : ""}`}
+      ref={ref}
+    >
       <Row>
         <Col span={4}>
           <ToolIcon iconSrc={toolInfo?.icon} showBorder={true} />
@@ -21,6 +27,13 @@ function ToolInfoCard({ toolInfo }) {
           <div className="tool-info-header">
             <div className="tool-info-title">
               <Typography.Text strong>{toolInfo?.name}</Typography.Text>
+              {isDeprecated && (
+                <Tooltip title={toolInfo?.deprecation_message}>
+                  <Tag color="orange" style={{ marginLeft: 8 }}>
+                    Deprecated
+                  </Tag>
+                </Tooltip>
+              )}
             </div>
             <Typography
               type="secondary"

--- a/unstract/tool-registry/src/unstract/tool_registry/tool_registry.py
+++ b/unstract/tool-registry/src/unstract/tool_registry/tool_registry.py
@@ -207,6 +207,10 @@ class ToolRegistry:
                     ToolKey.DESCRIPTION: data.get(PropKey.DESCRIPTION),
                     ToolKey.ICON: icon,
                     ToolKey.FUNCTION_NAME: data.get(PropKey.FUNCTION_NAME),
+                    "deprecated": configuration.get("deprecated", False),
+                    "deprecation_message": configuration.get(
+                        "deprecation_message", ""
+                    ),
                 }
                 tools_list.append(tool_data)
         return tools_list

--- a/unstract/tool-registry/src/unstract/tool_registry/tool_registry.py
+++ b/unstract/tool-registry/src/unstract/tool_registry/tool_registry.py
@@ -208,9 +208,7 @@ class ToolRegistry:
                     ToolKey.ICON: icon,
                     ToolKey.FUNCTION_NAME: data.get(PropKey.FUNCTION_NAME),
                     "deprecated": configuration.get("deprecated", False),
-                    "deprecation_message": configuration.get(
-                        "deprecation_message", ""
-                    ),
+                    "deprecation_message": configuration.get("deprecation_message", ""),
                 }
                 tools_list.append(tool_data)
         return tools_list

--- a/unstract/tool-registry/tool_registry_config/public_tools.json
+++ b/unstract/tool-registry/tool_registry_config/public_tools.json
@@ -1,6 +1,8 @@
 {
     "classify": {
         "tool_uid": "classify",
+        "deprecated": true,
+        "deprecation_message": "File Classifier is deprecated and will be removed in a future release. Use Prompt Studio with an LLM for classification.",
         "properties": {
             "schemaVersion": "0.0.1",
             "displayName": "File Classifier",
@@ -112,6 +114,8 @@
     },
     "text_extractor": {
         "tool_uid": "text_extractor",
+        "deprecated": true,
+        "deprecation_message": "Text Extractor is deprecated and will be removed in a future release. Use the X2Text adapter instead.",
         "properties": {
             "schemaVersion": "0.0.1",
             "displayName": "Text Extractor",


### PR DESCRIPTION

- Add deprecated/deprecation_message fields to public_tools.json for classify and text_extractor tools
- Pass deprecation fields through ToolRegistry.fetch_tools_descriptions() to the frontend API
- Show orange "Deprecated" tag with tooltip on deprecated tool cards
- Disable drag-and-drop for deprecated tools (canDrag: false)
- Add legacy-runner profile to runner service in docker-compose so it no longer starts by default (use --profile legacy-runner to enable)

## What

-

## Why

-

## How

-

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

-

## Database Migrations

- 

## Env Config

- 

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

-

## Notes on Testing

-

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
