### PR TITLE
UN-3559 [FEAT] PG Queue 9e PR 1 — execution transport seam (inert)

### DIFF
--- a/backend/workflow_manager/internal_api_views.py
+++ b/backend/workflow_manager/internal_api_views.py
@@ -324,12 +324,9 @@ def create_workflow_execution(request):
         # Resolve the transport this execution rides (9e). Decided once here, at
         # the creation chokepoint, and returned so the caller carries it in the
         # dispatched task's payload — not persisted on the row. PR 1 always
-        # resolves "celery"; PR 3 wires Flipt in resolve_transport().
-        transport = resolve_transport(
-            workflow_id=str(workflow.id),
-            pipeline_id=data.get("pipeline_id"),
-            organization_id=org_id,
-        )
+        # resolves "celery"; PR 3 wires Flipt (keyed on workflow/pipeline/org) in
+        # resolve_transport().
+        transport = resolve_transport()
 
         return Response(
             {

--- a/backend/workflow_manager/internal_api_views.py
+++ b/backend/workflow_manager/internal_api_views.py
@@ -20,6 +20,7 @@ from tool_instance_v2.models import ToolInstance
 
 from workflow_manager.workflow_v2.enums import ExecutionStatus
 from workflow_manager.workflow_v2.models import Workflow, WorkflowExecution
+from workflow_manager.workflow_v2.transport import resolve_transport
 
 logger = logging.getLogger(__name__)
 
@@ -320,11 +321,22 @@ def create_workflow_execution(request):
             # Handle tags logic if needed
             pass
 
+        # Resolve the transport this execution rides (9e). Decided once here, at
+        # the creation chokepoint, and returned so the caller carries it in the
+        # dispatched task's payload — not persisted on the row. PR 1 always
+        # resolves "celery"; PR 3 wires Flipt in resolve_transport().
+        transport = resolve_transport(
+            workflow_id=str(workflow.id),
+            pipeline_id=data.get("pipeline_id"),
+            organization_id=org_id,
+        )
+
         return Response(
             {
                 "execution_id": str(execution.id),
                 "status": execution.status,
                 "execution_log_id": execution.execution_log_id,  # Return for workers to use
+                "transport": transport,
             }
         )
 

--- a/backend/workflow_manager/workflow_v2/tests/test_transport.py
+++ b/backend/workflow_manager/workflow_v2/tests/test_transport.py
@@ -1,0 +1,40 @@
+"""Tests for the 9e transport-resolution seam.
+
+PR 1 is the *inert* seam: ``resolve_transport`` always returns Celery, so the
+whole pipeline is byte-identical to today. These tests pin that contract so a
+future change (PR 3, Flipt wiring) can't silently flip the default.
+"""
+
+from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, WorkflowTransport
+from workflow_manager.workflow_v2.transport import resolve_transport
+
+
+class TestWorkflowTransportEnum:
+    def test_values(self):
+        assert WorkflowTransport.CELERY.value == "celery"
+        assert WorkflowTransport.PG_QUEUE.value == "pg_queue"
+
+    def test_default_is_celery(self):
+        assert DEFAULT_WORKFLOW_TRANSPORT == WorkflowTransport.CELERY.value
+
+
+class TestResolveTransport:
+    def test_resolves_celery_by_default(self):
+        """PR 1: always Celery, regardless of inputs."""
+        assert resolve_transport(workflow_id="wf-1") == WorkflowTransport.CELERY.value
+
+    def test_accepts_optional_args_without_changing_result(self):
+        """The pipeline/org args are accepted now (stable signature for PR 3's
+        Flipt wiring) but must not change the inert result."""
+        assert (
+            resolve_transport(
+                workflow_id="wf-1",
+                pipeline_id="pipe-1",
+                organization_id="org-1",
+            )
+            == WorkflowTransport.CELERY.value
+        )
+
+    def test_result_is_a_valid_transport_value(self):
+        valid = {t.value for t in WorkflowTransport}
+        assert resolve_transport(workflow_id="wf-1") in valid

--- a/backend/workflow_manager/workflow_v2/tests/test_transport.py
+++ b/backend/workflow_manager/workflow_v2/tests/test_transport.py
@@ -5,7 +5,13 @@ whole pipeline is byte-identical to today. These tests pin that contract so a
 future change (PR 3, Flipt wiring) can't silently flip the default.
 """
 
-from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, WorkflowTransport
+from unittest.mock import MagicMock
+
+from unstract.core.data_models import (
+    DEFAULT_WORKFLOW_TRANSPORT,
+    WorkflowTransport,
+    normalize_transport,
+)
 from workflow_manager.workflow_v2.transport import resolve_transport
 
 
@@ -38,3 +44,29 @@ class TestResolveTransport:
     def test_result_is_a_valid_transport_value(self):
         valid = {t.value for t in WorkflowTransport}
         assert resolve_transport(workflow_id="wf-1") in valid
+
+
+class TestNormalizeTransport:
+    """The fail-closed coercion used at every untrusted read boundary."""
+
+    def test_recognized_values_pass_through(self):
+        assert normalize_transport("celery") == "celery"
+        assert normalize_transport("pg_queue") == "pg_queue"
+
+    def test_unrecognized_value_falls_back_to_celery(self):
+        assert normalize_transport("celary") == DEFAULT_WORKFLOW_TRANSPORT
+        assert normalize_transport("pg-queue") == DEFAULT_WORKFLOW_TRANSPORT
+
+    def test_none_and_empty_fall_back_to_celery(self):
+        assert normalize_transport(None) == DEFAULT_WORKFLOW_TRANSPORT
+        assert normalize_transport("") == DEFAULT_WORKFLOW_TRANSPORT
+
+    def test_invalid_value_logs_a_warning_when_logger_given(self):
+        log = MagicMock()
+        assert normalize_transport("bogus", logger=log, context=" [exec:x]") == "celery"
+        log.warning.assert_called_once()
+
+    def test_valid_value_does_not_warn(self):
+        log = MagicMock()
+        normalize_transport("pg_queue", logger=log)
+        log.warning.assert_not_called()

--- a/backend/workflow_manager/workflow_v2/tests/test_transport.py
+++ b/backend/workflow_manager/workflow_v2/tests/test_transport.py
@@ -25,25 +25,14 @@ class TestWorkflowTransportEnum:
 
 
 class TestResolveTransport:
-    def test_resolves_celery_by_default(self):
-        """PR 1: always Celery, regardless of inputs."""
-        assert resolve_transport(workflow_id="wf-1") == WorkflowTransport.CELERY.value
-
-    def test_accepts_optional_args_without_changing_result(self):
-        """The pipeline/org args are accepted now (stable signature for PR 3's
-        Flipt wiring) but must not change the inert result."""
-        assert (
-            resolve_transport(
-                workflow_id="wf-1",
-                pipeline_id="pipe-1",
-                organization_id="org-1",
-            )
-            == WorkflowTransport.CELERY.value
-        )
+    def test_resolves_celery_in_pr1(self):
+        """PR 1: always Celery (inert seam, no inputs). PR 3 adds the
+        workflow/pipeline/org params + Flipt evaluation."""
+        assert resolve_transport() == WorkflowTransport.CELERY.value
 
     def test_result_is_a_valid_transport_value(self):
         valid = {t.value for t in WorkflowTransport}
-        assert resolve_transport(workflow_id="wf-1") in valid
+        assert resolve_transport() in valid
 
 
 class TestNormalizeTransport:

--- a/backend/workflow_manager/workflow_v2/transport.py
+++ b/backend/workflow_manager/workflow_v2/transport.py
@@ -16,11 +16,7 @@ kill-switch and failing closed to Celery.
 
 from __future__ import annotations
 
-import logging
-
 from unstract.core.data_models import WorkflowTransport
-
-logger = logging.getLogger(__name__)
 
 
 def resolve_transport(
@@ -41,5 +37,10 @@ def resolve_transport(
     Note:
         PR 1 always returns ``"celery"``. The arguments are accepted now so the
         call sites and the contract are stable when PR 3 wires Flipt in here.
+        PR 3 must wrap the Flipt evaluation in ``try/except`` and fall back to
+        ``WorkflowTransport.CELERY.value`` (fail-closed), so a Flipt outage can
+        never break execution creation — mirroring ``normalize_transport`` on
+        the read side. (A module ``logger`` is intentionally omitted until then,
+        when the fallback path needs it.)
     """
     return WorkflowTransport.CELERY.value

--- a/backend/workflow_manager/workflow_v2/transport.py
+++ b/backend/workflow_manager/workflow_v2/transport.py
@@ -1,0 +1,45 @@
+"""Transport resolution for a workflow execution (9e).
+
+A workflow execution rides one transport end-to-end — legacy Celery/RabbitMQ
+or the bespoke Postgres queue. The choice is resolved **once**, at the
+execution-creation chokepoint, and returned to the caller so it can be carried
+in the dispatched task's payload (see ``workers/queue_backend/pg_queue/
+9e-design.md``). It is deliberately **not** persisted on the ``WorkflowExecution``
+row: the payload is the single carrier, durable for PG via the queue row's
+JSONB, and the giant shared table is never migrated for this work.
+
+PR 1 (this seam) hardwires the result to Celery, so behaviour is byte-identical
+to today. PR 3 replaces the body with a Flipt evaluation (percentage rollout via
+``entity_id`` hashing + per-org segment via ``context``), wrapped by an env
+kill-switch and failing closed to Celery.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from unstract.core.data_models import WorkflowTransport
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_transport(
+    workflow_id: str,
+    pipeline_id: str | None = None,
+    organization_id: str | None = None,
+) -> str:
+    """Resolve the transport for a new workflow execution.
+
+    Args:
+        workflow_id: The workflow being executed.
+        pipeline_id: The pipeline, if this execution belongs to one.
+        organization_id: The owning organization (for per-org rollout in PR 3).
+
+    Returns:
+        The transport value (a :class:`WorkflowTransport` value string).
+
+    Note:
+        PR 1 always returns ``"celery"``. The arguments are accepted now so the
+        call sites and the contract are stable when PR 3 wires Flipt in here.
+    """
+    return WorkflowTransport.CELERY.value

--- a/backend/workflow_manager/workflow_v2/transport.py
+++ b/backend/workflow_manager/workflow_v2/transport.py
@@ -19,28 +19,22 @@ from __future__ import annotations
 from unstract.core.data_models import WorkflowTransport
 
 
-def resolve_transport(
-    workflow_id: str,
-    pipeline_id: str | None = None,
-    organization_id: str | None = None,
-) -> str:
+def resolve_transport() -> str:
     """Resolve the transport for a new workflow execution.
-
-    Args:
-        workflow_id: The workflow being executed.
-        pipeline_id: The pipeline, if this execution belongs to one.
-        organization_id: The owning organization (for per-org rollout in PR 3).
 
     Returns:
         The transport value (a :class:`WorkflowTransport` value string).
 
     Note:
-        PR 1 always returns ``"celery"``. The arguments are accepted now so the
-        call sites and the contract are stable when PR 3 wires Flipt in here.
-        PR 3 must wrap the Flipt evaluation in ``try/except`` and fall back to
+        PR 1 always returns ``"celery"`` and takes no arguments (the inert seam
+        needs no inputs). PR 3 reintroduces ``workflow_id`` / ``pipeline_id`` /
+        ``organization_id`` parameters when it wires Flipt here — percentage
+        rollout via ``entity_id`` hashing + per-org segment via ``context`` —
+        and updates the two call sites (``internal_api_views`` view and
+        ``workflow_helper.execute_workflow_async``). PR 3 must wrap the Flipt
+        evaluation in ``try/except`` and fall back to
         ``WorkflowTransport.CELERY.value`` (fail-closed), so a Flipt outage can
         never break execution creation — mirroring ``normalize_transport`` on
-        the read side. (A module ``logger`` is intentionally omitted until then,
-        when the fallback path needs it.)
+        the read side.
     """
     return WorkflowTransport.CELERY.value

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -520,11 +520,7 @@ class WorkflowHelper:
             # an independent Flipt evaluation; before then, both must be funnelled
             # through a single per-execution chokepoint (so a percentage re-roll
             # can't split one execution across transports). Tracked for PR 3.
-            transport = resolve_transport(
-                workflow_id=workflow_id,
-                pipeline_id=pipeline_id,
-                organization_id=org_schema,
-            )
+            transport = resolve_transport()
             async_execution: AsyncResult = celery_app.send_task(
                 "async_execute_bin",
                 args=[

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -62,11 +62,15 @@ from workflow_manager.workflow_v2.transport import resolve_transport
 logger = logging.getLogger(__name__)
 
 # Parameters to exclude when calling create_workflow_execution
+# (the classmethod takes no **kwargs, so any task kwarg not a real parameter —
+# incl. the 9e ``transport`` carried in the async_execute_bin payload — must be
+# filtered out here before it reaches the legacy ``execute_workflow`` path).
 EXECUTION_EXCLUDED_PARAMS = {
     "llm_profile_id",
     "hitl_queue_name",
     "hitl_packet_id",
     "custom_data",
+    "transport",
 }
 
 
@@ -507,6 +511,15 @@ class WorkflowHelper:
             # Resolve the transport this execution rides (9e) and carry it in the
             # task payload — the pipeline reads it to stay on one transport
             # end-to-end. PR 1 always resolves "celery" (no behaviour change).
+            #
+            # NOTE (deliberate, two resolution sites): transport is resolved here
+            # for the API/manual/async paths and separately in
+            # internal_api_views.create_workflow_execution for the scheduler
+            # path. These are DISTINCT entry paths — never a double-resolution of
+            # the same execution — so today they cannot diverge. PR 3 makes each
+            # an independent Flipt evaluation; before then, both must be funnelled
+            # through a single per-execution chokepoint (so a percentage re-roll
+            # can't split one execution across transports). Tracked for PR 3.
             transport = resolve_transport(
                 workflow_id=workflow_id,
                 pipeline_id=pipeline_id,

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -57,6 +57,7 @@ from workflow_manager.workflow_v2.execution import WorkflowExecutionServiceHelpe
 from workflow_manager.workflow_v2.file_history_helper import FileHistoryHelper
 from workflow_manager.workflow_v2.models.execution import WorkflowExecution
 from workflow_manager.workflow_v2.models.workflow import Workflow
+from workflow_manager.workflow_v2.transport import resolve_transport
 
 logger = logging.getLogger(__name__)
 
@@ -503,6 +504,14 @@ class WorkflowHelper:
             }
             org_schema = UserContext.get_organization_identifier()
             log_events_id = StateStore.get(Common.LOG_EVENTS_ID)
+            # Resolve the transport this execution rides (9e) and carry it in the
+            # task payload — the pipeline reads it to stay on one transport
+            # end-to-end. PR 1 always resolves "celery" (no behaviour change).
+            transport = resolve_transport(
+                workflow_id=workflow_id,
+                pipeline_id=pipeline_id,
+                organization_id=org_schema,
+            )
             async_execution: AsyncResult = celery_app.send_task(
                 "async_execute_bin",
                 args=[
@@ -521,6 +530,7 @@ class WorkflowHelper:
                     "hitl_queue_name": hitl_queue_name,
                     "hitl_packet_id": hitl_packet_id,
                     "custom_data": custom_data,
+                    "transport": transport,
                 },
                 queue=queue,
             )

--- a/unstract/core/src/unstract/core/data_models.py
+++ b/unstract/core/src/unstract/core/data_models.py
@@ -200,6 +200,25 @@ class SourceConnectionType(str, Enum):
     API = "API"
 
 
+class WorkflowTransport(str, Enum):
+    """Transport a single workflow execution rides end-to-end.
+
+    The migration unit is the *execution*, not the task: every stage of a
+    coupled pipeline (async_execute → file-batch fan-out → callback) must run
+    on one transport, decided once at execution creation and carried in the
+    task payload (see ``9e-design.md``). ``CELERY`` is the legacy default;
+    ``PG_QUEUE`` is the bespoke Postgres queue.
+    """
+
+    CELERY = "celery"
+    PG_QUEUE = "pg_queue"
+
+
+# Default transport when none is resolved/carried — keeps every pre-existing
+# payload and caller on the legacy path until a transport is explicitly chosen.
+DEFAULT_WORKFLOW_TRANSPORT = WorkflowTransport.CELERY.value
+
+
 class FileListingResult:
     """Result of listing files from a source."""
 

--- a/unstract/core/src/unstract/core/data_models.py
+++ b/unstract/core/src/unstract/core/data_models.py
@@ -219,6 +219,36 @@ class WorkflowTransport(str, Enum):
 DEFAULT_WORKFLOW_TRANSPORT = WorkflowTransport.CELERY.value
 
 
+def normalize_transport(value: object, *, logger: Any = None, context: str = "") -> str:
+    """Coerce an inbound transport value to a known ``WorkflowTransport`` value.
+
+    The transport crosses untrusted boundaries — a task payload, PG JSONB, an
+    older backend that omits the field — so a missing/garbage value must never
+    route an execution onto an unknown substrate. This **fails closed**: an
+    unrecognized value (``None``, ``"celary"``, ``""``) logs a warning (when a
+    ``logger`` is given) and falls back to :data:`DEFAULT_WORKFLOW_TRANSPORT`
+    (Celery). A recognized value passes through as its canonical string.
+
+    Coerce-not-raise is deliberate, and differs from how
+    ``WorkflowContextData.workflow_type`` is validated: ``transport`` has an
+    explicit safe default by design (the whole point of the seam is reversible
+    fallback to Celery), so a bad value should degrade to Celery, not crash the
+    execution. ``context`` is an optional suffix for the log line (e.g. an
+    ``exec:<id>`` tag) to make a version-skew warning traceable.
+    """
+    try:
+        return WorkflowTransport(value).value
+    except ValueError:
+        if logger is not None:
+            logger.warning(
+                "Unrecognized workflow transport %r%s; falling back to %r",
+                value,
+                context,
+                DEFAULT_WORKFLOW_TRANSPORT,
+            )
+        return DEFAULT_WORKFLOW_TRANSPORT
+
+
 class FileListingResult:
     """Result of listing files from a source."""
 

--- a/workers/general/tasks.py
+++ b/workers/general/tasks.py
@@ -51,6 +51,7 @@ from worker import app, config
 
 # Import shared data models for type safety
 from unstract.core.data_models import (
+    DEFAULT_WORKFLOW_TRANSPORT,
     ExecutionStatus,
     FileBatchData,
     FileHashData,
@@ -156,6 +157,7 @@ def async_execute_bin_general(
     pipeline_id: str | None = None,
     log_events_id: str | None = None,
     use_file_history: bool = False,
+    transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     **kwargs: dict[str, Any],
 ) -> dict[str, Any]:
     """Lightweight general workflow execution task.
@@ -267,6 +269,7 @@ def async_execute_bin_general(
                 use_file_history,
                 scheduled,
                 schema_name,
+                transport=transport,
                 **kwargs,
             )
 
@@ -462,6 +465,7 @@ def _execute_general_workflow(
     use_file_history: bool,
     scheduled: bool,
     schema_name: str,
+    transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     **kwargs: dict[str, Any],
 ) -> dict[str, Any]:
     """Execute general workflow specific logic for ETL/TASK workflows.
@@ -522,6 +526,7 @@ def _execute_general_workflow(
                 "execution_mode": execution_mode,
             },
             is_scheduled=scheduled,
+            transport=transport,
         )
 
         logger.info(

--- a/workers/queue_backend/pg_queue/9e-design.md
+++ b/workers/queue_backend/pg_queue/9e-design.md
@@ -1,0 +1,318 @@
+# 9e — Coupled-Pipeline Migration (Design)
+
+**Status:** design locked, pre-implementation
+**Epic:** UN-3445 (PG Queue) · **Phase:** 9e
+**Predecessors:** 9a–9c (dispatch seam + PG consumer), 9d (leader-election lease + reaper / barrier-orphan sweep) — all merged.
+
+This document defines how a **whole workflow execution** is migrated from the
+legacy Celery/RabbitMQ transport to the bespoke Postgres queue, and why the
+transport choice is **carried in the task payload** rather than persisted on a
+shared model column.
+
+---
+
+## 1. The problem 9e solves
+
+Earlier slices (9a–9c) added a `dispatch()` seam that routes a task by
+**name** via `select_backend(task_name)` against the `WORKER_PG_QUEUE_ENABLED_TASKS`
+allow-list. That is correct for **leaf / independent** tasks, but it cannot
+migrate the execution pipeline, because the pipeline is a **coupled, multi-stage
+fan-out/fan-in**:
+
+```
+async_execute_bin   →   fan-out: N × process_file_batch   →   fan-in: callback   →   destination
+   (stage 1)                  (stage 2, parallel)                 (stage 3)
+```
+
+Two facts make this hard:
+
+1. **The worker code is shared.** The same `process_file_batch` /
+   orchestration code runs whether a **Celery worker** (pulled from RabbitMQ)
+   or a **PG consumer** (polled from `pg_queue_message` via `SELECT … FOR UPDATE
+   SKIP LOCKED`) picked the task up. The running task does **not** inherently
+   know which transport it is on.
+
+2. **Stages 2 and 3 are enqueued from inside the workers**, not by the backend.
+   The worker running `async_execute_bin` is the one that must enqueue the file
+   batches *and* set up the barrier/callback — so **it** has to know whether to
+   use a Celery `chord` or a PG enqueue + `PgBarrier`.
+
+> **Migration coherence rule.** An execution must run **entirely** on one
+> transport, end-to-end. The migration unit is the **execution**, not the task.
+> A pipeline that starts on PG must fan-out, fan-in, and recover on PG; likewise
+> for Celery. Splitting a single execution across transports (e.g. a callback
+> looking for a Celery chord whose counter actually lives in `pg_barrier_state`)
+> is the failure mode this phase is designed to prevent.
+
+So `select_backend(task_name)` (per-task, name-based) is **insufficient**: the
+same task name must go to PG for one execution and Celery for another. We need a
+**per-execution** transport decision that every stage can read.
+
+---
+
+## 2. Decision split: Flipt **decides**, the payload **remembers**
+
+These are two distinct jobs and must not be conflated.
+
+### Flipt = make the decision (once, at creation)
+
+The rollout question — *"should this **new** execution ride PG queue?"* — is
+answered **once**, at the single creation chokepoint, using the existing
+`@unstract/flags` Flipt infrastructure
+(`check_feature_flag_status(flag_key, entity_id, context)`):
+
+- `entity_id` → consistent **percentage-rollout** hashing.
+- `context={"organization_id": ...}` → **per-org** segment targeting.
+
+This is the only place Flipt is consulted.
+
+#### Flipt flag contract (fixed — created 2026-06-16, Flipt v2.3.1)
+
+PR 3's `resolve_transport` reads this exact flag. The flag is **created and live
+in dev** but carries **no rollouts yet**, so it is inert until PR 3 wires it.
+
+| Property | Value |
+|----------|-------|
+| Flipt version | `v2.3.1` (`docker/docker-compose-dev-essentials.yaml`) |
+| Flag type | **Boolean** (binary decision — no variant/payload needed) |
+| Key | `pg_queue_execution_enabled` |
+| Default value | **`false`** → legacy Celery (fails closed; returned when no rollout matches) |
+| Rollouts | **none yet** — added in PR 3 / rollout ops (percentage 0%→ramp; optional per-org segment) |
+| Helper | `check_feature_flag_status(flag_key="pg_queue_execution_enabled", entity_id=…, context={"organization_id": org_id})` → `evaluate_boolean`; already fails closed to `False` on any error / when `FLIPT_SERVICE_AVAILABLE != "true"` |
+| Mapping | `True → "pg_queue"`, `False → "celery"` |
+| `entity_id` (stickiness) | **TBD in PR 3** — `execution_id` (per-execution bucketing) or `organization_id` (whole orgs move together). Must be stable so an in-flight execution never re-buckets. |
+
+Boolean (not Variant) because the choice is binary and Flipt Boolean flags
+natively carry the two knobs we need: a **percentage rollout** (the canary,
+sticky via `entity_id`) **plus segment rollouts** (per-org). Variant would
+require Variants + Segments + Rules all configured or it returns `match=False`.
+
+### Why Flipt cannot also be the per-stage source of truth
+
+Three hard facts (verified against `unstract/flags/src/unstract/flags/`):
+
+1. **The answer changes; the execution doesn't.** A percentage rollback
+   (10% → 0%) or a segment edit flips Flipt's answer. But an execution already
+   in flight on PG **must finish on PG**. Re-querying Flipt per stage would
+   re-route a half-done execution → split-brain.
+2. **Flipt fails closed to `False`.** `FliptClient.service_available` defaults
+   `false`, and every error path returns `False` (`except Exception: return
+   False`). A transient gRPC blip during the callback stage would silently say
+   "Celery" and orphan a live PG execution. Per-stage coherence can never depend
+   on a best-effort network call.
+3. **The reaper has no Flipt context.** It recovers executions it did not
+   dispatch; Flipt can only say "what would a *new* execution be now," never
+   "what *was* this one dispatched as."
+
+**Therefore:** evaluate Flipt once at creation → write the answer into the
+**first task's payload** → never consult Flipt again for that execution.
+
+---
+
+## 3. Chosen design — transport carried in the task payload
+
+The transport string (`"celery"` | `"pg_queue"`) is decided at
+`create_workflow_execution` and threaded through the pipeline **in the task
+payload / `ExecutionContext`** — never read from a shared DB column.
+
+### Why payload-carry is the right home
+
+- **It is not extra.** The shared worker code already *needs* the transport to
+  pick the next-stage topology (chord vs PG+PgBarrier). Putting it in the
+  payload satisfies that need directly — no separate mechanism.
+- **It is durable for PG without any new column.** A PG-routed dispatch
+  serialises `kwargs` into the `pg_queue_message.message` JSONB column
+  (`TaskPayload`, see `pg_queue/task_payload.py`). If a worker crashes and the
+  task is redelivered on visibility-timeout, the transport comes back **with the
+  redelivered payload**. Recovery is covered for free.
+- **The reaper needs no flag to classify executions.** The reaper only ever acts
+  on **PG-specific tables** (`pg_barrier_state`, `pg_queue_message`) — presence
+  there *is* "this is a PG execution." Celery executions never appear in those
+  tables, so there is nothing to disambiguate. When the reaper needs the
+  transport (e.g. future pipeline re-enqueue), it reads it from the payload it
+  already finds in the PG row.
+- **All PG-specific durable state stays in PG-specific tables.** Those tables are
+  `DROP`-ped wholesale when the feature is retired. The huge, shared
+  `WorkflowExecution` table is **never altered, never migrated** for this work.
+
+### Flow
+
+```
+backend: create_workflow_execution(...)
+  └─ resolve_transport(workflow, pipeline_id, org)   # Flipt, once
+        → transport ∈ {"celery", "pg_queue"}
+  └─ dispatch("async_execute_bin", kwargs={..., "transport": transport})
+        → routed to that transport's first hop
+
+worker: async_execute_bin   (reads transport from its own kwargs / ExecutionContext)
+  └─ for each batch: dispatch("process_file_batch", kwargs={..., "transport": transport})
+  └─ barrier/callback set up on the SAME transport (get_barrier honours it)
+
+worker: process_file_batch   (transport rides in kwargs → re-stamped onward)
+worker: callback             (transport in kwargs → finalises on the same transport)
+```
+
+`ExecutionContext` (`workers/shared/models/execution_models.py`,
+`WorkflowExecutionContext`) gains a `transport: str = "celery"` field, populated
+from the inbound task kwargs and re-emitted into every downstream dispatch.
+Default `"celery"` keeps every pre-existing payload working unchanged.
+
+---
+
+## 4. Rejected alternative — a `transport` column on `WorkflowExecution`
+
+A persisted `WorkflowExecution.transport` column (single queryable source of
+truth) was considered and **rejected** in favour of payload-carry.
+
+**What it would have bought:** a single `WHERE transport='pg_queue'` query for
+dashboards and post-completion history.
+
+**Why rejected:**
+- It touches the **shared, very large** `WorkflowExecution` table. Even though
+  the change is cheap (see cost note), all of PG-queue's other durable state
+  already lives in disposable PG-specific tables; adding one field to the shared
+  table is the *only* migration that would outlive the feature unless explicitly
+  dropped.
+- The transport is **already required in the payload** for next-stage routing,
+  so a column would be redundant with information we must carry anyway.
+- The observability gap is small: in-flight PG executions are queryable directly
+  via `pg_queue_message` / `pg_barrier_state`; historical classification comes
+  from logs/metrics we already emit.
+
+**Cost note (for the record).** The rejection is *not* on migration-cost
+grounds — on Postgres 11+ both operations are cheap:
+- **`ADD COLUMN`** with a nullable / constant (empty-string) default is a
+  **metadata-only** catalog change — no table rewrite, near-instant regardless
+  of row count (brief `ACCESS EXCLUSIVE` lock; run off-peak with a short
+  `lock_timeout`).
+- **`DROP COLUMN`** is likewise metadata-only (marks the column dropped, no
+  rewrite).
+
+So the column would have been operationally safe; payload-carry wins on
+**design cleanliness** (no shared-table coupling, transport not duplicated, all
+PG state confined to droppable PG tables), not on migration cost.
+
+---
+
+## 5. Deployment topology over the rollout
+
+The payload pin classifies each in-flight execution; it does **not** remove the
+need for both consumers to be live during migration. Work is delivered on two
+physically separate channels:
+
+- **Celery-pinned** executions → tasks land in **RabbitMQ** → only a **Celery
+  worker** can pick them up.
+- **PG-pinned** executions → tasks land in **`pg_queue_message`** → only a **PG
+  consumer** (SKIP LOCKED poller) can pick them up.
+
+| Rollout stage      | Consumers running                                              |
+|--------------------|----------------------------------------------------------------|
+| Today / 0%         | Celery workers only                                            |
+| Canary (e.g. 10%)  | Celery workers **and** PG consumers + reaper, side by side     |
+| 100% / retire      | PG consumers + reaper only; RabbitMQ + Celery workers torn down |
+
+Both consumer sets can be **co-located in one deployment** as parallel processes
+— the `pg` set (PG consumers + leader-elected singleton reaper) plus the Celery
+set — which is what `run-worker.sh` already supports (`pg` / `pg-queue` set vs
+the Celery sets). "One fleet, two transports in parallel," not "one loop polling
+the DB."
+
+---
+
+## 6. Gating prerequisite — per-batch idempotency key
+
+PG queue is **at-least-once** (visibility-timeout redelivery); the pipeline
+tasks are **non-idempotent** with `max_retries=0`. Before *any* real traffic
+rides PG, `process_file_batch` must carry a **per-batch idempotency key** and
+guard side effects with `INSERT … ON CONFLICT (execution_id, batch_index)` so a
+redelivered batch cannot double-process. This is a **hard gate** before the
+canary slice, not optional hardening.
+
+---
+
+## 7. Slice breakdown — 3 PRs
+
+Three PRs (each one Jira sub-task), non-regressive, dev-tested against a running
+stack before any PR is opened. Ordering is forced: **PR 1 → PR 2 → PR 3** (the
+seam must exist before the PG path; Flipt is pointless before the PG path
+works). All land on `feat/UN-3445-pg-queue-integration`, not `main`.
+
+> **Why 3 and not 6 or 1.** The earlier draft over-sliced. The scheduled/ETL
+> path is *not* a separate PR — the chokepoint is universal (the scheduler mints
+> via the same `create_workflow_execution`), so it rides PR 1 with at most one
+> extra test. Rollout is *ops*, not a code PR. The idempotency key is the safety
+> belt for the PG path and ships **with** it (PR 2), never separately ahead of
+> it. We stop at 3 (not 1) to keep PR 1 **inert and isolated** — it merges with
+> near-zero review risk and makes the branch carry `transport` everywhere, so
+> PR 2 is reviewed purely as "the PG behaviour" (the highest-blast-radius code in
+> the epic). Collapsing the inert seam into the risky rewire is the one merge to
+> avoid.
+
+### PR 1 — transport seam (inert, no routing change)
+- `resolve_transport(...)` helper at `create_workflow_execution`
+  (`backend/workflow_manager/workflow_v2/execution.py:126`); **PR 1 hardwires it
+  to `"celery"`** — Flipt wiring is PR 3.
+- Add `transport: str = "celery"` to `WorkflowExecutionContext`
+  (`workers/shared/models/execution_models.py`); populate from inbound kwargs.
+- Thread `transport` into the kwargs of every pipeline dispatch site
+  (`workflow_helper.py` stage-1/2/3 dispatches) across **all four entry paths**
+  (API / async / scheduled-ETL/TASK / manual UI — all funnel through the same
+  chokepoint), reading it back but **branching only into today's Celery path**
+  (the `pg_queue` branch is present but unreachable until PR 2).
+- Tests: resolver returns `"celery"`; `ExecutionContext` carries/defaults the
+  field; payload round-trips the field through `to_payload`/decode; scheduled
+  path carries it through.
+- **Net behaviour change: none.** Pure plumbing behind a default.
+
+### PR 2 — live PG pipeline + idempotency gate (ship together)
+- Implement the `pg_queue` branch at each dispatch site: enqueue next stage via
+  `dispatch()` onto PG; barrier via `get_barrier()` → `PgBarrier`.
+- Fire-and-forget self-chaining (labs §5): each task enqueues the next and does
+  its own in-body barrier decrement; no chord/`.link` (the PG payload carries no
+  Celery `.link`).
+- **Per-batch idempotency key in the same PR** — `process_file_batch` carries it;
+  side effects guarded by `INSERT … ON CONFLICT (execution_id, batch_index)` so a
+  vt-redelivered batch is a no-op. The PG path is never mergeable-and-enableable
+  without its guard.
+- Still **defaults-off** (transport still resolves to `"celery"` from PR 1).
+- Dev-test end-to-end on PG via a forced `transport="pg_queue"` test workflow;
+  characterisation test that a redelivered batch double-fires nothing.
+
+### PR 3 — Flipt canary wiring (turn the knob on)
+- `resolve_transport` consults Flipt (`entity_id` = execution/org for %-hashing;
+  `context` = org segment), replacing the hardwired `"celery"`. Env kill-switch
+  wraps it for instant rollback; Flipt fails-closed to `"celery"`.
+- Reads the **fixed flag contract** in §2 (key `pg_queue_execution_enabled`,
+  Boolean, default `false`). The flag already exists in dev with no rollouts —
+  PR 3 only adds the read + decides the `entity_id` stickiness.
+
+### Rollout — ops, not a PR
+- Canary %, dashboards (off `pg_queue_message` / `pg_barrier_state`), runbook,
+  ramp + Celery teardown criteria.
+
+---
+
+## 8. Key files (call-graph anchors)
+
+| Concern                     | Location |
+|-----------------------------|----------|
+| Creation chokepoint         | `backend/workflow_manager/workflow_v2/execution.py:126` (`create_workflow_execution`) |
+| Callers (API/async/sched/UI)| `api_v2/deployment_helper.py:202`, `workflow_manager/workflow_v2/workflow_helper.py:686/744/935` |
+| Pipeline dispatch sites     | `workflow_helper.py` (stage-1 send, stage-2 batch signatures, stage-3 chord) |
+| ExecutionContext            | `workers/shared/models/execution_models.py` (`WorkflowExecutionContext`) |
+| Dispatch seam               | `workers/queue_backend/dispatch.py`, `routing.py` (`select_backend`) |
+| PG task payload (durable)   | `workers/queue_backend/pg_queue/task_payload.py` (`TaskPayload` → `pg_queue_message.message` JSONB) |
+| Barrier factory             | `workers/queue_backend/__init__.py` (`get_barrier`) |
+| Barrier impls               | `barrier.py` (chord), `redis_barrier.py`, `pg_barrier.py` |
+| Barrier invocation          | `workers/shared/workflow/execution/orchestration_utils.py` |
+| Reaper / sweep              | `workers/queue_backend/pg_queue/reaper.py` |
+
+---
+
+## 9. References
+
+- Labs architecture: `labs/workflow-execution-architecture/architecture-explorer-v2.html`
+  and `labs/workflow-execution-architecture/docs/` — §5 fire-and-forget
+  self-chaining is the target model for slice 3.
+- 9d (merged): leader-election lease (`leader_election.py`) + reaper /
+  barrier-orphan sweep (`reaper.py`).

--- a/workers/queue_backend/pg_queue/9e-design.md
+++ b/workers/queue_backend/pg_queue/9e-design.md
@@ -66,18 +66,19 @@ answered **once**, at the single creation chokepoint, using the existing
 
 This is the only place Flipt is consulted.
 
-#### Flipt flag contract (fixed — created 2026-06-16, Flipt v2.3.1)
+#### Flipt flag contract (fixed)
 
-PR 3's `resolve_transport` reads this exact flag. The flag is **created and live
-in dev** but carries **no rollouts yet**, so it is inert until PR 3 wires it.
+PR 3's `resolve_transport` reads this exact flag. Live rollout state (whether the
+flag exists in a given env, current rollout %) is tracked in the PR / ticket, not
+here — this table is just the durable contract PR 3 codes against.
 
 | Property | Value |
 |----------|-------|
-| Flipt version | `v2.3.1` (`docker/docker-compose-dev-essentials.yaml`) |
+| Flipt version | the `flipt` image pinned in `docker/docker-compose-dev-essentials.yaml` (single source — don't duplicate the tag here) |
 | Flag type | **Boolean** (binary decision — no variant/payload needed) |
 | Key | `pg_queue_execution_enabled` |
 | Default value | **`false`** → legacy Celery (fails closed; returned when no rollout matches) |
-| Rollouts | **none yet** — added in PR 3 / rollout ops (percentage 0%→ramp; optional per-org segment) |
+| Rollouts | percentage (0%→ramp) + optional per-org segment, added in PR 3 / rollout ops |
 | Helper | `check_feature_flag_status(flag_key="pg_queue_execution_enabled", entity_id=…, context={"organization_id": org_id})` → `evaluate_boolean`; already fails closed to `False` on any error / when `FLIPT_SERVICE_AVAILABLE != "true"` |
 | Mapping | `True → "pg_queue"`, `False → "celery"` |
 | `entity_id` (stickiness) | **TBD in PR 3** — `execution_id` (per-execution bucketing) or `organization_id` (whole orgs move together). Must be stable so an in-flight execution never re-buckets. |
@@ -152,10 +153,14 @@ worker: process_file_batch   (transport rides in kwargs → re-stamped onward)
 worker: callback             (transport in kwargs → finalises on the same transport)
 ```
 
-`ExecutionContext` (`workers/shared/models/execution_models.py`,
-`WorkflowExecutionContext`) gains a `transport: str = "celery"` field, populated
-from the inbound task kwargs and re-emitted into every downstream dispatch.
-Default `"celery"` keeps every pre-existing payload working unchanged.
+The live worker context `WorkflowContextData`
+(`workers/shared/models/execution_models.py`) gains a
+`transport: str = "celery"` field, populated from the inbound task kwargs.
+Default `"celery"` keeps every pre-existing payload working unchanged. In PR 1
+the field is carried but **not yet re-emitted** to the stage-2/3 dispatches; the
+downstream re-stamp + fan-out read land in PR 2. (Note: the unrelated
+`WorkflowExecutionContext` dataclass in the same file is dead scaffolding and is
+**not** the carrier.)
 
 ---
 
@@ -249,16 +254,21 @@ works). All land on `feat/UN-3445-pg-queue-integration`, not `main`.
 > avoid.
 
 ### PR 1 — transport seam (inert, no routing change)
-- `resolve_transport(...)` helper at `create_workflow_execution`
-  (`backend/workflow_manager/workflow_v2/execution.py:126`); **PR 1 hardwires it
-  to `"celery"`** — Flipt wiring is PR 3.
-- Add `transport: str = "celery"` to `WorkflowExecutionContext`
-  (`workers/shared/models/execution_models.py`); populate from inbound kwargs.
-- Thread `transport` into the kwargs of every pipeline dispatch site
-  (`workflow_helper.py` stage-1/2/3 dispatches) across **all four entry paths**
-  (API / async / scheduled-ETL/TASK / manual UI — all funnel through the same
-  chokepoint), reading it back but **branching only into today's Celery path**
-  (the `pg_queue` branch is present but unreachable until PR 2).
+- `resolve_transport(...)` helper (`backend/workflow_manager/workflow_v2/
+  transport.py`), **hardwired to `"celery"`** (Flipt wiring is PR 3), called at
+  the two transport-emit sites: the scheduler-path HTTP view
+  (`internal_api_views.py:create_workflow_execution`, returns `transport`) and
+  the API/manual/async path (`workflow_helper.py:execute_workflow_async`, adds
+  it to the `async_execute_bin` kwargs).
+- Add `transport: str = "celery"` to the live `WorkflowContextData`
+  (`workers/shared/models/execution_models.py`); populate from inbound kwargs
+  (NOT `WorkflowExecutionContext`, which is dead scaffolding).
+- Thread `transport` into the **stage-1** dispatch kwargs only
+  (`workflow_helper.py` send + `scheduler/tasks.py` dispatch) across the entry
+  paths (API / async / scheduled-ETL/TASK / manual). Stage-2 fan-out
+  (`process_file_batch`) and stage-3 callback are **not** modified in PR 1 —
+  they carry no `transport` yet; the downstream re-stamp + the `pg_queue` branch
+  land in PR 2.
 - Tests: resolver returns `"celery"`; `ExecutionContext` carries/defaults the
   field; payload round-trips the field through `to_payload`/decode; scheduled
   path carries it through.
@@ -283,8 +293,8 @@ works). All land on `feat/UN-3445-pg-queue-integration`, not `main`.
   `context` = org segment), replacing the hardwired `"celery"`. Env kill-switch
   wraps it for instant rollback; Flipt fails-closed to `"celery"`.
 - Reads the **fixed flag contract** in §2 (key `pg_queue_execution_enabled`,
-  Boolean, default `false`). The flag already exists in dev with no rollouts —
-  PR 3 only adds the read + decides the `entity_id` stickiness.
+  Boolean, default `false`). PR 3 adds the read + decides the `entity_id`
+  stickiness; provisioning the flag/rollouts per env is rollout ops.
 
 ### Rollout — ops, not a PR
 - Canary %, dashboards (off `pg_queue_message` / `pg_barrier_state`), runbook,
@@ -296,10 +306,11 @@ works). All land on `feat/UN-3445-pg-queue-integration`, not `main`.
 
 | Concern                     | Location |
 |-----------------------------|----------|
-| Creation chokepoint         | `backend/workflow_manager/workflow_v2/execution.py:126` (`create_workflow_execution`) |
-| Callers (API/async/sched/UI)| `api_v2/deployment_helper.py:202`, `workflow_manager/workflow_v2/workflow_helper.py:686/744/935` |
-| Pipeline dispatch sites     | `workflow_helper.py` (stage-1 send, stage-2 batch signatures, stage-3 chord) |
-| ExecutionContext            | `workers/shared/models/execution_models.py` (`WorkflowExecutionContext`) |
+| Transport resolve + emit    | `workflow_v2/transport.py` (`resolve_transport`); emitted at `internal_api_views.py` (`create_workflow_execution` view → response, scheduler path) and `workflow_helper.py` (`execute_workflow_async` → `async_execute_bin` kwargs, API/manual/async path) |
+| Row-builder (no transport)  | `workflow_v2/execution.py` (`WorkflowExecutionServiceHelper.create_workflow_execution` — builds the row; does NOT resolve transport) |
+| Entry paths                 | API deploy, async, scheduled-ETL/TASK, manual UI — all reach one of the two emit sites above |
+| Pipeline dispatch sites     | `workflow_helper.py` (stage-1 send, stage-2 batch signatures, stage-3 chord) — only stage-1 threads transport in PR 1 |
+| Worker context (carrier)    | `workers/shared/models/execution_models.py` (`WorkflowContextData` — NOT the dead `WorkflowExecutionContext`) |
 | Dispatch seam               | `workers/queue_backend/dispatch.py`, `routing.py` (`select_backend`) |
 | PG task payload (durable)   | `workers/queue_backend/pg_queue/task_payload.py` (`TaskPayload` → `pg_queue_message.message` JSONB) |
 | Barrier factory             | `workers/queue_backend/__init__.py` (`get_barrier`) |

--- a/workers/scheduler/tasks.py
+++ b/workers/scheduler/tasks.py
@@ -27,6 +27,7 @@ from unstract.core.data_models import (
     DEFAULT_WORKFLOW_TRANSPORT,
     NotificationPayload,
     NotificationSource,
+    normalize_transport,
 )
 
 # Import the exact backend logic to ensure consistency
@@ -134,9 +135,15 @@ def _execute_scheduled_workflow(
         )
         execution_id = workflow_execution.get("execution_id")
         # Transport this execution rides (9e), decided by the backend at creation
-        # and carried in the dispatched task's payload. Defaults to celery if the
-        # backend doesn't return it (older backend / no-op until PR 3).
-        transport = workflow_execution.get("transport", DEFAULT_WORKFLOW_TRANSPORT)
+        # and carried in the dispatched task's payload. Absent key (older backend)
+        # → celery default; a present-but-unrecognized value (version skew) is
+        # coerced to celery with a loud warning rather than dispatched onto an
+        # unknown substrate (fail-closed).
+        transport = normalize_transport(
+            workflow_execution.get("transport", DEFAULT_WORKFLOW_TRANSPORT),
+            logger=logger,
+            context=f" [exec:{execution_id}]",
+        )
 
         if not execution_id:
             return SchedulerExecutionResult.error(

--- a/workers/scheduler/tasks.py
+++ b/workers/scheduler/tasks.py
@@ -23,7 +23,11 @@ from shared.models.scheduler_models import (
 from shared.patterns.notification.helper import trigger_notification
 from shared.utils.api_client_singleton import get_singleton_api_client
 
-from unstract.core.data_models import NotificationPayload, NotificationSource
+from unstract.core.data_models import (
+    DEFAULT_WORKFLOW_TRANSPORT,
+    NotificationPayload,
+    NotificationSource,
+)
 
 # Import the exact backend logic to ensure consistency
 
@@ -129,6 +133,10 @@ def _execute_scheduled_workflow(
             execution_request.to_dict()
         )
         execution_id = workflow_execution.get("execution_id")
+        # Transport this execution rides (9e), decided by the backend at creation
+        # and carried in the dispatched task's payload. Defaults to celery if the
+        # backend doesn't return it (older backend / no-op until PR 3).
+        transport = workflow_execution.get("transport", DEFAULT_WORKFLOW_TRANSPORT)
 
         if not execution_id:
             return SchedulerExecutionResult.error(
@@ -163,6 +171,7 @@ def _execute_scheduled_workflow(
                 kwargs={
                     "use_file_history": context.use_file_history,
                     "pipeline_id": context.pipeline_id,
+                    "transport": transport,
                 },
                 queue=QueueName.GENERAL,
                 fairness=FairnessKey(

--- a/workers/scheduler/tasks.py
+++ b/workers/scheduler/tasks.py
@@ -134,6 +134,14 @@ def _execute_scheduled_workflow(
             execution_request.to_dict()
         )
         execution_id = workflow_execution.get("execution_id")
+
+        if not execution_id:
+            return SchedulerExecutionResult.error(
+                error="Failed to create workflow execution",
+                workflow_id=context.workflow_id,
+                pipeline_id=context.pipeline_id,
+            )
+
         # Transport this execution rides (9e), decided by the backend at creation
         # and carried in the dispatched task's payload. Absent key (older backend)
         # → celery default; a present-but-unrecognized value (version skew) is
@@ -144,13 +152,6 @@ def _execute_scheduled_workflow(
             logger=logger,
             context=f" [exec:{execution_id}]",
         )
-
-        if not execution_id:
-            return SchedulerExecutionResult.error(
-                error="Failed to create workflow execution",
-                workflow_id=context.workflow_id,
-                pipeline_id=context.pipeline_id,
-            )
 
         logger.info(
             f"[exec:{execution_id}] [pipeline:{context.pipeline_id}] Created workflow execution for scheduled pipeline {context.pipeline_name}"

--- a/workers/shared/models/execution_models.py
+++ b/workers/shared/models/execution_models.py
@@ -4,6 +4,7 @@ This module provides strongly-typed dataclasses for workflow execution contexts,
 replacing fragile dictionary-based parameter passing with type-safe structures.
 """
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -12,6 +13,7 @@ from unstract.core.data_models import (
     DEFAULT_WORKFLOW_TRANSPORT,
     ExecutionStatus,
     PreCreatedFileData,
+    normalize_transport,
     serialize_dataclass_to_dict,
 )
 
@@ -20,6 +22,8 @@ if TYPE_CHECKING:
     from ..api_client import InternalAPIClient
 
 from ..enums import PipelineType
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -386,9 +390,10 @@ class WorkflowContextData:
     settings: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = None
     is_scheduled: bool = False
-    # Transport this execution rides end-to-end (9e). Carried in the task
-    # payload from the creation chokepoint; read at the fan-out to keep the
-    # whole pipeline on one transport. Defaults to legacy Celery.
+    # Transport this execution rides end-to-end (9e). Populated from the inbound
+    # task payload; the fan-out read that keeps the pipeline on one transport
+    # lands in PR 2. Defaults to legacy Celery; coerced fail-closed in
+    # __post_init__ so a garbage payload value can't reach the PR 2 read site.
     transport: str = DEFAULT_WORKFLOW_TRANSPORT
     pre_created_file_executions: dict[str, PreCreatedFileData] = field(
         default_factory=dict
@@ -418,6 +423,16 @@ class WorkflowContextData:
                 f"Invalid workflow_type '{self.workflow_type}'. "
                 f"Must be one of: {valid_types}"
             )
+
+        # Coerce transport fail-closed: a garbage payload value (version skew,
+        # bad PG JSONB) degrades to Celery here rather than reaching the PR 2
+        # fan-out read. Unlike workflow_type (no safe default → raise), transport
+        # is reversible by design, so it falls back instead of crashing.
+        self.transport = normalize_transport(
+            self.transport,
+            logger=logger,
+            context=f" (execution {self.execution_id})",
+        )
 
     @property
     def file_count(self) -> int:

--- a/workers/shared/models/execution_models.py
+++ b/workers/shared/models/execution_models.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 # Import shared domain models from core
 from unstract.core.data_models import (
+    DEFAULT_WORKFLOW_TRANSPORT,
     ExecutionStatus,
     PreCreatedFileData,
     serialize_dataclass_to_dict,
@@ -385,6 +386,10 @@ class WorkflowContextData:
     settings: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = None
     is_scheduled: bool = False
+    # Transport this execution rides end-to-end (9e). Carried in the task
+    # payload from the creation chokepoint; read at the fan-out to keep the
+    # whole pipeline on one transport. Defaults to legacy Celery.
+    transport: str = DEFAULT_WORKFLOW_TRANSPORT
     pre_created_file_executions: dict[str, PreCreatedFileData] = field(
         default_factory=dict
     )

--- a/workers/tests/test_dispatch_sites_characterisation.py
+++ b/workers/tests/test_dispatch_sites_characterisation.py
@@ -219,7 +219,12 @@ class TestSchedulerDispatchSite:
         assert args[4] is True  # scheduled flag (always True here)
 
     def test_dispatch_kwargs_layout(self):
-        """Kwargs MUST contain use_file_history and pipeline_id."""
+        """Kwargs MUST contain use_file_history, pipeline_id, and transport.
+
+        ``transport`` (9e) is carried in the task payload so the pipeline stays
+        on one transport end-to-end. It defaults to ``"celery"`` when the
+        create-execution response omits it (older backend / inert PR 1).
+        """
         from scheduler.tasks import _execute_scheduled_workflow
 
         ctx = self._make_context()
@@ -232,7 +237,24 @@ class TestSchedulerDispatchSite:
         assert kwargs == {
             "use_file_history": True,
             "pipeline_id": "pipe-007",
+            "transport": "celery",
         }
+
+    def test_dispatch_carries_backend_resolved_transport(self):
+        """The transport the backend returns from create-execution is threaded
+        verbatim into the dispatched task's payload (payload-carry, 9e)."""
+        from scheduler.tasks import _execute_scheduled_workflow
+
+        api = MagicMock()
+        api.create_workflow_execution.return_value = {
+            "execution_id": "exec-123",
+            "transport": "pg_queue",
+        }
+
+        with patch("scheduler.tasks.dispatch") as mock_dispatch:
+            _execute_scheduled_workflow(api, self._make_context())
+
+        assert mock_dispatch.call_args.kwargs["kwargs"]["transport"] == "pg_queue"
 
     def test_no_dispatch_when_execution_creation_fails(self):
         """If api_client.create_workflow_execution returns no execution_id,

--- a/workers/tests/test_workflow_context_transport.py
+++ b/workers/tests/test_workflow_context_transport.py
@@ -42,3 +42,10 @@ class TestWorkflowContextTransport:
     def test_carries_pg_queue_when_set(self):
         ctx = _make_context(transport=WorkflowTransport.PG_QUEUE.value)
         assert ctx.transport == "pg_queue"
+
+    def test_invalid_transport_coerced_to_celery(self):
+        """A garbage payload value (version skew / bad PG JSONB) must fail closed
+        at construction, not reach the PR 2 fan-out read."""
+        assert _make_context(transport="pg-queue").transport == "celery"
+        assert _make_context(transport="bogus").transport == "celery"
+        assert _make_context(transport=None).transport == "celery"

--- a/workers/tests/test_workflow_context_transport.py
+++ b/workers/tests/test_workflow_context_transport.py
@@ -1,0 +1,44 @@
+"""Tests for the 9e transport field carried on ``WorkflowContextData``.
+
+The transport a workflow execution rides is decided once at creation and
+carried in the task payload; on the worker side it lands on the live
+``WorkflowContextData`` so the fan-out (PR 2) can read it. PR 1 only adds the
+field with a Celery default — these tests pin that it defaults and round-trips.
+"""
+
+from unittest.mock import MagicMock
+
+from shared.models.execution_models import (
+    WorkerOrganizationContext,
+    WorkflowContextData,
+)
+
+from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, WorkflowTransport
+
+
+def _make_context(**overrides):
+    org_context = WorkerOrganizationContext(
+        organization_id="org-1",
+        api_client=MagicMock(),
+    )
+    kwargs = dict(
+        workflow_id="wf-1",
+        workflow_name="wf-name",
+        workflow_type="TASK",
+        execution_id="exec-1",
+        organization_context=org_context,
+        files={},
+    )
+    kwargs.update(overrides)
+    return WorkflowContextData(**kwargs)
+
+
+class TestWorkflowContextTransport:
+    def test_defaults_to_celery(self):
+        """A context built without a transport rides legacy Celery."""
+        assert _make_context().transport == DEFAULT_WORKFLOW_TRANSPORT
+        assert _make_context().transport == WorkflowTransport.CELERY.value
+
+    def test_carries_pg_queue_when_set(self):
+        ctx = _make_context(transport=WorkflowTransport.PG_QUEUE.value)
+        assert ctx.transport == "pg_queue"

--- a/workers/tests/test_workflow_context_transport.py
+++ b/workers/tests/test_workflow_context_transport.py
@@ -21,14 +21,14 @@ def _make_context(**overrides):
         organization_id="org-1",
         api_client=MagicMock(),
     )
-    kwargs = dict(
-        workflow_id="wf-1",
-        workflow_name="wf-name",
-        workflow_type="TASK",
-        execution_id="exec-1",
-        organization_context=org_context,
-        files={},
-    )
+    kwargs = {
+        "workflow_id": "wf-1",
+        "workflow_name": "wf-name",
+        "workflow_type": "TASK",
+        "execution_id": "exec-1",
+        "organization_context": org_context,
+        "files": {},
+    }
     kwargs.update(overrides)
     return WorkflowContextData(**kwargs)
 


### PR DESCRIPTION
## What & why

First of **3 PRs** for **9e** (the coupled-pipeline migration). This one establishes the **per-execution transport seam** and nothing else — the transport a workflow execution rides (`"celery"` | `"pg_queue"`) is resolved **once** at the creation chokepoint and **carried in the task payload**. It is **inert**: transport always resolves to `"celery"`, so behaviour is byte-identical to today.

Why a seam first: 9e migrates the coupled pipeline (`async_execute_bin` → file-batch fan-out → callback) onto the Postgres queue. Because the worker code is shared across both transports and later stages are enqueued from inside the workers, every stage needs to know — per execution — which transport to stay on. This PR lays that plumbing dead (always celery) so the next PR only adds the live PG branch.

**Design:** `workers/queue_backend/pg_queue/9e-design.md` (included). Chosen approach = **payload-carry**, deliberately **not** a `WorkflowExecution` column (no migration on the large shared table; all PG-specific state stays in droppable PG tables).

## Changes
- **core** — `WorkflowTransport` enum (`celery` | `pg_queue`) + `DEFAULT_WORKFLOW_TRANSPORT` (shared vocabulary).
- **backend** — `resolve_transport()` hardwired to celery (signature shaped for the Flipt wiring in PR 3); create-execution internal API returns `"transport"`; `execute_workflow_async` adds it to the `async_execute_bin` kwargs.
- **workers** — scheduler threads `transport` from the create response into the dispatch kwargs; `async_execute_bin_general` / `_execute_general_workflow` carry it onto the live `WorkflowContextData`.

## Tests
- backend `test_transport.py` — resolver + enum (5)
- worker `test_workflow_context_transport.py` — `WorkflowContextData` carry/default (2)
- dispatch characterisation updated — kwargs now include `transport`, + a new test that the backend-resolved transport is threaded verbatim
- **22 green** locally.

## Dev-test (against a running stack)
- Live `create-execution` internal API now returns `"transport":"celery"`.
- Workers killed + restarted on the new code (9 types RUNNING); a full **API-deployment execution completed** end-to-end on the new code (1 batch orchestrated, `async_execute_bin` succeeded, execution `COMPLETED`).

## Out of scope (later)
- PR 2: live PG routing (self-chaining + `PgBarrier` decrement) **+ the per-batch idempotency key** (ships together).
- PR 3: Flipt canary wiring. The Boolean flag `pg_queue_execution_enabled` (default `false`, no rollouts) already exists in dev — inert until PR 3 reads it.
- Rollout: ops (canary %, dashboards, teardown).

## Notes
- Targets `feat/UN-3445-pg-queue-integration` (not `main`).
- Ticket: UN-3559 (sub-task of the Phase 9 story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
