### PR TITLE
UN-3541 [FEAT] Wire PG-queue consumer into run-worker.sh + bootstrap guard

### DIFF
--- a/workers/pg_queue_consumer/__init__.py
+++ b/workers/pg_queue_consumer/__init__.py
@@ -1,0 +1,12 @@
+"""PG-queue consumer worker — a standalone process that drains ``pg_queue_message``.
+
+It bootstraps a source worker's Celery app (registering that worker type's
+tasks, like ``celery -A worker worker`` for a single type) so the consumer can
+resolve and run them, then runs the
+:class:`~queue_backend.pg_queue.consumer.PgQueueConsumer` poll loop. The source
+worker type is selected by ``WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE`` (default
+``notification``); see ``__main__`` for why this must precede ``import worker``.
+
+Launch via ``python -m pg_queue_consumer`` or ``./run-worker.sh
+pg-queue-consumer``. Config via ``WORKER_PG_QUEUE_CONSUMER_*`` env.
+"""

--- a/workers/pg_queue_consumer/__main__.py
+++ b/workers/pg_queue_consumer/__main__.py
@@ -1,0 +1,33 @@
+"""Entry point: bootstrap a worker app's tasks, then run the PG-queue consumer.
+
+The root ``worker`` module loads exactly ONE worker type's tasks, chosen by the
+``WORKER_TYPE`` env (``worker.py`` → ``WorkerBuilder.build_celery_app`` →
+imports that type's ``tasks.py``). The PG consumer drains a specific source
+worker's queue, so it must register THAT worker's tasks: we set ``WORKER_TYPE``
+from ``WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE`` (default ``notification`` — the
+first migrated leaf task) BEFORE importing ``worker``.
+
+This override is required: ``run-worker.sh`` exports its own ``WORKER_TYPE``
+(the consumer pseudo-type ``pg_queue_consumer``, which owns no tasks), so a
+plain import would fall back to the ``general`` worker's tasks and every
+notification message would be dropped as an unknown task. The consumer's
+startup guard only catches an *empty* registry, not a *wrong* one — so the
+right worker type must be selected here.
+
+Launch via ``python -m pg_queue_consumer`` or ``./run-worker.sh pg-queue-consumer``.
+"""
+
+import os
+
+# Select the source worker whose tasks back this consumer's queue. Must run
+# BEFORE `import worker`, which reads WORKER_TYPE at import time. We overwrite
+# (not setdefault) because the launcher's own WORKER_TYPE owns no tasks.
+os.environ["WORKER_TYPE"] = os.environ.get(
+    "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
+)
+
+import worker  # noqa: E402,F401 — side-effect: registers the source worker's tasks
+from queue_backend.pg_queue.consumer import main  # noqa: E402
+
+if __name__ == "__main__":
+    main()

--- a/workers/pg_queue_consumer/__main__.py
+++ b/workers/pg_queue_consumer/__main__.py
@@ -1,18 +1,21 @@
 """Entry point: bootstrap a worker app's tasks, then run the PG-queue consumer.
 
 The root ``worker`` module loads exactly ONE worker type's tasks, chosen by the
-``WORKER_TYPE`` env (``worker.py`` → ``WorkerBuilder.build_celery_app`` →
-imports that type's ``tasks.py``). The PG consumer drains a specific source
+``WORKER_TYPE`` env: ``worker.py`` builds the Celery app via
+``WorkerBuilder.build_celery_app`` (which configures, but does NOT import
+tasks), then — in separate module-level logic in ``worker.py`` — ``importlib``-
+loads that type's ``tasks.py``. The PG consumer drains a specific source
 worker's queue, so it must register THAT worker's tasks: we set ``WORKER_TYPE``
 from ``WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE`` (default ``notification`` — the
-first migrated leaf task) BEFORE importing ``worker``.
+worker that owns the first migrated leaf task, ``send_webhook_notification``)
+BEFORE importing ``worker``.
 
 This override is required: ``run-worker.sh`` exports its own ``WORKER_TYPE``
 (the consumer pseudo-type ``pg_queue_consumer``, which owns no tasks), so a
 plain import would fall back to the ``general`` worker's tasks and every
-notification message would be dropped as an unknown task. The consumer's
-startup guard only catches an *empty* registry, not a *wrong* one — so the
-right worker type must be selected here.
+message for the intended worker would be dropped as an unknown task. The
+consumer's startup guard only catches an *empty* registry, not a *wrong* one —
+so the right worker type must be selected here.
 
 Launch via ``python -m pg_queue_consumer`` or ``./run-worker.sh pg-queue-consumer``.
 """

