### PR TITLE
UN-3166 [FIX] Use group-shared adapters in Prompt Studio & workflows

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -11,6 +11,7 @@ from account_v2.models import User
 from adapter_processor_v2.models import AdapterInstance, UserDefaultAdapter
 from django.conf import settings
 from django.db import transaction
+from permissions.permission import has_group_access
 from plugins import get_plugin
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
@@ -209,6 +210,7 @@ class PromptStudioHelper:
             or profile_manager.llm.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()
+            or has_group_access(profile_manager_owner, profile_manager.llm)
         )
         is_vector_store_owned = (
             profile_manager.vector_store.shared_to_org
@@ -216,6 +218,7 @@ class PromptStudioHelper:
             or profile_manager.vector_store.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()
+            or has_group_access(profile_manager_owner, profile_manager.vector_store)
         )
         is_embedding_model_owned = (
             profile_manager.embedding_model.shared_to_org
@@ -223,6 +226,7 @@ class PromptStudioHelper:
             or profile_manager.embedding_model.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()
+            or has_group_access(profile_manager_owner, profile_manager.embedding_model)
         )
         is_x2text_owned = (
             profile_manager.x2text.shared_to_org
@@ -230,6 +234,7 @@ class PromptStudioHelper:
             or profile_manager.x2text.shared_users.filter(
                 pk=profile_manager_owner.pk
             ).exists()
+            or has_group_access(profile_manager_owner, profile_manager.x2text)
         )
 
         if not (

--- a/backend/tool_instance_v2/tool_instance_helper.py
+++ b/backend/tool_instance_v2/tool_instance_helper.py
@@ -9,6 +9,7 @@ from adapter_processor_v2.models import AdapterInstance
 from django.core.exceptions import PermissionDenied
 from django.core.exceptions import ValidationError as DjangoValidationError
 from jsonschema.exceptions import ValidationError as JSONValidationError
+from permissions.permission import has_group_access
 from prompt_studio.prompt_studio_registry_v2.models import PromptStudioRegistry
 from tenant_account_v2.organization_member_service import OrganizationMemberService
 from workflow_manager.workflow_v2.constants import WorkflowKey
@@ -508,6 +509,7 @@ class ToolInstanceHelper:
                 or adapter_instance.shared_to_org
                 or adapter_instance.created_by == user
                 or adapter_instance.shared_users.filter(pk=user.pk).exists()
+                or has_group_access(user, adapter_instance)
             ):
                 logger.error(
                     "User %s doesn't have access to adapter %s",


### PR DESCRIPTION
## What

- `prompt_studio_helper.py`: `validate_profile_manager_owner_access` now ORs `has_group_access` into all four adapter checks (LLM, vector store, embedding, x2text).
- `tool_instance_helper.py`: `validate_adapter_access` ORs `has_group_access` into its adapter check.

## Why

- Adapters shared with a user **via a group** were rejected in Prompt Studio and workflow tools — the hand-rolled checks only honored `created_by | shared_users | shared_to_org`, missing the group axis from the UN-2977 share model.

## How

- Reuse the canonical `permissions.permission.has_group_access(user, obj)` helper (reads `ResourceGroupShare`), bringing these hand-rolled checks to parity with `AdapterInstance.for_user`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. The change is an additive `or` clause that only widens access to adapters already shared to the user's group; owner, direct-share, and org-share paths are unchanged.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

-

## Related Issues or PRs

- Cloud counterpart: Zipstack/unstract-cloud#1538

## Dependencies Versions

- None

## Notes on Testing

- Manual: share an adapter to a group; a member of that group can select and use it in a Prompt Studio profile and in workflow tools.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).