### PR TITLE
UN-3534 [FEAT] PG Queue Phase 8a — queue-transport routing gate + scaffold

### DIFF
--- a/workers/queue_backend/__init__.py
+++ b/workers/queue_backend/__init__.py
@@ -23,6 +23,15 @@ is dormant until an operator explicitly flips the flag.
 Unknown values raise — operators get a loud error at module import
 time rather than silently falling back, which would mask a typo'd
 flag in a production env.
+
+**Queue-transport routing (separate axis).** ``dispatch()`` consults
+:func:`~queue_backend.routing.select_backend`, which reads the
+PG-queue routing table (``WORKER_PG_QUEUE_ENABLED_TASKS``) to decide
+Celery-vs-PG per task. This is orthogonal to the barrier choice above:
+the barrier is *how a batch's fan-in fires the callback*; the transport
+is *how messages travel*. Both default to Celery. The routing table is
+a scaffold today — PG-selected tasks still ride Celery (no PG consumer
+yet) — so it is observable but inert.
 """
 
 import os
@@ -37,6 +46,7 @@ from .redis_barrier import (
     barrier_abort,
     barrier_decr_and_check,
 )
+from .routing import QueueBackend, select_backend
 
 __all__ = [
     "Barrier",
@@ -44,11 +54,13 @@ __all__ = [
     "BarrierHandle",
     "CeleryChordBarrier",
     "FairnessKey",
+    "QueueBackend",
     "RedisDecrBarrier",
     "barrier_abort",
     "barrier_decr_and_check",
     "dispatch",
     "get_barrier",
+    "select_backend",
     "worker_task",
 ]
 

--- a/workers/queue_backend/dispatch.py
+++ b/workers/queue_backend/dispatch.py
@@ -19,6 +19,11 @@ from .routing import QueueBackend, select_backend
 
 logger = logging.getLogger(__name__)
 
+# Task names already logged as PG-routed in this process. Bounds the
+# routing log to once per task name (per prefork child) so an opted-in
+# high-throughput task doesn't log on every dispatch.
+_pg_routing_logged: set[str] = set()
+
 
 def dispatch(
     task_name: str,
@@ -42,8 +47,14 @@ def dispatch(
     outside it guarantees today's wire is byte-identical regardless of
     the routing decision.
     """
