### PR TITLE
UN-3544 [FEAT] PG-queue consumer liveness endpoint (poll-loop heartbeat)

### DIFF
--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -25,7 +25,7 @@ import os
 import signal
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from celery import current_app
 
@@ -33,6 +33,9 @@ from ..fairness import FAIRNESS_HEADER_NAME
 from .client import PgQueueClient
 
 if TYPE_CHECKING:
+    from http.server import HTTPServer
+    from threading import Thread
+
     from celery import Celery
 
     from .client import QueueMessage
@@ -208,6 +211,15 @@ class PgQueueConsumer:
         liveness probe should report unhealthy and let the orchestrator restart
         it. Pick a threshold comfortably above ``backoff_max`` and the longest
         expected task so normal idle/backoff never trips it.
+
+        Note the heartbeat is stamped at the *top* of ``poll_once`` (before the
+        DB read), so a loop that fails fast every cycle — e.g. ``read()`` raising
+        on an unreachable DB, caught and backed off by ``run()`` — keeps stamping
+        and stays *healthy*. That is deliberate: a liveness probe must not couple
+        to backend reachability (a restart can't fix a DB outage, and coupling
+        would crash-loop every consumer during one). Surfacing a permanent
+        config fault (bad creds, missing schema) is a readiness/alerting concern,
+        not liveness.
         """
         return self.seconds_since_last_poll() > stale_after_seconds
 
@@ -291,7 +303,9 @@ def main() -> None:
         # offending var name instead of a context-free `int('abc')` ValueError.
         var = f"WORKER_PG_QUEUE_CONSUMER_{suffix}"
         raw = os.getenv(var)
-        if raw is None:
+        # Treat empty-string as unset: an empty HEALTH_PORT (e.g. a run-worker.sh
+        # fallback resolving empty) must hit the clean opt-out, not int("") crash.
+        if raw is None or raw == "":
             return default
         try:
             return cast(raw)
@@ -321,11 +335,12 @@ def main() -> None:
 def _maybe_start_health_server(
     consumer: PgQueueConsumer, *, port: int | None, stale_after: float
 ) -> LivenessServer | None:
-    """Start the liveness server when a port is configured; else ``None``.
+    """Start the liveness server when ``port`` is not None; else ``None``.
 
-    Opt-in by ``WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT`` — a bare
-    ``python -m pg_queue_consumer`` with no port set binds nothing (no stray
-    port to collide).
+    ``main()`` wires ``port`` from ``WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT`` (unset
+    → ``None`` → no server, no stray port). A bind failure degrades gracefully:
+    the probe is auxiliary, so it must never stop the consumer from draining the
+    queue — we log and continue probe-less rather than abort startup.
     """
     if port is None:
         logger.info(
@@ -334,7 +349,16 @@ def _maybe_start_health_server(
         )
         return None
     server = LivenessServer(consumer, port=port, stale_after=stale_after)
-    server.start()
+    try:
+        server.start()
+    except OSError as exc:
+        logger.error(
+            "PG-queue consumer: liveness server could not bind :%s (%s) — "
+            "continuing WITHOUT a probe",
+            port,
+            exc,
+        )
+        return None
     logger.info(
         "PG-queue consumer: liveness server on :%s/health (stale after %ss)",
         server.bound_port,
@@ -355,9 +379,11 @@ class LivenessServer:
     checks meant for richer health reporting, not liveness) — it reports solely
     on the poll-loop heartbeat (:meth:`PgQueueConsumer.is_poll_stale`).
 
-    Serves ``/health`` (also ``/healthz``, ``/livez``) in a daemon thread.
-    Bind ``port=0`` to let the OS pick a free port (read back via
-    :attr:`bound_port`) — used in tests.
+    Serves ``/health`` (also ``/healthz``, ``/livez``) on ``0.0.0.0`` (all
+    interfaces — a container/k8s probe reaches it from outside the process) in a
+    daemon thread. Bind ``port=0`` to let the OS pick a free port (read back via
+    :attr:`bound_port`) — used in tests. Start once; :meth:`stop` returns it to
+    the inert state.
     """
 
     _PATHS = frozenset({"/health", "/healthz", "/livez"})
@@ -368,13 +394,16 @@ class LivenessServer:
         self._consumer = consumer
         self._port = port
         self._stale_after = stale_after
-        self._httpd: Any = None
-        self._thread: Any = None
+        self._httpd: HTTPServer | None = None
+        self._thread: Thread | None = None
 
     def start(self) -> None:
         import json
         import threading
         from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        if self._httpd is not None:
+            raise RuntimeError("LivenessServer already started")
 
         consumer = self._consumer
         stale_after = self._stale_after
@@ -386,8 +415,10 @@ class LivenessServer:
                     self.send_response(404)
                     self.end_headers()
                     return
+                # One clock read so age and the healthy/stale verdict are
+                # derived from the same instant.
                 age = consumer.seconds_since_last_poll()
-                stale = consumer.is_poll_stale(stale_after)
+                stale = age > stale_after
                 body = json.dumps(
                     {
                         "status": "unhealthy" if stale else "healthy",
@@ -399,32 +430,58 @@ class LivenessServer:
                 self.send_response(503 if stale else 200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
-                self.wfile.write(body)
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass  # client (probe) hung up mid-response — not our problem
 
             def log_message(self, *_: object) -> None:
                 pass  # silence per-request access logging
 
-        self._httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
+            def log_error(self, fmt: str, *args: object) -> None:
+                # BaseHTTPRequestHandler routes errors through log_message too;
+                # don't let the pass above swallow them — surface to our logger.
+                logger.warning("pg-queue liveness handler: " + fmt, *args)
+
+        def _serve(httpd: HTTPServer) -> None:
+            try:
+                httpd.serve_forever()
+            except Exception:
+                # A daemon thread dying silently would make /health stop
+                # answering (connection refused) with no breadcrumb.
+                logger.exception("pg-queue liveness server thread crashed")
+
+        httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
+        self._httpd = httpd
         self._thread = threading.Thread(
-            target=self._httpd.serve_forever,
-            daemon=True,
-            name="pg-consumer-liveness",
+            target=_serve, args=(httpd,), daemon=True, name="pg-consumer-liveness"
         )
         self._thread.start()
 
     @property
     def bound_port(self) -> int:
-        """The actual listening port (resolves ``port=0`` to the OS choice)."""
+        """Actual listening port (resolves ``port=0``); the requested port if not started."""
         if self._httpd is not None:
             return self._httpd.server_address[1]
         return self._port
 
     def stop(self) -> None:
-        if self._httpd is not None:
-            self._httpd.shutdown()
-            self._httpd.server_close()
-        if self._thread is not None:
-            self._thread.join(timeout=5)
+        """Shut the server down. Defensive: never raises (called from a finally)."""
+        try:
+            if self._httpd is not None:
+                self._httpd.shutdown()
+                self._httpd.server_close()
+            if self._thread is not None:
+                self._thread.join(timeout=5)
+                if self._thread.is_alive():
+                    logger.warning(
+                        "PG-queue consumer: liveness thread did not stop within 5s"
+                    )
+        except Exception:
+            logger.exception("PG-queue consumer: error stopping liveness server")
+        finally:
+            self._httpd = None
+            self._thread = None
 
 
 if __name__ == "__main__":

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -351,12 +351,11 @@ def _maybe_start_health_server(
     server = LivenessServer(consumer, port=port, stale_after=stale_after)
     try:
         server.start()
-    except OSError as exc:
-        logger.error(
-            "PG-queue consumer: liveness server could not bind :%s (%s) — "
+    except OSError:
+        logger.exception(
+            "PG-queue consumer: liveness server could not bind :%s — "
             "continuing WITHOUT a probe",
             port,
-            exc,
         )
         return None
     logger.info(

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -25,7 +25,7 @@ import os
 import signal
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from celery import current_app
 
@@ -53,6 +53,10 @@ _DEFAULT_BACKOFF_MAX = 2.0
 # A task claimed more than this many times keeps failing — drop it (poison)
 # rather than redeliver forever.
 _DEFAULT_MAX_ATTEMPTS = 5
+# Liveness: a poll loop that hasn't cycled in this many seconds is reported
+# unhealthy. Well above _DEFAULT_BACKOFF_MAX (idle backoff) and any sane task
+# duration, so only a genuinely wedged loop trips it.
+_DEFAULT_HEALTH_STALE_SECONDS = 60.0
 
 
 class PgQueueConsumer:
@@ -97,9 +101,16 @@ class PgQueueConsumer:
         self.backoff_max = backoff_max
         self.max_attempts = max_attempts
         self._running = False
+        # Heartbeat for the liveness probe: monotonic timestamp of the most
+        # recent poll attempt. Seeded at construction so a just-started consumer
+        # reads healthy. Updated at the TOP of poll_once, so a loop wedged on a
+        # long-running task (poll_once not returning) goes stale and is caught —
+        # something pgrep-based --status and the launch-time check cannot see.
+        self._last_poll_monotonic = time.monotonic()
 
     def poll_once(self) -> int:
         """Claim + process one batch; returns the number of messages claimed."""
+        self._last_poll_monotonic = time.monotonic()
         messages = self._client.read(
             self.queue_name, vt_seconds=self.vt_seconds, qty=self.batch_size
         )
@@ -184,6 +195,21 @@ class PgQueueConsumer:
     def _registered_task_count(self) -> int:
         """Count application tasks (excluding Celery's built-ins)."""
         return sum(1 for name in self._app.tasks if not name.startswith("celery."))
+
+    def seconds_since_last_poll(self) -> float:
+        """Seconds since the last poll attempt (for the liveness heartbeat)."""
+        return time.monotonic() - self._last_poll_monotonic
+
+    def is_poll_stale(self, stale_after_seconds: float) -> bool:
+        """True if the poll loop hasn't cycled within ``stale_after_seconds``.
+
+        Drives the health endpoint: a stale loop means the consumer is wedged
+        (deadlock, or a single task running longer than the threshold), so the
+        liveness probe should report unhealthy and let the orchestrator restart
+        it. Pick a threshold comfortably above ``backoff_max`` and the longest
+        expected task so normal idle/backoff never trips it.
+        """
+        return self.seconds_since_last_poll() > stale_after_seconds
 
     def run(self, *, install_signals: bool = True, require_tasks: bool = True) -> None:
         """Poll loop with empty-queue backoff and graceful shutdown.
@@ -272,14 +298,133 @@ def main() -> None:
         except (ValueError, TypeError) as exc:
             raise ValueError(f"Invalid {var}={raw!r}: {exc}") from exc
 
-    PgQueueConsumer(
+    consumer = PgQueueConsumer(
         queue_name=_env("QUEUE", _DEFAULT_QUEUE, str),
         batch_size=_env("BATCH", _DEFAULT_BATCH, int),
         vt_seconds=_env("VT_SECONDS", _DEFAULT_VT_SECONDS, int),
         poll_interval=_env("POLL_INTERVAL", _DEFAULT_POLL_INTERVAL, float),
         backoff_max=_env("BACKOFF_MAX", _DEFAULT_BACKOFF_MAX, float),
         max_attempts=_env("MAX_ATTEMPTS", _DEFAULT_MAX_ATTEMPTS, int),
-    ).run()
+    )
+    health_server = _maybe_start_health_server(
+        consumer,
+        port=_env("HEALTH_PORT", None, int),
+        stale_after=_env("HEALTH_STALE_SECONDS", _DEFAULT_HEALTH_STALE_SECONDS, float),
+    )
+    try:
+        consumer.run()
+    finally:
+        if health_server is not None:
+            health_server.stop()
+
+
+def _maybe_start_health_server(
+    consumer: PgQueueConsumer, *, port: int | None, stale_after: float
+) -> LivenessServer | None:
+    """Start the liveness server when a port is configured; else ``None``.
+
+    Opt-in by ``WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT`` — a bare
+    ``python -m pg_queue_consumer`` with no port set binds nothing (no stray
+    port to collide).
+    """
+    if port is None:
+        logger.info(
+            "PG-queue consumer: WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT unset — "
+            "liveness server disabled"
+        )
+        return None
+    server = LivenessServer(consumer, port=port, stale_after=stale_after)
+    server.start()
+    logger.info(
+        "PG-queue consumer: liveness server on :%s/health (stale after %ss)",
+        server.bound_port,
+        stale_after,
+    )
+    return server
+
+
+class LivenessServer:
+    """Tiny HTTP liveness probe: 200 while the poll loop is fresh, else 503.
+
+    Deliberately lean. A *liveness* probe must answer one question — "is this
+    process still making progress?" — and nothing else. It must NOT depend on
+    broker/API reachability or resource pressure: a transient backend blip or a
+    busy moment would otherwise make the orchestrator crash-loop an
+    otherwise-healthy consumer. So this intentionally does *not* reuse the
+    shared ``HealthChecker`` (which bundles api-connectivity / system-resource
+    checks meant for richer health reporting, not liveness) — it reports solely
+    on the poll-loop heartbeat (:meth:`PgQueueConsumer.is_poll_stale`).
+
+    Serves ``/health`` (also ``/healthz``, ``/livez``) in a daemon thread.
+    Bind ``port=0`` to let the OS pick a free port (read back via
+    :attr:`bound_port`) — used in tests.
+    """
+
+    _PATHS = frozenset({"/health", "/healthz", "/livez"})
+
+    def __init__(
+        self, consumer: PgQueueConsumer, *, port: int, stale_after: float
+    ) -> None:
+        self._consumer = consumer
+        self._port = port
+        self._stale_after = stale_after
+        self._httpd: Any = None
+        self._thread: Any = None
+
+    def start(self) -> None:
+        import json
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        consumer = self._consumer
+        stale_after = self._stale_after
+        paths = self._PATHS
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                if self.path not in paths:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                age = consumer.seconds_since_last_poll()
+                stale = consumer.is_poll_stale(stale_after)
+                body = json.dumps(
+                    {
+                        "status": "unhealthy" if stale else "healthy",
+                        "check": "pg_queue_poll",
+                        "seconds_since_last_poll": round(age, 3),
+                        "stale_after_seconds": stale_after,
+                    }
+                ).encode()
+                self.send_response(503 if stale else 200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_: object) -> None:
+                pass  # silence per-request access logging
+
+        self._httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
+        self._thread = threading.Thread(
+            target=self._httpd.serve_forever,
+            daemon=True,
+            name="pg-consumer-liveness",
+        )
+        self._thread.start()
+
+    @property
+    def bound_port(self) -> int:
+        """The actual listening port (resolves ``port=0`` to the OS choice)."""
+        if self._httpd is not None:
+            return self._httpd.server_address[1]
+        return self._port
+
+    def stop(self) -> None:
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
 
 
 if __name__ == "__main__":

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -57,8 +57,13 @@ _DEFAULT_BACKOFF_MAX = 2.0
 # rather than redeliver forever.
 _DEFAULT_MAX_ATTEMPTS = 5
 # Liveness: a poll loop that hasn't cycled in this many seconds is reported
-# unhealthy. Well above _DEFAULT_BACKOFF_MAX (idle backoff) and any sane task
-# duration, so only a genuinely wedged loop trips it.
+# unhealthy. The heartbeat is stamped at the top of each poll_once and frozen
+# during task execution, so this threshold doubles as an UPPER BOUND on a single
+# task's wall-clock: a task running longer than it trips the probe → pod restart
+# → the in-flight task is killed and (at-least-once) redelivered. 60s suits the
+# current sub-second leaf (send_webhook_notification); for longer-running tasks,
+# raise WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS above
+# max(batch_size x worst_case_task_seconds, backoff_max).
 _DEFAULT_HEALTH_STALE_SECONDS = 60.0
 
 
@@ -400,6 +405,7 @@ class LivenessServer:
         import json
         import threading
         from http.server import BaseHTTPRequestHandler, HTTPServer
+        from urllib.parse import urlsplit
 
         if self._httpd is not None:
             raise RuntimeError("LivenessServer already started")
@@ -410,7 +416,9 @@ class LivenessServer:
 
         class _Handler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:
-                if self.path not in paths:
+                # Strip any query string — self.path includes it, so a probe
+                # like /health?foo=bar must still match.
+                if urlsplit(self.path).path not in paths:
                     self.send_response(404)
                     self.end_headers()
                     return

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -84,9 +84,10 @@ declare -A WORKER_HEALTH_PORTS=(
     ["scheduler"]="8087"
     ["${EXECUTOR_WORKER_TYPE}"]="8088"
     ["${IDE_CALLBACK_WORKER_TYPE}"]="8089"
-    # pg_queue_consumer: no entry — it runs no health server, so it binds no
-    # port (avoids a hard-coded port that could collide). A liveness endpoint,
-    # if added later, should read WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT.
+    # pg_queue_consumer: 8090 — outside the 8080-8089 core range, so no
+    # collision. The consumer binds it only when WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT
+    # is exported (below); a bare `python -m pg_queue_consumer` binds nothing.
+    ["$PG_QUEUE_CONSUMER_TYPE"]="8090"
 )
 
 # Opt-in workers: experimental and NOT part of the default "all" fleet, so
@@ -119,7 +120,8 @@ WORKER_TYPE:
 
 Note: Pluggable workers in pluggable_worker/ directory are automatically discovered and can be run by name.
 Note: pg-queue-consumer overrides: WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE (source worker whose
-      tasks to load, default notification) and WORKER_PG_QUEUE_CONSUMER_QUEUE (queue to poll).
+      tasks to load, default notification), WORKER_PG_QUEUE_CONSUMER_QUEUE (queue to poll),
+      and WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT (liveness server port, default 8090).
 
 OPTIONS:
     -e, --env-file FILE   Use specific environment file (default: .env)
@@ -705,6 +707,9 @@ run_worker() {
         # the worker that owns the first migrated leaf task,
         # send_webhook_notification; override to drain another worker's queue.
         export WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE="${WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE:-notification}"
+        # Liveness HTTP server port (-p override wins, else the map default).
+        # Exported so the launcher's main() opts into the health server.
+        export WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT="${health_port:-${WORKER_HEALTH_PORTS[$worker_type]}}"
         cmd_args=("uv" "run" "python" "-m" "$PG_QUEUE_CONSUMER_TYPE")
     fi
 

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -84,9 +84,11 @@ declare -A WORKER_HEALTH_PORTS=(
     ["scheduler"]="8087"
     ["${EXECUTOR_WORKER_TYPE}"]="8088"
     ["${IDE_CALLBACK_WORKER_TYPE}"]="8089"
-    # pg_queue_consumer: 8090 — outside the 8080-8089 core range, so no
-    # collision. The consumer binds it only when WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT
-    # is exported (below); a bare `python -m pg_queue_consumer` binds nothing.
+    # pg_queue_consumer: 8090 — reserved here, just past the 8080-8089 core
+    # range and just below where pluggable-worker discovery starts allocating
+    # (8091+, see below), so it collides with neither. The consumer binds it
+    # only when WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT is exported (below); a bare
+    # `python -m pg_queue_consumer` binds nothing.
     ["$PG_QUEUE_CONSUMER_TYPE"]="8090"
 )
 
@@ -274,9 +276,11 @@ discover_pluggable_workers() {
                 WORKER_QUEUES["$worker_name"]="$worker_name"
             fi
 
-            # Assign health port dynamically (starting from 8090)
+            # Assign health port dynamically (starting from 8091; 8090 is
+            # reserved for pg_queue_consumer, so the first pluggable worker
+            # doesn't collide with it).
             if [[ -z "${WORKER_HEALTH_PORTS[$worker_name]:-}" ]]; then
-                WORKER_HEALTH_PORTS["$worker_name"]=$((8090 + discovered_count))
+                WORKER_HEALTH_PORTS["$worker_name"]=$((8091 + discovered_count))
             fi
 
             print_status $GREEN "Discovered pluggable worker: $worker_name"
@@ -717,7 +721,8 @@ run_worker() {
     print_status $BLUE "Directory: $worker_dir"
     print_status $BLUE "Worker Name: $worker_instance_name"
     print_status $BLUE "Queues: $queues"
-    print_status $BLUE "Health Port: ${WORKER_HEALTH_PORTS[$worker_type]:-n/a}"
+    # Show the effective port: a -p/--health-port override wins over the map.
+    print_status $BLUE "Health Port: ${health_port:-${WORKER_HEALTH_PORTS[$worker_type]:-n/a}}"
     print_status $BLUE "Command: ${cmd_args[*]}"
 
     # Change to appropriate directory

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -285,7 +285,8 @@ class TestPollHeartbeat:
         # (before read), so a task running longer than the threshold still trips
         # the probe. A bottom-of-poll stamp would pass test_poll_once_refreshes
         # but fail here.
-        consumer = PgQueueConsumer("q", client=(client := MagicMock()))
+        client = MagicMock()
+        consumer = PgQueueConsumer("q", client=client)
         before = consumer._last_poll_monotonic
         seen: dict[str, float] = {}
         client.read.side_effect = lambda *a, **k: (

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -266,6 +266,66 @@ class TestRunLoop:
         )
 
 
+# --- Liveness heartbeat (drives the health endpoint) ---
+
+
+class TestPollHeartbeat:
+    def test_poll_once_refreshes_heartbeat(self):
+        client = MagicMock()
+        client.read.return_value = []
+        consumer = PgQueueConsumer("q", client=client)
+        # Simulate a long-idle consumer, then poll → heartbeat resets to ~now.
+        consumer._last_poll_monotonic -= 120
+        assert consumer.seconds_since_last_poll() > 100
+        consumer.poll_once()
+        assert consumer.seconds_since_last_poll() < 1.0
+
+    def test_is_poll_stale_threshold(self):
+        consumer = PgQueueConsumer("q", client=MagicMock())
+        consumer._last_poll_monotonic -= 120  # last poll 120s ago
+        assert consumer.is_poll_stale(60) is True  # past threshold → stale
+        assert consumer.is_poll_stale(200) is False  # within threshold → fresh
+
+    def test_fresh_consumer_is_not_stale(self):
+        # Seeded at construction, so a just-started consumer reads healthy.
+        consumer = PgQueueConsumer("q", client=MagicMock())
+        assert consumer.is_poll_stale(60) is False
+
+    def test_health_server_disabled_without_port(self):
+        # No port configured → no server bound (opt-in).
+        from queue_backend.pg_queue.consumer import _maybe_start_health_server
+
+        consumer = PgQueueConsumer("q", client=MagicMock())
+        assert _maybe_start_health_server(consumer, port=None, stale_after=60) is None
+
+    def test_liveness_server_reports_200_then_503(self):
+        # Real endpoint: 200 while the poll loop is fresh, 503 once it goes
+        # stale. Bind port 0 so the OS picks a free port (no fixed-port clash).
+        import json
+        import urllib.request
+
+        from queue_backend.pg_queue.consumer import LivenessServer
+
+        consumer = PgQueueConsumer("q", client=MagicMock())
+        server = LivenessServer(consumer, port=0, stale_after=60)
+        server.start()
+        try:
+            url = f"http://127.0.0.1:{server.bound_port}/health"
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                assert resp.status == 200
+                assert json.loads(resp.read())["status"] == "healthy"
+
+            consumer._last_poll_monotonic -= 120  # force the loop stale
+            try:
+                urllib.request.urlopen(url, timeout=5)
+                raise AssertionError("expected HTTP 503")
+            except urllib.error.HTTPError as exc:
+                assert exc.code == 503
+                assert json.loads(exc.read())["status"] == "unhealthy"
+        finally:
+            server.stop()
+
+
 # --- Integration: full enqueue → poll → execute → ack against real PG ---
 # Uses the shared ``pg_client`` fixture from conftest.py.
 

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -280,6 +280,21 @@ class TestPollHeartbeat:
         consumer.poll_once()
         assert consumer.seconds_since_last_poll() < 1.0
 
+    def test_heartbeat_stamped_before_read(self):
+        # Pins the headline design: the stamp lands at the TOP of poll_once
+        # (before read), so a task running longer than the threshold still trips
+        # the probe. A bottom-of-poll stamp would pass test_poll_once_refreshes
+        # but fail here.
+        consumer = PgQueueConsumer("q", client=(client := MagicMock()))
+        before = consumer._last_poll_monotonic
+        seen: dict[str, float] = {}
+        client.read.side_effect = lambda *a, **k: (
+            seen.setdefault("during", consumer._last_poll_monotonic),
+            [],
+        )[1]
+        consumer.poll_once()
+        assert seen["during"] > before  # refreshed BEFORE read ran, not after
+
     def test_is_poll_stale_threshold(self):
         consumer = PgQueueConsumer("q", client=MagicMock())
         consumer._last_poll_monotonic -= 120  # last poll 120s ago
@@ -302,6 +317,7 @@ class TestPollHeartbeat:
         # Real endpoint: 200 while the poll loop is fresh, 503 once it goes
         # stale. Bind port 0 so the OS picks a free port (no fixed-port clash).
         import json
+        import urllib.error
         import urllib.request
 
         from queue_backend.pg_queue.consumer import LivenessServer
@@ -316,14 +332,49 @@ class TestPollHeartbeat:
                 assert json.loads(resp.read())["status"] == "healthy"
 
             consumer._last_poll_monotonic -= 120  # force the loop stale
-            try:
+            with pytest.raises(urllib.error.HTTPError) as ei:
                 urllib.request.urlopen(url, timeout=5)
-                raise AssertionError("expected HTTP 503")
-            except urllib.error.HTTPError as exc:
-                assert exc.code == 503
-                assert json.loads(exc.read())["status"] == "unhealthy"
+            assert ei.value.code == 503
+            assert json.loads(ei.value.read())["status"] == "unhealthy"
         finally:
             server.stop()
+
+    def test_liveness_aliases_and_unknown_path(self):
+        # All three probe aliases answer 200 (different orchestrators probe
+        # different paths); an unknown path is 404 (guards against a regression
+        # that makes every path pass).
+        import urllib.error
+        import urllib.request
+
+        from queue_backend.pg_queue.consumer import LivenessServer
+
+        consumer = PgQueueConsumer("q", client=MagicMock())
+        server = LivenessServer(consumer, port=0, stale_after=60)
+        server.start()
+        try:
+            base = f"http://127.0.0.1:{server.bound_port}"
+            for path in ("/health", "/healthz", "/livez"):
+                with urllib.request.urlopen(f"{base}{path}", timeout=5) as resp:
+                    assert resp.status == 200, path
+            with pytest.raises(urllib.error.HTTPError) as ei:
+                urllib.request.urlopen(f"{base}/nope", timeout=5)
+            assert ei.value.code == 404
+        finally:
+            server.stop()
+
+    def test_double_start_is_rejected(self):
+        from queue_backend.pg_queue.consumer import LivenessServer
+
+        server = LivenessServer(PgQueueConsumer("q", client=MagicMock()), port=0, stale_after=60)
+        server.start()
+        try:
+            with pytest.raises(RuntimeError, match="already started"):
+                server.start()
+        finally:
+            server.stop()
+        # stop() returns it to the inert state → can start again.
+        server.start()
+        server.stop()
 
 
 # --- Integration: full enqueue → poll → execute → ack against real PG ---

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -354,7 +354,8 @@ class TestPollHeartbeat:
         server.start()
         try:
             base = f"http://127.0.0.1:{server.bound_port}"
-            for path in ("/health", "/healthz", "/livez"):
+            # Aliases, plus a query string (self.path includes it) must match.
+            for path in ("/health", "/healthz", "/livez", "/health?probe=k8s"):
                 with urllib.request.urlopen(f"{base}{path}", timeout=5) as resp:
                     assert resp.status == 200, path
             with pytest.raises(urllib.error.HTTPError) as ei:


### PR DESCRIPTION
Gives the PG-queue consumer a `/health` HTTP endpoint for K8s liveness probing — the same pattern every other worker exposes (8080–8089) — keyed on a **poll-loop heartbeat**. Targets `feat/UN-3445-pg-queue-integration`.

## Why
The consumer had no health server. This closes the recurring review thread from #2047 (toolkit "opt-in-hides-crash" steady-state gap + Greptile "no health port") *properly*: the heartbeat detects a **stuck/wedged poll loop** (process alive but not draining) — which neither `run-worker.sh --status` (pgrep) nor the launch-liveness check can see. It also pre-positions the K8s rollout, where a liveness probe needs a known endpoint.

## What
- **`consumer.py`** — `_last_poll_monotonic` heartbeat, refreshed at the *top* of `poll_once` (so a loop wedged on a long-running task goes stale). `seconds_since_last_poll()` / `is_poll_stale()`. `main()` starts a `LivenessServer` when `WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT` is set (opt-in), stops it on exit.
- **`LivenessServer`** — tiny stdlib HTTP server (`/health`, `/healthz`, `/livez`) → **200 while fresh, 503 once stale**. Deliberately **lean**: a liveness probe must report only "is this process making progress?", **not** broker/API reachability or resource pressure — coupling those would crash-loop a healthy consumer on a transient blip.
- **`run-worker.sh`** — default port **8090** (outside the 8080–8089 core range → no collision), exported opt-in, documented in `--help`. Bare `python -m pg_queue_consumer` binds nothing.

## Design notes
- **Fixed-but-configurable port (not dynamic):** a probe must hit a *known* port; a dynamically-chosen one can't be probed. In K8s each container has its own network namespace, so 8090 is per-container (no host collision); the Deployment sets the probe port. Overridable locally via the env / `-p`.
- **Why not reuse the shared `HealthChecker`/`HealthServer`:** besides the liveness-semantics point above, its built-in `api_connectivity` check has a real import bug — `from .api_client_singleton` resolves to a non-existent `shared.infrastructure.monitoring.api_client_singleton` (the module is at `shared.utils.api_client_singleton`), so it returns 503 for any checker without a pre-set `api_client`. Reusing it would ship a broken endpoint. Filed separately (fleet-wide).

## Testing
- **Unit:** heartbeat fresh/stale + `is_poll_stale` threshold + a **real bind-and-GET test** asserting `200` (healthy) then `503` (forced stale). 23/23 non-integration tests green.
- **Live:** `curl :8090/health` → `200 {"status":"healthy","check":"pg_queue_poll",...}`; unknown path → 404; no port set → no server.

## Out of scope
- The K8s Deployment manifest + probe wiring (rollout) — this provides the endpoint they'll point at.
- The shared `health.py` `api_connectivity` import bug (separate ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)