### PR TITLE
UN-3554 [FEAT] PG Queue 9d slice 2 — reaper process + barrier-orphan sweep

### DIFF
--- a/workers/queue_backend/pg_queue/__init__.py
+++ b/workers/queue_backend/pg_queue/__init__.py
@@ -32,15 +32,19 @@ so they're tracked on the ticket / PR rather than baked in here.
 from .client import PgQueueClient, QueueMessage
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id, lease_seconds_from_env
+from .reaper import PgReaper, reaper_interval_from_env, sweep_expired_barriers
 from .task_payload import TaskPayload, to_payload
 
 __all__ = [
     "LeaderLease",
     "PgQueueClient",
+    "PgReaper",
     "QueueMessage",
     "TaskPayload",
     "create_pg_connection",
     "default_worker_id",
     "lease_seconds_from_env",
+    "reaper_interval_from_env",
+    "sweep_expired_barriers",
     "to_payload",
 ]

--- a/workers/queue_backend/pg_queue/__init__.py
+++ b/workers/queue_backend/pg_queue/__init__.py
@@ -32,15 +32,23 @@ so they're tracked on the ticket / PR rather than baked in here.
 from .client import PgQueueClient, QueueMessage
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id, lease_seconds_from_env
-from .reaper import PgReaper, reaper_interval_from_env, sweep_expired_barriers
+from .reaper import (
+    LeaderLeaseLike,
+    PgReaper,
+    TickOutcome,
+    reaper_interval_from_env,
+    sweep_expired_barriers,
+)
 from .task_payload import TaskPayload, to_payload
 
 __all__ = [
     "LeaderLease",
+    "LeaderLeaseLike",
     "PgQueueClient",
     "PgReaper",
     "QueueMessage",
     "TaskPayload",
+    "TickOutcome",
     "create_pg_connection",
     "default_worker_id",
     "lease_seconds_from_env",

--- a/workers/queue_backend/pg_queue/leader_election.py
+++ b/workers/queue_backend/pg_queue/leader_election.py
@@ -146,6 +146,10 @@ class LeaderLease:
     def worker_id(self) -> str:
         return self._worker_id
 
+    @property
+    def lease_seconds(self) -> int:
+        return self._lease_seconds
+
     def _get_conn(self) -> PgConnection:
         # Recreate only an OWNED connection that's missing/closed. An injected
         # (caller-owned) connection is never swapped — if it's dead, the next

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -269,6 +269,13 @@ class PgReaper:
                         self._lease.lease_seconds,
                         exc_info=True,
                     )
+            # Close our owned sweep connection (an injected one is the caller's).
+            # Harmless for the main() process — the OS reclaims it — but keeps the
+            # class clean if it's ever embedded / driven from a test.
+            if self._owns_sweep_conn and self._sweep_conn is not None:
+                with contextlib.suppress(Exception):
+                    self._sweep_conn.close()
+                self._sweep_conn = None
             logger.info("Reaper stopped")
 
     def stop(self, *_: object) -> None:

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -20,10 +20,10 @@ defined against the coupled pipeline running on PG, which doesn't exist yet — 
 it lands with 9e, against a real PG pipeline it can be tested on.
 
 **Lease maintenance.** Each cycle the leader renews; if ``renew()`` returns
-``False`` it lost the lease (stalled past the window) and steps down to standby.
-A standby tries to acquire each cycle. The cycle interval MUST be shorter than
-the lease window, or the leader would lose the lease between renews — enforced in
-:meth:`PgReaper.__init__`.
+``False`` (or raises) it lost / can't confirm the lease and steps down to
+standby. A standby tries to acquire each cycle. The cycle interval MUST be
+shorter than the lease window, or the leader would lose the lease between
+renews — enforced in :meth:`PgReaper.__init__`.
 
 **Ships dark.** Launched explicitly (``python -m queue_backend.pg_queue.reaper``
 or, later, ``run-worker.sh``); never part of the default worker set. With
@@ -37,8 +37,9 @@ import contextlib
 import logging
 import os
 import signal
+import threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id
@@ -48,10 +49,41 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Cycle cadence: how often the leader renews + runs recovery. Must be shorter
-# than the lease window (PgReaper enforces it). The sweep is a cheap indexed
-# DELETE, so running it every cycle is fine.
+# Cadence: how often the leader renews + runs recovery. Enforced shorter than
+# the lease window in PgReaper.__init__.
 _DEFAULT_REAPER_INTERVAL_SECONDS = 5.0
+
+
+class LeaderLeaseLike(Protocol):
+    """Structural contract :class:`PgReaper` needs from a lease.
+
+    The dependency is structural (the tests substitute a duck-typed fake), so the
+    param is typed against this Protocol — :class:`LeaderLease` satisfies it, and
+    a fake conforms without inheritance. Same convention as the ``Barrier``
+    Protocol elsewhere in the package.
+    """
+
+    @property
+    def lease_seconds(self) -> int: ...
+
+    @property
+    def worker_id(self) -> str: ...
+
+    def try_acquire(self) -> bool: ...
+
+    def renew(self) -> bool: ...
+
+    def release(self) -> None: ...
+
+
+class TickOutcome(NamedTuple):
+    """Result of one :meth:`PgReaper.tick` — keeps "was I leader" and "how much
+    work" on separate channels (an ``int`` sentinel like ``-1`` is truthy and
+    conflates the two).
+    """
+
+    was_leader: bool
+    reclaimed: int  # 0 when standby
 
 
 def reaper_interval_from_env() -> float:
@@ -81,17 +113,29 @@ def reaper_interval_from_env() -> float:
 def sweep_expired_barriers(conn: PgConnection) -> list[str]:
     """Reclaim ``pg_barrier_state`` rows past ``expires_at``. Returns their ids.
 
-    A single ``DELETE … RETURNING`` — atomic, and safe to race (the orchestrator
-    is a singleton anyway). Each reclaimed barrier is logged at WARNING: an
-    orphaned barrier means an execution's header tasks never all completed, which
-    is worth surfacing even though deleting the row is the correct backstop.
+    A single atomic ``DELETE … RETURNING``: concurrent sweepers would each
+    reclaim a disjoint subset (``RETURNING`` reports only the rows *this*
+    statement deleted), so it stays correct even if leadership gating ever fails —
+    in practice only the leader calls it. Each reclaimed barrier is logged at
+    WARNING: an orphaned barrier means an execution's header tasks never all
+    completed, worth surfacing even though deleting the row is the right backstop.
+
+    ``conn`` runs in manual-commit mode, so on any error we roll back before
+    re-raising — otherwise the connection is left in an aborted-transaction state
+    and every later statement on it fails with ``InFailedSqlTransaction``.
     """
-    with conn.cursor() as cur:
-        cur.execute(
-            "DELETE FROM pg_barrier_state WHERE expires_at < now() RETURNING execution_id"
-        )
-        reclaimed = [row[0] for row in cur.fetchall()]
-    conn.commit()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM pg_barrier_state WHERE expires_at < now() "
+                "RETURNING execution_id"
+            )
+            reclaimed = [row[0] for row in cur.fetchall()]
+        conn.commit()
+    except Exception:
+        with contextlib.suppress(Exception):
+            conn.rollback()
+        raise
     for execution_id in reclaimed:
         logger.warning(
             "Reaper: reclaimed orphaned barrier for execution %s — header tasks "
@@ -107,7 +151,7 @@ class PgReaper:
 
     def __init__(
         self,
-        lease: LeaderLease,
+        lease: LeaderLeaseLike,
         *,
         interval_seconds: float | None = None,
         sweep_conn: PgConnection | None = None,
@@ -118,6 +162,8 @@ class PgReaper:
             if interval_seconds is not None
             else reaper_interval_from_env()
         )
+        # Load-bearing even though reaper_interval_from_env validates: an
+        # explicitly-injected interval_seconds<=0 reaches here unvalidated.
         if self._interval <= 0:
             raise ValueError("interval_seconds must be positive")
         if self._interval >= lease.lease_seconds:
@@ -133,32 +179,60 @@ class PgReaper:
         self._running = False
         self._is_leader = False
 
+    @property
+    def is_leader(self) -> bool:
+        """Whether this process currently holds leadership (last tick's view)."""
+        return self._is_leader
+
     def _get_sweep_conn(self) -> PgConnection:
-        # Owned sweep connection self-recovers; an injected one is the caller's.
+        # Recreate only an OWNED missing/closed connection; an injected one is the
+        # caller's and is never swapped (mirrors LeaderLease / PgQueueClient).
         if self._sweep_conn is None or (
             self._owns_sweep_conn and self._sweep_conn.closed
         ):
             self._sweep_conn = create_pg_connection(env_prefix="DB_")
         return self._sweep_conn
 
-    def tick(self) -> int:
-        """One cycle: maintain leadership, then sweep iff leader.
-
-        Returns the number of barriers reclaimed, or ``-1`` if this process is a
-        standby (not the leader) this cycle.
-        """
-        if self._is_leader and not self._lease.renew():
+    def _discard_owned_sweep_conn(self) -> None:
+        # After a sweep error, drop an owned connection so the next tick
+        # reconnects — covers a poisoned (aborted-txn) or dead-socket handle that
+        # `.closed` alone wouldn't catch.
+        if self._owns_sweep_conn and self._sweep_conn is not None:
+            with contextlib.suppress(Exception):
+                self._sweep_conn.close()
+            self._sweep_conn = None
             logger.warning(
-                "Reaper: lost leadership (lease taken over) — stepping down to "
-                "standby; will retry acquire next cycle"
+                "Reaper: discarded sweep connection after a failed sweep; "
+                "reconnecting next cycle"
             )
-            self._is_leader = False
+
+    def tick(self) -> TickOutcome:
+        """One cycle: maintain leadership, then sweep iff leader."""
+        if self._is_leader:
+            try:
+                still_leader = self._lease.renew()
+            except Exception:
+                # A raised renew == "leadership unknown": stop acting (honour the
+                # lease's documented contract) before letting it propagate.
+                self._is_leader = False
+                raise
+            if not still_leader:
+                logger.warning(
+                    "Reaper: lost leadership (lease taken over) — stepping down "
+                    "to standby"
+                )
+                self._is_leader = False
         if not self._is_leader and self._lease.try_acquire():
             self._is_leader = True
             logger.info("Reaper: acquired leadership")
         if not self._is_leader:
-            return -1
-        return len(sweep_expired_barriers(self._get_sweep_conn()))
+            return TickOutcome(was_leader=False, reclaimed=0)
+        try:
+            reclaimed = len(sweep_expired_barriers(self._get_sweep_conn()))
+        except Exception:
+            self._discard_owned_sweep_conn()
+            raise
+        return TickOutcome(was_leader=True, reclaimed=reclaimed)
 
     def run(self, *, install_signals: bool = True) -> None:
         """Lease-maintenance + recovery loop until stopped; releases on exit."""
@@ -176,16 +250,25 @@ class PgReaper:
                 try:
                     self.tick()
                 except Exception:
-                    # A transient DB blip must not tear the loop down — the
-                    # connections self-recover, so log and keep cycling.
+                    # A transient DB blip must not tear the loop down — the lease
+                    # connection rolls back + discards a dead handle, and a failed
+                    # sweep discards its owned connection, so log and keep cycling.
                     logger.exception("Reaper: cycle failed; continuing")
                 time.sleep(self._interval)
         finally:
             # Hand the lease over promptly so a standby takes leadership without
             # waiting out the full lease window.
             if self._is_leader:
-                with contextlib.suppress(Exception):
+                try:
                     self._lease.release()
+                except Exception:
+                    logger.warning(
+                        "Reaper: failed to release lease on shutdown; a standby "
+                        "will take over after the lease window (~%ss) instead of "
+                        "immediately",
+                        self._lease.lease_seconds,
+                        exc_info=True,
+                    )
             logger.info("Reaper stopped")
 
     def stop(self, *_: object) -> None:
@@ -193,11 +276,14 @@ class PgReaper:
         self._running = False
 
     def _install_signal_handlers(self) -> None:
-        # signal.signal only works in the main thread.
         try:
             signal.signal(signal.SIGTERM, self.stop)
             signal.signal(signal.SIGINT, self.stop)
         except ValueError:
+            # signal.signal raises ValueError off the main thread — assert that
+            # cause rather than mislabelling an unrelated ValueError.
+            if threading.current_thread() is threading.main_thread():
+                raise
             logger.warning(
                 "Reaper: signal handlers not installed (non-main thread) — "
                 "SIGTERM/SIGINT will not trigger graceful shutdown"

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -1,0 +1,214 @@
+"""Reaper — the leader-elected recovery process for the PG queue.
+
+A singleton, guarded by :class:`LeaderLease` over ``pg_orchestrator_lock``: only
+the elected leader runs recovery work each cycle (several reapers would contend
+and double-act). This slice ships the process *harness* (lease-maintenance loop
++ graceful shutdown) plus ONE recovery job — the **barrier-orphan sweep**.
+
+**Barrier-orphan sweep.** Reclaims ``pg_barrier_state`` rows past their
+``expires_at`` — a barrier whose header tasks never all completed (the documented
+:class:`PgBarrier` backstop). It ``DELETE``s the orphaned row; by PgBarrier's
+existing semantics a late in-flight decrement then finds no row and abandons (no
+spurious callback). The owning execution is logged loudly. Marking that
+execution *terminal* (ERROR) is recovery that needs the backend and the
+pipeline's PG shape — that's 9e, not here; this slice is the storage/orphan
+backstop only.
+
+**Deferred to 9e.** Pipeline recovery (counter reconstruction from
+``WorkflowFileExecution``, per-stage re-enqueue of stuck file executions) is
+defined against the coupled pipeline running on PG, which doesn't exist yet — so
+it lands with 9e, against a real PG pipeline it can be tested on.
+
+**Lease maintenance.** Each cycle the leader renews; if ``renew()`` returns
+``False`` it lost the lease (stalled past the window) and steps down to standby.
+A standby tries to acquire each cycle. The cycle interval MUST be shorter than
+the lease window, or the leader would lose the lease between renews — enforced in
+:meth:`PgReaper.__init__`.
+
+**Ships dark.** Launched explicitly (``python -m queue_backend.pg_queue.reaper``
+or, later, ``run-worker.sh``); never part of the default worker set. With
+``WORKER_BARRIER_BACKEND`` left at ``chord`` (default) there are no
+``pg_barrier_state`` rows, so the sweep is a no-op until the PG barrier is used.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import signal
+import time
+from typing import TYPE_CHECKING
+
+from .connection import create_pg_connection
+from .leader_election import LeaderLease, default_worker_id
+
+if TYPE_CHECKING:
+    from psycopg2.extensions import connection as PgConnection
+
+logger = logging.getLogger(__name__)
+
+# Cycle cadence: how often the leader renews + runs recovery. Must be shorter
+# than the lease window (PgReaper enforces it). The sweep is a cheap indexed
+# DELETE, so running it every cycle is fine.
+_DEFAULT_REAPER_INTERVAL_SECONDS = 5.0
+
+
+def reaper_interval_from_env() -> float:
+    """Cycle interval from ``WORKER_PG_REAPER_INTERVAL_SECONDS`` (default 5s).
+
+    Read at call time. Invalid / non-positive values raise (loud-on-misconfig,
+    matching the lease/barrier-TTL posture).
+    """
+    raw = os.getenv("WORKER_PG_REAPER_INTERVAL_SECONDS")
+    if raw is None:
+        return _DEFAULT_REAPER_INTERVAL_SECONDS
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"WORKER_PG_REAPER_INTERVAL_SECONDS={raw!r} is not a number. "
+            f"Unset it to default to {_DEFAULT_REAPER_INTERVAL_SECONDS}s."
+        ) from exc
+    if value <= 0:
+        raise ValueError(
+            f"WORKER_PG_REAPER_INTERVAL_SECONDS={value} must be positive. "
+            f"Unset it to default to {_DEFAULT_REAPER_INTERVAL_SECONDS}s."
+        )
+    return value
+
+
+def sweep_expired_barriers(conn: PgConnection) -> list[str]:
+    """Reclaim ``pg_barrier_state`` rows past ``expires_at``. Returns their ids.
+
+    A single ``DELETE … RETURNING`` — atomic, and safe to race (the orchestrator
+    is a singleton anyway). Each reclaimed barrier is logged at WARNING: an
+    orphaned barrier means an execution's header tasks never all completed, which
+    is worth surfacing even though deleting the row is the correct backstop.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM pg_barrier_state WHERE expires_at < now() RETURNING execution_id"
+        )
+        reclaimed = [row[0] for row in cur.fetchall()]
+    conn.commit()
+    for execution_id in reclaimed:
+        logger.warning(
+            "Reaper: reclaimed orphaned barrier for execution %s — header tasks "
+            "never all completed before expiry; barrier deleted (no callback "
+            "fired). Execution terminal-status recovery is 9e's job.",
+            execution_id,
+        )
+    return reclaimed
+
+
+class PgReaper:
+    """Leader-elected recovery loop. Only the lease holder runs recovery work."""
+
+    def __init__(
+        self,
+        lease: LeaderLease,
+        *,
+        interval_seconds: float | None = None,
+        sweep_conn: PgConnection | None = None,
+    ) -> None:
+        self._lease = lease
+        self._interval = (
+            interval_seconds
+            if interval_seconds is not None
+            else reaper_interval_from_env()
+        )
+        if self._interval <= 0:
+            raise ValueError("interval_seconds must be positive")
+        if self._interval >= lease.lease_seconds:
+            # A leader that ticks slower than its lease window loses the lease
+            # between renews → it would thrash leadership every cycle.
+            raise ValueError(
+                f"reaper interval {self._interval}s must be shorter than the "
+                f"lease window {lease.lease_seconds}s, or the leader loses the "
+                f"lease between renews"
+            )
+        self._sweep_conn = sweep_conn
+        self._owns_sweep_conn = sweep_conn is None
+        self._running = False
+        self._is_leader = False
+
+    def _get_sweep_conn(self) -> PgConnection:
+        # Owned sweep connection self-recovers; an injected one is the caller's.
+        if self._sweep_conn is None or (
+            self._owns_sweep_conn and self._sweep_conn.closed
+        ):
+            self._sweep_conn = create_pg_connection(env_prefix="DB_")
+        return self._sweep_conn
+
+    def tick(self) -> int:
+        """One cycle: maintain leadership, then sweep iff leader.
+
+        Returns the number of barriers reclaimed, or ``-1`` if this process is a
+        standby (not the leader) this cycle.
+        """
+        if self._is_leader and not self._lease.renew():
+            logger.warning(
+                "Reaper: lost leadership (lease taken over) — stepping down to "
+                "standby; will retry acquire next cycle"
+            )
+            self._is_leader = False
+        if not self._is_leader and self._lease.try_acquire():
+            self._is_leader = True
+            logger.info("Reaper: acquired leadership")
+        if not self._is_leader:
+            return -1
+        return len(sweep_expired_barriers(self._get_sweep_conn()))
+
+    def run(self, *, install_signals: bool = True) -> None:
+        """Lease-maintenance + recovery loop until stopped; releases on exit."""
+        self._running = True
+        if install_signals:
+            self._install_signal_handlers()
+        logger.info(
+            "Reaper started (interval=%ss, lease=%ss, worker_id=%s)",
+            self._interval,
+            self._lease.lease_seconds,
+            self._lease.worker_id,
+        )
+        try:
+            while self._running:
+                try:
+                    self.tick()
+                except Exception:
+                    # A transient DB blip must not tear the loop down — the
+                    # connections self-recover, so log and keep cycling.
+                    logger.exception("Reaper: cycle failed; continuing")
+                time.sleep(self._interval)
+        finally:
+            # Hand the lease over promptly so a standby takes leadership without
+            # waiting out the full lease window.
+            if self._is_leader:
+                with contextlib.suppress(Exception):
+                    self._lease.release()
+            logger.info("Reaper stopped")
+
+    def stop(self, *_: object) -> None:
+        """Request a graceful stop after the current cycle."""
+        self._running = False
+
+    def _install_signal_handlers(self) -> None:
+        # signal.signal only works in the main thread.
+        try:
+            signal.signal(signal.SIGTERM, self.stop)
+            signal.signal(signal.SIGINT, self.stop)
+        except ValueError:
+            logger.warning(
+                "Reaper: signal handlers not installed (non-main thread) — "
+                "SIGTERM/SIGINT will not trigger graceful shutdown"
+            )
+
+
+def main() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+    lease = LeaderLease(default_worker_id())
+    PgReaper(lease).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -1,0 +1,215 @@
+"""Tests for the PG-queue reaper (:mod:`queue_backend.pg_queue.reaper`).
+
+Three layers:
+
+1. **Env / construction** — no DB (``reaper_interval_from_env``, the
+   interval-shorter-than-lease guard).
+2. **Leadership gating** — a fake lease + a patched sweep, no DB: recovery runs
+   only while leader; a lost lease steps the reaper down; the lease is released
+   on shutdown.
+3. **Barrier-orphan sweep** — real Postgres: only rows past ``expires_at`` are
+   reclaimed; fresh barriers are left intact.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from unittest.mock import patch
+
+import psycopg2
+import pytest
+from queue_backend.pg_queue import reaper as reaper_mod
+from queue_backend.pg_queue.connection import create_pg_connection
+from queue_backend.pg_queue.reaper import (
+    PgReaper,
+    reaper_interval_from_env,
+    sweep_expired_barriers,
+)
+
+# --- Layer 1: env + construction (no DB) ---
+
+
+class TestIntervalEnv:
+    def test_default_is_five_seconds(self, monkeypatch):
+        monkeypatch.delenv("WORKER_PG_REAPER_INTERVAL_SECONDS", raising=False)
+        assert reaper_interval_from_env() == 5.0
+
+    def test_overridable(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_REAPER_INTERVAL_SECONDS", "2.5")
+        assert reaper_interval_from_env() == 2.5
+
+    @pytest.mark.parametrize("bad", ["0", "-1", "abc"])
+    def test_invalid_raises(self, monkeypatch, bad):
+        monkeypatch.setenv("WORKER_PG_REAPER_INTERVAL_SECONDS", bad)
+        with pytest.raises(ValueError):
+            reaper_interval_from_env()
+
+
+class _FakeLease:
+    """Stand-in for LeaderLease with scriptable acquire/renew outcomes."""
+
+    def __init__(self, *, acquires=True, renews=True, lease_seconds=10):
+        self._acquires = acquires
+        self._renews = renews
+        self.lease_seconds = lease_seconds
+        self.worker_id = "fake"
+        self.released = False
+        self.acquire_calls = 0
+        self.renew_calls = 0
+
+    def try_acquire(self):
+        self.acquire_calls += 1
+        return self._acquires
+
+    def renew(self):
+        self.renew_calls += 1
+        return self._renews
+
+    def release(self):
+        self.released = True
+
+
+class TestConstruction:
+    def test_interval_must_be_shorter_than_lease(self):
+        with pytest.raises(ValueError, match="shorter than the lease"):
+            PgReaper(_FakeLease(lease_seconds=5), interval_seconds=5, sweep_conn=object())
+
+    def test_non_positive_interval_rejected(self):
+        with pytest.raises(ValueError):
+            PgReaper(_FakeLease(), interval_seconds=0, sweep_conn=object())
+
+    def test_valid_interval_accepted(self):
+        PgReaper(_FakeLease(lease_seconds=10), interval_seconds=3, sweep_conn=object())
+
+
+# --- Layer 2: leadership gating (fake lease + patched sweep, no DB) ---
+
+
+class TestLeadershipGating:
+    def _reaper(self, lease):
+        return PgReaper(lease, interval_seconds=0.01, sweep_conn=object())
+
+    def test_sweeps_when_leader(self):
+        lease = _FakeLease(acquires=True, renews=True)
+        reaper = self._reaper(lease)
+        with patch.object(
+            reaper_mod, "sweep_expired_barriers", return_value=["x"]
+        ) as sweep:
+            assert reaper.tick() == 1  # acquired leadership → swept
+        sweep.assert_called_once()
+
+    def test_standby_does_not_sweep(self):
+        lease = _FakeLease(acquires=False)  # can't get the lease
+        reaper = self._reaper(lease)
+        with patch.object(reaper_mod, "sweep_expired_barriers") as sweep:
+            assert reaper.tick() == -1
+        sweep.assert_not_called()
+
+    def test_steps_down_when_renew_fails(self):
+        # Already leader, but the lease was taken over → renew False → step down
+        # and (acquires=False) stay standby; no sweep this cycle.
+        lease = _FakeLease(acquires=False, renews=False)
+        reaper = self._reaper(lease)
+        reaper._is_leader = True
+        with patch.object(reaper_mod, "sweep_expired_barriers") as sweep:
+            assert reaper.tick() == -1
+        assert reaper._is_leader is False
+        sweep.assert_not_called()
+
+    def test_release_on_stop_when_leader(self):
+        lease = _FakeLease(acquires=True, renews=True)
+        reaper = self._reaper(lease)
+        with patch.object(reaper_mod, "sweep_expired_barriers", return_value=[]):
+            t = threading.Thread(target=reaper.run, kwargs={"install_signals": False})
+            t.start()
+            time.sleep(0.05)  # let it acquire + tick a few times
+            reaper.stop()
+            t.join(timeout=5)
+        assert not t.is_alive()
+        assert lease.released is True
+
+
+# --- Layer 3: barrier-orphan sweep (real Postgres) ---
+
+
+def _new_conn():
+    os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
+    conn = create_pg_connection(env_prefix="TEST_DB_")
+    conn.autocommit = True
+    return conn
+
+
+@pytest.fixture
+def barrier_conn():
+    try:
+        conn = _new_conn()
+    except psycopg2.OperationalError as exc:
+        pytest.skip(f"Postgres not reachable: {exc}")
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('pg_barrier_state')")
+        if cur.fetchone()[0] is None:
+            conn.close()
+            pytest.skip("pg_barrier_state migration not applied (run backend migrate)")
+        cur.execute("DELETE FROM pg_barrier_state")
+    yield conn
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM pg_barrier_state")
+    conn.close()
+
+
+def _seed(conn, execution_id, *, expired):
+    # expired → expires_at in the past; created_at must precede expires_at
+    # (CheckConstraint pg_barrier_expires_after_created).
+    with conn.cursor() as cur:
+        if expired:
+            cur.execute(
+                "INSERT INTO pg_barrier_state "
+                "(execution_id, remaining, results, created_at, expires_at) "
+                "VALUES (%s, 1, '[]'::jsonb, now() - interval '2 hours', "
+                "        now() - interval '1 hour')",
+                (execution_id,),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO pg_barrier_state "
+                "(execution_id, remaining, results, created_at, expires_at) "
+                "VALUES (%s, 1, '[]'::jsonb, now(), now() + interval '6 hours')",
+                (execution_id,),
+            )
+
+
+def _ids(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT execution_id FROM pg_barrier_state ORDER BY execution_id")
+        return [r[0] for r in cur.fetchall()]
+
+
+class TestSweepExpiredBarriers:
+    def test_reclaims_only_expired(self, barrier_conn):
+        _seed(barrier_conn, "exp-1", expired=True)
+        _seed(barrier_conn, "exp-2", expired=True)
+        _seed(barrier_conn, "fresh-1", expired=False)
+        reclaimed = sweep_expired_barriers(barrier_conn)
+        assert sorted(reclaimed) == ["exp-1", "exp-2"]
+        assert _ids(barrier_conn) == ["fresh-1"]  # fresh barrier untouched
+
+    def test_noop_when_nothing_expired(self, barrier_conn):
+        _seed(barrier_conn, "fresh-1", expired=False)
+        assert sweep_expired_barriers(barrier_conn) == []
+        assert _ids(barrier_conn) == ["fresh-1"]
+
+    def test_tick_sweeps_via_real_conn(self, barrier_conn):
+        _seed(barrier_conn, "exp-1", expired=True)
+        reaper = PgReaper(
+            _FakeLease(acquires=True, renews=True),
+            interval_seconds=1,
+            sweep_conn=barrier_conn,
+        )
+        assert reaper.tick() == 1  # became leader and reclaimed the orphan
+        assert _ids(barrier_conn) == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -239,9 +239,11 @@ class TestSweepConnection:
 
 def _new_conn():
     os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
-    conn = create_pg_connection(env_prefix="TEST_DB_")
-    conn.autocommit = True
-    return conn
+    # Manual-commit — exactly as the production reaper opens it
+    # (create_pg_connection default). NOT autocommit: that would make
+    # sweep_expired_barriers' own commit() a no-op and its rollback unreachable,
+    # so Layer 4 would test a different mode than the real reaper runs in.
+    return create_pg_connection(env_prefix="TEST_DB_")
 
 
 @pytest.fixture
@@ -256,15 +258,19 @@ def barrier_conn():
             conn.close()
             pytest.skip("pg_barrier_state migration not applied (run backend migrate)")
         cur.execute("DELETE FROM pg_barrier_state")
+    conn.commit()
     yield conn
     with conn.cursor() as cur:
         cur.execute("DELETE FROM pg_barrier_state")
+    conn.commit()
     conn.close()
 
 
 def _seed(conn, execution_id, *, expired):
     # created_at must precede expires_at (CheckConstraint
-    # pg_barrier_expires_after_created).
+    # pg_barrier_expires_after_created). Commit so the seed is durable like a
+    # real barrier row (written by PgBarrier in another transaction) — and so the
+    # manual-commit sweep's own commit() is what persists the DELETE.
     with conn.cursor() as cur:
         if expired:
             cur.execute(
@@ -281,12 +287,15 @@ def _seed(conn, execution_id, *, expired):
                 "VALUES (%s, 1, '[]'::jsonb, now(), now() + interval '6 hours')",
                 (execution_id,),
             )
+    conn.commit()
 
 
 def _ids(conn):
     with conn.cursor() as cur:
         cur.execute("SELECT execution_id FROM pg_barrier_state ORDER BY execution_id")
-        return [r[0] for r in cur.fetchall()]
+        rows = [r[0] for r in cur.fetchall()]
+    conn.commit()  # end the read transaction (manual-commit conn)
+    return rows
 
 
 class TestSweepExpiredBarriers:

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -1,13 +1,15 @@
 """Tests for the PG-queue reaper (:mod:`queue_backend.pg_queue.reaper`).
 
-Three layers:
+Layers:
 
 1. **Env / construction** — no DB (``reaper_interval_from_env``, the
    interval-shorter-than-lease guard).
 2. **Leadership gating** — a fake lease + a patched sweep, no DB: recovery runs
-   only while leader; a lost lease steps the reaper down; the lease is released
-   on shutdown.
-3. **Barrier-orphan sweep** — real Postgres: only rows past ``expires_at`` are
+   only while leader; a lost lease steps the reaper down; it re-acquires a later
+   cycle; the lease is released on shutdown; ``run`` swallows a tick error.
+3. **Connection handling** — mocked: a failed sweep rolls back + discards the
+   owned connection; an injected connection is never swapped; the SQL contract.
+4. **Barrier-orphan sweep** — real Postgres: only rows past ``expires_at`` are
    reclaimed; fresh barriers are left intact.
 """
 
@@ -16,7 +18,7 @@ from __future__ import annotations
 import os
 import threading
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import psycopg2
 import pytest
@@ -48,7 +50,9 @@ class TestIntervalEnv:
 
 
 class _FakeLease:
-    """Stand-in for LeaderLease with scriptable acquire/renew outcomes."""
+    """Duck-typed LeaderLease. ``acquires``/``renews`` accept a bool (constant)
+    or a list (one outcome popped per call, then ``False``).
+    """
 
     def __init__(self, *, acquires=True, renews=True, lease_seconds=10):
         self._acquires = acquires
@@ -59,13 +63,19 @@ class _FakeLease:
         self.acquire_calls = 0
         self.renew_calls = 0
 
+    @staticmethod
+    def _next(val):
+        if isinstance(val, list):
+            return val.pop(0) if val else False
+        return val
+
     def try_acquire(self):
         self.acquire_calls += 1
-        return self._acquires
+        return self._next(self._acquires)
 
     def renew(self):
         self.renew_calls += 1
-        return self._renews
+        return self._next(self._renews)
 
     def release(self):
         self.released = True
@@ -92,31 +102,51 @@ class TestLeadershipGating:
         return PgReaper(lease, interval_seconds=0.01, sweep_conn=object())
 
     def test_sweeps_when_leader(self):
-        lease = _FakeLease(acquires=True, renews=True)
-        reaper = self._reaper(lease)
+        reaper = self._reaper(_FakeLease(acquires=True, renews=True))
         with patch.object(
             reaper_mod, "sweep_expired_barriers", return_value=["x"]
         ) as sweep:
-            assert reaper.tick() == 1  # acquired leadership → swept
+            outcome = reaper.tick()  # acquires leadership → sweeps
+        assert outcome.was_leader is True
+        assert outcome.reclaimed == 1
+        assert reaper.is_leader is True
         sweep.assert_called_once()
 
     def test_standby_does_not_sweep(self):
-        lease = _FakeLease(acquires=False)  # can't get the lease
-        reaper = self._reaper(lease)
+        reaper = self._reaper(_FakeLease(acquires=False))  # can't get the lease
         with patch.object(reaper_mod, "sweep_expired_barriers") as sweep:
-            assert reaper.tick() == -1
+            outcome = reaper.tick()
+        assert outcome == (False, 0)
+        assert reaper.is_leader is False
         sweep.assert_not_called()
 
     def test_steps_down_when_renew_fails(self):
-        # Already leader, but the lease was taken over → renew False → step down
-        # and (acquires=False) stay standby; no sweep this cycle.
-        lease = _FakeLease(acquires=False, renews=False)
+        # tick 1 acquires; tick 2 renew fails → step down, acquire also fails →
+        # standby. Driven through ticks, no private-flag poking.
+        reaper = self._reaper(_FakeLease(acquires=[True, False], renews=[False]))
+        with patch.object(reaper_mod, "sweep_expired_barriers", return_value=[]):
+            assert reaper.tick().was_leader is True
+            assert reaper.tick().was_leader is False
+        assert reaper.is_leader is False
+
+    def test_steps_down_then_reacquires(self):
+        # leader → lose the lease one cycle → re-acquire the next and resume.
+        reaper = self._reaper(_FakeLease(acquires=[True, False, True], renews=[False]))
+        with patch.object(reaper_mod, "sweep_expired_barriers", return_value=[]):
+            assert reaper.tick().was_leader is True  # acquired
+            assert reaper.tick().was_leader is False  # renew failed → standby
+            assert reaper.tick().was_leader is True  # re-acquired
+        assert reaper.is_leader is True
+
+    def test_renew_raising_steps_down(self):
+        lease = _FakeLease(acquires=True, renews=True)
         reaper = self._reaper(lease)
-        reaper._is_leader = True
-        with patch.object(reaper_mod, "sweep_expired_barriers") as sweep:
-            assert reaper.tick() == -1
-        assert reaper._is_leader is False
-        sweep.assert_not_called()
+        with patch.object(reaper_mod, "sweep_expired_barriers", return_value=[]):
+            reaper.tick()  # becomes leader
+        lease.renew = MagicMock(side_effect=psycopg2.OperationalError("boom"))
+        with pytest.raises(psycopg2.OperationalError):
+            reaper.tick()
+        assert reaper.is_leader is False  # raised renew == stop acting
 
     def test_release_on_stop_when_leader(self):
         lease = _FakeLease(acquires=True, renews=True)
@@ -124,14 +154,87 @@ class TestLeadershipGating:
         with patch.object(reaper_mod, "sweep_expired_barriers", return_value=[]):
             t = threading.Thread(target=reaper.run, kwargs={"install_signals": False})
             t.start()
-            time.sleep(0.05)  # let it acquire + tick a few times
+            time.sleep(0.05)
             reaper.stop()
             t.join(timeout=5)
         assert not t.is_alive()
         assert lease.released is True
 
+    def test_run_swallows_tick_exception(self):
+        reaper = PgReaper(_FakeLease(), interval_seconds=0.01, sweep_conn=object())
+        calls = {"n": 0}
 
-# --- Layer 3: barrier-orphan sweep (real Postgres) ---
+        def boom():
+            calls["n"] += 1
+            reaper.stop()  # one cycle only
+            raise RuntimeError("transient blip")
+
+        with patch.object(reaper, "tick", side_effect=boom):
+            with patch.object(reaper_mod.logger, "exception") as logexc:
+                reaper.run(install_signals=False)  # must not propagate
+        assert calls["n"] == 1
+        logexc.assert_called_once()
+
+
+# --- Layer 3: connection handling (mocked, no DB) ---
+
+
+class TestSweepConnection:
+    def test_sql_contract(self):
+        cur = MagicMock()
+        cur.fetchall.return_value = [("e1",), ("e2",)]
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        assert sweep_expired_barriers(conn) == ["e1", "e2"]
+        sql = cur.execute.call_args[0][0]
+        assert "DELETE FROM pg_barrier_state" in sql
+        assert "expires_at < now()" in sql
+        assert "RETURNING execution_id" in sql
+        conn.commit.assert_called_once()
+
+    def test_rolls_back_on_error(self):
+        cur = MagicMock()
+        cur.execute.side_effect = psycopg2.OperationalError("dead")
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        with pytest.raises(psycopg2.OperationalError):
+            sweep_expired_barriers(conn)
+        conn.rollback.assert_called_once()
+        conn.commit.assert_not_called()
+
+    def test_owned_conn_recreated_when_closed(self, monkeypatch):
+        dead = MagicMock(closed=True)
+        fresh = MagicMock(closed=False)
+        factory = MagicMock(side_effect=[dead, fresh])
+        monkeypatch.setattr(reaper_mod, "create_pg_connection", factory)
+        reaper = PgReaper(_FakeLease(), interval_seconds=1)  # owns its conn
+        assert reaper._get_sweep_conn() is dead
+        assert reaper._get_sweep_conn() is fresh  # dead.closed → recreate
+        assert factory.call_count == 2
+
+    def test_injected_conn_never_swapped(self):
+        injected = MagicMock(closed=True)  # even closed, it's the caller's
+        reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=injected)
+        assert reaper._get_sweep_conn() is injected
+
+    def test_failed_sweep_discards_owned_conn(self, monkeypatch):
+        conn = MagicMock(closed=False)
+        monkeypatch.setattr(
+            reaper_mod, "create_pg_connection", MagicMock(return_value=conn)
+        )
+        reaper = PgReaper(_FakeLease(acquires=True, renews=True), interval_seconds=1)
+        with patch.object(
+            reaper_mod,
+            "sweep_expired_barriers",
+            side_effect=psycopg2.OperationalError("x"),
+        ):
+            with pytest.raises(psycopg2.OperationalError):
+                reaper.tick()
+        conn.close.assert_called_once()
+        assert reaper._sweep_conn is None  # next tick reconnects
+
+
+# --- Layer 4: barrier-orphan sweep (real Postgres) ---
 
 
 def _new_conn():
@@ -160,8 +263,8 @@ def barrier_conn():
 
 
 def _seed(conn, execution_id, *, expired):
-    # expired → expires_at in the past; created_at must precede expires_at
-    # (CheckConstraint pg_barrier_expires_after_created).
+    # created_at must precede expires_at (CheckConstraint
+    # pg_barrier_expires_after_created).
     with conn.cursor() as cur:
         if expired:
             cur.execute(
@@ -207,7 +310,9 @@ class TestSweepExpiredBarriers:
             interval_seconds=1,
             sweep_conn=barrier_conn,
         )
-        assert reaper.tick() == 1  # became leader and reclaimed the orphan
+        outcome = reaper.tick()  # became leader and reclaimed the orphan
+        assert outcome.was_leader is True
+        assert outcome.reclaimed == 1
         assert _ids(barrier_conn) == []
 
 

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -36,11 +36,11 @@ from queue_backend.pg_queue.reaper import (
 class TestIntervalEnv:
     def test_default_is_five_seconds(self, monkeypatch):
         monkeypatch.delenv("WORKER_PG_REAPER_INTERVAL_SECONDS", raising=False)
-        assert reaper_interval_from_env() == 5.0
+        assert reaper_interval_from_env() == pytest.approx(5.0)
 
     def test_overridable(self, monkeypatch):
         monkeypatch.setenv("WORKER_PG_REAPER_INTERVAL_SECONDS", "2.5")
-        assert reaper_interval_from_env() == 2.5
+        assert reaper_interval_from_env() == pytest.approx(2.5)
 
     @pytest.mark.parametrize("bad", ["0", "-1", "abc"])
     def test_invalid_raises(self, monkeypatch, bad):


### PR DESCRIPTION
## What

Second slice of **9d**. Builds on the leader-election lease (UN-3553) to stand up the **reaper process** — the leader-elected recovery loop — with its first recovery job, the **barrier-orphan sweep**. **Ships dark**: launched explicitly, never part of the default worker set, and a no-op until the PG barrier is used.

## Why now (and why not folded into 9e)

9d is 9e's safety net. The reaper *harness* (lease-maintenance loop + graceful shutdown + entrypoint) is **transport-agnostic** — identical regardless of what recovery runs inside it — so building it now isn't throwaway; 9e just drops recovery functions into a proven loop. Keeping it out of 9e shrinks that phase's blast radius, and the barrier sweep makes `WORKER_BARRIER_BACKEND=pg` production-safe independently.

## What's in it

**`workers/queue_backend/pg_queue/reaper.py`**
- `sweep_expired_barriers(conn)` — `DELETE FROM pg_barrier_state WHERE expires_at < now() RETURNING execution_id` + a loud per-orphan `WARNING`. The documented `PgBarrier` backstop: reclaims a barrier whose header tasks never all completed. By PgBarrier's existing semantics, a late in-flight decrement then finds no row and abandons (no spurious callback). Marking the owning execution *terminal* needs the backend + the pipeline's PG shape — that's 9e.
- `PgReaper` — leader-elected loop. Each cycle: renew (step down to standby if `renew()` returns `False`), else try to acquire; sweep **only while leader**. `run()` loops with graceful SIGTERM/SIGINT shutdown + lease release on exit. Guard: cycle interval **must be shorter than the lease window**, or the leader thrashes leadership between renews.
- `reaper_interval_from_env()` (`WORKER_PG_REAPER_INTERVAL_SECONDS`, default 5s), `main()`, and a `python -m queue_backend.pg_queue.reaper` entrypoint (no worker-app bootstrap needed — it's pure SQL).

**`leader_election.py`** — exposes a `lease_seconds` property (the reaper validates its cycle against it).

**Tests (`test_pg_reaper.py`)** — 15:
- env/construction guards (interval-shorter-than-lease, non-positive rejected);
- leadership gating (sweeps only while leader; steps down on renew-fail; releases the lease on stop);
- real-PG sweep (reclaims only rows past `expires_at`, leaves fresh barriers intact; no-op when nothing expired).

## Out of scope (follow-ups)

- `run-worker.sh` wiring + liveness probe — separate followup (mirrors 9c → 9c-followup).
- **Pipeline recovery** — counter reconstruction from `WorkflowFileExecution`, per-stage re-enqueue of stuck files, marking orphaned executions terminal — deferred to 9e, where there's a real PG pipeline to test against. This slice is the storage/orphan backstop only.

## Testing

15/15 pass, stable across reruns; 70/70 across reaper + leader-election + pg_barrier (no regression). Ruff clean. Pre-commit green.

Base: `feat/UN-3445-pg-queue-integration` (not `main`). Sub-task UN-3554 under UN-3536 (Phase 9), builds on UN-3553.
