### PR TITLE
UN-3525 [FIX] De-duplicate users by Auth0 user_id on login

### DIFF
--- a/backend/account_v2/authentication_helper.py
+++ b/backend/account_v2/authentication_helper.py
@@ -34,19 +34,29 @@ class AuthenticationHelper:
 
     @staticmethod
     def get_or_create_user_by_email(user_id: str, email: str) -> User:
-        """Get or create a user with the given email.
+        """Get or create the canonical user for an Auth0 identity.
 
-        If a user with the given email already exists, return that user.
-        Otherwise, create a new user with the given email and return it.
+        Resolution order:
+        1. By ``user_id`` (the stable Auth0 subject). This reuses an existing
+           row even when it was created by a different login path — e.g. an
+           enterprise/SSO row with a populated ``auth_provider`` — and is the
+           key guard against duplicate accounts for one person who signs in via
+           more than one Auth0 connection (e.g. SAML + passwordless email).
+        2. By email — for a pre-provisioned row (e.g. an invited user) that has
+           no ``user_id`` yet; backfill the ``user_id`` onto it.
+        3. Otherwise create a new user.
 
         Parameters:
-            user_id (str): The ID of the user.
+            user_id (str): The Auth0 subject (``sub``) of the user.
             email (str): The email of the user.
 
         Returns:
-            User: The user with the given email.
+            User: The canonical user for this identity.
         """
         user_service = UserService()
+        user = user_service.get_user_by_user_id(user_id)
+        if user:
+            return user
         user = user_service.get_user_by_email(email)
         if user and not user.user_id:
             user = user_service.update_user(user, user_id)

--- a/backend/account_v2/tests.py
+++ b/backend/account_v2/tests.py
@@ -1,1 +1,95 @@
-# Create your tests here.
+"""Unit tests for user-identity resolution in ``AuthenticationHelper``.
+
+These are no-database ``SimpleTestCase`` tests: ``UserService`` is mocked so
+only the resolution/branching logic of ``get_or_create_user_by_email`` is
+exercised. They guard against the duplicate-account regression where a person
+with more than one Auth0 connection (e.g. SAML + passwordless email) on the
+same email ended up with two ``User`` rows (see UN-3525).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from account_v2.authentication_helper import AuthenticationHelper
+
+
+class GetOrCreateUserByEmailTests(SimpleTestCase):
+    @patch("account_v2.authentication_helper.UserService")
+    def test_resolves_by_user_id_first(self, mock_user_service: MagicMock) -> None:
+        """An existing row matching the Auth0 ``user_id`` is reused as-is, even
+        though it may have been created by a different login path.
+        """
+        svc = mock_user_service.return_value
+        existing = MagicMock(name="existing_user")
+        svc.get_user_by_user_id.return_value = existing
+
+        result = AuthenticationHelper.get_or_create_user_by_email(
+            user_id="samlp|mars|user@example.com", email="user@example.com"
+        )
+
+        self.assertIs(result, existing)
+        svc.get_user_by_user_id.assert_called_once_with("samlp|mars|user@example.com")
+        # Must not fall through to email lookup / create when user_id matched.
+        svc.get_user_by_email.assert_not_called()
+        svc.update_user.assert_not_called()
+        svc.create_user.assert_not_called()
+
+    @patch("account_v2.authentication_helper.UserService")
+    def test_backfills_user_id_on_email_match_without_user_id(
+        self, mock_user_service: MagicMock
+    ) -> None:
+        """A pre-provisioned (invited) row with no ``user_id`` gets the
+        ``user_id`` backfilled instead of creating a new row.
+        """
+        svc = mock_user_service.return_value
+        svc.get_user_by_user_id.return_value = None
+        invited = MagicMock(user_id="")
+        svc.get_user_by_email.return_value = invited
+        updated = MagicMock(name="updated_user")
+        svc.update_user.return_value = updated
+
+        result = AuthenticationHelper.get_or_create_user_by_email(
+            user_id="auth0|abc", email="user@example.com"
+        )
+
+        svc.update_user.assert_called_once_with(invited, "auth0|abc")
+        self.assertIs(result, updated)
+        svc.create_user.assert_not_called()
+
+    @patch("account_v2.authentication_helper.UserService")
+    def test_reuses_email_match_with_existing_user_id(
+        self, mock_user_service: MagicMock
+    ) -> None:
+        """An email match that already has a ``user_id`` is reused without
+        overwriting its ``user_id`` and without creating a new row.
+        """
+        svc = mock_user_service.return_value
+        svc.get_user_by_user_id.return_value = None
+        existing = MagicMock()
+        existing.user_id = "auth0|other"
+        svc.get_user_by_email.return_value = existing
+
+        result = AuthenticationHelper.get_or_create_user_by_email(
+            user_id="auth0|abc", email="user@example.com"
+        )
+
+        self.assertIs(result, existing)
+        svc.update_user.assert_not_called()
+        svc.create_user.assert_not_called()
+
+    @patch("account_v2.authentication_helper.UserService")
+    def test_creates_user_when_no_match(self, mock_user_service: MagicMock) -> None:
+        """A brand-new identity (no user_id and no email match) is created."""
+        svc = mock_user_service.return_value
+        svc.get_user_by_user_id.return_value = None
+        svc.get_user_by_email.return_value = None
+        created = MagicMock(name="created_user")
+        svc.create_user.return_value = created
+
+        result = AuthenticationHelper.get_or_create_user_by_email(
+            user_id="auth0|abc", email="user@example.com"
+        )
+
+        svc.create_user.assert_called_once_with("user@example.com", "auth0|abc")
+        self.assertIs(result, created)