--- a/workers/pg_queue_consumer/__main__.py
+++ b/workers/pg_queue_consumer/__main__.py
@@ -22,15 +22,25 @@ Launch via ``python -m pg_queue_consumer`` or ``./run-worker.sh pg-queue-consume
 
 import os
 
-# Select the source worker whose tasks back this consumer's queue. Must run
-# BEFORE `import worker`, which reads WORKER_TYPE at import time. We overwrite
-# (not setdefault) because the launcher's own WORKER_TYPE owns no tasks.
-os.environ["WORKER_TYPE"] = os.environ.get(
-    "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
-)
 
-import worker  # noqa: E402,F401 — side-effect: registers the source worker's tasks
-from queue_backend.pg_queue.consumer import main  # noqa: E402
+def _bootstrap_and_run() -> None:
+    # Select the source worker whose tasks back this consumer's queue. Must run
+    # BEFORE `import worker`, which reads WORKER_TYPE at import time. We overwrite
+    # (not setdefault) because the launcher's own WORKER_TYPE owns no tasks.
+    #
+    # Kept inside this guarded function (not at module scope) so the env mutation
+    # and the heavy `import worker` bootstrap only happen on the `python -m`
+    # entry — never as a side-effect if this module is imported by a test, IDE,
+    # or type-checker walking `__main__` files.
+    os.environ["WORKER_TYPE"] = os.environ.get(
+        "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
+    )
+
+    import worker  # noqa: F401 — side-effect: registers the source worker's tasks
+    from queue_backend.pg_queue.consumer import main
+
+    main()
+
 
 if __name__ == "__main__":
-    main()
+    _bootstrap_and_run()

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -24,7 +24,8 @@ import logging
 import os
 import signal
 import time
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, TypeVar
 
 from celery import current_app
 
@@ -37,6 +38,8 @@ if TYPE_CHECKING:
     from .client import QueueMessage
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 _DEFAULT_QUEUE = "default"
 # Default 1: the whole batch shares one vt window (set atomically at claim),
@@ -202,11 +205,22 @@ class PgQueueConsumer:
         self._running = True
         if install_signals:
             self._install_signal_handlers()
+        # Log the registered application tasks at startup. The guard above only
+        # catches an *empty* registry; a *wrong* one (e.g. the launcher selected
+        # the wrong source worker type) is non-empty but missing the target
+        # task, so each message would be dropped as "unknown task". Surfacing
+        # the registry here makes a wrong-type boot diagnosable from one line.
+        app_tasks = sorted(
+            name for name in self._app.tasks if not name.startswith("celery.")
+        )
         logger.info(
-            "PG-queue consumer started (queue=%r, batch=%s, vt=%ss)",
+            "PG-queue consumer started (queue=%r, batch=%s, vt=%ss) — "
+            "%d application task(s) registered: %s",
             self.queue_name,
             self.batch_size,
             self.vt_seconds,
+            len(app_tasks),
+            ", ".join(app_tasks) or "(none)",
         )
         backoff = self.poll_interval
         while self._running:
@@ -245,8 +259,18 @@ class PgQueueConsumer:
 def main() -> None:
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
 
-    def _env(suffix: str, default: object, cast: type) -> object:
-        return cast(os.getenv(f"WORKER_PG_QUEUE_CONSUMER_{suffix}", default))
+    def _env(suffix: str, default: _T, cast: Callable[[str], _T]) -> _T:
+        # Preserve the default's type through to PgQueueConsumer's typed
+        # __init__ (a bare `type` would erase it). On a bad value, fail with the
+        # offending var name instead of a context-free `int('abc')` ValueError.
+        var = f"WORKER_PG_QUEUE_CONSUMER_{suffix}"
+        raw = os.getenv(var)
+        if raw is None:
+            return default
+        try:
+            return cast(raw)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"Invalid {var}={raw!r}: {exc}") from exc
 
     PgQueueConsumer(
         queue_name=_env("QUEUE", _DEFAULT_QUEUE, str),

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -178,8 +178,27 @@ class PgQueueConsumer:
                 message.msg_id,
             )
 