-    if select_backend(task_name) is QueueBackend.PG:
-        logger.debug(
+    if (
+        select_backend(task_name) is QueueBackend.PG
+        and task_name not in _pg_routing_logged
+    ):
+        # INFO (not DEBUG) so the cutover is visible under a default log
+        # config; log-once per task name keeps the volume bounded.
+        _pg_routing_logged.add(task_name)
+        logger.info(
             "PG-queue routing selected for task=%r; dispatching via "
             "Celery (scaffold — no PG consumer yet)",
             task_name,

--- a/workers/queue_backend/dispatch.py
+++ b/workers/queue_backend/dispatch.py
@@ -7,6 +7,7 @@ call sites.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -14,6 +15,9 @@ from celery import current_app
 
 from .fairness import FairnessKey
 from .handle import DispatchHandle
+from .routing import QueueBackend, select_backend
+
+logger = logging.getLogger(__name__)
 
 
 def dispatch(
@@ -28,7 +32,23 @@ def dispatch(
 
     ``fairness`` is attached as the ``x-fairness-key`` header (not in
     kwargs). Pass ``None`` for non-workflow worker tasks.
+
+    The transport is chosen by :func:`select_backend` from the PG-queue
+    routing table (``WORKER_PG_QUEUE_ENABLED_TASKS``). In this phase the
+    table is a scaffold: PG-selected tasks are *logged* but still
+    dispatched via Celery, because no PG consumer exists yet. The
+    ``QueueBackend.PG`` branch below is the seam where the real PG
+    enqueue lands in a later phase — keeping the ``send_task`` call
+    outside it guarantees today's wire is byte-identical regardless of
+    the routing decision.
     """
+    if select_backend(task_name) is QueueBackend.PG:
+        logger.debug(
+            "PG-queue routing selected for task=%r; dispatching via "
+            "Celery (scaffold — no PG consumer yet)",
+            task_name,
+        )
+
     headers = fairness.as_header() if fairness is not None else None
     return current_app.send_task(
         task_name,

--- a/workers/queue_backend/pg_queue/__init__.py
+++ b/workers/queue_backend/pg_queue/__init__.py
@@ -5,20 +5,20 @@ Reserved home for the PostgreSQL-backed queue substrate (PGMQ +
 migration. PGMQ is a *core* worker transport — the intended primary
 backend — so it lives inside the queue-backend seam next to its sibling
 substrates (``dispatch``, ``routing``, ``barrier``, ``redis_barrier``),
-**not** under ``workers/plugins/`` (that directory is the git-ignored
-overlay for cloud/enterprise plugins copied in at build time).
+**not** under ``workers/plugins/``, whose plugin *implementation
+subdirectories* are the git-ignored overlay copied in at build time (the
+directory itself — ``__init__.py``, ``plugin_manager.py`` — is tracked).
 
-A subpackage (rather than a single module like the barriers) because
-the real implementation spans several files — ``config.py`` (per-task
-timeouts/retries), ``consumer.py`` (poll loop + graceful shutdown), and
-the single-orchestrator (admit / reap / route, fair-admission query).
+A subpackage (rather than a single module like the barriers) because the
+real implementation will likely span several modules (config, consumer
+poll loop, orchestrator) — exact layout TBD.
 
 Empty by design in this phase. Routing decisions are made by
 :func:`queue_backend.routing.select_backend`; until a consumer exists
 here, PG-selected dispatches still ride Celery (see
 ``queue_backend.dispatch``).
 
-Labs reference: ``Zipstack/labs:labs-ali/workflow-execution-architecture``
-— ``docs/pg-queue-implementation-guide.md`` (§3 Worker Lifecycle,
-§6 Orchestrator).
+Design reference: the PG Queue implementation guide in the labs repo
+(``workflow-execution-architecture``). Branch and section pointers move,
+so they're tracked on UN-3534 / the PR rather than baked in here.
 """

--- a/workers/queue_backend/pg_queue/__init__.py
+++ b/workers/queue_backend/pg_queue/__init__.py
@@ -1,0 +1,24 @@
+"""PG Queue (PGMQ) transport substrate — scaffold.
+
+Reserved home for the PostgreSQL-backed queue substrate (PGMQ +
+``SKIP LOCKED``) that will run alongside Celery during the Strangler-Fig
+migration. PGMQ is a *core* worker transport — the intended primary
+backend — so it lives inside the queue-backend seam next to its sibling
+substrates (``dispatch``, ``routing``, ``barrier``, ``redis_barrier``),
+**not** under ``workers/plugins/`` (that directory is the git-ignored
+overlay for cloud/enterprise plugins copied in at build time).
+
+A subpackage (rather than a single module like the barriers) because
+the real implementation spans several files — ``config.py`` (per-task
+timeouts/retries), ``consumer.py`` (poll loop + graceful shutdown), and
+the single-orchestrator (admit / reap / route, fair-admission query).
+
+Empty by design in this phase. Routing decisions are made by
+:func:`queue_backend.routing.select_backend`; until a consumer exists
+here, PG-selected dispatches still ride Celery (see
+``queue_backend.dispatch``).
+
+Labs reference: ``Zipstack/labs:labs-ali/workflow-execution-architecture``
+— ``docs/pg-queue-implementation-guide.md`` (§3 Worker Lifecycle,
+§6 Orchestrator).
+"""

--- a/workers/queue_backend/routing.py
+++ b/workers/queue_backend/routing.py
@@ -1,0 +1,78 @@
+"""Queue-transport routing gate (Strangler-Fig).
+
+Decides whether a given dispatch should ride the **Celery** transport
+(today's only real path) or the future **PG Queue** (PGMQ) transport,
+based on a per-task-type opt-in allow-list read from env:
+
+- ``WORKER_PG_QUEUE_ENABLED_TASKS`` — comma-separated task names routed
+  to PG. Empty / unset → everything routes to Celery.
+
+**Why an allow-list, not a global boolean.** A single
+``WORKER_QUEUE_BACKEND=pg`` switch would move *all* traffic at once —
+the big-bang migration the PG Queue rollout explicitly forbids. The
+allow-list lets an operator migrate one task type at a time
+(drain-and-cutover) and roll back instantly by removing an entry.
+
+(Per-org granularity is intentionally out of scope here. When tenant-level
+canarying is needed it slots in behind :func:`select_backend` as a small
+additive change — no call site touches the routing decision directly.)
+
+**Scaffold posture.** This module only makes the routing *decision*.
+In the current phase there is no PG consumer, so ``dispatch()`` still
+sends PG-selected tasks via Celery (the decision is observable in logs
+but inert). ``select_backend()`` is the seam where the real PG dispatch
+lands in a later phase.
+
+**Fail-safe parsing.** Unlike ``get_barrier()`` (which raises on an
+unrecognised value, because a typo'd substrate must not silently fall
+back), the routing table is a membership set with no "invalid value"
+concept: blanks and stray whitespace are simply dropped. Malformed or
+empty config can only ever resolve to the safe ``CELERY`` default —
+``select_backend()`` never raises.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import StrEnum
+
+# Env var name kept as a module literal (mirrors how the sibling
+# ``WORKER_BARRIER_BACKEND`` flag is read in ``queue_backend.__init__``)
+# so the queue-backend seam stays self-contained.
+_ENABLED_TASKS_ENV_VAR = "WORKER_PG_QUEUE_ENABLED_TASKS"
+
+
+class QueueBackend(StrEnum):
+    """Transport a dispatch is routed to.
+
+    ``StrEnum`` (3.11+) so ``QueueBackend.CELERY == "celery"`` holds at
+    runtime — members stand in anywhere a string is expected.
+    """
+
+    CELERY = "celery"
+    PG = "pg"
+
+
+def _parse_allow_list(env_var: str) -> frozenset[str]:
+    """Parse a comma-separated env allow-list into a set.
+
+    Trims surrounding whitespace per entry and drops blanks, so
+    ``"a, b ,, c"`` → ``{"a", "b", "c"}`` and ``""`` / unset → ``frozenset()``.
+    Read at call time (not import) so test harnesses that
+    ``monkeypatch.setenv`` flip the table per-test without a reload.
+    """
+    raw = os.getenv(env_var, "")
+    return frozenset(entry.strip() for entry in raw.split(",") if entry.strip())
+
+
+def select_backend(task_name: str) -> QueueBackend:
+    """Return the transport a dispatch should ride.
+
+    ``PG`` if ``task_name`` is in ``WORKER_PG_QUEUE_ENABLED_TASKS``;
+    otherwise ``CELERY``. Empty / unset allow-list → always ``CELERY``.
+
+    Never raises — the worst case is the safe ``CELERY`` default.
+    """
+    if task_name in _parse_allow_list(_ENABLED_TASKS_ENV_VAR):
+        return QueueBackend.PG
+    return QueueBackend.CELERY

--- a/workers/queue_backend/routing.py
+++ b/workers/queue_backend/routing.py
@@ -17,6 +17,22 @@ allow-list lets an operator migrate one task type at a time
 canarying is needed it slots in behind :func:`select_backend` as a small
 additive change — no call site touches the routing decision directly.)
 
+**Migration coherence — what the allow-list may and may not split.**
+Per-task routing is the right granularity for *independent / leaf* tasks
+(e.g. ``process_log_history``, ``send_webhook_notification``): no chain,
+no barrier, so one can ride PG while the rest stay on Celery — these are
+the safe first migration candidates. It is **not** valid to split the
+*coupled execution pipeline* (``async_execute_bin`` → file processing →
+callback, with the barrier fan-in) across substrates: a chain hands off
+stage→stage and the barrier coordinates a batch, so a single execution
+must run **entirely on one transport**. The migration unit for the
+pipeline is therefore the *execution*, not the task — the next phase will
+resolve the transport once at kickoff and carry it in ``ExecutionContext``
+(like the fairness key), and downstream dispatches will honour that
+carried choice over the per-task env. ``select_backend`` then becomes:
+"if the dispatch carries an execution-transport marker, use it; otherwise
+consult this allow-list." Until then, only enable *leaf* tasks here.
+
 **Scaffold posture.** This module only makes the routing *decision*.
 In the current phase there is no PG consumer, so ``dispatch()`` still
 sends PG-selected tasks via Celery (the decision is observable in logs

--- a/workers/queue_backend/routing.py
+++ b/workers/queue_backend/routing.py
@@ -23,6 +23,13 @@ sends PG-selected tasks via Celery (the decision is observable in logs
 but inert). ``select_backend()`` is the seam where the real PG dispatch
 lands in a later phase.
 
+**Observability.** Because the gate is silent-by-construction (a
+misrouted task still runs on Celery), the only signals are logs, emitted
+at INFO so they survive a default log config: the configured allow-list
+is logged once per process (:func:`_log_allow_list_once`, so a typo is
+visible even if it never matches a real task), and the first time each
+task is routed to PG (``dispatch()``, log-once per task name).
+
 **Fail-safe parsing.** Unlike ``get_barrier()`` (which raises on an
 unrecognised value, because a typo'd substrate must not silently fall
 back), the routing table is a membership set with no "invalid value"
@@ -33,36 +40,67 @@ empty config can only ever resolve to the safe ``CELERY`` default —
 
 from __future__ import annotations
 
+import logging
 import os
 from enum import StrEnum
+
+logger = logging.getLogger(__name__)
 
 # Env var name kept as a module literal (mirrors how the sibling
 # ``WORKER_BARRIER_BACKEND`` flag is read in ``queue_backend.__init__``)
 # so the queue-backend seam stays self-contained.
 _ENABLED_TASKS_ENV_VAR = "WORKER_PG_QUEUE_ENABLED_TASKS"
 
+# One-shot guard so the configured allow-list is logged once per process
+# (see ``_log_allow_list_once``). Module-level → per prefork child.
+_allow_list_logged = False
+
 
 class QueueBackend(StrEnum):
     """Transport a dispatch is routed to.
 
-    ``StrEnum`` (3.11+) so ``QueueBackend.CELERY == "celery"`` holds at
-    runtime — members stand in anywhere a string is expected.
+    ``StrEnum`` (3.11+) is inherited for symmetry with ``BarrierBackend``,
+    but unlike that enum this one is never read from / written to env —
+    only the task-name allow-list is. So callers MUST compare by identity
+    (``backend is QueueBackend.PG``), never ``== "pg"``: ``StrEnum`` makes a
+    typo'd ``== "cellery"`` a silent ``False`` rather than an error.
     """
 
     CELERY = "celery"
     PG = "pg"
 
 
-def _parse_allow_list(env_var: str) -> frozenset[str]:
-    """Parse a comma-separated env allow-list into a set.
+def _parse_allow_list() -> frozenset[str]:
+    """Parse ``WORKER_PG_QUEUE_ENABLED_TASKS`` into a set of task names.
 
     Trims surrounding whitespace per entry and drops blanks, so
     ``"a, b ,, c"`` → ``{"a", "b", "c"}`` and ``""`` / unset → ``frozenset()``.
     Read at call time (not import) so test harnesses that
     ``monkeypatch.setenv`` flip the table per-test without a reload.
     """
-    raw = os.getenv(env_var, "")
-    return frozenset(entry.strip() for entry in raw.split(",") if entry.strip())
+    stripped = (
+        entry.strip() for entry in os.getenv(_ENABLED_TASKS_ENV_VAR, "").split(",")
+    )
+    return frozenset(entry for entry in stripped if entry)
+
+
+def _log_allow_list_once(allow_list: frozenset[str]) -> None:
+    """Log the configured allow-list once per process, at INFO.
+
+    Makes a misconfiguration eyeballable at boot: a typo'd task name
+    (``async_execute_bni``) silently routes everything to Celery, but it
+    still shows up here so an operator can spot it. Only fires for a
+    *non-empty* allow-list — the default (feature off) stays silent so
+    the scaffold is truly inert when unused.
+    """
+    global _allow_list_logged
+    if _allow_list_logged or not allow_list:
+        return
+    _allow_list_logged = True
+    logger.info(
+        "PG-queue routing enabled for tasks: %s (all others → Celery)",
+        sorted(allow_list),
+    )
 
 
 def select_backend(task_name: str) -> QueueBackend:
@@ -73,6 +111,8 @@ def select_backend(task_name: str) -> QueueBackend:
 
     Never raises — the worst case is the safe ``CELERY`` default.
     """
-    if task_name in _parse_allow_list(_ENABLED_TASKS_ENV_VAR):
+    allow_list = _parse_allow_list()
+    _log_allow_list_once(allow_list)
+    if task_name in allow_list:
         return QueueBackend.PG
     return QueueBackend.CELERY

--- a/workers/sample.env
+++ b/workers/sample.env
@@ -149,10 +149,15 @@ WORKER_BARRIER_KEY_TTL_SECONDS=21600
 # zero behaviour change. No Flipt server required.
 #
 # Roll back instantly by removing an entry; flips take effect on worker
-# restart (same posture as every other WORKER_* env). The value must be
-# a task dispatched via queue_backend.dispatch() — e.g. async_execute_bin
-# (scheduler) or send_webhook_notification (notifications).
-# WORKER_PG_QUEUE_ENABLED_TASKS=async_execute_bin
+# restart (same posture as every other WORKER_* env).
+#
+# Only list *leaf* tasks dispatched via queue_backend.dispatch() — i.e. no
+# downstream chain or barrier fan-in (e.g. send_webhook_notification). Do
+# NOT list coupled pipeline tasks like async_execute_bin here: one execution
+# must run wholly on one transport, so the pipeline migrates per-execution
+# (via ExecutionContext) in a later phase, not per-task. See the routing.py
+# module docstring for the full constraint.
+# WORKER_PG_QUEUE_ENABLED_TASKS=send_webhook_notification
 
 # Database URL (for fallback usage)
 DATABASE_URL=postgresql://unstract_dev:unstract_pass@unstract-db:5432/unstract_db

--- a/workers/sample.env
+++ b/workers/sample.env
@@ -131,6 +131,29 @@ WORKER_BARRIER_BACKEND=chord
 # workflows can plausibly span >6h.
 WORKER_BARRIER_KEY_TTL_SECONDS=21600
 
+# =============================================================================
+# PG Queue Routing (Strangler-Fig)
+# =============================================================================
+# Selects the queue *transport* per task — Celery (default) or PG Queue
+# (PGMQ). Separate axis from the barrier above: the barrier is how a
+# batch's fan-in fires the callback; this is how messages travel.
+#
+# A comma-separated allow-list drives a gradual, per-task-type migration
+# (NOT a global on/off switch). A task routes to PG if its name is
+# listed. Unset / empty (the default) → everything routes to Celery,
+# exactly as today.
+#
+# Scaffold note: in this release there is no PG consumer yet, so
+# PG-selected tasks are logged but still dispatched via Celery. Setting
+# this flag is therefore safe to test routing decisions locally with
+# zero behaviour change. No Flipt server required.
+#
+# Roll back instantly by removing an entry; flips take effect on worker
+# restart (same posture as every other WORKER_* env). The value must be
+# a task dispatched via queue_backend.dispatch() — e.g. async_execute_bin
+# (scheduler) or send_webhook_notification (notifications).
+# WORKER_PG_QUEUE_ENABLED_TASKS=async_execute_bin
+
 # Database URL (for fallback usage)
 DATABASE_URL=postgresql://unstract_dev:unstract_pass@unstract-db:5432/unstract_db
 

--- a/workers/tests/test_queue_backend_seam.py
+++ b/workers/tests/test_queue_backend_seam.py
@@ -193,9 +193,9 @@ class TestWorkerTaskEquivalence:
     def test_worker_task_matches_shared_task_registration(self):
         """A function decorated with @worker_task is the same kind of object as
         one decorated with @shared_task — same registration semantics, same
-        invocation interface."""
+        invocation interface.
+        """
         from celery import shared_task
-
         from queue_backend import worker_task
 
         @worker_task(name="queue_backend_test.via_seam")
@@ -280,17 +280,22 @@ class TestPublicSurface:
         # (registered as a Celery task on import) + the BarrierBackend
         # enum + the get_barrier factory that the WORKER_BARRIER_BACKEND
         # env flag drives.
+        # Phase 8a adds QueueBackend + select_backend — the queue-transport
+        # routing gate that the WORKER_PG_QUEUE_ENABLED_TASKS / _ORGS
+        # allow-lists drive.
         assert set(queue_backend.__all__) == {
             "Barrier",
             "BarrierBackend",
             "BarrierHandle",
             "CeleryChordBarrier",
             "FairnessKey",
+            "QueueBackend",
             "RedisDecrBarrier",
             "barrier_abort",
             "barrier_decr_and_check",
             "dispatch",
             "get_barrier",
+            "select_backend",
             "worker_task",
         }
 

--- a/workers/tests/test_queue_backend_seam.py
+++ b/workers/tests/test_queue_backend_seam.py
@@ -281,8 +281,8 @@ class TestPublicSurface:
         # enum + the get_barrier factory that the WORKER_BARRIER_BACKEND
         # env flag drives.
         # Phase 8a adds QueueBackend + select_backend — the queue-transport
-        # routing gate that the WORKER_PG_QUEUE_ENABLED_TASKS / _ORGS
-        # allow-lists drive.
+        # routing gate that the WORKER_PG_QUEUE_ENABLED_TASKS allow-list
+        # drives.
         assert set(queue_backend.__all__) == {
             "Barrier",
             "BarrierBackend",

--- a/workers/tests/test_routing.py
+++ b/workers/tests/test_routing.py
@@ -1,0 +1,135 @@
+"""Tests for the PG-queue routing gate (``queue_backend.routing``).
+
+Two layers:
+
+1. **select_backend()** resolves the per-task allow-list correctly,
+   defaults to ``CELERY`` when unset, and never raises on malformed
+   input.
+
+2. **dispatch() is inert under routing** — the ``current_app.send_task``
+   call is byte-identical whether the routing table selects ``CELERY``
+   or ``PG``. This pins the scaffold invariant: the seam is observable
+   (a log line) but changes nothing on the wire until a real PG
+   consumer lands.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from queue_backend import QueueBackend, select_backend
+from queue_backend.fairness import FairnessKey, WorkloadType
+
+ENABLED_TASKS_ENV = "WORKER_PG_QUEUE_ENABLED_TASKS"
+
+
+@pytest.fixture(autouse=True)
+def _clear_routing_env(monkeypatch):
+    """Each test starts from an empty routing table (all-Celery default)."""
+    monkeypatch.delenv(ENABLED_TASKS_ENV, raising=False)
+
+
+# --- select_backend() resolution ---
+
+
+class TestSelectBackend:
+    def test_empty_table_routes_to_celery(self):
+        assert select_backend("any_task") is QueueBackend.CELERY
+
+    def test_task_opted_in_routes_to_pg(self, monkeypatch):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "process_log_history")
+        assert select_backend("process_log_history") is QueueBackend.PG
+
+    def test_task_not_opted_in_routes_to_celery(self, monkeypatch):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "process_log_history")
+        assert select_backend("some_other_task") is QueueBackend.CELERY
+
+    def test_multiple_entries_membership(self, monkeypatch):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "a,b,c")
+        assert select_backend("b") is QueueBackend.PG
+        assert select_backend("d") is QueueBackend.CELERY
+
+
+class TestSelectBackendTolerantParsing:
+    """Malformed / whitespace input resolves to the safe default, never raises."""
+
+    def test_whitespace_around_entries_trimmed(self, monkeypatch):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, " a , b ,  c ")
+        assert select_backend("b") is QueueBackend.PG
+
+    def test_empty_and_blank_segments_ignored(self, monkeypatch):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "a,,  ,b")
+        assert select_backend("a") is QueueBackend.PG
+        # A blank segment must not become a matchable empty-string entry.
+        assert select_backend("") is QueueBackend.CELERY
+
+    def test_empty_string_env_routes_to_celery(self, monkeypatch):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "   ")
+        assert select_backend("any_task") is QueueBackend.CELERY
+
+    def test_does_not_raise_on_any_input(self, monkeypatch):
+        for value in ("", "   ", ",,,", "a,b", "\t\n", ",a,"):
+            monkeypatch.setenv(ENABLED_TASKS_ENV, value)
+            # Must resolve to an enum member, never raise.
+            assert select_backend("a") in (QueueBackend.CELERY, QueueBackend.PG)
+
+
+class TestQueueBackendEnum:
+    def test_string_values(self):
+        assert QueueBackend.CELERY == "celery"
+        assert QueueBackend.PG == "pg"
+
+    def test_members(self):
+        assert {b.value for b in QueueBackend} == {"celery", "pg"}
+
+
+# --- dispatch() is inert under routing (the scaffold invariant) ---
+
+
+class TestDispatchByteIdenticalRegardlessOfRouting:
+    """``dispatch()`` produces the same send_task call whether routed PG or Celery."""
+
+    def _capture_send_task(self, task_name, fairness):
+        from queue_backend import dispatch
+
+        with patch("queue_backend.dispatch.current_app") as mock_app:
+            dispatch(
+                task_name,
+                args=["a", 1],
+                kwargs={"k": "v"},
+                queue="general",
+                fairness=fairness,
+            )
+        return mock_app.send_task.call_args
+
+    def test_pg_selection_does_not_change_the_wire(self, monkeypatch):
+        fairness = FairnessKey(org_id="org-1", workload_type=WorkloadType.API)
+
+        # Celery path (empty table).
+        celery_call = self._capture_send_task("t1", fairness)
+
+        # PG path (task opted in) — same inputs.
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "t1")
+        pg_call = self._capture_send_task("t1", fairness)
+
+        assert celery_call == pg_call
+        assert pg_call.args[0] == "t1"
+        assert pg_call.kwargs["args"] == ["a", 1]
+        assert pg_call.kwargs["kwargs"] == {"k": "v"}
+        assert pg_call.kwargs["queue"] == "general"
+
+    def test_dispatch_without_fairness_still_routes_by_task(self, monkeypatch):
+        """Routing keys on task name only; fairness is irrelevant to the decision."""
+        from queue_backend import dispatch
+
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "bare_task")
+        with patch("queue_backend.dispatch.current_app") as mock_app:
+            dispatch("bare_task")
+        # Still dispatched (via Celery), header is None (no fairness).
+        assert mock_app.send_task.call_args.args[0] == "bare_task"
+        assert mock_app.send_task.call_args.kwargs["headers"] is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/workers/tests/test_routing.py
+++ b/workers/tests/test_routing.py
@@ -1,33 +1,49 @@
 """Tests for the PG-queue routing gate (``queue_backend.routing``).
 
-Two layers:
+Three layers:
 
 1. **select_backend()** resolves the per-task allow-list correctly,
    defaults to ``CELERY`` when unset, and never raises on malformed
    input.
 
-2. **dispatch() is inert under routing** — the ``current_app.send_task``
+2. **Observability** — the configured allow-list is logged once, and a
+   PG cutover emits a log. These are the gate's only observable effect,
+   so they're asserted explicitly (a future "the gate is inert, delete
+   it" refactor must fail a test, not pass silently).
+
+3. **dispatch() is inert under routing** — the ``current_app.send_task``
    call is byte-identical whether the routing table selects ``CELERY``
-   or ``PG``. This pins the scaffold invariant: the seam is observable
-   (a log line) but changes nothing on the wire until a real PG
-   consumer lands.
+   or ``PG``.
 """
 
 from __future__ import annotations
 
+import importlib
+import logging
 from unittest.mock import patch
 
 import pytest
-from queue_backend import QueueBackend, select_backend
+from queue_backend import QueueBackend, dispatch, select_backend
+from queue_backend import routing as routing_mod
 from queue_backend.fairness import FairnessKey, WorkloadType
+from queue_backend.routing import _ENABLED_TASKS_ENV_VAR as ENABLED_TASKS_ENV
 
-ENABLED_TASKS_ENV = "WORKER_PG_QUEUE_ENABLED_TASKS"
+# ``queue_backend.__init__`` binds ``dispatch`` to the *function*, shadowing
+# the submodule attribute — import the module explicitly to reach its globals.
+dispatch_mod = importlib.import_module("queue_backend.dispatch")
 
 
 @pytest.fixture(autouse=True)
-def _clear_routing_env(monkeypatch):
-    """Each test starts from an empty routing table (all-Celery default)."""
+def _reset_routing_state(monkeypatch):
+    """Empty allow-list + cleared log-once guards before each test.
+
+    The allow-list-logged flag and the per-task routing-logged set are
+    process-global one-shot guards; reset them so caplog assertions are
+    deterministic regardless of test order.
+    """
     monkeypatch.delenv(ENABLED_TASKS_ENV, raising=False)
+    routing_mod._allow_list_logged = False
+    dispatch_mod._pg_routing_logged.clear()
 
 
 # --- select_backend() resolution ---
@@ -84,6 +100,57 @@ class TestQueueBackendEnum:
         assert {b.value for b in QueueBackend} == {"celery", "pg"}
 
 
+# --- Observability (the gate's only observable effect) ---
+
+
+class TestObservability:
+    def test_allow_list_logged_once_when_configured(self, monkeypatch, caplog):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "async_execute_bin")
+        with caplog.at_level(logging.INFO, logger="queue_backend.routing"):
+            select_backend("x")
+            select_backend("y")  # second call must NOT re-log
+        hits = [r for r in caplog.records if "PG-queue routing enabled" in r.getMessage()]
+        assert len(hits) == 1
+        assert "async_execute_bin" in hits[0].getMessage()
+
+    def test_empty_allow_list_logs_nothing(self, caplog):
+        """Default (feature off) stays silent — truly inert."""
+        with caplog.at_level(logging.INFO, logger="queue_backend.routing"):
+            select_backend("x")
+        assert "PG-queue routing enabled" not in caplog.text
+
+    def test_pg_selection_emits_routing_log(self, monkeypatch, caplog):
+        """Pins the dispatch() routing branch: deleting it must fail here."""
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "t1")
+        with (
+            patch("queue_backend.dispatch.current_app"),
+            caplog.at_level(logging.INFO, logger="queue_backend.dispatch"),
+        ):
+            dispatch("t1")
+        assert "PG-queue routing selected" in caplog.text
+
+    def test_celery_selection_emits_no_routing_log(self, caplog):
+        """Negative case — guards against the gate being made unconditional."""
+        with (
+            patch("queue_backend.dispatch.current_app"),
+            caplog.at_level(logging.INFO, logger="queue_backend.dispatch"),
+        ):
+            dispatch("t1")  # empty allow-list → CELERY
+        assert "PG-queue routing selected" not in caplog.text
+
+    def test_routing_log_bounded_to_once_per_task(self, monkeypatch, caplog):
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "t1")
+        with (
+            patch("queue_backend.dispatch.current_app"),
+            caplog.at_level(logging.INFO, logger="queue_backend.dispatch"),
+        ):
+            dispatch("t1")
+            dispatch("t1")
+            dispatch("t1")
+        hits = [r for r in caplog.records if "PG-queue routing selected" in r.getMessage()]
+        assert len(hits) == 1
+
+
 # --- dispatch() is inert under routing (the scaffold invariant) ---
 
 
@@ -91,8 +158,6 @@ class TestDispatchByteIdenticalRegardlessOfRouting:
     """``dispatch()`` produces the same send_task call whether routed PG or Celery."""
 
     def _capture_send_task(self, task_name, fairness):
-        from queue_backend import dispatch
-
         with patch("queue_backend.dispatch.current_app") as mock_app:
             dispatch(
                 task_name,
@@ -121,8 +186,6 @@ class TestDispatchByteIdenticalRegardlessOfRouting:
 
     def test_dispatch_without_fairness_still_routes_by_task(self, monkeypatch):
         """Routing keys on task name only; fairness is irrelevant to the decision."""
-        from queue_backend import dispatch
-
         monkeypatch.setenv(ENABLED_TASKS_ENV, "bare_task")
         with patch("queue_backend.dispatch.current_app") as mock_app:
             dispatch("bare_task")


### PR DESCRIPTION
## What

Adds the Strangler-Fig **queue-transport routing gate** that lets PG Queue (PGMQ) coexist with Celery, so task types can be migrated one at a time. **Scaffold only** — the PG branch is a Celery-routing stub (no PG consumer exists yet), so this is **zero-behaviour-change by construction**.

Targets the `feat/UN-3445-pg-queue-integration` integration branch (not `main`) — PG-queue work accumulates there until the full path is vetted.

## Changes

- **`queue_backend/routing.py`** *(new)* — `QueueBackend{CELERY,PG}` enum + `select_backend(task_name)` reading the `WORKER_PG_QUEUE_ENABLED_TASKS` allow-list. Tolerant comma-separated parsing (trims whitespace, drops blanks); empty/unset → all Celery; never raises.
- **`queue_backend/dispatch.py`** — consults `select_backend()` and logs the decision at DEBUG. The `send_task` call sits **outside** the `QueueBackend.PG` branch, so the wire is **byte-identical** regardless of the routing decision. PG-selected tasks still dispatch via Celery.
- **`queue_backend/pg_queue/__init__.py`** *(new)* — scaffold subpackage. PGMQ is a core transport substrate, so it lives in the seam beside `dispatch`/`routing`/`barrier`, not under the git-ignored `plugins/` cloud overlay.
- **`queue_backend/__init__.py`** — exports `QueueBackend` + `select_backend`; docstring documents the routing axis as orthogonal to the barrier axis.
- **`sample.env`** — documents the flag (default-safe, OSS-friendly, no Flipt server required).
- **tests** — 12 routing tests including the byte-identical-dispatch characterisation pinning the inert-scaffold invariant; seam `__all__` surface updated.

## Why a per-task allow-list (not a global boolean)

A single global switch would move all traffic at once — the big-bang migration we explicitly avoid. The allow-list migrates one task type at a time and rolls back instantly by removing an entry. Per-org routing is intentionally deferred to the rollout phase; it slots in behind `select_backend()` as an additive change when tenant-level canarying is needed.

## Scope guards

- **Barrier axis untouched** — `WORKER_BARRIER_BACKEND` stays `chord`. Separate concern.
- No call-site changes; no new mandatory worker; system works with and without the flag set.
- Out of scope (later phases): real PGMQ enqueue/dequeue, consumer poll loop, orchestrator.

## Testing

- 45 queue_backend unit tests green (12 new routing tests); ruff clean.
- Dev-tested on a running worker stack: opting `send_webhook_notification` into the allow-list produced the routing-selected DEBUG line while the task still dispatched via Celery and the notification delivered normally. Unset → no line, normal behaviour. New code loaded into all workers without breaking startup.

Ticket: UN-3534 (parent UN-3533, epic UN-3445)

🤖 Generated with [Claude Code](https://claude.com/claude-code)