### PR TITLE
UN-3539 [FEAT] PG Queue Phase 9c — consumer poll loop (claim → run → ack)

### DIFF
--- a/workers/queue_backend/pg_queue/client.py
+++ b/workers/queue_backend/pg_queue/client.py
@@ -79,13 +79,15 @@ class QueueMessage:
     ``message`` is the already-decoded JSONB payload (psycopg2 parses
     ``jsonb`` to a Python ``dict``). ``frozen`` freezes the binding only —
     the ``dict`` itself is mutable, so treat the payload as read-only by
-    convention. ``read_ct`` is the post-claim delivery count (1 on the
-    first claim), so consumers can cap redelivery of a poison message.
+    convention. ``read_ct`` is the post-claim delivery count — always ``>= 1``
+    from the dequeue (``read_ct = read_ct + 1 RETURNING``), so consumers can
+    cap redelivery of a poison message. No default: a ``0`` ("never claimed")
+    can't come from the dequeue and would silently bypass the poison guard.
     """
 
     msg_id: int
     message: dict[str, Any]
-    read_ct: int = 0
+    read_ct: int
 
 
 class PgQueueClient:
@@ -191,16 +193,17 @@ class PgQueueClient:
 
         ``False`` means the row was already gone — typically its visibility
         timeout expired during processing and another worker (re)claimed it,
-        i.e. the work may be processed twice. Logged at WARNING so this
-        at-least-once condition is visible rather than silently swallowed.
+        i.e. the work may be processed twice. Logged at DEBUG here; the
+        consumer emits the contextual WARNING (it names the task), so this
+        avoids a duplicate warning per double-run.
         """
         with self._cursor() as cur:
             cur.execute("DELETE FROM pg_queue_message WHERE msg_id = %s", (msg_id,))
             deleted = cur.rowcount
         if deleted == 0:
-            logger.warning(
-                "PG-queue: delete(msg_id=%s) removed no row — message was already "
-                "gone (vt likely expired during processing; possible re-delivery).",
+            logger.debug(
+                "PG-queue: delete(msg_id=%s) removed no row — already gone "
+                "(vt likely expired; consumer logs the contextual warning).",
                 msg_id,
             )
         return deleted == 1

--- a/workers/queue_backend/pg_queue/client.py
+++ b/workers/queue_backend/pg_queue/client.py
@@ -68,7 +68,7 @@ UPDATE pg_queue_message
         FOR UPDATE SKIP LOCKED
       LIMIT %s
  )
-RETURNING msg_id, message
+RETURNING msg_id, message, read_ct
 """
 
 
@@ -79,11 +79,13 @@ class QueueMessage:
     ``message`` is the already-decoded JSONB payload (psycopg2 parses
     ``jsonb`` to a Python ``dict``). ``frozen`` freezes the binding only —
     the ``dict`` itself is mutable, so treat the payload as read-only by
-    convention.
+    convention. ``read_ct`` is the post-claim delivery count (1 on the
+    first claim), so consumers can cap redelivery of a poison message.
     """
 
     msg_id: int
     message: dict[str, Any]
+    read_ct: int = 0
 
 
 class PgQueueClient:
@@ -180,7 +182,9 @@ class PgQueueClient:
         with self._cursor() as cur:
             cur.execute(_DEQUEUE_SQL, (vt_seconds, queue_name, qty))
             rows = cur.fetchall()
