### PR TITLE
UN-3555 [FEAT] PG Queue 9d slice-2 followup — run-worker.sh reaper type + pg-queue set

### DIFF
--- a/workers/pg_queue_reaper/__init__.py
+++ b/workers/pg_queue_reaper/__init__.py
@@ -1,0 +1,7 @@
+"""Launcher package for the PG-queue reaper process.
+
+A thin top-level package so the reaper has a stable ``python -m pg_queue_reaper``
+invocation that ``run-worker.sh`` can launch and pgrep-match — mirroring
+``pg_queue_consumer``. The actual loop lives in
+``queue_backend.pg_queue.reaper``.
+"""

--- a/workers/pg_queue_reaper/__main__.py
+++ b/workers/pg_queue_reaper/__main__.py
@@ -1,0 +1,15 @@
+"""Entry point: run the PG-queue reaper (leader-elected recovery loop).
+
+Unlike the consumer, the reaper runs no Celery tasks — it only does SQL recovery
+(the barrier-orphan sweep) — so it needs **no** worker-app bootstrap (no
+``import worker``, no ``WORKER_TYPE`` juggling). This package exists purely so the
+process has a stable ``python -m pg_queue_reaper`` name that ``run-worker.sh`` can
+launch and match, parallel to ``pg_queue_consumer``.
+
+Launch via ``python -m pg_queue_reaper`` or ``./run-worker.sh reaper``.
+"""
+
+from queue_backend.pg_queue.reaper import main
+
+if __name__ == "__main__":
+    main()

