### PR TITLE
UN-2742 [FIX] Show profile name instead of LLM name in Output Analyzer tabs

### DIFF
--- a/frontend/src/components/custom-tools/combined-output/JsonView.jsx
+++ b/frontend/src/components/custom-tools/combined-output/JsonView.jsx
@@ -1,4 +1,4 @@
-import { Tabs } from "antd";
+import { Tabs, Tooltip } from "antd";
 import TabPane from "antd/es/tabs/TabPane";
 import Prism from "prismjs";
 import PropTypes from "prop-types";
@@ -70,7 +70,11 @@ function JsonView({
           )}
           {adapterData.map((adapter) => (
             <TabPane
-              tab={<span>{adapter?.llm_model || adapter?.profile_name}</span>}
+              tab={
+                <Tooltip title={adapter?.llm_model}>
+                  <span>{adapter?.profile_name || adapter?.llm_model}</span>
+                </Tooltip>
+              }
               key={adapter?.profile_id}
             />
           ))}

--- a/frontend/src/components/custom-tools/combined-output/JsonView.jsx
+++ b/frontend/src/components/custom-tools/combined-output/JsonView.jsx
@@ -71,8 +71,12 @@ function JsonView({
           {adapterData.map((adapter) => (
             <TabPane
               tab={
-                <Tooltip title={adapter?.llm_model}>
-                  <span>{adapter?.profile_name || adapter?.llm_model}</span>
+                <Tooltip title={adapter?.llm_model || adapter?.profile_name}>
+                  <span>
+                    {adapter?.profile_name ||
+                      adapter?.llm_model ||
+                      `Profile ${adapter?.profile_id ?? "?"}`}
+                  </span>
                 </Tooltip>
               }
               key={adapter?.profile_id}

--- a/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
+++ b/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
@@ -341,8 +341,12 @@ function OutputForDocModal({
             {adapterData?.map((adapter, index) => (
               <TabPane
                 tab={
-                  <Tooltip title={adapter?.llm_model}>
-                    <span>{adapter?.profile_name || adapter?.llm_model}</span>
+                  <Tooltip title={adapter?.llm_model || adapter?.profile_name}>
+                    <span>
+                      {adapter?.profile_name ||
+                        adapter?.llm_model ||
+                        `Profile ${index + 1}`}
+                    </span>
                   </Tooltip>
                 }
                 key={(index + 1)?.toString()}

--- a/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
+++ b/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
@@ -3,7 +3,7 @@ import {
   CloseCircleFilled,
   InfoCircleFilled,
 } from "@ant-design/icons";
-import { Button, Modal, Table, Tabs, Typography } from "antd";
+import { Button, Modal, Table, Tabs, Tooltip, Typography } from "antd";
 import TabPane from "antd/es/tabs/TabPane";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
@@ -340,7 +340,11 @@ function OutputForDocModal({
             <TabPane tab={<span>Default</span>} key={"0"}></TabPane>
             {adapterData?.map((adapter, index) => (
               <TabPane
-                tab={<span>{adapter?.llm_model || adapter?.profile_name}</span>}
+                tab={
+                  <Tooltip title={adapter?.llm_model}>
+                    <span>{adapter?.profile_name || adapter?.llm_model}</span>
+                  </Tooltip>
+                }
                 key={(index + 1)?.toString()}
               ></TabPane>
             ))}


### PR DESCRIPTION
## What

- Output tabs in Prompt Studio now show the **LLM profile name** as the label, with the LLM model name available as a tooltip on hover. Previously the tab label was the model name, falling back to profile name.

## Why

[UN-2742](https://zipstack.atlassian.net/browse/UN-2742) — users create profiles with specific intent (the same model can be used with different LLMWhisperer modes, chunking, retrieval settings). When comparing outputs across profiles, the model name is ambiguous — two tabs can read identically while being different profiles. The profile name is the meaningful identity; the model is secondary context, now preserved in a tooltip.

## How

- `combined-output/JsonView.jsx` — flipped label preference to `profile_name || llm_model`, wrapped in `<Tooltip title={llm_model}>`. This is the shared tab strip used by both the Output Analyzer and the main combined-output view, so both stay consistent.
- `output-for-doc-modal/OutputForDocModal.jsx` — same pattern applied to the identical tab strip there.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. Tab selection is keyed on `profile_id` (JsonView) / index (OutputForDocModal), never on the label text, so behavior is unchanged — only the visible label flips. No tests, e2e selectors, or CSS reference the label text. `profile_name` is a required, whitespace-validated field at profile creation, so labels can't be blank. If a profile's adapter was deleted (no resolvable model), the tooltip simply doesn't render (antd disables tooltips with undefined title) — previously that case showed the profile name with no tooltip, so nothing is lost.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

- N/A

## Related Issues or PRs

- Jira: UN-2742

## Dependent Features

- None

## Notes on Testing

- Biome lint clean; `vite build` succeeds.
- Manual: open a Prompt Studio project with 2+ profiles → Output Analyzer and combined output tabs show profile names; hovering a tab shows the model name; tab switching unaffected.

## Screenshots

N/A

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UN-2742]: https://zipstack.atlassian.net/browse/UN-2742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