-        return [QueueMessage(msg_id=int(r[0]), message=r[1]) for r in rows]
+        return [
+            QueueMessage(msg_id=int(r[0]), message=r[1], read_ct=int(r[2])) for r in rows
+        ]
 
     def delete(self, msg_id: int) -> bool:
         """Ack a processed message. Returns ``True`` if a row was removed.

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -1,0 +1,157 @@
+"""PG queue consumer — claims tasks from ``pg_queue_message`` and runs them.
+
+The producer side (9b) enqueues a :class:`~queue_backend.pg_queue.TaskPayload`
+when a task is routed to PG. This is the other half: it polls the queue with
+``SKIP LOCKED`` + a visibility timeout (via :class:`PgQueueClient`), runs each
+claimed task **in-process** (no Celery broker), and acks by deleting the row.
+
+A task that fails — or a crash before ack — is redelivered once its ``vt``
+expires (at-least-once; tasks must be idempotent). A task name not in the
+registry can never run, so it is dropped (with a loud log) rather than left to
+redeliver forever as a poison message.
+
+Run as ``python -m queue_backend.pg_queue.consumer`` (config via env). The
+worker bootstrap must have imported/registered the Celery tasks so they
+resolve in ``current_app.tasks``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from typing import TYPE_CHECKING
+
+from celery import current_app
+
+from .client import PgQueueClient
+
+if TYPE_CHECKING:
+    from celery import Celery
+
+    from .client import QueueMessage
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_QUEUE = "default"
+_DEFAULT_BATCH = 10
+_DEFAULT_VT_SECONDS = 30
+_DEFAULT_POLL_INTERVAL = 0.1
+_DEFAULT_BACKOFF_MAX = 2.0
+
+
+class PgQueueConsumer:
+    """Polls one PG queue, runs each claimed task in-process, acks on success."""
+
+    def __init__(
+        self,
+        queue_name: str,
+        *,
+        client: PgQueueClient | None = None,
+        app: Celery | None = None,
+        batch_size: int = _DEFAULT_BATCH,
+        vt_seconds: int = _DEFAULT_VT_SECONDS,
+        poll_interval: float = _DEFAULT_POLL_INTERVAL,
+        backoff_max: float = _DEFAULT_BACKOFF_MAX,
+    ) -> None:
+        self.queue_name = queue_name
+        self._client = client if client is not None else PgQueueClient()
+        self._app = app if app is not None else current_app
+        self.batch_size = batch_size
+        self.vt_seconds = vt_seconds
+        self.poll_interval = poll_interval
+        self.backoff_max = backoff_max
+        self._running = False
+
+    def poll_once(self) -> int:
+        """Claim + process one batch; returns the number of messages claimed."""
+        messages = self._client.read(
+            self.queue_name, vt_seconds=self.vt_seconds, qty=self.batch_size
+        )
+        for message in messages:
+            self._handle(message)
+        return len(messages)
+
+    def _handle(self, message: QueueMessage) -> None:
+        payload = message.message
+        task_name = payload.get("task_name")
+        task = self._app.tasks.get(task_name)
+        if task is None:
+            # Can never run → drop (and shout) rather than redeliver forever.
+            logger.error(
+                "PG-queue consumer: unknown task %r (msg_id=%s) — dropping",
+                task_name,
+                message.msg_id,
+            )
+            self._client.delete(message.msg_id)
+            return
+        try:
+            # Run the task body in-process (eager), propagating failures.
+            task.apply(
+                args=payload.get("args") or [],
+                kwargs=payload.get("kwargs") or {},
+                throw=True,
+            )
+        except Exception:
+            # Leave the row: its vt expires and it is redelivered.
+            logger.exception(
+                "PG-queue consumer: task %r (msg_id=%s) failed — leaving for "
+                "vt-expiry redelivery",
+                task_name,
+                message.msg_id,
+            )
+            return
+        self._client.delete(message.msg_id)  # ack
+
+    def run(self, *, install_signals: bool = True) -> None:
+        """Poll loop with empty-queue backoff and graceful shutdown."""
+        self._running = True
+        if install_signals:
+            self._install_signal_handlers()
+        logger.info(
+            "PG-queue consumer started (queue=%r, batch=%s, vt=%ss)",
+            self.queue_name,
+            self.batch_size,
+            self.vt_seconds,
+        )
+        backoff = self.poll_interval
+        while self._running:
+            if self.poll_once():
+                backoff = self.poll_interval
+            else:
+                time.sleep(backoff)
+                backoff = min(backoff * 2, self.backoff_max)
+        logger.info("PG-queue consumer stopped (queue=%r)", self.queue_name)
+
+    def stop(self, *_: object) -> None:
+        """Request a graceful stop after the current batch."""
+        self._running = False
+
+    def _install_signal_handlers(self) -> None:
+        # signal.signal only works in the main thread.
+        try:
+            signal.signal(signal.SIGTERM, self.stop)
+            signal.signal(signal.SIGINT, self.stop)
+        except ValueError:
+            logger.debug(
+                "PG-queue consumer: signal handlers not installed (non-main thread)"
+            )
+
+
+def main() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+    PgQueueConsumer(
+        queue_name=os.getenv("WORKER_PG_QUEUE_CONSUMER_QUEUE", _DEFAULT_QUEUE),
+        batch_size=int(os.getenv("WORKER_PG_QUEUE_CONSUMER_BATCH", _DEFAULT_BATCH)),
+        vt_seconds=int(
+            os.getenv("WORKER_PG_QUEUE_CONSUMER_VT_SECONDS", _DEFAULT_VT_SECONDS)
+        ),
+        poll_interval=float(
+            os.getenv("WORKER_PG_QUEUE_CONSUMER_POLL_INTERVAL", _DEFAULT_POLL_INTERVAL)
+        ),
+    ).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -6,9 +6,12 @@ when a task is routed to PG. This is the other half: it polls the queue with
 claimed task **in-process** (no Celery broker), and acks by deleting the row.
 
 A task that fails — or a crash before ack — is redelivered once its ``vt``
-expires (at-least-once; tasks must be idempotent). A task name not in the
-registry can never run, so it is dropped (with a loud log) rather than left to
-redeliver forever as a poison message.
+expires (at-least-once; tasks must be idempotent), bounded by ``max_attempts``
+(``read_ct``): a task that keeps failing past the cap is dropped as a poison
+message (logged with its payload) rather than redelivered forever. A message
+with no ``task_name`` (malformed/foreign) or a name not in the registry can
+never run, so it is likewise dropped with a loud log. The fairness header is
+rebuilt from the payload so a PG-routed run mirrors the Celery dispatch path.
 
 Run as ``python -m queue_backend.pg_queue.consumer`` (config via env). The
 worker bootstrap must have imported/registered the Celery tasks so they
@@ -25,6 +28,7 @@ from typing import TYPE_CHECKING
 
 from celery import current_app
 
+from ..fairness import FAIRNESS_HEADER_NAME
 from .client import PgQueueClient
 
 if TYPE_CHECKING:
