### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Built for teams in **finance**, **insurance**, **healthcare**, **KYC/compliance*
 
 ```bash
 # Clone and start
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/zipstack-unstract)
+
 git clone https://github.com/Zipstack/unstract.git
 cd unstract
 ./run-platform.sh


### PR DESCRIPTION
Hi! 👋 **unstract** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/zipstack-unstract

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building unstract! 🙏