--- a/backend/account_v2/user.py
+++ b/backend/account_v2/user.py
@@ -41,11 +41,14 @@ class UserService:
         return user
 
     def get_user_by_email(self, email: str) -> User | None:
-        try:
-            user: User = User.objects.get(email=email, auth_provider="")
-            return user
-        except User.DoesNotExist:
-            return None
+        # Resolve a single canonical row for an email, matched case-insensitively
+        # and across auth providers. The previous ``auth_provider=""`` filter
+        # only matched standard-login rows, so a person who also had an
+        # enterprise/SSO row (populated ``auth_provider``) was invisible here and
+        # a duplicate account got created. ``.first()`` (oldest row, ordered
+        # deterministically) also avoids ``MultipleObjectsReturned`` for emails
+        # that already have duplicate rows.
+        return User.objects.filter(email__iexact=email).order_by("created_at").first()
 
     def get_user_by_user_id(self, user_id: str) -> Any:
         try:


### PR DESCRIPTION
## What

Prevents a single person from getting **two `User` rows** (and two `OrganizationMember` rows in the same org) when they have more than one Auth0 connection on the same email — e.g. a **SAML/enterprise** connection plus a **passwordless email (OTP)** connection.

## Why

`Auth0Service.handle_authorization_callback`'s social/passwordless path calls `AuthenticationHelper.get_or_create_user_by_email`, which resolved the local user **by email only**. `UserService.get_user_by_email` additionally filtered on `auth_provider=""`, so an existing **enterprise** row (which has a populated `auth_provider`) was invisible to it → a duplicate `User` row was created carrying the same Auth0 `user_id` but `auth_provider=""`.

Because org-membership eligibility is keyed on `user_id` (shared by both rows) while the "already a member?" check is keyed on the DB primary key (distinct), the duplicate then also acquired its own `OrganizationMember` row in the same org. Downstream features that key on `user.id` (e.g. HITL `reviewer_id`) break — a doc gets locked to one row while the user is logged in as the other.

Context: the `auth_provider=""` filter was added in #1300 (commit `f25874da4`); before that, `get_user_by_email` matched on email alone (one email = one user). #1300 introduced an `(email, auth_provider)` split but only inside that single query, and added no uniqueness — so the rest of the system (which still assumes one row per person) collides with it. Full analysis on UN-3525.

## How

Code-only, preventive (no data migration, no schema change):

- **`AuthenticationHelper.get_or_create_user_by_email`** now resolves by **`user_id` (the stable Auth0 subject) first**, reusing an existing row regardless of which login path created it, then falls back to email, then creates. This is the key guard: the passwordless login now finds the existing enterprise row instead of minting a duplicate.
- **`UserService.get_user_by_email`** now matches email **case-insensitively and across auth providers**, returning the oldest row via `.first()` (deterministic, and no longer raises `MultipleObjectsReturned` on already-duplicated emails).

This scope intentionally **does not** include de-duplicating existing rows or adding a `user_id`/email uniqueness constraint — those are higher-risk, interdependent (a constraint rejects until data is clean), and tracked separately on the ticket.

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why.

Low risk. `get_user_by_email` becomes provider-agnostic, which affects three callers — all benefit:
- `get_or_create_user_by_email` (social login) — now reuses any existing row; primary fix.
- Invite flow (`platform_admin/views.py`) — previously created a placeholder row for invitees who only had an enterprise row; now reuses it.
- `get_or_create_user` (`authentication_controller.py`) — more lenient account-by-email match.

The enterprise login path itself is unaffected (it uses `create_or_update_user`, not these lookups). No DB schema change.

## Relevant Docs

-

## Related Issues or PRs

- Jira: UN-3525
- Identity-model context introduced in #1300

## Dependencies Versions / Env Variables

- None

## Notes on Testing

- Added no-DB `SimpleTestCase` coverage (`account_v2/tests.py`) mocking `UserService` to assert the resolution order: user_id-first reuse, email-match backfill, email-match reuse (no overwrite), and create-on-no-match.
- **Not executed in my local sandbox**: this backend has no wired unit-test harness here (`pytest-django` absent, `account_v2/tests.py` was empty, conftest notes backend tests don't run under tox in CI, and Django setup needs `test.env`/service env vars not present locally). Verified with **ruff** (passes) only. Please run `python manage.py test account_v2` in a configured environment / CI.
- Suggested manual verification: with a user that has both a SAML and a passwordless Auth0 account on one email, log in via passwordless after the SAML row exists → confirm **no new `User` row** is created and the existing row is reused.

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)