@@ -39,6 +43,9 @@ _DEFAULT_BATCH = 10
 _DEFAULT_VT_SECONDS = 30
 _DEFAULT_POLL_INTERVAL = 0.1
 _DEFAULT_BACKOFF_MAX = 2.0
+# A task claimed more than this many times keeps failing — drop it (poison)
+# rather than redeliver forever.
+_DEFAULT_MAX_ATTEMPTS = 5
 
 
 class PgQueueConsumer:
@@ -54,7 +61,19 @@ class PgQueueConsumer:
         vt_seconds: int = _DEFAULT_VT_SECONDS,
         poll_interval: float = _DEFAULT_POLL_INTERVAL,
         backoff_max: float = _DEFAULT_BACKOFF_MAX,
+        max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     ) -> None:
+        # Validate at construction so a misconfigured consumer fails here
+        # rather than batch-after-batch once the loop starts.
+        for name, value in (
+            ("batch_size", batch_size),
+            ("vt_seconds", vt_seconds),
+            ("poll_interval", poll_interval),
+            ("backoff_max", backoff_max),
+            ("max_attempts", max_attempts),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value!r}")
         self.queue_name = queue_name
         self._client = client if client is not None else PgQueueClient()
         self._app = app if app is not None else current_app
@@ -62,6 +81,7 @@ class PgQueueConsumer:
         self.vt_seconds = vt_seconds
         self.poll_interval = poll_interval
         self.backoff_max = backoff_max
+        self.max_attempts = max_attempts
         self._running = False
 
     def poll_once(self) -> int:
@@ -76,9 +96,38 @@ class PgQueueConsumer:
     def _handle(self, message: QueueMessage) -> None:
         payload = message.message
         task_name = payload.get("task_name")
+
+        # Malformed / foreign payload: no task name → can't run; drop with a
+        # log that points at the payload, not at task registration.
+        if not task_name:
+            logger.error(
+                "PG-queue consumer: payload missing task_name (msg_id=%s) — "
+                "dropping malformed message: %r",
+                message.msg_id,
+                payload,
+            )
+            self._client.delete(message.msg_id)
+            return
+
+        # Poison message: a task re-claimed past the cap keeps failing. Drop
+        # it (with the payload, so it's recoverable from logs) instead of
+        # redelivering on every vt expiry forever.
+        if message.read_ct > self.max_attempts:
+            logger.error(
+                "PG-queue consumer: task %r (msg_id=%s) exceeded max_attempts=%s "
+                "(read_ct=%s) — dropping poison message: %r",
+                task_name,
+                message.msg_id,
+                self.max_attempts,
+                message.read_ct,
+                payload,
+            )
+            self._client.delete(message.msg_id)
+            return
+
         task = self._app.tasks.get(task_name)
         if task is None:
-            # Can never run → drop (and shout) rather than redeliver forever.
+            # A named-but-unregistered task can never run → drop and shout.
             logger.error(
                 "PG-queue consumer: unknown task %r (msg_id=%s) — dropping",
                 task_name,
@@ -86,23 +135,37 @@ class PgQueueConsumer:
             )
             self._client.delete(message.msg_id)
             return
+
         try:
-            # Run the task body in-process (eager), propagating failures.
+            # Run the task body in-process (eager), carrying the fairness
+            # header so a PG-routed run mirrors the Celery dispatch path.
+            fairness = payload.get("fairness")
+            headers = {FAIRNESS_HEADER_NAME: fairness} if fairness else None
             task.apply(
                 args=payload.get("args") or [],
                 kwargs=payload.get("kwargs") or {},
+                headers=headers,
                 throw=True,
             )
         except Exception:
-            # Leave the row: its vt expires and it is redelivered.
+            # Leave the row: its vt expires and it is redelivered (bounded by
+            # max_attempts above).
             logger.exception(
-                "PG-queue consumer: task %r (msg_id=%s) failed — leaving for "
-                "vt-expiry redelivery",
+                "PG-queue consumer: task %r (msg_id=%s, read_ct=%s) failed — "
+                "leaving for vt-expiry redelivery",
+                task_name,
+                message.msg_id,
+                message.read_ct,
+            )
+            return
+
+        if not self._client.delete(message.msg_id):  # ack
+            logger.warning(
+                "PG-queue consumer: ack found no row for task %r (msg_id=%s) — "
+                "it likely exceeded vt and was re-claimed (possible double-run)",
                 task_name,
                 message.msg_id,
             )
-            return
-        self._client.delete(message.msg_id)  # ack
 
     def run(self, *, install_signals: bool = True) -> None:
         """Poll loop with empty-queue backoff and graceful shutdown."""
@@ -117,7 +180,16 @@ class PgQueueConsumer:
         )
         backoff = self.poll_interval
         while self._running:
-            if self.poll_once():
+            try:
+                claimed = self.poll_once()
+            except Exception:
+                # A transient read/DB blip must not tear down the loop — the
+                # client self-recovers its connection, so log and back off.
+                logger.exception(
+                    "PG-queue consumer: poll cycle failed; backing off and continuing"
+                )
+                claimed = 0
+            if claimed:
                 backoff = self.poll_interval
             else:
                 time.sleep(backoff)
@@ -134,22 +206,25 @@ class PgQueueConsumer:
             signal.signal(signal.SIGTERM, self.stop)
             signal.signal(signal.SIGINT, self.stop)
         except ValueError:
