### PR TITLE
UN-3556 [FEAT] PG Queue 9d — reaper liveness probe (heartbeat + is_leader)

### DIFF
--- a/workers/queue_backend/pg_queue/__init__.py
+++ b/workers/queue_backend/pg_queue/__init__.py
@@ -32,6 +32,7 @@ so they're tracked on the ticket / PR rather than baked in here.
 from .client import PgQueueClient, QueueMessage
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id, lease_seconds_from_env
+from .liveness import LivenessServer
 from .reaper import (
     LeaderLeaseLike,
     PgReaper,
@@ -45,6 +46,7 @@ from .task_payload import TaskPayload, to_payload
 __all__ = [
     "LeaderLease",
     "LeaderLeaseLike",
+    "LivenessServer",
     "PgQueueClient",
     "PgReaper",
     "QueueMessage",

--- a/workers/queue_backend/pg_queue/__init__.py
+++ b/workers/queue_backend/pg_queue/__init__.py
@@ -35,6 +35,7 @@ from .leader_election import LeaderLease, default_worker_id, lease_seconds_from_
 from .reaper import (
     LeaderLeaseLike,
     PgReaper,
+    ReaperLivenessServer,
     TickOutcome,
     reaper_interval_from_env,
     sweep_expired_barriers,
@@ -47,6 +48,7 @@ __all__ = [
     "PgQueueClient",
     "PgReaper",
     "QueueMessage",
+    "ReaperLivenessServer",
     "TaskPayload",
     "TickOutcome",
     "create_pg_connection",

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -31,11 +31,9 @@ from celery import current_app
 
 from ..fairness import FAIRNESS_HEADER_NAME
 from .client import PgQueueClient
+from .liveness import LivenessServer as _BaseLivenessServer
 
 if TYPE_CHECKING:
-    from http.server import HTTPServer
-    from threading import Thread
-
     from celery import Celery
 
     from .client import QueueMessage
@@ -97,8 +95,7 @@ class PgQueueConsumer:
             # Otherwise min(poll_interval*2, backoff_max) shrinks the backoff
             # below poll_interval — it would decrease instead of grow.
             raise ValueError(
-                f"backoff_max ({backoff_max}) must be >= poll_interval "
-                f"({poll_interval})"
+                f"backoff_max ({backoff_max}) must be >= poll_interval ({poll_interval})"
             )
         self.queue_name = queue_name
         self._client = client if client is not None else PgQueueClient()
@@ -371,124 +368,24 @@ def _maybe_start_health_server(
     return server
 
 
-class LivenessServer:
-    """Tiny HTTP liveness probe: 200 while the poll loop is fresh, else 503.
-
-    Deliberately lean. A *liveness* probe must answer one question — "is this
-    process still making progress?" — and nothing else. It must NOT depend on
-    broker/API reachability or resource pressure: a transient backend blip or a
-    busy moment would otherwise make the orchestrator crash-loop an
-    otherwise-healthy consumer. So this intentionally does *not* reuse the
-    shared ``HealthChecker`` (which bundles api-connectivity / system-resource
-    checks meant for richer health reporting, not liveness) — it reports solely
-    on the poll-loop heartbeat (:meth:`PgQueueConsumer.is_poll_stale`).
-
-    Serves ``/health`` (also ``/healthz``, ``/livez``) on ``0.0.0.0`` (all
-    interfaces — a container/k8s probe reaches it from outside the process) in a
-    daemon thread. Bind ``port=0`` to let the OS pick a free port (read back via
-    :attr:`bound_port`) — used in tests. Start once; :meth:`stop` returns it to
-    the inert state.
+class LivenessServer(_BaseLivenessServer):
+    """Consumer poll-loop liveness — a thin wrapper over the shared
+    :class:`queue_backend.pg_queue.liveness.LivenessServer`, bound to the
+    consumer's heartbeat (``seconds_since_last_poll``). Same wire shape as before
+    (``/health`` → 200 fresh / 503 stale, ``check="pg_queue_poll"``).
     """
-
-    _PATHS = frozenset({"/health", "/healthz", "/livez"})
 
     def __init__(
         self, consumer: PgQueueConsumer, *, port: int, stale_after: float
     ) -> None:
-        self._consumer = consumer
-        self._port = port
-        self._stale_after = stale_after
-        self._httpd: HTTPServer | None = None
-        self._thread: Thread | None = None
-
-    def start(self) -> None:
-        import json
-        import threading
-        from http.server import BaseHTTPRequestHandler, HTTPServer
-        from urllib.parse import urlsplit
-
-        if self._httpd is not None:
-            raise RuntimeError("LivenessServer already started")
-
-        consumer = self._consumer
-        stale_after = self._stale_after
-        paths = self._PATHS
-
-        class _Handler(BaseHTTPRequestHandler):
-            def do_GET(self) -> None:
-                # Strip any query string — self.path includes it, so a probe
-                # like /health?foo=bar must still match.
-                if urlsplit(self.path).path not in paths:
-                    self.send_response(404)
-                    self.end_headers()
-                    return
-                # One clock read so age and the healthy/stale verdict are
-                # derived from the same instant.
-                age = consumer.seconds_since_last_poll()
-                stale = age > stale_after
-                body = json.dumps(
-                    {
-                        "status": "unhealthy" if stale else "healthy",
-                        "check": "pg_queue_poll",
-                        "seconds_since_last_poll": round(age, 3),
-                        "stale_after_seconds": stale_after,
-                    }
-                ).encode()
-                self.send_response(503 if stale else 200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                try:
-                    self.wfile.write(body)
-                except (BrokenPipeError, ConnectionResetError):
-                    pass  # client (probe) hung up mid-response — not our problem
-
-            def log_message(self, *_: object) -> None:
-                pass  # silence per-request access logging
-
-            def log_error(self, fmt: str, *args: object) -> None:
-                # BaseHTTPRequestHandler routes errors through log_message too;
-                # don't let the pass above swallow them — surface to our logger.
-                logger.warning("pg-queue liveness handler: " + fmt, *args)
-
-        def _serve(httpd: HTTPServer) -> None:
-            try:
-                httpd.serve_forever()
-            except Exception:
-                # A daemon thread dying silently would make /health stop
-                # answering (connection refused) with no breadcrumb.
-                logger.exception("pg-queue liveness server thread crashed")
-
-        httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
-        self._httpd = httpd
-        self._thread = threading.Thread(
-            target=_serve, args=(httpd,), daemon=True, name="pg-consumer-liveness"
+        super().__init__(
+            freshness_fn=consumer.seconds_since_last_poll,
+            stale_after=stale_after,
+            port=port,
+            check_name="pg_queue_poll",
+            age_key="seconds_since_last_poll",
+            thread_name="pg-consumer-liveness",
         )
-        self._thread.start()
-
-    @property
-    def bound_port(self) -> int:
-        """Actual listening port (resolves ``port=0``); the requested port if not started."""
-        if self._httpd is not None:
-            return self._httpd.server_address[1]
-        return self._port
-
-    def stop(self) -> None:
-        """Shut the server down. Defensive: never raises (called from a finally)."""
-        try:
-            if self._httpd is not None:
-                self._httpd.shutdown()
-                self._httpd.server_close()
-            if self._thread is not None:
-                self._thread.join(timeout=5)
-                if self._thread.is_alive():
-                    logger.warning(
-                        "PG-queue consumer: liveness thread did not stop within 5s"
-                    )
-        except Exception:
-            logger.exception("PG-queue consumer: error stopping liveness server")
-        finally:
-            self._httpd = None
-            self._thread = None
 
 
 if __name__ == "__main__":

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -385,6 +385,7 @@ class LivenessServer(_BaseLivenessServer):
             check_name="pg_queue_poll",
             age_key="seconds_since_last_poll",
             thread_name="pg-consumer-liveness",
+            log_label="pg-queue consumer",
         )
 
 

--- a/workers/queue_backend/pg_queue/liveness.py
+++ b/workers/queue_backend/pg_queue/liveness.py
@@ -1,0 +1,152 @@
+"""Shared tiny HTTP liveness probe for PG-queue processes.
+
+Both the consumer (poll loop) and the reaper (tick loop) need the same probe:
+"is this loop still making progress?". This is the single implementation,
+parameterised by a freshness callable + the payload's ``check``/age labels (and
+an optional extra-status callable — e.g. the reaper's ``is_leader``). Each side
+wraps it in a thin subclass with its own constructor shape.
+
+Deliberately lean. A *liveness* probe must answer one question — progress — and
+nothing else. It must NOT depend on broker/DB reachability or resource pressure:
+a transient backend blip or a busy moment would otherwise make the orchestrator
+crash-loop an otherwise-healthy process. So this does not reuse the shared
+``HealthChecker`` (which bundles api-connectivity / system-resource checks meant
+for richer health reporting, not liveness).
+
+Serves ``/health`` (also ``/healthz``, ``/livez``) on ``0.0.0.0`` (a
+container/k8s probe reaches it from outside the process) in a daemon thread.
+Bind ``port=0`` to let the OS pick a free port (read back via :attr:`bound_port`)
+— used in tests. Start once; :meth:`stop` returns it to the inert state.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class LivenessServer:
+    """Generic liveness probe: 200 while ``freshness_fn()`` is within
+    ``stale_after`` seconds, else 503.
+
+    ``check_name`` / ``age_key`` label the JSON payload; ``extra_status_fn``
+    (optional) merges extra fields in (informational — it never affects the
+    200/503 verdict, which is purely the freshness heartbeat).
+    """
+
+    _PATHS = frozenset({"/health", "/healthz", "/livez"})
+
+    def __init__(
+        self,
+        *,
+        freshness_fn: Callable[[], float],
+        stale_after: float,
+        port: int,
+        check_name: str,
+        age_key: str,
+        extra_status_fn: Callable[[], dict[str, Any]] | None = None,
+        thread_name: str = "pg-queue-liveness",
+    ) -> None:
+        self._freshness_fn = freshness_fn
+        self._stale_after = stale_after
+        self._port = port
+        self._check_name = check_name
+        self._age_key = age_key
+        self._extra_status_fn = extra_status_fn
+        self._thread_name = thread_name
+        self._httpd: Any = None
+        self._thread: Any = None
+
+    def start(self) -> None:
+        import json
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from urllib.parse import urlsplit
+
+        if self._httpd is not None:
+            raise RuntimeError("LivenessServer already started")
+
+        freshness_fn = self._freshness_fn
+        stale_after = self._stale_after
+        paths = self._PATHS
+        check_name = self._check_name
+        age_key = self._age_key
+        extra_status_fn = self._extra_status_fn
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                # Strip any query string — a probe like /health?foo=bar must match.
+                if urlsplit(self.path).path not in paths:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                # One clock read so age and the healthy/stale verdict share an
+                # instant. The verdict is purely freshness — extra_status_fn
+                # fields are informational and never flip it.
+                age = freshness_fn()
+                stale = age > stale_after
+                payload: dict[str, Any] = {
+                    "status": "unhealthy" if stale else "healthy",
+                    "check": check_name,
+                    age_key: round(age, 3),
+                    "stale_after_seconds": stale_after,
+                }
+                if extra_status_fn is not None:
+                    payload.update(extra_status_fn())
+                body = json.dumps(payload).encode()
+                self.send_response(503 if stale else 200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass  # client (probe) hung up mid-response — not our problem
+
+            def log_message(self, *_: object) -> None:
+                pass  # silence per-request access logging
+
+            def log_error(self, fmt: str, *args: object) -> None:
+                # BaseHTTPRequestHandler routes errors through log_message too;
+                # don't let the pass above swallow them — surface to our logger.
+                logger.warning("pg-queue liveness handler: " + fmt, *args)
+
+        def _serve(httpd: Any) -> None:
+            try:
+                httpd.serve_forever()
+            except Exception:
+                # A daemon thread dying silently would make /health stop
+                # answering (connection refused) with no breadcrumb.
+                logger.exception("pg-queue liveness server thread crashed")
+
+        httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
+        self._httpd = httpd
+        self._thread = threading.Thread(
+            target=_serve, args=(httpd,), daemon=True, name=self._thread_name
+        )
+        self._thread.start()
+
+    @property
+    def bound_port(self) -> int:
+        """Actual listening port (resolves ``port=0``); the requested port if not started."""
+        if self._httpd is not None:
+            return self._httpd.server_address[1]
+        return self._port
+
+    def stop(self) -> None:
+        """Shut the server down. Defensive: never raises (called from a finally)."""
+        try:
+            if self._httpd is not None:
+                self._httpd.shutdown()
+                self._httpd.server_close()
+            if self._thread is not None:
+                self._thread.join(timeout=5)
+                if self._thread.is_alive():
+                    logger.warning("pg-queue liveness thread did not stop within 5s")
+        except Exception:
+            logger.exception("pg-queue: error stopping liveness server")
+        finally:
+            self._httpd = None
+            self._thread = None

--- a/workers/queue_backend/pg_queue/liveness.py
+++ b/workers/queue_backend/pg_queue/liveness.py
@@ -23,7 +23,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from http.server import HTTPServer
+    from threading import Thread
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +54,11 @@ class LivenessServer:
         extra_status_fn: Callable[[], dict[str, Any]] | None = None,
         thread_name: str = "pg-queue-liveness",
     ) -> None:
+        # Re-validate here (not only at the env boundary): a direct caller could
+        # otherwise build an always-503 probe that crash-loops the pod. Mirrors
+        # the codebase's load-bearing re-validation convention (PgReaper.__init__).
+        if stale_after <= 0:
+            raise ValueError(f"stale_after must be positive, got {stale_after!r}")
         self._freshness_fn = freshness_fn
         self._stale_after = stale_after
         self._port = port
@@ -57,8 +66,8 @@ class LivenessServer:
         self._age_key = age_key
         self._extra_status_fn = extra_status_fn
         self._thread_name = thread_name
-        self._httpd: Any = None
-        self._thread: Any = None
+        self._httpd: HTTPServer | None = None
+        self._thread: Thread | None = None
 
     def start(self) -> None:
         import json
@@ -113,7 +122,7 @@ class LivenessServer:
                 # don't let the pass above swallow them — surface to our logger.
                 logger.warning("pg-queue liveness handler: " + fmt, *args)
 
-        def _serve(httpd: Any) -> None:
+        def _serve(httpd: HTTPServer) -> None:
             try:
                 httpd.serve_forever()
             except Exception:
@@ -130,7 +139,10 @@ class LivenessServer:
 
     @property
     def bound_port(self) -> int:
-        """Actual listening port (resolves ``port=0``); the requested port if not started."""
+        """Actual listening port once started (resolves ``port=0`` to the
+        OS-chosen port). Before :meth:`start` / after :meth:`stop`, returns the
+        configured port value (which is ``0`` when the OS is asked to choose).
+        """
         if self._httpd is not None:
             return self._httpd.server_address[1]
         return self._port

--- a/workers/queue_backend/pg_queue/liveness.py
+++ b/workers/queue_backend/pg_queue/liveness.py
@@ -53,6 +53,7 @@ class LivenessServer:
         age_key: str,
         extra_status_fn: Callable[[], dict[str, Any]] | None = None,
         thread_name: str = "pg-queue-liveness",
+        log_label: str = "pg-queue",
     ) -> None:
         # Re-validate here (not only at the env boundary): a direct caller could
         # otherwise build an always-503 probe that crash-loops the pod. Mirrors
@@ -66,6 +67,10 @@ class LivenessServer:
         self._age_key = age_key
         self._extra_status_fn = extra_status_fn
         self._thread_name = thread_name
+        # Prefixes the (now-shared) log messages so they stay attributable to the
+        # source process after the consumer/reaper extraction (e.g. "pg-queue
+        # consumer" / "pg-queue reaper") — they all log via this module's logger.
+        self._log_label = log_label
         self._httpd: HTTPServer | None = None
         self._thread: Thread | None = None
 
@@ -84,6 +89,7 @@ class LivenessServer:
         check_name = self._check_name
         age_key = self._age_key
         extra_status_fn = self._extra_status_fn
+        log_label = self._log_label
 
         class _Handler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:
@@ -97,14 +103,20 @@ class LivenessServer:
                 # fields are informational and never flip it.
                 age = freshness_fn()
                 stale = age > stale_after
-                payload: dict[str, Any] = {
-                    "status": "unhealthy" if stale else "healthy",
-                    "check": check_name,
-                    age_key: round(age, 3),
-                    "stale_after_seconds": stale_after,
-                }
+                # Extra fields first, then overlay the core fields — so a caller's
+                # extra_status_fn can NEVER clobber status/check/age_key/
+                # stale_after_seconds (which a monitor reads): core always wins.
+                payload: dict[str, Any] = {}
                 if extra_status_fn is not None:
                     payload.update(extra_status_fn())
+                payload.update(
+                    {
+                        "status": "unhealthy" if stale else "healthy",
+                        "check": check_name,
+                        age_key: round(age, 3),
+                        "stale_after_seconds": stale_after,
+                    }
+                )
                 body = json.dumps(payload).encode()
                 self.send_response(503 if stale else 200)
                 self.send_header("Content-Type", "application/json")
@@ -120,7 +132,7 @@ class LivenessServer:
             def log_error(self, fmt: str, *args: object) -> None:
                 # BaseHTTPRequestHandler routes errors through log_message too;
                 # don't let the pass above swallow them — surface to our logger.
-                logger.warning("pg-queue liveness handler: " + fmt, *args)
+                logger.warning(f"{log_label} liveness handler: " + fmt, *args)
 
         def _serve(httpd: HTTPServer) -> None:
             try:
@@ -128,7 +140,7 @@ class LivenessServer:
             except Exception:
                 # A daemon thread dying silently would make /health stop
                 # answering (connection refused) with no breadcrumb.
-                logger.exception("pg-queue liveness server thread crashed")
+                logger.exception("%s liveness server thread crashed", log_label)
 
         httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
         self._httpd = httpd
@@ -156,9 +168,11 @@ class LivenessServer:
             if self._thread is not None:
                 self._thread.join(timeout=5)
                 if self._thread.is_alive():
-                    logger.warning("pg-queue liveness thread did not stop within 5s")
+                    logger.warning(
+                        "%s liveness thread did not stop within 5s", self._log_label
+                    )
         except Exception:
-            logger.exception("pg-queue: error stopping liveness server")
+            logger.exception("%s: error stopping liveness server", self._log_label)
         finally:
             self._httpd = None
             self._thread = None

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -39,10 +39,11 @@ import os
 import signal
 import threading
 import time
-from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id
+from .liveness import LivenessServer as _BaseLivenessServer
 
 if TYPE_CHECKING:
     from psycopg2.extensions import connection as PgConnection
@@ -319,108 +320,24 @@ class PgReaper:
 _DEFAULT_HEALTH_STALE_SECONDS = 30.0
 
 
-class ReaperLivenessServer:
-    """Tiny HTTP liveness probe for the reaper: 200 while the tick loop is fresh,
-    else 503. Also surfaces ``is_leader`` (which pod holds the lease).
-
-    Deliberately lean, mirroring the consumer's ``LivenessServer``: a *liveness*
-    probe answers one question — "is this loop still making progress?" — and must
-    NOT depend on DB reachability or leadership (a standby is healthy), or a
-    transient blip would crash-loop a fine process. The 200/503 verdict is purely
-    the tick heartbeat; ``is_leader`` is informational. Serves ``/health`` (also
-    ``/healthz``, ``/livez``) on ``0.0.0.0`` in a daemon thread; ``port=0`` lets
-    the OS pick a free port (read back via :attr:`bound_port`) — used in tests.
+class ReaperLivenessServer(_BaseLivenessServer):
+    """Reaper tick-loop liveness — a thin wrapper over the shared
+    :class:`queue_backend.pg_queue.liveness.LivenessServer`, bound to the reaper's
+    heartbeat (``seconds_since_last_tick``) and surfacing ``is_leader`` (which pod
+    holds the lease — informational; the 200/503 verdict is purely the heartbeat,
+    so a standby is healthy).
     """
 
-    _PATHS = frozenset({"/health", "/healthz", "/livez"})
-
     def __init__(self, reaper: PgReaper, *, port: int, stale_after: float) -> None:
-        self._reaper = reaper
-        self._port = port
-        self._stale_after = stale_after
-        self._httpd: Any = None
-        self._thread: Any = None
-
-    def start(self) -> None:
-        import json
-        import threading as _threading
-        from http.server import BaseHTTPRequestHandler, HTTPServer
-        from urllib.parse import urlsplit
-
-        if self._httpd is not None:
-            raise RuntimeError("ReaperLivenessServer already started")
-
-        reaper = self._reaper
-        stale_after = self._stale_after
-        paths = self._PATHS
-
-        class _Handler(BaseHTTPRequestHandler):
-            def do_GET(self) -> None:
-                if urlsplit(self.path).path not in paths:
-                    self.send_response(404)
-                    self.end_headers()
-                    return
-                # One clock read so age and the verdict share an instant.
-                age = reaper.seconds_since_last_tick()
-                stale = age > stale_after
-                body = json.dumps(
-                    {
-                        "status": "unhealthy" if stale else "healthy",
-                        "check": "pg_reaper_tick",
-                        "seconds_since_last_tick": round(age, 3),
-                        "stale_after_seconds": stale_after,
-                        "is_leader": reaper.is_leader,
-                    }
-                ).encode()
-                self.send_response(503 if stale else 200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                try:
-                    self.wfile.write(body)
-                except (BrokenPipeError, ConnectionResetError):
-                    pass  # probe hung up mid-response — not our problem
-
-            def log_message(self, *_: object) -> None:
-                pass  # silence per-request access logging
-
-            def log_error(self, fmt: str, *args: object) -> None:
-                logger.warning("pg-reaper liveness handler: " + fmt, *args)
-
-        def _serve(httpd: Any) -> None:
-            try:
-                httpd.serve_forever()
-            except Exception:
-                logger.exception("pg-reaper liveness server thread crashed")
-
-        httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
-        self._httpd = httpd
-        self._thread = _threading.Thread(
-            target=_serve, args=(httpd,), daemon=True, name="pg-reaper-liveness"
+        super().__init__(
+            freshness_fn=reaper.seconds_since_last_tick,
+            stale_after=stale_after,
+            port=port,
+            check_name="pg_reaper_tick",
+            age_key="seconds_since_last_tick",
+            extra_status_fn=lambda: {"is_leader": reaper.is_leader},
+            thread_name="pg-reaper-liveness",
         )
-        self._thread.start()
-
-    @property
-    def bound_port(self) -> int:
-        """Actual listening port (resolves ``port=0``); the requested port if not started."""
-        if self._httpd is not None:
-            return self._httpd.server_address[1]
-        return self._port
-
-    def stop(self) -> None:
-        """Shut the server down. Defensive: never raises (called from a finally)."""
-        try:
-            if self._httpd is not None:
-                self._httpd.shutdown()
-                self._httpd.server_close()
-            if self._thread is not None:
-                self._thread.join(timeout=5)
-                if self._thread.is_alive():
-                    logger.warning("pg-reaper liveness thread did not stop within 5s")
-        except Exception:
-            logger.exception("pg-reaper: error stopping liveness server")
-        finally:
-            self._httpd = None
-            self._thread = None
 
 
 def _reaper_health_stale_from_env() -> float:

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -39,7 +39,7 @@ import os
 import signal
 import threading
 import time
-from typing import TYPE_CHECKING, NamedTuple, Protocol
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id
@@ -178,11 +178,23 @@ class PgReaper:
         self._owns_sweep_conn = sweep_conn is None
         self._running = False
         self._is_leader = False
+        # Liveness heartbeat: monotonic timestamp of the last tick start. A
+        # standby tick counts as progress too (the loop is alive), so this tracks
+        # loop liveness, not leadership.
+        self._last_tick_monotonic = time.monotonic()
 
     @property
     def is_leader(self) -> bool:
         """Whether this process currently holds leadership (last tick's view)."""
         return self._is_leader
+
+    def seconds_since_last_tick(self) -> float:
+        """Seconds since the last tick started — the liveness heartbeat age."""
+        return time.monotonic() - self._last_tick_monotonic
+
+    def is_tick_stale(self, stale_after_seconds: float) -> bool:
+        """Whether the loop has gone quiet past ``stale_after_seconds``."""
+        return self.seconds_since_last_tick() > stale_after_seconds
 
     def _get_sweep_conn(self) -> PgConnection:
         # Recreate only an OWNED missing/closed connection; an injected one is the
@@ -208,6 +220,9 @@ class PgReaper:
 
     def tick(self) -> TickOutcome:
         """One cycle: maintain leadership, then sweep iff leader."""
+        # Heartbeat at the START of the cycle: a tick that begins but then errors
+        # still proves the loop is running (the error path is caught by run()).
+        self._last_tick_monotonic = time.monotonic()
         if self._is_leader:
             try:
                 still_leader = self._lease.renew()
@@ -297,10 +312,180 @@ class PgReaper:
             )
 
 
+# Default staleness window for the liveness probe. Comfortably above the
+# default 5s tick interval so a single slow cycle (a long sweep / DB blip)
+# doesn't flap the probe; an operator tightening the interval should tighten
+# this too.
+_DEFAULT_HEALTH_STALE_SECONDS = 30.0
+
+
+class ReaperLivenessServer:
+    """Tiny HTTP liveness probe for the reaper: 200 while the tick loop is fresh,
+    else 503. Also surfaces ``is_leader`` (which pod holds the lease).
+
+    Deliberately lean, mirroring the consumer's ``LivenessServer``: a *liveness*
+    probe answers one question — "is this loop still making progress?" — and must
+    NOT depend on DB reachability or leadership (a standby is healthy), or a
+    transient blip would crash-loop a fine process. The 200/503 verdict is purely
+    the tick heartbeat; ``is_leader`` is informational. Serves ``/health`` (also
+    ``/healthz``, ``/livez``) on ``0.0.0.0`` in a daemon thread; ``port=0`` lets
+    the OS pick a free port (read back via :attr:`bound_port`) — used in tests.
+    """
+
+    _PATHS = frozenset({"/health", "/healthz", "/livez"})
+
+    def __init__(self, reaper: PgReaper, *, port: int, stale_after: float) -> None:
+        self._reaper = reaper
+        self._port = port
+        self._stale_after = stale_after
+        self._httpd: Any = None
+        self._thread: Any = None
+
+    def start(self) -> None:
+        import json
+        import threading as _threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from urllib.parse import urlsplit
+
+        if self._httpd is not None:
+            raise RuntimeError("ReaperLivenessServer already started")
+
+        reaper = self._reaper
+        stale_after = self._stale_after
+        paths = self._PATHS
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                if urlsplit(self.path).path not in paths:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                # One clock read so age and the verdict share an instant.
+                age = reaper.seconds_since_last_tick()
+                stale = age > stale_after
+                body = json.dumps(
+                    {
+                        "status": "unhealthy" if stale else "healthy",
+                        "check": "pg_reaper_tick",
+                        "seconds_since_last_tick": round(age, 3),
+                        "stale_after_seconds": stale_after,
+                        "is_leader": reaper.is_leader,
+                    }
+                ).encode()
+                self.send_response(503 if stale else 200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass  # probe hung up mid-response — not our problem
+
+            def log_message(self, *_: object) -> None:
+                pass  # silence per-request access logging
+
+            def log_error(self, fmt: str, *args: object) -> None:
+                logger.warning("pg-reaper liveness handler: " + fmt, *args)
+
+        def _serve(httpd: Any) -> None:
+            try:
+                httpd.serve_forever()
+            except Exception:
+                logger.exception("pg-reaper liveness server thread crashed")
+
+        httpd = HTTPServer(("0.0.0.0", self._port), _Handler)
+        self._httpd = httpd
+        self._thread = _threading.Thread(
+            target=_serve, args=(httpd,), daemon=True, name="pg-reaper-liveness"
+        )
+        self._thread.start()
+
+    @property
+    def bound_port(self) -> int:
+        """Actual listening port (resolves ``port=0``); the requested port if not started."""
+        if self._httpd is not None:
+            return self._httpd.server_address[1]
+        return self._port
+
+    def stop(self) -> None:
+        """Shut the server down. Defensive: never raises (called from a finally)."""
+        try:
+            if self._httpd is not None:
+                self._httpd.shutdown()
+                self._httpd.server_close()
+            if self._thread is not None:
+                self._thread.join(timeout=5)
+                if self._thread.is_alive():
+                    logger.warning("pg-reaper liveness thread did not stop within 5s")
+        except Exception:
+            logger.exception("pg-reaper: error stopping liveness server")
+        finally:
+            self._httpd = None
+            self._thread = None
+
+
+def _reaper_health_stale_from_env() -> float:
+    raw = os.getenv("WORKER_PG_REAPER_HEALTH_STALE_SECONDS")
+    if raw is None or raw == "":
+        return _DEFAULT_HEALTH_STALE_SECONDS
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"WORKER_PG_REAPER_HEALTH_STALE_SECONDS={raw!r} is not a number."
+        ) from exc
+    if value <= 0:
+        raise ValueError(
+            f"WORKER_PG_REAPER_HEALTH_STALE_SECONDS={value} must be positive."
+        )
+    return value
+
+
+def _maybe_start_health_server(
+    reaper: PgReaper, *, port: int | None, stale_after: float
+) -> ReaperLivenessServer | None:
+    """Start the liveness server when ``port`` is not None; else ``None``.
+
+    A bind failure degrades gracefully — the probe is auxiliary and must never
+    stop the reaper from running; we log and continue probe-less.
+    """
+    if port is None:
+        logger.info(
+            "PG-queue reaper: WORKER_PG_REAPER_HEALTH_PORT unset — liveness "
+            "server disabled"
+        )
+        return None
+    server = ReaperLivenessServer(reaper, port=port, stale_after=stale_after)
+    try:
+        server.start()
+    except OSError:
+        logger.exception(
+            "PG-queue reaper: liveness server could not bind :%s — continuing "
+            "WITHOUT a probe",
+            port,
+        )
+        return None
+    logger.info(
+        "PG-queue reaper: liveness server on :%s/health (stale after %ss)",
+        server.bound_port,
+        stale_after,
+    )
+    return server
+
+
 def main() -> None:
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+    raw_port = os.getenv("WORKER_PG_REAPER_HEALTH_PORT")
+    port = int(raw_port) if raw_port not in (None, "") else None
     lease = LeaderLease(default_worker_id())
-    PgReaper(lease).run()
+    reaper = PgReaper(lease)
+    health = _maybe_start_health_server(
+        reaper, port=port, stale_after=_reaper_health_stale_from_env()
+    )
+    try:
+        reaper.run()
+    finally:
+        if health is not None:
+            health.stop()
 
 
 if __name__ == "__main__":

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -337,6 +337,7 @@ class ReaperLivenessServer(_BaseLivenessServer):
             age_key="seconds_since_last_tick",
             extra_status_fn=lambda: {"is_leader": reaper.is_leader},
             thread_name="pg-reaper-liveness",
+            log_label="pg-queue reaper",
         )
 
 

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -313,10 +313,10 @@ class PgReaper:
             )
 
 
-# Default staleness window for the liveness probe. Comfortably above the
-# default 5s tick interval so a single slow cycle (a long sweep / DB blip)
-# doesn't flap the probe; an operator tightening the interval should tighten
-# this too.
+# Default staleness window for the liveness probe. Comfortably above the default
+# tick interval (_DEFAULT_REAPER_INTERVAL_SECONDS) so a single slow cycle (a long
+# sweep / DB blip) doesn't flap the probe; the durable rationale is the headroom
+# ratio — an operator tightening the interval should tighten this too.
 _DEFAULT_HEALTH_STALE_SECONDS = 30.0
 
 
@@ -357,6 +357,26 @@ def _reaper_health_stale_from_env() -> float:
     return value
 
 
+def _reaper_health_port_from_env() -> int | None:
+    """Liveness port from ``WORKER_PG_REAPER_HEALTH_PORT`` (unset/empty → None,
+    i.e. no server). Validates + names the var here so a garbled value (a common
+    run-worker.sh shell-fallback mistake) fails with a clear message rather than a
+    context-free ``int('abc')`` crash — and so an out-of-range value is rejected
+    at parse time rather than escaping the bind catch as ``OverflowError`` inside
+    ``start()``.
+    """
+    raw = os.getenv("WORKER_PG_REAPER_HEALTH_PORT")
+    if raw is None or raw == "":
+        return None
+    try:
+        port = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"Invalid WORKER_PG_REAPER_HEALTH_PORT={raw!r}: {exc}") from exc
+    if not (0 <= port <= 65535):
+        raise ValueError(f"WORKER_PG_REAPER_HEALTH_PORT={port} out of range 0-65535")
+    return port
+
+
 def _maybe_start_health_server(
     reaper: PgReaper, *, port: int | None, stale_after: float
 ) -> ReaperLivenessServer | None:
@@ -391,12 +411,12 @@ def _maybe_start_health_server(
 
 def main() -> None:
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
-    raw_port = os.getenv("WORKER_PG_REAPER_HEALTH_PORT")
-    port = int(raw_port) if raw_port not in (None, "") else None
     lease = LeaderLease(default_worker_id())
     reaper = PgReaper(lease)
     health = _maybe_start_health_server(
-        reaper, port=port, stale_after=_reaper_health_stale_from_env()
+        reaper,
+        port=_reaper_health_port_from_env(),
+        stale_after=_reaper_health_stale_from_env(),
     )
     try:
         reaper.run()

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -101,6 +101,11 @@ declare -A WORKER_HEALTH_PORTS=(
     # only when WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT is exported (below); a bare
     # `python -m pg_queue_consumer` binds nothing.
     ["$PG_QUEUE_CONSUMER_TYPE"]="8090"
+    # pg_queue_reaper: 8086 — the one free slot in the 8080-8090 band (8086 sits
+    # between callback's 8085 and scheduler's 8087). Bound only when
+    # WORKER_PG_REAPER_HEALTH_PORT is exported (below); a bare
+    # `python -m pg_queue_reaper` binds nothing.
+    ["$PG_QUEUE_REAPER_TYPE"]="8086"
 )
 
 # Opt-in workers: experimental and NOT part of the default "all" fleet, so
@@ -141,7 +146,9 @@ Note: pg-queue-consumer overrides: WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE (source 
       tasks to load, default notification), WORKER_PG_QUEUE_CONSUMER_QUEUE (queue to poll),
       and WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT (liveness server port, default 8090).
 Note: reaper overrides: WORKER_PG_ORCHESTRATOR_LEASE_SECONDS (lease window, default 10),
-      WORKER_PG_REAPER_INTERVAL_SECONDS (cycle interval, default 5).
+      WORKER_PG_REAPER_INTERVAL_SECONDS (cycle interval, default 5),
+      WORKER_PG_REAPER_HEALTH_PORT (liveness server port, default 8086),
+      WORKER_PG_REAPER_HEALTH_STALE_SECONDS (liveness staleness window, default 30).
 
 OPTIONS:
     -e, --env-file FILE   Use specific environment file (default: .env)
@@ -748,9 +755,11 @@ run_worker() {
 
     # PG queue reaper — a leader-elected SQL recovery loop (no Celery, no task
     # bootstrap). Override the celery command with the plain `python -m` entry.
-    # Tunables (lease window, cycle interval) come from env; no liveness port is
-    # wired yet (that's a follow-on slice), so it binds nothing.
+    # Tunables (lease window, cycle interval) come from env. The liveness server
+    # binds when WORKER_PG_REAPER_HEALTH_PORT is set (-p override wins, else the
+    # map default) — exported so the reaper's main() opts in.
     if [[ "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
+        export WORKER_PG_REAPER_HEALTH_PORT="${health_port:-${WORKER_HEALTH_PORTS[$worker_type]}}"
         cmd_args=("uv" "run" "python" "-m" "$PG_QUEUE_REAPER_TYPE")
     fi
 

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -446,6 +446,88 @@ class TestHealthEnv:
             is None
         )
 
+    def test_health_server_bind_failure_degrades_to_none(self, monkeypatch):
+        # The documented graceful-degrade path: a bind failure must NOT stop the
+        # reaper — log and run probe-less.
+        reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=object())
+        monkeypatch.setattr(
+            reaper_mod.ReaperLivenessServer,
+            "start",
+            MagicMock(side_effect=OSError("address already in use")),
+        )
+        with patch.object(reaper_mod.logger, "exception") as logexc:
+            result = reaper_mod._maybe_start_health_server(
+                reaper, port=12345, stale_after=30
+            )
+        assert result is None
+        logexc.assert_called_once()
+
+    def test_stale_after_non_positive_rejected(self):
+        # Constructor re-validates (not only the env reader) — an always-503 probe
+        # would crash-loop the pod.
+        reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=object())
+        with pytest.raises(ValueError, match="stale_after"):
+            reaper_mod.ReaperLivenessServer(reaper, port=0, stale_after=0)
+
+
+class TestHealthPortEnv:
+    def test_unset_is_none(self, monkeypatch):
+        monkeypatch.delenv("WORKER_PG_REAPER_HEALTH_PORT", raising=False)
+        assert reaper_mod._reaper_health_port_from_env() is None
+
+    def test_empty_is_none(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_REAPER_HEALTH_PORT", "")
+        assert reaper_mod._reaper_health_port_from_env() is None
+
+    def test_valid_port(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_REAPER_HEALTH_PORT", "8086")
+        assert reaper_mod._reaper_health_port_from_env() == 8086
+
+    def test_non_int_raises_named(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_REAPER_HEALTH_PORT", "abc")
+        with pytest.raises(ValueError, match="WORKER_PG_REAPER_HEALTH_PORT"):
+            reaper_mod._reaper_health_port_from_env()
+
+    def test_out_of_range_raises(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_REAPER_HEALTH_PORT", "99999")
+        with pytest.raises(ValueError, match="out of range"):
+            reaper_mod._reaper_health_port_from_env()
+
+
+class TestMainWiring:
+    def _patch_main(self, monkeypatch):
+        # Don't open a DB connection or run the loop.
+        monkeypatch.setattr(reaper_mod, "LeaderLease", lambda _wid: _FakeLease())
+        monkeypatch.setattr(reaper_mod.PgReaper, "run", lambda self, **_kw: None)
+
+    def test_wires_health_port_and_stops_on_exit(self, monkeypatch):
+        self._patch_main(monkeypatch)
+        monkeypatch.setenv("WORKER_PG_REAPER_HEALTH_PORT", "0")
+        fake_health = MagicMock()
+        captured: dict = {}
+
+        def fake_start(_reaper, *, port, stale_after):
+            captured["port"] = port
+            return fake_health
+
+        monkeypatch.setattr(reaper_mod, "_maybe_start_health_server", fake_start)
+        reaper_mod.main()
+        assert captured["port"] == 0  # parsed int reached the wiring
+        fake_health.stop.assert_called_once()  # stopped in the finally
+
+    def test_no_health_when_port_unset(self, monkeypatch):
+        self._patch_main(monkeypatch)
+        monkeypatch.delenv("WORKER_PG_REAPER_HEALTH_PORT", raising=False)
+        captured: dict = {}
+
+        def fake_start(_reaper, *, port, stale_after):
+            captured["port"] = port
+            return None
+
+        monkeypatch.setattr(reaper_mod, "_maybe_start_health_server", fake_start)
+        reaper_mod.main()  # must not raise even though health is None
+        assert captured["port"] is None
+
 
 # --- Entry point (the `python -m pg_queue_reaper` launch path) ---
 

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -325,6 +325,128 @@ class TestSweepExpiredBarriers:
         assert _ids(barrier_conn) == []
 
 
+# --- Heartbeat + liveness probe ---
+
+
+class TestHeartbeat:
+    def test_fresh_after_init(self):
+        reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=object())
+        assert reaper.seconds_since_last_tick() < 5
+        assert reaper.is_tick_stale(1) is False
+
+    def test_tick_refreshes_heartbeat(self):
+        # Even a standby tick (no sweep) counts as loop progress.
+        reaper = PgReaper(
+            _FakeLease(acquires=False), interval_seconds=0.01, sweep_conn=object()
+        )
+        reaper._last_tick_monotonic = time.monotonic() - 100  # force stale
+        assert reaper.is_tick_stale(1) is True
+        reaper.tick()
+        assert reaper.is_tick_stale(1) is False
+
+
+def _http_get(server, path="/health"):
+    import http.client
+    import json as _json
+
+    conn = http.client.HTTPConnection("127.0.0.1", server.bound_port, timeout=3)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, (_json.loads(raw) if raw else None)
+    finally:
+        conn.close()
+
+
+class TestLivenessServer:
+    def _server(self, reaper, *, stale_after=30.0):
+        server = reaper_mod.ReaperLivenessServer(reaper, port=0, stale_after=stale_after)
+        server.start()
+        return server
+
+    def test_fresh_returns_200(self):
+        reaper = PgReaper(
+            _FakeLease(acquires=False), interval_seconds=0.01, sweep_conn=object()
+        )
+        server = self._server(reaper)
+        try:
+            status, body = _http_get(server)
+        finally:
+            server.stop()
+        assert status == 200
+        assert body["status"] == "healthy"
+        assert body["check"] == "pg_reaper_tick"
+        assert body["is_leader"] is False
+
+    def test_stale_returns_503(self):
+        reaper = PgReaper(_FakeLease(), interval_seconds=0.01, sweep_conn=object())
+        reaper._last_tick_monotonic = time.monotonic() - 100
+        server = self._server(reaper, stale_after=1.0)
+        try:
+            status, body = _http_get(server)
+        finally:
+            server.stop()
+        assert status == 503
+        assert body["status"] == "unhealthy"
+
+    def test_is_leader_reflected(self):
+        reaper = PgReaper(
+            _FakeLease(acquires=True, renews=True),
+            interval_seconds=0.01,
+            sweep_conn=object(),
+        )
+        with patch.object(reaper_mod, "sweep_expired_barriers", return_value=[]):
+            reaper.tick()  # becomes leader
+        server = self._server(reaper)
+        try:
+            _, body = _http_get(server)
+        finally:
+            server.stop()
+        assert body["is_leader"] is True
+
+    def test_unknown_path_404(self):
+        reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=object())
+        server = self._server(reaper)
+        try:
+            status, _ = _http_get(server, "/nope")
+        finally:
+            server.stop()
+        assert status == 404
+
+    def test_double_start_raises(self):
+        reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=object())
+        server = self._server(reaper)
+        try:
+            with pytest.raises(RuntimeError):
+                server.start()
+        finally:
+            server.stop()
+
+
+class TestHealthEnv:
+    def test_stale_default_is_thirty(self, monkeypatch):
+        monkeypatch.delenv("WORKER_PG_REAPER_HEALTH_STALE_SECONDS", raising=False)
+        assert reaper_mod._reaper_health_stale_from_env() == pytest.approx(30.0)
+
+    def test_stale_overridable(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_REAPER_HEALTH_STALE_SECONDS", "10")
+        assert reaper_mod._reaper_health_stale_from_env() == pytest.approx(10.0)
+
+    @pytest.mark.parametrize("bad", ["0", "-1", "x"])
+    def test_stale_invalid_raises(self, monkeypatch, bad):
+        monkeypatch.setenv("WORKER_PG_REAPER_HEALTH_STALE_SECONDS", bad)
+        with pytest.raises(ValueError):
+            reaper_mod._reaper_health_stale_from_env()
+
+    def test_health_server_disabled_when_no_port(self):
+        reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=object())
+        assert (
+            reaper_mod._maybe_start_health_server(reaper, port=None, stale_after=30)
+            is None
+        )
+
+
 # --- Entry point (the `python -m pg_queue_reaper` launch path) ---
 
 

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -405,6 +405,29 @@ class TestLivenessServer:
             server.stop()
         assert body["is_leader"] is True
 
+    def test_extra_status_cannot_clobber_core_fields(self):
+        # A future extra_status_fn returning a reserved key must not corrupt the
+        # core payload a monitor reads — core fields always win.
+        from queue_backend.pg_queue.liveness import LivenessServer
+
+        server = LivenessServer(
+            freshness_fn=lambda: 0.0,
+            stale_after=30,
+            port=0,
+            check_name="x",
+            age_key="age",
+            extra_status_fn=lambda: {"status": "HACKED", "check": "HACKED", "extra": 1},
+        )
+        server.start()
+        try:
+            status, body = _http_get(server)
+        finally:
+            server.stop()
+        assert status == 200
+        assert body["status"] == "healthy"  # core not clobbered
+        assert body["check"] == "x"  # core not clobbered
+        assert body["extra"] == 1  # non-reserved extra preserved
+
     def test_unknown_path_404(self):
         reaper = PgReaper(_FakeLease(), interval_seconds=1, sweep_conn=object())
         server = self._server(reaper)


### PR DESCRIPTION
## What

The reaper **liveness probe** — closing the gap flagged in #2059's review: a reaper that crashes *after* startup was invisible (opt-in skip in `--status` + no health port). This finishes 9d. Mirrors the consumer's liveness (UN-3544).

## What's in it

- **`PgReaper` heartbeat** — `_last_tick_monotonic` stamped at the **start** of every tick (a standby tick counts as progress — liveness tracks the *loop*, not leadership) + `seconds_since_last_tick()` / `is_tick_stale()`.
- **`ReaperLivenessServer`** — lean HTTP probe (mirrors the consumer's `LivenessServer`): `/health` (also `/healthz`, `/livez`) → **200** while the tick loop is fresh, **503** when stale. Payload also surfaces **`is_leader`** (which pod holds the lease — handy for 9e debugging). The 200/503 verdict is **purely the heartbeat** — never leadership (a standby is healthy) or DB reachability (a blip must not crash-loop a healthy process).
- **`main()` wiring** — `WORKER_PG_REAPER_HEALTH_PORT` (unset → no server, no stray port); staleness window `WORKER_PG_REAPER_HEALTH_STALE_SECONDS` (default 30s, comfortably above the 5s tick interval). A bind failure degrades gracefully (logs, runs probe-less).
- **`run-worker.sh`** — reserves port **8086** for the reaper, exports the health-port env in the reaper special-case, documents the two new env vars in `--help`.

## Tests (+13 → 37 total)

Heartbeat fresh/stale + tick-refresh; liveness server 200-fresh / 503-stale / `is_leader` reflected / 404 / double-start-raises; health-staleness env default+override+invalid; server-disabled-when-no-port.

## Dev-test (live)

`./run-worker.sh reaper -d` → `GET :8086/health` →
`{"status":"healthy","check":"pg_reaper_tick","seconds_since_last_tick":4.79,"stale_after_seconds":30.0,"is_leader":true}`

## Design note

Kept in `reaper.py` (not a shared module) — consistent with the consumer's `LivenessServer` living in `consumer.py`. A future cleanup could extract a shared generic server; out of scope here to avoid refactoring the merged-and-tested consumer probe.

Base: `feat/UN-3445-pg-queue-integration`. **This completes 9d** (orchestrator/reaper). Sub-task UN-3556 under UN-3536.
