### PR TITLE
fix(llama-parse): rename schema field url to base_url (#1972)

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/constants.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/constants.py
@@ -3,6 +3,9 @@ class LlamaParseConfig:
 
     API_KEY = "api_key"
     BASE_URL = "base_url"
+    # Legacy schema key for the base URL, kept for backward compatibility with
+    # adapter instances saved before the rename (#1972).
+    LEGACY_BASE_URL = "url"
     RESULT_TYPE = "result_type"
     NUM_WORKERS = "num_workers"
     VERBOSE = "verbose"

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/llama_parse.py
@@ -52,7 +52,8 @@ class LlamaParseAdapter(X2TextAdapter):
             fs = FileStorage(provider=FileStorageProvider.LOCAL)
         parser = LlamaParse(
             api_key=self.config.get(LlamaParseConfig.API_KEY),
-            base_url=self.config.get(LlamaParseConfig.BASE_URL),
+            base_url=self.config.get(LlamaParseConfig.BASE_URL)
+            or self.config.get(LlamaParseConfig.LEGACY_BASE_URL),
             result_type=self.config.get(LlamaParseConfig.RESULT_TYPE),
             verbose=self.config.get(LlamaParseConfig.VERBOSE),
             language="en",

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/static/json_schema.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/static/json_schema.json
@@ -18,7 +18,7 @@
             "default": "",
             "description": "Provide the token (API Key) of the Llama Parse server"
         },
-      "url": {
+      "base_url": {
         "type": "string",
         "title": "URL",
         "format": "url",

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/static/json_schema.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llama_parse/src/static/json_schema.json
@@ -20,8 +20,8 @@
         },
       "base_url": {
         "type": "string",
-        "title": "URL",
-        "format": "url",
+        "title": "Base URL",
+        "format": "uri",
         "default": "https://api.cloud.llamaindex.ai",
         "description": "Provide the Base URL of llama Parse server."
       },


### PR DESCRIPTION
## What

- Rename the LlamaParse x2text adapter UI schema field from `url` to `base_url` in `json_schema.json`.

## Why

- The schema defined the base-URL field as `url`, but the adapter code reads it via `LlamaParseConfig.BASE_URL` (`"base_url"`). The mismatch meant the value a user entered was stored under `url` and never read, so `LlamaParse` always fell back to its hardcoded US endpoint (`https://api.cloud.llamaindex.ai`).
- As a result, EU-region LlamaCloud users could not use LlamaParse — their key was sent to the US endpoint, returning `401 Unauthorized`.

## How

- Changed the property key `"url"` → `"base_url"` in `unstract/sdk1/.../llama_parse/src/static/json_schema.json` so it matches `constants.py` and the lookup in `llama_parse.py`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No new breakage. This is a forward fix for new adapter instances.
- Note on existing instances: any LlamaParse adapter already saved before this fix has its value persisted under the old `url` key (configs are stored Fernet-encrypted in `adapter_instance.adapter_metadata_b`), so it will not auto-migrate. Those few users simply need to re-open and re-save the adapter to populate `base_url`. A data migration was considered but intentionally skipped to keep the change minimal.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- N/A

## Related Issues or PRs

- Fixes #1972

## Dependencies Versions

- N/A

## Notes on Testing

- Validated the JSON and ran the repo pre-commit JSON/whitespace hooks (all pass).
- Manual verification: configure a LlamaParse adapter with the EU base URL (`https://api.cloud.eu.llamaindex.ai`) and confirm extraction succeeds instead of returning 401.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