-            logger.debug(
-                "PG-queue consumer: signal handlers not installed (non-main thread)"
+            logger.warning(
+                "PG-queue consumer: signal handlers not installed (non-main "
+                "thread) — SIGTERM/SIGINT will not trigger graceful shutdown"
             )
 
 
 def main() -> None:
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+    def _env(suffix: str, default: object, cast: type) -> object:
+        return cast(os.getenv(f"WORKER_PG_QUEUE_CONSUMER_{suffix}", default))
+
     PgQueueConsumer(
-        queue_name=os.getenv("WORKER_PG_QUEUE_CONSUMER_QUEUE", _DEFAULT_QUEUE),
-        batch_size=int(os.getenv("WORKER_PG_QUEUE_CONSUMER_BATCH", _DEFAULT_BATCH)),
-        vt_seconds=int(
-            os.getenv("WORKER_PG_QUEUE_CONSUMER_VT_SECONDS", _DEFAULT_VT_SECONDS)
-        ),
-        poll_interval=float(
-            os.getenv("WORKER_PG_QUEUE_CONSUMER_POLL_INTERVAL", _DEFAULT_POLL_INTERVAL)
-        ),
+        queue_name=_env("QUEUE", _DEFAULT_QUEUE, str),
+        batch_size=_env("BATCH", _DEFAULT_BATCH, int),
+        vt_seconds=_env("VT_SECONDS", _DEFAULT_VT_SECONDS, int),
+        poll_interval=_env("POLL_INTERVAL", _DEFAULT_POLL_INTERVAL, float),
+        backoff_max=_env("BACKOFF_MAX", _DEFAULT_BACKOFF_MAX, float),
+        max_attempts=_env("MAX_ATTEMPTS", _DEFAULT_MAX_ATTEMPTS, int),
     ).run()
 
 

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -39,7 +39,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DEFAULT_QUEUE = "default"
-_DEFAULT_BATCH = 10
+# Default 1: the whole batch shares one vt window (set atomically at claim),
+# but messages run sequentially — so with batch_size > 1 the tail can exceed
+# its vt and be re-claimed mid-run (double-run). Batching is opt-in; if you
+# raise it, keep vt_seconds > batch_size x worst-case task duration.
+_DEFAULT_BATCH = 1
 _DEFAULT_VT_SECONDS = 30
 _DEFAULT_POLL_INTERVAL = 0.1
 _DEFAULT_BACKOFF_MAX = 2.0
@@ -74,6 +78,13 @@ class PgQueueConsumer:
         ):
             if value <= 0:
                 raise ValueError(f"{name} must be positive, got {value!r}")