--- a/workers/pg_queue_reaper/__main__.py
+++ b/workers/pg_queue_reaper/__main__.py
@@ -1,10 +1,13 @@
 """Entry point: run the PG-queue reaper (leader-elected recovery loop).
 
 Unlike the consumer, the reaper runs no Celery tasks — it only does SQL recovery
-(the barrier-orphan sweep) — so it needs **no** worker-app bootstrap (no
-``import worker``, no ``WORKER_TYPE`` juggling). This package exists purely so the
-process has a stable ``python -m pg_queue_reaper`` name that ``run-worker.sh`` can
-launch and match, parallel to ``pg_queue_consumer``.
+(the barrier-orphan sweep) — so it needs **no** worker-app bootstrap: it never
+``import``s ``worker``. (``run-worker.sh`` still exports ``WORKER_TYPE`` for every
+worker, reaper included, but — unlike the consumer, which overwrites it before
+``import worker`` to select which tasks to register — the reaper neither reads
+nor mutates it.) This package exists purely so the process has a stable
+``python -m pg_queue_reaper`` name that ``run-worker.sh`` can launch and match,
+parallel to ``pg_queue_consumer``.
 
 Launch via ``python -m pg_queue_reaper`` or ``./run-worker.sh reaper``.
 """

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -748,7 +748,7 @@ run_worker() {
     print_status $GREEN "Starting $worker_type worker..."
     print_status $BLUE "Directory: $worker_dir"
     print_status $BLUE "Worker Name: $worker_instance_name"
-    print_status $BLUE "Queues: $queues"
+    print_status $BLUE "Queues: ${queues:-n/a}"
     # Show the effective port: a -p/--health-port override wins over the map.
     print_status $BLUE "Health Port: ${health_port:-${WORKER_HEALTH_PORTS[$worker_type]:-n/a}}"
     print_status $BLUE "Command: ${cmd_args[*]}"
@@ -855,23 +855,36 @@ run_all_workers() {
 }
 
 # Function to run the PG-queue worker set (consumer + reaper) together.
-# A set is multiple processes, so — like 'all' — it always runs detached. This
-# is the PG-queue counterpart to 'all' (the Celery set): run both for a
-# dual-transport (strangler-fig) setup. The reaper is a leader-elected singleton,
-# so running it on several hosts is safe (only one wins the lease).
+# A set is multiple processes, so — like 'all' — it ALWAYS runs detached
+# (it ignores -d/--detach; there's no foreground form). The PG-queue counterpart
+# to 'all' (the Celery set): run both for a dual-transport (strangler-fig) setup.
+# The reaper is a leader-elected singleton, so running it on several hosts is
+# safe (only one wins the lease). Returns non-zero if any member dies on start —
+# the reaper has no health port yet, so this launch check is the only
+# programmatic startup signal a caller (systemd/CI) gets.
 run_pg_queue_set() {
     local log_level=$1
     local concurrency=$2
     local pool_type=$3
 
     print_status $GREEN "Starting PG-queue set (consumer + reaper)..."
+    local failed=0
     for worker in "$PG_QUEUE_CONSUMER_TYPE" "$PG_QUEUE_REAPER_TYPE"; do
         print_status $BLUE "Starting $worker in background..."
-        (
-            run_worker "$worker" "true" "$log_level" "$concurrency" "" "" "$pool_type" ""
-        ) &
-        sleep 2
+        # A FOREGROUND subshell: run_worker (detach=true) nohup-backgrounds the
+        # actual worker and returns 1 on an immediate crash-on-start — so the
+        # subshell's exit status IS that signal. The subshell isolates run_worker's
+        # `cd` from this loop; the nohup'd worker survives the subshell exiting.
+        # (A background `( … ) &` would lose the status — its `$!` is the launcher
+        # subshell, which exits the instant it backgrounds the worker.)
+        ( run_worker "$worker" "true" "$log_level" "$concurrency" "" "" "$pool_type" "" ) \
+            || failed=1
     done
+    if [[ $failed -ne 0 ]]; then
+        print_status $RED "PG-queue set: a member failed to start (see logs above)"
+        show_status
+        return 1
+    fi
     print_status $GREEN "PG-queue set started in background"
     show_status
 }
@@ -993,9 +1006,17 @@ if [[ "$RESTART_MODE" == "true" ]]; then
     if [[ "${WORKERS[$WORKER_TYPE]:-}" == "$PG_QUEUE_SET" ]]; then
         # Restart the PG-queue set: kill both members, then fall through to the
         # launch path (which runs run_pg_queue_set since WORKER_TYPE is the set).
+        # Aggregate kill failures (kill_one_worker returns 1 if a process survives
+        # SIGKILL) and abort rather than relaunch over a survivor — a second
+        # consumer would double-poll Postgres. Mirrors kill_workers' discipline.
         print_status $BLUE "Restarting PG-queue set..."
-        kill_one_worker "$PG_QUEUE_CONSUMER_TYPE"
-        kill_one_worker "$PG_QUEUE_REAPER_TYPE"
+        restart_failed=0
+        kill_one_worker "$PG_QUEUE_CONSUMER_TYPE" || restart_failed=1
+        kill_one_worker "$PG_QUEUE_REAPER_TYPE" || restart_failed=1
+        if [[ $restart_failed -ne 0 ]]; then
+            print_status $RED "Cannot restart PG-queue set: a member survived SIGKILL; aborting to avoid duplicate processes"
+            exit 1
+        fi
     elif [[ -n "$WORKER_TYPE" && "$WORKER_TYPE" != "all" ]]; then
         restart_target_dir="${WORKERS[$WORKER_TYPE]:-${PLUGGABLE_WORKERS[$WORKER_TYPE]:-}}"
         if [[ -z "$restart_target_dir" ]]; then
@@ -1052,7 +1073,9 @@ if [[ "$WORKER_TYPE" == "all" ]]; then
     run_all_workers "$DETACH" "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE"
 elif [[ "${WORKERS[$WORKER_TYPE]:-}" == "$PG_QUEUE_SET" ]]; then
     # The PG-queue set (consumer + reaper). Always backgrounded (multiple procs).
-    run_pg_queue_set "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE"
+    # Propagate a member start-failure to the script exit code — the reaper has
+    # no health port, so this is the only programmatic startup signal.
+    run_pg_queue_set "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE" || exit 1
 else
     # Resolve worker directory name from either WORKERS or PLUGGABLE_WORKERS
     WORKER_DIR_NAME="${WORKERS[$WORKER_TYPE]}"

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -27,6 +27,10 @@ readonly IDE_CALLBACK_WORKER_TYPE="ide_callback"
 # Canonical name of the PG-queue consumer worker (referenced in several maps
 # and special-cases below; a constant keeps them in sync).
 readonly PG_QUEUE_CONSUMER_TYPE="pg_queue_consumer"
+# Canonical name of the PG-queue reaper (leader-elected recovery process).
+readonly PG_QUEUE_REAPER_TYPE="pg_queue_reaper"
+# Set alias that launches the whole PG-queue group (consumer + reaper) together.
+readonly PG_QUEUE_SET="pg-queue"
 
 # Available workers
 declare -A WORKERS=(
@@ -51,6 +55,13 @@ declare -A WORKERS=(
     ["pg-queue-consumer"]="$PG_QUEUE_CONSUMER_TYPE"
     ["$PG_QUEUE_CONSUMER_TYPE"]="$PG_QUEUE_CONSUMER_TYPE"
     ["pg-consumer"]="$PG_QUEUE_CONSUMER_TYPE"
+    # PG Queue reaper — leader-elected recovery loop (barrier-orphan sweep)
+    ["reaper"]="$PG_QUEUE_REAPER_TYPE"
+    ["pg-queue-reaper"]="$PG_QUEUE_REAPER_TYPE"
+    ["$PG_QUEUE_REAPER_TYPE"]="$PG_QUEUE_REAPER_TYPE"
+    # Set: launch the whole PG-queue group (consumer + reaper) in one shot
+    ["$PG_QUEUE_SET"]="$PG_QUEUE_SET"
+    ["pg"]="$PG_QUEUE_SET"
     ["all"]="all"
 )
 
@@ -98,6 +109,7 @@ declare -A WORKER_HEALTH_PORTS=(
 # failure (they'd otherwise show STOPPED after every `all`).
 declare -A OPTIN_WORKERS=(
     ["$PG_QUEUE_CONSUMER_TYPE"]=1
+    ["$PG_QUEUE_REAPER_TYPE"]=1
 )
 
 # Function to display usage
@@ -118,12 +130,18 @@ WORKER_TYPE:
     executor              Run executor worker (extraction execution tasks)
     ide-callback          Run IDE callback worker (Prompt Studio post-execution callbacks)
     pg-queue-consumer     Run PG-queue poll-loop consumer (opt-in; not part of 'all')
+    reaper, pg-queue-reaper Run PG-queue reaper (leader-elected recovery; opt-in)
+    pg, pg-queue          Run the PG-queue set (consumer + reaper) together
     all                   Run all workers (in separate processes, includes auto-discovered pluggable workers)
 
 Note: Pluggable workers in pluggable_worker/ directory are automatically discovered and can be run by name.
+Note: 'all' is the Celery worker set; 'pg-queue' is the PG-queue set. They are independent —
+      run both in parallel for a dual-transport (strangler-fig) setup.
 Note: pg-queue-consumer overrides: WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE (source worker whose
       tasks to load, default notification), WORKER_PG_QUEUE_CONSUMER_QUEUE (queue to poll),
       and WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT (liveness server port, default 8090).
+Note: reaper overrides: WORKER_PG_ORCHESTRATOR_LEASE_SECONDS (lease window, default 10),
+      WORKER_PG_REAPER_INTERVAL_SECONDS (cycle interval, default 5).
 
 OPTIONS:
     -e, --env-file FILE   Use specific environment file (default: .env)
@@ -331,11 +349,11 @@ validate_env() {
 #   --hostname=callback-worker-${id}@%h   (when WORKER_INSTANCE_ID is set)
 get_worker_pids() {
     local worker_type=$1 pattern out rc
-    # The PG-queue consumer runs as `python -m pg_queue_consumer`, not a Celery
-    # `<type>-worker@host` process, so it has no `-worker` token to anchor on.
-    # Match its module invocation instead (covers both the `uv run python`
-    # parent and the `python -m` child). Keeps --status / -k / -r working for it.
-    if [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" ]]; then
+    # The PG-queue consumer and reaper run as `python -m <pkg>`, not a Celery
+    # `<type>-worker@host` process, so they have no `-worker` token to anchor on.
+    # Match the module invocation instead (covers both the `uv run python` parent
+    # and the `python -m` child). Keeps --status / -k / -r working for them.
+    if [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
         pattern="-m[[:space:]]+${worker_type}([[:space:]]|\$)"
     else
         pattern="[^[:alnum:]_]${worker_type}-worker(@|-)"
@@ -366,7 +384,9 @@ list_core_worker_dirs() {
     local seen=""
     for key in "${!WORKERS[@]}"; do
         local value="${WORKERS[$key]}"
-        if [[ "$value" == "all" ]]; then
+        # Skip set aliases ("all", "pg-queue") — they're groups, not real worker
+        # dirs/processes, so status must not list them as phantom STOPPED workers.
+        if [[ "$value" == "all" || "$value" == "$PG_QUEUE_SET" ]]; then
             continue
         fi
         if [[ "$seen" == *" $value "* ]]; then
@@ -717,6 +737,14 @@ run_worker() {
         cmd_args=("uv" "run" "python" "-m" "$PG_QUEUE_CONSUMER_TYPE")
     fi
 
+    # PG queue reaper — a leader-elected SQL recovery loop (no Celery, no task
+    # bootstrap). Override the celery command with the plain `python -m` entry.
+    # Tunables (lease window, cycle interval) come from env; no liveness port is
+    # wired yet (that's a follow-on slice), so it binds nothing.
+    if [[ "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
+        cmd_args=("uv" "run" "python" "-m" "$PG_QUEUE_REAPER_TYPE")
+    fi
+
     print_status $GREEN "Starting $worker_type worker..."
     print_status $BLUE "Directory: $worker_dir"
     print_status $BLUE "Worker Name: $worker_instance_name"
@@ -728,9 +756,9 @@ run_worker() {
     # Change to appropriate directory
     # For pluggable workers, stay at workers root to allow module imports
     # For core workers, change to worker directory
-    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" ]]; then
-        # Run from the workers root so `python -m pg_queue_consumer` (and the
-        # `worker` app it bootstraps) resolve.
+    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
+        # Run from the workers root so `python -m pg_queue_consumer` /
+        # `python -m pg_queue_reaper` (and what they import) resolve.
         cd "$WORKERS_DIR"
     else
         cd "$worker_dir"
@@ -824,6 +852,28 @@ run_all_workers() {
         print_status $GREEN "All workers started in background"
         show_status
     fi
+}
+
+# Function to run the PG-queue worker set (consumer + reaper) together.
+# A set is multiple processes, so — like 'all' — it always runs detached. This
+# is the PG-queue counterpart to 'all' (the Celery set): run both for a
+# dual-transport (strangler-fig) setup. The reaper is a leader-elected singleton,
+# so running it on several hosts is safe (only one wins the lease).
+run_pg_queue_set() {
+    local log_level=$1
+    local concurrency=$2
+    local pool_type=$3
+
+    print_status $GREEN "Starting PG-queue set (consumer + reaper)..."
+    for worker in "$PG_QUEUE_CONSUMER_TYPE" "$PG_QUEUE_REAPER_TYPE"; do
+        print_status $BLUE "Starting $worker in background..."
+        (
+            run_worker "$worker" "true" "$log_level" "$concurrency" "" "" "$pool_type" ""
+        ) &
+        sleep 2
+    done
+    print_status $GREEN "PG-queue set started in background"
+    show_status
 }
 
 # Parse command line arguments
@@ -940,7 +990,13 @@ fi
 #   WORKER_TYPE as "all" once we set it below.
 if [[ "$RESTART_MODE" == "true" ]]; then
     discover_pluggable_workers
-    if [[ -n "$WORKER_TYPE" && "$WORKER_TYPE" != "all" ]]; then
+    if [[ "${WORKERS[$WORKER_TYPE]:-}" == "$PG_QUEUE_SET" ]]; then
+        # Restart the PG-queue set: kill both members, then fall through to the
+        # launch path (which runs run_pg_queue_set since WORKER_TYPE is the set).
+        print_status $BLUE "Restarting PG-queue set..."
+        kill_one_worker "$PG_QUEUE_CONSUMER_TYPE"
+        kill_one_worker "$PG_QUEUE_REAPER_TYPE"
+    elif [[ -n "$WORKER_TYPE" && "$WORKER_TYPE" != "all" ]]; then
         restart_target_dir="${WORKERS[$WORKER_TYPE]:-${PLUGGABLE_WORKERS[$WORKER_TYPE]:-}}"
         if [[ -z "$restart_target_dir" ]]; then
             print_status $RED "Error: Unknown worker type for restart: $WORKER_TYPE"
@@ -994,6 +1050,9 @@ export PYTHONPATH="$WORKERS_DIR:${PYTHONPATH:-}"
 # Run the requested worker(s)
 if [[ "$WORKER_TYPE" == "all" ]]; then
     run_all_workers "$DETACH" "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE"
+elif [[ "${WORKERS[$WORKER_TYPE]:-}" == "$PG_QUEUE_SET" ]]; then
+    # The PG-queue set (consumer + reaper). Always backgrounded (multiple procs).
+    run_pg_queue_set "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE"
 else
     # Resolve worker directory name from either WORKERS or PLUGGABLE_WORKERS
     WORKER_DIR_NAME="${WORKERS[$WORKER_TYPE]}"

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -439,13 +439,22 @@ tail_logs() {
             print_status $BLUE "Tip: omit the worker type to tail all logs"
             exit 1
         fi
-        local f
-        f=$(resolve_log_file "$canonical")
-        if [[ -z "$f" ]]; then
-            print_status $YELLOW "No log file found for $canonical. Did you start it with -d?"
-            exit 0
+        if [[ "$canonical" == "$PG_QUEUE_SET" ]]; then
+            # The set alias maps to no single dir — tail both member logs.
+            for d in "$PG_QUEUE_CONSUMER_TYPE" "$PG_QUEUE_REAPER_TYPE"; do
+                local member_log
+                member_log=$(resolve_log_file "$d")
+                [[ -n "$member_log" ]] && log_files+=("$member_log")
+            done
+        else
+            local f
+            f=$(resolve_log_file "$canonical")
+            if [[ -z "$f" ]]; then
+                print_status $YELLOW "No log file found for $canonical. Did you start it with -d?"
+                exit 0
+            fi
+            log_files+=("$f")
         fi
-        log_files+=("$f")
     fi
 
     if [[ ${#log_files[@]} -eq 0 ]]; then
@@ -881,7 +890,13 @@ run_pg_queue_set() {
             || failed=1
     done
     if [[ $failed -ne 0 ]]; then
-        print_status $RED "PG-queue set: a member failed to start (see logs above)"
+        print_status $RED "PG-queue set: a member failed to start — tearing down the set (see logs above)"
+        # Don't leave a survivor: a restart-on-failure relaunch would spawn a
+        # second instance on top of it (the consumer would double-poll Postgres).
+        # Kill both members (the crashed one is already gone → no-op). Same
+        # all-or-nothing discipline as the restart path.
+        kill_one_worker "$PG_QUEUE_CONSUMER_TYPE"
+        kill_one_worker "$PG_QUEUE_REAPER_TYPE"
         show_status
         return 1
     fi

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -325,5 +325,21 @@ class TestSweepExpiredBarriers:
         assert _ids(barrier_conn) == []
 
 
+# --- Entry point (the `python -m pg_queue_reaper` launch path) ---
+
+
+class TestEntryPoint:
+    def test_main_module_reexports_real_main(self):
+        # The single point where `run-worker.sh reaper` / `python -m
+        # pg_queue_reaper` either works or dies on ImportError. Pin that the
+        # launcher module re-exports the real reaper main.
+        import importlib
+
+        from queue_backend.pg_queue.reaper import main as real_main
+
+        module = importlib.import_module("pg_queue_reaper.__main__")
+        assert module.main is real_main
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Followup to the reaper slice (UN-3554): wires the reaper into `run-worker.sh` and adds a **`pg-queue` set** so the whole PG-queue group launches in one shot. Mirrors the 9c → 9c-followup split (launcher wiring as its own slice). The reaper's liveness probe is a separate follow-on.

## What's in it

**`workers/pg_queue_reaper/`** — a thin entrypoint package (`python -m pg_queue_reaper` → `queue_backend.pg_queue.reaper.main`). Unlike `pg_queue_consumer` it needs **no** worker-app bootstrap (the reaper runs no Celery tasks, only SQL recovery); it exists so the process has a stable name `run-worker.sh` can launch and pgrep-match.

**`run-worker.sh`**
- **`reaper` / `pg-queue-reaper`** worker type — opt-in (**not** in `all`), launches `python -m pg_queue_reaper`, runs from the workers root, `--status`/`-k`/`-r` matching via the `-m` pgrep branch (now covers consumer + reaper). Lease/interval env documented in `--help`.
- **`pg` / `pg-queue` set** — `run_pg_queue_set` launches consumer + reaper together (always detached, like `all`). `-r pg-queue` kills both members then relaunches. `list_core_worker_dirs` skips the set alias so status shows no phantom `pg-queue` worker.
- **Help** documents the Celery `all` set and the PG `pg-queue` set as independent — run both in parallel for a dual-transport (strangler-fig) setup.

## Why a set (and what stays env/K8s)

`run-worker.sh` is the **dev / host-launch** path; the `pg-queue` set is its ergonomics win — bring up the whole PG group in one command, alongside `all`, for dual-transport dev. **Production** still runs each component as its own K8s Deployment, with `WORKER_PG_QUEUE_ENABLED_TASKS` / `WORKER_BARRIER_BACKEND` controlling what's active — so no dynamic "auto-detect available queues" logic is baked into the shell.

## Dev-test (live, against the running stack)

- `run-worker.sh reaper -d` → launched, **acquired leadership**, ticking; `--status` shows `pg_queue_reaper: RUNNING (2 proc)`.
- `run-worker.sh pg-queue` → consumer + reaper both up + RUNNING, reaper leader, **no phantom set entry** in status.
- `bash -n` clean; `--help` renders the new entries; entrypoint imports cleanly.

## Out of scope (follow-ons)

- Reaper **liveness probe** (LivenessServer exposing `is_leader` + last-tick freshness) — separate slice, mirroring how consumer liveness (UN-3544) followed the consumer wiring.
- Production K8s manifests.

Base: `feat/UN-3445-pg-queue-integration`. Sub-task UN-3555 under UN-3536, followup to UN-3554.