-    def run(self, *, install_signals: bool = True) -> None:
-        """Poll loop with empty-queue backoff and graceful shutdown."""
+    def _registered_task_count(self) -> int:
+        """Count application tasks (excluding Celery's built-ins)."""
+        return sum(1 for name in self._app.tasks if not name.startswith("celery."))
+
+    def run(self, *, install_signals: bool = True, require_tasks: bool = True) -> None:
+        """Poll loop with empty-queue backoff and graceful shutdown.
+
+        Refuses to start if no application tasks are registered — a strong
+        signal the worker app wasn't bootstrapped, in which case *every*
+        message would be dropped as "unknown task". This makes a
+        misconfigured launch fail loudly instead of silently destroying data.
+        """
+        if require_tasks and self._registered_task_count() == 0:
+            raise RuntimeError(
+                "PG-queue consumer: no application tasks are registered — the "
+                "worker app was not bootstrapped. Launch via "
+                "`python -m pg_queue_consumer` (or ./run-worker.sh "
+                "pg-queue-consumer), not bare "
+                "`python -m queue_backend.pg_queue.consumer`. Refusing to start "
+                "to avoid dropping every message as an unknown task."
+            )
         self._running = True
         if install_signals:
             self._install_signal_handlers()

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -114,9 +114,12 @@ WORKER_TYPE:
     scheduler, schedule   Run scheduler worker (scheduled pipeline tasks)
     executor              Run executor worker (extraction execution tasks)
     ide-callback          Run IDE callback worker (Prompt Studio post-execution callbacks)
+    pg-queue-consumer     Run PG-queue poll-loop consumer (opt-in; not part of 'all')
     all                   Run all workers (in separate processes, includes auto-discovered pluggable workers)
 
 Note: Pluggable workers in pluggable_worker/ directory are automatically discovered and can be run by name.
+Note: pg-queue-consumer overrides: WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE (source worker whose
+      tasks to load, default notification) and WORKER_PG_QUEUE_CONSUMER_QUEUE (queue to poll).
 
 OPTIONS:
     -e, --env-file FILE   Use specific environment file (default: .env)