+        if backoff_max < poll_interval:
+            # Otherwise min(poll_interval*2, backoff_max) shrinks the backoff
+            # below poll_interval — it would decrease instead of grow.
+            raise ValueError(
+                f"backoff_max ({backoff_max}) must be >= poll_interval "
+                f"({poll_interval})"
+            )
         self.queue_name = queue_name
         self._client = client if client is not None else PgQueueClient()
         self._app = app if app is not None else current_app

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -6,9 +6,53 @@ shared/constants/api_endpoints.py raises ValueError at import
 time if INTERNAL_API_BASE_URL is not set.
 """
 
+import os
 from pathlib import Path
 
+import psycopg2
+import pytest
 from dotenv import load_dotenv
 
 _env_test = Path(__file__).resolve().parent.parent / ".env.test"
 load_dotenv(_env_test)
+
+
+# --- Shared PG-queue integration fixtures (real Postgres) ---
+#
+# Connect to the dev DB via TEST_DB_* — NOT the generic DB_*, which the
+# suite's unit isolation sets to DB_USER=test. Skip gracefully when Postgres
+# is unreachable or the pg_queue migration hasn't been applied, so CI without
+# a migrated DB doesn't fail (only the real-DB seam is gated).
+
+
+def integration_pg_conn():
+    """Raw psycopg2 connection to the dev DB (host defaults to localhost)."""
+    from queue_backend.pg_queue.connection import create_pg_connection
+
+    os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
+    return create_pg_connection(env_prefix="TEST_DB_")
+
+
+@pytest.fixture
+def pg_conn():
+    """A real connection; skips if Postgres is unreachable or unmigrated."""
+    try:
+        conn = integration_pg_conn()
+    except psycopg2.OperationalError as exc:
+        pytest.skip(f"Postgres not reachable: {exc}")
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('pg_queue_message')")
+        if cur.fetchone()[0] is None:
+            conn.close()
+            pytest.skip("pg_queue migration not applied (run backend migrate)")
+    yield conn
+    conn.rollback()
+    conn.close()
+
+
+@pytest.fixture
+def pg_client(pg_conn):
+    """A :class:`PgQueueClient` over the integration connection."""
+    from queue_backend.pg_queue import PgQueueClient
+
+    return PgQueueClient(conn=pg_conn)

--- a/workers/tests/test_dispatch_pg.py
+++ b/workers/tests/test_dispatch_pg.py
@@ -14,12 +14,10 @@ import json
 import os
 from unittest.mock import patch
 
-import psycopg2
 import pytest
 from queue_backend import dispatch
 from queue_backend.fairness import FairnessKey, WorkloadType
-from queue_backend.pg_queue import PgQueueClient, to_payload
-from queue_backend.pg_queue.connection import create_pg_connection
+from queue_backend.pg_queue import to_payload
 from queue_backend.routing import _ENABLED_TASKS_ENV_VAR as ENABLED_TASKS_ENV
 
 # ``queue_backend.dispatch`` the attribute is the function (shadows the
@@ -69,27 +67,7 @@ class TestToPayload:
 
 
 # --- Integration: dispatch() lands a decodable row in pg_queue_message ---
-
-
-def _test_conn():
-    os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
-    return create_pg_connection(env_prefix="TEST_DB_")
-
-
-@pytest.fixture
-def pg_client():
-    try:
-        conn = _test_conn()
-    except psycopg2.OperationalError as exc:
-        pytest.skip(f"Postgres not reachable: {exc}")
-    with conn.cursor() as cur:
-        cur.execute("SELECT to_regclass('pg_queue_message')")
-        if cur.fetchone()[0] is None:
-            conn.close()
-            pytest.skip("pg_queue migration not applied (run backend migrate)")
-    yield PgQueueClient(conn=conn)
-    conn.rollback()
-    conn.close()
+# Uses the shared ``pg_client`` fixture from conftest.py.
 
 
 class TestDispatchEnqueueIntegration:

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -231,35 +231,7 @@ class TestCreatePgConnection:
         assert "failed to connect" in caplog.text
 
 
-# --- Integration: real Postgres ---
-
-
-def _integration_conn():
-    # Reuse create_pg_connection (single source of connection logic) via the
-    # dedicated TEST_DB_* prefix — NOT the generic DB_*, which the suite's
-    # conftest sets to DB_USER=test for unit isolation (wrong real-DB creds).
-    # Default the host to the dev-compose published port on localhost.
-    os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
-    return create_pg_connection(env_prefix="TEST_DB_")
-
-
-@pytest.fixture
-def pg_conn():
-    try:
-        conn = _integration_conn()
-    except psycopg2.OperationalError as exc:
-        # Only an unreachable/unauthenticated DB skips — ImportError, bugs,
-        # and schema/permission errors surface as real failures.
-        pytest.skip(f"Postgres not reachable: {exc}")
-    with conn.cursor() as cur:
-        cur.execute("SELECT to_regclass('pg_queue_message')")
-        (table,) = cur.fetchone()
-    if table is None:
-        conn.close()
-        pytest.skip("pg_queue migration not applied (run backend migrate)")
-    yield conn
-    conn.rollback()
-    conn.close()
+# --- Integration: real Postgres (pg_conn fixture from conftest.py) ---
 
 
 @pytest.fixture
@@ -306,7 +278,8 @@ class TestPgQueueClientIntegration:
         client_a = PgQueueClient(conn=pg_conn)
         for i in range(5):
             client_a.send(queue_name, {"i": i})
-        conn_b = _integration_conn()
+        # Second connection (TEST_DB_HOST already set by the pg_conn fixture).
+        conn_b = create_pg_connection(env_prefix="TEST_DB_")
         try:
             client_b = PgQueueClient(conn=conn_b)
             ids_a = {m.msg_id for m in client_a.read(queue_name, vt_seconds=30, qty=3)}

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -69,14 +69,14 @@ class TestPgQueueClientUnit:
         assert params[2] == ""
 
     def test_read_runs_skip_locked_dequeue(self):
-        conn, cur = _mock_conn(fetchall=[(7, {"k": "v"})])
+        conn, cur = _mock_conn(fetchall=[(7, {"k": "v"}, 1)])
         msgs = PgQueueClient(conn=conn).read("q1", vt_seconds=15, qty=3)
         sql, params = cur.execute.call_args.args
         assert "FOR UPDATE SKIP LOCKED" in sql
         assert "UPDATE pg_queue_message" in sql
         # Param order follows the %s positions: vt_seconds, queue_name, qty.
         assert params == (15, "q1", 3)
-        assert msgs == [QueueMessage(msg_id=7, message={"k": "v"})]
+        assert msgs == [QueueMessage(msg_id=7, message={"k": "v"}, read_ct=1)]
         conn.commit.assert_called_once()
 
     def test_delete_returns_true_when_row_removed(self):

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -1,0 +1,144 @@
+"""Tests for the PG queue consumer (claim → run → ack).
+
+Unit tests drive ``poll_once`` with a mocked client and *real* registered
+Celery tasks (so ``apply()`` actually runs the body). The integration test
+exercises the full enqueue → poll → execute → ack loop against real Postgres
+(skips if unreachable / unmigrated).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import MagicMock
+
+import psycopg2
+import pytest
+from celery import shared_task
+from queue_backend.pg_queue import PgQueueClient, to_payload
+from queue_backend.pg_queue.client import QueueMessage
+from queue_backend.pg_queue.connection import create_pg_connection
+from queue_backend.pg_queue.consumer import PgQueueConsumer
+
+# Registered test tasks (namespaced). apply() runs their bodies in-process.
+_calls: list = []
+
+
+@shared_task(name="test_pg_consumer.ok")
+def _ok_task(x, y=0):
+    _calls.append((x, y))
+    return x + y
+
+
+@shared_task(name="test_pg_consumer.boom")
+def _boom_task():
+    raise RuntimeError("boom")
+
+
+@pytest.fixture(autouse=True)
+def _clear_calls():
+    _calls.clear()
+
+
+def _msg(msg_id, payload):
+    return QueueMessage(msg_id=msg_id, message=payload)
+
+
+# --- poll_once (mocked client, real tasks) ---
+
+
+class TestPollOnce:
+    def test_runs_task_and_acks(self):
+        client = MagicMock()
+        client.read.return_value = [
+            _msg(1, {"task_name": "test_pg_consumer.ok", "args": [3], "kwargs": {"y": 4}})
+        ]
+        assert PgQueueConsumer("q", client=client).poll_once() == 1
+        assert _calls == [(3, 4)]  # task body ran
+        client.delete.assert_called_once_with(1)  # acked
+
+    def test_failed_task_is_not_acked(self):
+        client = MagicMock()
+        client.read.return_value = [
+            _msg(2, {"task_name": "test_pg_consumer.boom", "args": [], "kwargs": {}})
+        ]
+        PgQueueConsumer("q", client=client).poll_once()
+        client.delete.assert_not_called()  # left for vt-expiry redelivery
+
+    def test_unknown_task_is_dropped(self, caplog):
+        client = MagicMock()
+        client.read.return_value = [
+            _msg(3, {"task_name": "nope.nope", "args": [], "kwargs": {}})
+        ]
+        with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
+            PgQueueConsumer("q", client=client).poll_once()
+        client.delete.assert_called_once_with(3)  # dropped, not redelivered
+        assert "unknown task" in caplog.text
+
+    def test_empty_batch_acks_nothing(self):
+        client = MagicMock()
+        client.read.return_value = []
+        assert PgQueueConsumer("q", client=client).poll_once() == 0
+        client.delete.assert_not_called()
+
+
+class TestRunLoop:
+    def test_run_stops_gracefully(self, monkeypatch):
+        client = MagicMock()
+        client.read.return_value = []  # always empty → backoff path
+        consumer = PgQueueConsumer("q", client=client)
+        # First empty poll → sleep (patched to request stop) → loop exits.
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.consumer.time.sleep", lambda _s: consumer.stop()
+        )
+        consumer.run(install_signals=False)
+        assert consumer._running is False
+
+
+# --- Integration: full enqueue → poll → execute → ack against real PG ---
+
+
+def _test_conn():
+    os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
+    return create_pg_connection(env_prefix="TEST_DB_")
+
+
+@pytest.fixture
+def pg_client():
+    try:
+        conn = _test_conn()
+    except psycopg2.OperationalError as exc:
+        pytest.skip(f"Postgres not reachable: {exc}")
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('pg_queue_message')")
+        if cur.fetchone()[0] is None:
+            conn.close()
+            pytest.skip("pg_queue migration not applied (run backend migrate)")
+    yield PgQueueClient(conn=conn)
+    conn.rollback()
+    conn.close()
+
+
+class TestConsumerIntegration:
+    def test_enqueue_poll_execute_ack(self, pg_client):
+        queue_name = f"test_consumer_{os.getpid()}"
+        try:
+            pg_client.send(
+                queue_name,
+                to_payload("test_pg_consumer.ok", args=[5], kwargs={"y": 6}),
+            )
+            claimed = PgQueueConsumer(queue_name, client=pg_client).poll_once()
+            assert claimed == 1
+            assert (5, 6) in _calls  # task actually executed off Postgres
+            # Row was acked (deleted) — nothing left to claim.
+            assert pg_client.read(queue_name, vt_seconds=30, qty=10) == []
+        finally:
+            with pg_client.conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM pg_queue_message WHERE queue_name = %s", (queue_name,)
+                )
+            pg_client.conn.commit()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from celery import shared_task
+from queue_backend.fairness import FAIRNESS_HEADER_NAME
 from queue_backend.pg_queue import to_payload
 from queue_backend.pg_queue.client import QueueMessage
 from queue_backend.pg_queue.consumer import PgQueueConsumer
