### PR TITLE
UN-1009 [FIX] Correct LLMWhisperer adapter API key field label from 'Unstract Key' to 'LLMWhisperer Key'

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -23,7 +23,7 @@
     },
     "unstract_key": {
       "type": "string",
-      "title": "Unstract Key",
+      "title": "LLMWhisperer Key",
       "format": "password",
       "description": "API key obtained from the [Unstract developer portal](https://unstract-api-resource.developer.azure-api.net)"
     },

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/static/json_schema.json
@@ -22,7 +22,7 @@
     },
     "unstract_key": {
       "type": "string",
-      "title": "Unstract Key",
+      "title": "LLMWhisperer Key",
       "format": "password",
       "description": "API key obtained from the [Unstract developer portal](https://us-central.unstract.com/landing?selectedProduct=llm-whisperer)"
     },


### PR DESCRIPTION
## What

- Renames the `unstract_key` field's display label from **Unstract Key** to **LLMWhisperer Key** in both LLMWhisperer (v1) and LLMWhisperer v2 X2Text adapter JSON schemas.

## Why

- When creating a new LLMWhisperer profile, the API key field was labeled "Unstract Key", which is confusing — the key being asked for is the LLMWhisperer API key obtained from the LLMWhisperer portal (Jira: UN-1009).

## How

- Changed the `title` of the `unstract_key` property in `unstract/sdk1/.../x2text/llm_whisperer/src/static/json_schema.json` and `.../llm_whisperer_v2/src/static/json_schema.json`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. `title` is display-only in the JSON schema; the property key `unstract_key` (which backend code and the cloud subscription-plugin schema transform reference) is unchanged.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

- None

## Related Issues or PRs

- Jira: UN-1009

## Dependencies Versions

- None

## Notes on Testing

- Verified `grep -rn '"Unstract Key"'` now returns no occurrences in the repo; only the two schema titles changed.

## Screenshots

- N/A (label text change in adapter config form)

## Checklist

I have read and understood the [Contribution Guidelines](https://github.com/Zipstack/unstract/blob/main/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)