@@ -736,7 +739,14 @@ run_worker() {
         # startup (e.g. the consumer's require_tasks RuntimeError, an
         # `import worker` failure, a bad env cast) would still be reported as
         # "started" — and for pg_queue_consumer, which has no health port, a
-        # dead process then just reads as absent in --status. Verify liveness.
+        # dead process then just reads as absent in --status. Catch an
+        # *immediate* exit. This is a best-effort fast-fail for crash-on-import
+        # / bad-config faults (sub-second), NOT a connectivity check: a worker
+        # that dies slowly (e.g. a broker connect timing out after >1s) still
+        # passes here and surfaces later via its health port / --status. Run all
+        # detached workers share it — an immediate crash can hit any worker type;
+        # in `all` the subshells are backgrounded, so this 1s overlaps the
+        # inter-launch sleep rather than serializing.
         sleep 1
         if ! kill -0 "$pid" 2>/dev/null; then
             print_status $RED "$worker_type worker failed to start (PID $pid exited) — last log lines:"

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -44,6 +44,10 @@ declare -A WORKERS=(
     ["${EXECUTOR_WORKER_TYPE}"]="${EXECUTOR_WORKER_TYPE}"
     ["ide-callback"]="${IDE_CALLBACK_WORKER_TYPE}"
     ["${IDE_CALLBACK_WORKER_TYPE}"]="${IDE_CALLBACK_WORKER_TYPE}"
+    # PG Queue consumer — polls Postgres (SKIP LOCKED), not RabbitMQ via Celery
+    ["pg-queue-consumer"]="pg_queue_consumer"
+    ["pg_queue_consumer"]="pg_queue_consumer"
+    ["pg-consumer"]="pg_queue_consumer"
     ["all"]="all"
 )
 
@@ -61,6 +65,9 @@ declare -A WORKER_QUEUES=(
     ["scheduler"]="scheduler"
     ["${EXECUTOR_WORKER_TYPE}"]="celery_executor_legacy"
     ["${IDE_CALLBACK_WORKER_TYPE}"]="${IDE_CALLBACK_WORKER_TYPE}"
+    # The PG queue (in pg_queue_message) this consumer polls — exported as
+    # WORKER_PG_QUEUE_CONSUMER_QUEUE, not a Celery --queues value.
+    ["pg_queue_consumer"]="notifications"
 )
 
 # Worker health ports
@@ -74,6 +81,17 @@ declare -A WORKER_HEALTH_PORTS=(
     ["scheduler"]="8087"
     ["${EXECUTOR_WORKER_TYPE}"]="8088"
     ["${IDE_CALLBACK_WORKER_TYPE}"]="8089"
+    # pg_queue_consumer: no entry — it runs no health server, so it binds no
+    # port (avoids a hard-coded port that could collide). A liveness endpoint,
+    # if added later, should read WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT.
+)
+
+# Opt-in workers: experimental and NOT part of the default "all" fleet, so
+# they're started only on explicit request. Status shows them only when they
+# are actually running, so a deliberate non-start isn't reported as a STOPPED
+# failure (they'd otherwise show STOPPED after every `all`).
+declare -A OPTIN_WORKERS=(
+    ["pg_queue_consumer"]=1
 )
 
 # Function to display usage
@@ -301,6 +319,14 @@ validate_env() {
 #   --hostname=callback-worker-${id}@%h   (when WORKER_INSTANCE_ID is set)
 get_worker_pids() {
     local worker_type=$1
+    # The PG-queue consumer runs as `python -m pg_queue_consumer`, not a Celery
+    # `<type>-worker@host` process, so it has no `-worker` token to anchor on.
+    # Match its module invocation instead (covers both the `uv run python`
+    # parent and the `python -m` child). Keeps --status / -k / -r working for it.
+    if [[ "$worker_type" == "pg_queue_consumer" ]]; then
+        pgrep -f -- "-m[[:space:]]+${worker_type}([[:space:]]|\$)" || true
+        return
+    fi
     pgrep -f -- "[^[:alnum:]_]${worker_type}-worker(@|-)" || true
 }
 
@@ -475,6 +501,12 @@ show_status() {
         local pids
         pids=$(get_worker_pids_oneline "$worker")
 
+        # Opt-in workers aren't part of `all`; only surface them when running
+        # so an intentional non-start doesn't read as a STOPPED failure.
+        if [[ -z "$pids" && -n "${OPTIN_WORKERS[$worker]:-}" ]]; then
+            continue
+        fi
+
         printf '  %-22s ' "$worker:"
 
         if [[ -n "$pids" ]]; then
@@ -647,25 +679,43 @@ run_worker() {
         esac
     fi
 
+    # PG queue consumer is a plain Python poll-loop (polls Postgres via
+    # SKIP LOCKED, not a Celery/RabbitMQ worker) — override the celery command
+    # with the bootstrapping launcher and route the queue via env.
+    if [[ "$worker_type" == "pg_queue_consumer" ]]; then
+        export WORKER_PG_QUEUE_CONSUMER_QUEUE="$queues"
+        # The consumer registers ONE source worker's tasks (the launcher sets
+        # WORKER_TYPE from this before `import worker`). Default: notification —
+        # the first migrated leaf task; override to drain another worker's queue.
+        export WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE="${WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE:-notification}"
+        cmd_args=("uv" "run" "python" "-m" "pg_queue_consumer")
+    fi
+
     print_status $GREEN "Starting $worker_type worker..."
     print_status $BLUE "Directory: $worker_dir"
     print_status $BLUE "Worker Name: $worker_instance_name"
     print_status $BLUE "Queues: $queues"
-    print_status $BLUE "Health Port: ${WORKER_HEALTH_PORTS[$worker_type]}"
+    print_status $BLUE "Health Port: ${WORKER_HEALTH_PORTS[$worker_type]:-n/a}"
     print_status $BLUE "Command: ${cmd_args[*]}"
 
     # Change to appropriate directory
     # For pluggable workers, stay at workers root to allow module imports
     # For core workers, change to worker directory
-    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" ]]; then
+    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "pg_queue_consumer" ]]; then
+        # Run from the workers root so `python -m pg_queue_consumer` (and the
+        # `worker` app it bootstraps) resolve.
         cd "$WORKERS_DIR"
     else
         cd "$worker_dir"
     fi
 
     if [[ "$detach" == "true" ]]; then
-        # Run in background
-        nohup "${cmd_args[@]}" > "$worker_type.log" 2>&1 &
+        # Run in background. Write to an ABSOLUTE log path ($worker_dir is
+        # absolute) so the file lands where resolve_log_file() / -L / -C look,
+        # regardless of cwd. Workers that run from the workers root (pluggable
+        # workers, pg_queue_consumer) would otherwise drop a relative
+        # "$worker_type.log" at the root, where -L/-C can't find it.
+        nohup "${cmd_args[@]}" > "$worker_dir/$worker_type.log" 2>&1 &
         local pid=$!
         print_status $GREEN "$worker_type worker started in background (PID: $pid)"
         print_status $BLUE "Logs: $worker_dir/$worker_type.log"

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -24,6 +24,9 @@ ENV_FILE="$WORKERS_DIR/.env"
 # Worker type constant for the executor worker
 readonly EXECUTOR_WORKER_TYPE="executor"
 readonly IDE_CALLBACK_WORKER_TYPE="ide_callback"
+# Canonical name of the PG-queue consumer worker (referenced in several maps
+# and special-cases below; a constant keeps them in sync).
+readonly PG_QUEUE_CONSUMER_TYPE="pg_queue_consumer"
 
 # Available workers
 declare -A WORKERS=(
@@ -45,9 +48,9 @@ declare -A WORKERS=(
     ["ide-callback"]="${IDE_CALLBACK_WORKER_TYPE}"
     ["${IDE_CALLBACK_WORKER_TYPE}"]="${IDE_CALLBACK_WORKER_TYPE}"
     # PG Queue consumer — polls Postgres (SKIP LOCKED), not RabbitMQ via Celery
-    ["pg-queue-consumer"]="pg_queue_consumer"
-    ["pg_queue_consumer"]="pg_queue_consumer"
-    ["pg-consumer"]="pg_queue_consumer"
+    ["pg-queue-consumer"]="$PG_QUEUE_CONSUMER_TYPE"
+    ["$PG_QUEUE_CONSUMER_TYPE"]="$PG_QUEUE_CONSUMER_TYPE"
+    ["pg-consumer"]="$PG_QUEUE_CONSUMER_TYPE"
     ["all"]="all"
 )
 
@@ -67,7 +70,7 @@ declare -A WORKER_QUEUES=(
     ["${IDE_CALLBACK_WORKER_TYPE}"]="${IDE_CALLBACK_WORKER_TYPE}"
     # The PG queue (in pg_queue_message) this consumer polls — exported as
     # WORKER_PG_QUEUE_CONSUMER_QUEUE, not a Celery --queues value.
-    ["pg_queue_consumer"]="notifications"
+    ["$PG_QUEUE_CONSUMER_TYPE"]="notifications"
 )
 
 # Worker health ports
@@ -91,7 +94,7 @@ declare -A WORKER_HEALTH_PORTS=(
 # are actually running, so a deliberate non-start isn't reported as a STOPPED
 # failure (they'd otherwise show STOPPED after every `all`).
 declare -A OPTIN_WORKERS=(
-    ["pg_queue_consumer"]=1
+    ["$PG_QUEUE_CONSUMER_TYPE"]=1
 )
 
 # Function to display usage
@@ -318,16 +321,26 @@ validate_env() {
 #   --hostname=callback-worker@%h         (default, no WORKER_INSTANCE_ID)
 #   --hostname=callback-worker-${id}@%h   (when WORKER_INSTANCE_ID is set)
 get_worker_pids() {
-    local worker_type=$1
+    local worker_type=$1 pattern out rc
     # The PG-queue consumer runs as `python -m pg_queue_consumer`, not a Celery
     # `<type>-worker@host` process, so it has no `-worker` token to anchor on.
     # Match its module invocation instead (covers both the `uv run python`
     # parent and the `python -m` child). Keeps --status / -k / -r working for it.
-    if [[ "$worker_type" == "pg_queue_consumer" ]]; then
-        pgrep -f -- "-m[[:space:]]+${worker_type}([[:space:]]|\$)" || true
-        return
+    if [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" ]]; then
+        pattern="-m[[:space:]]+${worker_type}([[:space:]]|\$)"
+    else
+        pattern="[^[:alnum:]_]${worker_type}-worker(@|-)"
     fi
-    pgrep -f -- "[^[:alnum:]_]${worker_type}-worker(@|-)" || true
+    # pgrep exits 1 for "no match" (normal — absorbed) but >=2 for an
+    # operational/regex error. Distinguish them: collapsing rc>=2 to empty would
+    # make a live worker look absent (a -k no-op, or a duplicate spawn on -r).
+    out=$(pgrep -f -- "$pattern")
+    rc=$?
+    if (( rc > 1 )); then
+        print_status "$YELLOW" "warning: pgrep failed (rc=$rc) while matching $worker_type" >&2
+    fi
+    [[ -n "$out" ]] && printf '%s\n' "$out"
+    return 0
 }
 
 # Returns get_worker_pids output as a single space-separated string with
@@ -682,13 +695,14 @@ run_worker() {
     # PG queue consumer is a plain Python poll-loop (polls Postgres via
     # SKIP LOCKED, not a Celery/RabbitMQ worker) — override the celery command
     # with the bootstrapping launcher and route the queue via env.
-    if [[ "$worker_type" == "pg_queue_consumer" ]]; then
+    if [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" ]]; then
         export WORKER_PG_QUEUE_CONSUMER_QUEUE="$queues"
         # The consumer registers ONE source worker's tasks (the launcher sets
         # WORKER_TYPE from this before `import worker`). Default: notification —
-        # the first migrated leaf task; override to drain another worker's queue.
+        # the worker that owns the first migrated leaf task,
+        # send_webhook_notification; override to drain another worker's queue.
         export WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE="${WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE:-notification}"
-        cmd_args=("uv" "run" "python" "-m" "pg_queue_consumer")
+        cmd_args=("uv" "run" "python" "-m" "$PG_QUEUE_CONSUMER_TYPE")
     fi
 
     print_status $GREEN "Starting $worker_type worker..."
@@ -701,7 +715,7 @@ run_worker() {
     # Change to appropriate directory
     # For pluggable workers, stay at workers root to allow module imports
     # For core workers, change to worker directory
-    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "pg_queue_consumer" ]]; then
+    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" ]]; then
         # Run from the workers root so `python -m pg_queue_consumer` (and the
         # `worker` app it bootstraps) resolve.
         cd "$WORKERS_DIR"
@@ -715,10 +729,22 @@ run_worker() {
         # regardless of cwd. Workers that run from the workers root (pluggable
         # workers, pg_queue_consumer) would otherwise drop a relative
         # "$worker_type.log" at the root, where -L/-C can't find it.
-        nohup "${cmd_args[@]}" > "$worker_dir/$worker_type.log" 2>&1 &
+        local log_file="$worker_dir/$worker_type.log"
+        nohup "${cmd_args[@]}" > "$log_file" 2>&1 &
         local pid=$!
+        # set -e does not apply to backgrounded jobs, so a fork that dies on
+        # startup (e.g. the consumer's require_tasks RuntimeError, an
+        # `import worker` failure, a bad env cast) would still be reported as
+        # "started" — and for pg_queue_consumer, which has no health port, a
+        # dead process then just reads as absent in --status. Verify liveness.
+        sleep 1
+        if ! kill -0 "$pid" 2>/dev/null; then
+            print_status $RED "$worker_type worker failed to start (PID $pid exited) — last log lines:"
+            tail -n 20 "$log_file" 2>/dev/null
+            return 1
+        fi
         print_status $GREEN "$worker_type worker started in background (PID: $pid)"
-        print_status $BLUE "Logs: $worker_dir/$worker_type.log"
+        print_status $BLUE "Logs: $log_file"
     else
         # Run in foreground
         exec "${cmd_args[@]}"

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -208,6 +208,16 @@ class TestRunLoop:
         consumer.run(install_signals=False)  # must not raise
         assert client.read.call_count == 2  # kept polling after the error
 
+    def test_run_refuses_to_start_with_empty_registry(self):
+        # A non-bootstrapped consumer would drop every message as "unknown" —
+        # fail loudly instead.
+        from celery import Celery
+
+        empty_app = Celery("empty-no-tasks")  # only celery.* built-ins
+        consumer = PgQueueConsumer("q", client=MagicMock(), app=empty_app)
+        with pytest.raises(RuntimeError, match="no application tasks"):
+            consumer.run(install_signals=False)
+
 
 # --- Integration: full enqueue → poll → execute → ack against real PG ---
 # Uses the shared ``pg_client`` fixture from conftest.py.

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -218,6 +218,53 @@ class TestRunLoop:
         with pytest.raises(RuntimeError, match="no application tasks"):
             consumer.run(install_signals=False)
 
+    def test_run_starts_with_registered_tasks(self, monkeypatch):
+        # Positive arm: a non-empty registry starts and polls. current_app has
+        # the module's @shared_task tasks registered, so the guard passes.
+        client = MagicMock()
+        client.read.return_value = []  # empty → loop sleeps → we stop it
+        consumer = PgQueueConsumer("q", client=client)
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.consumer.time.sleep", lambda _s: consumer.stop()
+        )
+        consumer.run(install_signals=False)  # must not raise
+        assert client.read.called
+
+    def test_run_bypasses_guard_when_require_tasks_false(self, monkeypatch):
+        # require_tasks=False skips the guard even on an empty registry (lets a
+        # caller opt out, e.g. a deliberately task-less smoke run).
+        from celery import Celery
+
+        empty_app = Celery("empty-no-tasks")
+        client = MagicMock()
+        client.read.return_value = []
+        consumer = PgQueueConsumer("q", client=client, app=empty_app)
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.consumer.time.sleep", lambda _s: consumer.stop()
+        )
+        consumer.run(install_signals=False, require_tasks=False)  # must not raise
+        assert client.read.called
+
+    def test_registered_task_count_excludes_celery_builtins(self):
+        # The guard counts application tasks only — celery.* built-ins (present
+        # in every app) must not mask an un-bootstrapped registry.
+        from celery import Celery
+
+        empty_app = Celery("empty-no-tasks")
+        assert (
+            PgQueueConsumer("q", client=MagicMock(), app=empty_app)._registered_task_count()
+            == 0
+        )
+
+        @empty_app.task(name="test_pg_consumer.demo")
+        def _demo():
+            return 1
+
+        assert (
+            PgQueueConsumer("q", client=MagicMock(), app=empty_app)._registered_task_count()
+            == 1
+        )
+
 
 # --- Integration: full enqueue → poll → execute → ack against real PG ---
 # Uses the shared ``pg_client`` fixture from conftest.py.


### PR DESCRIPTION
Makes the 9c PG-queue consumer (UN-3539, #2045) runnable through the normal worker flow — and safe to launch. Split out so #2045 stays focused on consumer logic.

Targets the long-lived `feat/UN-3445-pg-queue-integration` branch (not `main`).

## Why
The consumer is task-name routed: it reads a `task_name` from each PG message and runs it from the worker app's task registry. So the launch path must (a) bootstrap the **right** task set and (b) fail loudly if it didn't — otherwise every message is silently dropped as "unknown task".

## What

**Bootstrapping launcher** — `workers/pg_queue_consumer/__main__.py`
- Sets `WORKER_TYPE` to the source worker (default `notification`) **before** `import worker`. The root `worker.py` loads exactly one worker type's `tasks.py`; a bare import would load the `general` worker's tasks and drop every notification. Overridable via `WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE`.

**run-worker.sh wiring**
- New `pg-queue-consumer` worker type → `uv run python -m pg_queue_consumer` (a plain Postgres poll loop, not a Celery/RabbitMQ worker), run from the workers root; queue routed via `WORKER_PG_QUEUE_CONSUMER_QUEUE`.
- **Opt-in**: not part of `./run-worker.sh all` (default behaviour unchanged — the new arch is experimental/flag-gated). Status shows it only when running, so a deliberate non-start isn't reported as `STOPPED`.

**Startup guard** — `PgQueueConsumer.run(require_tasks=True)`
- Refuses to start on an empty task registry (a strong signal the worker app wasn't bootstrapped). Fails loud instead of silently destroying data.

**Health-port fix**
- Dropped the hard-coded `8086` — the consumer runs no health server, so it binds no port (avoids a collision). A liveness endpoint, if added later, reads an env port.

### Integration fixes found during live dev-test
- **Log path** — detached workers now write to an absolute `$worker_dir/$type.log`, so `-L`/`-C` find it (also fixes the same latent bug for pluggable workers, which likewise run from the workers root).
- **PID discovery** — `get_worker_pids` matches the `python -m` invocation, so `--status` / `-k` / `-r` work for the consumer.

## Testing
- **Live end-to-end**: `./run-worker.sh pg-queue-consumer` drained real `send_webhook_notification` messages from the PG queue → Slack **HTTP 200**, tasks succeeded, rows deleted.
- **Unit**: new test asserts the startup guard refuses an empty-registry app; full consumer suite green.
- Verified `--status` (RUNNING/hidden-when-stopped), single-worker `-r`, and log resolution.

## Out of scope (rollout)
- Real liveness/health endpoint + K8s Deployment for the consumer; per-org canary; runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)