@@ -38,8 +39,12 @@ def _clear_calls():
     _calls.clear()
 
 
-def _msg(msg_id, payload):
-    return QueueMessage(msg_id=msg_id, message=payload)
+def _msg(msg_id, payload, *, read_ct=1):
+    return QueueMessage(msg_id=msg_id, message=payload, read_ct=read_ct)
+
+
+def _ok_payload(x, y=0):
+    return {"task_name": "test_pg_consumer.ok", "args": [x], "kwargs": {"y": y}}
 
 
 # --- poll_once (mocked client, real tasks) ---
@@ -48,20 +53,20 @@ def _msg(msg_id, payload):
 class TestPollOnce:
     def test_runs_task_and_acks(self):
         client = MagicMock()
-        client.read.return_value = [
-            _msg(1, {"task_name": "test_pg_consumer.ok", "args": [3], "kwargs": {"y": 4}})
-        ]
+        client.read.return_value = [_msg(1, _ok_payload(3, 4))]
         assert PgQueueConsumer("q", client=client).poll_once() == 1
         assert _calls == [(3, 4)]  # task body ran
         client.delete.assert_called_once_with(1)  # acked
 
-    def test_failed_task_is_not_acked(self):
+    def test_failed_task_is_not_acked_and_logs(self, caplog):
         client = MagicMock()
         client.read.return_value = [
             _msg(2, {"task_name": "test_pg_consumer.boom", "args": [], "kwargs": {}})
         ]
-        PgQueueConsumer("q", client=client).poll_once()
+        with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
+            PgQueueConsumer("q", client=client).poll_once()
         client.delete.assert_not_called()  # left for vt-expiry redelivery
+        assert "failed" in caplog.text  # the cycling signal is logged
 
     def test_unknown_task_is_dropped(self, caplog):
         client = MagicMock()
@@ -73,11 +78,80 @@ class TestPollOnce:
         client.delete.assert_called_once_with(3)  # dropped, not redelivered
         assert "unknown task" in caplog.text
 
+    def test_missing_task_name_dropped_as_malformed(self, caplog):
+        client = MagicMock()
+        client.read.return_value = [_msg(4, {"args": [], "kwargs": {}})]  # no task_name
+        with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
+            PgQueueConsumer("q", client=client).poll_once()
+        client.delete.assert_called_once_with(4)
+        assert "missing task_name" in caplog.text  # distinct from "unknown task"
+
+    def test_poison_message_dropped_past_max_attempts(self, caplog):
+        client = MagicMock()
+        # boom task, claimed more than max_attempts times → drop instead of redeliver.
+        client.read.return_value = [
+            _msg(5, {"task_name": "test_pg_consumer.boom"}, read_ct=6)
+        ]
+        with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
+            PgQueueConsumer("q", client=client, max_attempts=5).poll_once()
+        client.delete.assert_called_once_with(5)  # dropped as poison
+        assert "poison" in caplog.text
+
+    def test_fairness_header_rebuilt_for_run(self):
+        # Mock app so we can inspect the apply() headers.
+        fairness = {"org_id": "o", "workload_type": "api", "pipeline_priority": 5}
+        task = MagicMock()
+        app = MagicMock()
+        app.tasks.get.return_value = task
+        client = MagicMock()
+        client.read.return_value = [
+            _msg(6, {"task_name": "t", "args": [1], "kwargs": {"k": "v"}, "fairness": fairness})
+        ]
+        PgQueueConsumer("q", client=client, app=app).poll_once()
+        kwargs = task.apply.call_args.kwargs
+        assert kwargs["args"] == [1]
+        assert kwargs["kwargs"] == {"k": "v"}
+        assert kwargs["headers"] == {FAIRNESS_HEADER_NAME: fairness}
+
+    def test_ack_finding_no_row_warns(self, caplog):
+        client = MagicMock()
+        client.delete.return_value = False  # row already gone (vt expired mid-run)
+        client.read.return_value = [_msg(7, _ok_payload(1))]
+        with caplog.at_level(logging.WARNING, logger="queue_backend.pg_queue.consumer"):
+            PgQueueConsumer("q", client=client).poll_once()
+        assert "possible double-run" in caplog.text
+
+    def test_multi_message_batch(self):
+        client = MagicMock()
+        client.read.return_value = [
+            _msg(10, _ok_payload(1)),
+            _msg(11, {"task_name": "test_pg_consumer.boom"}),
+            _msg(12, {"task_name": "nope.nope"}),
+            _msg(13, _ok_payload(2)),
+        ]
+        assert PgQueueConsumer("q", client=client).poll_once() == 4
+        assert _calls == [(1, 0), (2, 0)]  # ok tasks ran in order
+        deleted = {c.args[0] for c in client.delete.call_args_list}
+        assert deleted == {10, 12, 13}  # ok acked + unknown dropped; boom NOT acked
+
     def test_empty_batch_acks_nothing(self):
         client = MagicMock()
         client.read.return_value = []
         assert PgQueueConsumer("q", client=client).poll_once() == 0
         client.delete.assert_not_called()
+
+
+class TestConstruction:
+    def test_rejects_non_positive_params(self):
+        for kw in (
+            {"batch_size": 0},
+            {"vt_seconds": -1},
+            {"poll_interval": 0},
+            {"backoff_max": 0},
+            {"max_attempts": 0},
+        ):
+            with pytest.raises(ValueError):
+                PgQueueConsumer("q", client=MagicMock(), **kw)
 
 
 class TestRunLoop:
@@ -91,6 +165,41 @@ class TestRunLoop:
         )
         consumer.run(install_signals=False)
         assert consumer._running is False
+
+    def test_backoff_grows_then_resets(self, monkeypatch):
+        client = MagicMock()
+        # empty, empty, one message, empty → backoff doubles, resets, doubles.
+        client.read.side_effect = [[], [], [_msg(1, _ok_payload(1))], []]
+        consumer = PgQueueConsumer(
+            "q", client=client, poll_interval=0.1, backoff_max=0.25
+        )
+        sleeps: list[float] = []
+
+        def _sleep(secs):
+            sleeps.append(secs)
+            if len(sleeps) == 3:  # stop after the third sleep
+                consumer.stop()
+
+        monkeypatch.setattr("queue_backend.pg_queue.consumer.time.sleep", _sleep)
+        consumer.run(install_signals=False)
+        # empty→0.1, empty→0.2 (doubled), [msg] resets, empty→0.1 again.
+        assert sleeps == [0.1, 0.2, 0.1]
+
+    def test_poll_error_does_not_kill_loop(self, monkeypatch):
+        client = MagicMock()
+        # first poll raises (transient), then empty → loop must survive the raise.
+        client.read.side_effect = [RuntimeError("blip"), []]
+        consumer = PgQueueConsumer("q", client=client)
+        sleeps: list[float] = []
+
+        def _sleep(secs):
+            sleeps.append(secs)
+            if len(sleeps) == 2:  # stop after the post-error poll
+                consumer.stop()
+
+        monkeypatch.setattr("queue_backend.pg_queue.consumer.time.sleep", _sleep)
+        consumer.run(install_signals=False)  # must not raise
+        assert client.read.call_count == 2  # kept polling after the error
 
 
 # --- Integration: full enqueue → poll → execute → ack against real PG ---

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -153,6 +153,13 @@ class TestConstruction:
             with pytest.raises(ValueError):
                 PgQueueConsumer("q", client=MagicMock(), **kw)
 
+    def test_rejects_backoff_max_below_poll_interval(self):
+        # Otherwise backoff would shrink below poll_interval instead of growing.
+        with pytest.raises(ValueError, match="backoff_max"):
+            PgQueueConsumer(
+                "q", client=MagicMock(), poll_interval=0.5, backoff_max=0.1
+            )
+
 
 class TestRunLoop:
     def test_run_stops_gracefully(self, monkeypatch):

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -12,12 +12,10 @@ import logging
 import os
 from unittest.mock import MagicMock
 
-import psycopg2
 import pytest
 from celery import shared_task
-from queue_backend.pg_queue import PgQueueClient, to_payload
+from queue_backend.pg_queue import to_payload
 from queue_backend.pg_queue.client import QueueMessage
-from queue_backend.pg_queue.connection import create_pg_connection
 from queue_backend.pg_queue.consumer import PgQueueConsumer
 
 # Registered test tasks (namespaced). apply() runs their bodies in-process.
@@ -96,27 +94,7 @@ class TestRunLoop:
 
 
 # --- Integration: full enqueue → poll → execute → ack against real PG ---
-
-
-def _test_conn():
-    os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
-    return create_pg_connection(env_prefix="TEST_DB_")
-
-
-@pytest.fixture
-def pg_client():
-    try:
-        conn = _test_conn()
-    except psycopg2.OperationalError as exc:
-        pytest.skip(f"Postgres not reachable: {exc}")
-    with conn.cursor() as cur:
-        cur.execute("SELECT to_regclass('pg_queue_message')")
-        if cur.fetchone()[0] is None:
-            conn.close()
-            pytest.skip("pg_queue migration not applied (run backend migrate)")
-    yield PgQueueClient(conn=conn)
-    conn.rollback()
-    conn.close()
+# Uses the shared ``pg_client`` fixture from conftest.py.
 
 
 class TestConsumerIntegration:


### PR DESCRIPTION
## What

The consumer half — makes a PG-routed task actually **execute**. `PgQueueConsumer` drains `pg_queue_message` and runs each claimed task in-process. Completes the leaf-first end-to-end path: **8a route → 9b enqueue → 9a store → 9c consume+run.**

Targets `feat/UN-3445-pg-queue-integration`.

## Validated live (dev stack)

A real API execution's Slack webhook was opted into PG and the full loop ran end-to-end:
```
dispatch(send_webhook_notification) → pg_queue_message row (queue=notifications)
consumer.poll_once() → claim → run → Webhook sent to Slack (HTTP 200) → ack (row removed)
```
A production task executed entirely off Postgres, no Celery broker.

## Changes

- **`queue_backend/pg_queue/consumer.py`** *(new)* — `PgQueueConsumer`:
  - `poll_once()` — claims a batch via `PgQueueClient.read` (SKIP LOCKED + visibility timeout), runs each task via `current_app.tasks[name].apply(args, kwargs, throw=True)` (executes the body in-process), and **acks** by `delete()` on success.
  - **Task failure** → leave the row; its `vt` expires and it's redelivered (at-least-once → tasks must be idempotent). **Unknown task** → drop + `logger.error` (no poison loop).
  - `run()` — poll loop with empty-queue backoff + SIGTERM/SIGINT graceful stop. `main()` — `python -m queue_backend.pg_queue.consumer`, env-configured.
- **tests** — 5 unit (run+ack, fail→no-ack, unknown→drop, empty, graceful stop) + 1 real-PG integration (enqueue → poll → execute → ack).

## Deployment note (not consumer logic)

The consumer **process** must bootstrap the worker app (import the task modules) so `current_app.tasks` resolves the task — otherwise it treats every task as unknown. This is an entrypoint/rollout concern: the rollout phase wires a `worker-pg-queue-consumer` container that boots the worker app before polling. Documented in the module docstring.

## Out of scope (later)

- Poison-message dead-letter via `read_ct` cap; multi-queue fan-out; the single-orchestrator + fair admission (9d); container/K8s wiring (rollout).

Ticket: UN-3539 (parent UN-3536, epic UN-3445)

🤖 Generated with [Claude Code](https://claude.com/claude-code)