### PR TITLE
UN-3560 [FEAT] PG Queue 9 — run-worker.sh `-L celery` log alias

### DIFF
--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -31,9 +31,20 @@ readonly PG_QUEUE_CONSUMER_TYPE="pg_queue_consumer"
 readonly PG_QUEUE_REAPER_TYPE="pg_queue_reaper"
 # Set alias that launches the whole PG-queue group (consumer + reaper) together.
 readonly PG_QUEUE_SET="pg-queue"
-# Log-tail alias for the Celery set: every worker EXCEPT the PG-queue members.
-# Mirrors PG_QUEUE_SET so the two transports' logs can be tailed separately
-# (-L celery vs -L pg-queue). Logs-only — the Celery set is *run* via 'all'.
+# The PG-queue member worker dirs, as a set — the single source of truth for
+# "which workers belong to the PG-queue transport". Keeps the `celery = all −
+# pg-queue` complement correct by construction if a third member is ever added
+# (callers test membership via ${PG_QUEUE_MEMBERS[$dir]:-} instead of
+# hand-rolling the consumer/reaper pair).
+declare -rA PG_QUEUE_MEMBERS=(
+    ["$PG_QUEUE_CONSUMER_TYPE"]=1
+    ["$PG_QUEUE_REAPER_TYPE"]=1
+)
+# Log-tail alias for the Celery transport: every worker EXCEPT the PG-queue
+# members — the *complement* of the 'pg-queue' tail alias, so the two
+# transports' logs can be tailed separately (-L celery vs -L pg-queue).
+# Tail-only — there is no 'celery' run alias; this set is started via 'all',
+# which by design omits the opt-in PG-queue workers.
 readonly CELERY_SET="celery"
 
 # Available workers
@@ -444,18 +455,15 @@ tail_logs() {
     local requested=$1  # may be empty → tail all
     local log_files=()
 
-    if [[ -z "$requested" || "$requested" == "all" ]]; then
+    if [[ -z "$requested" || "$requested" == "all" || "$requested" == "$CELERY_SET" ]]; then
+        # 'all' (and empty) tails every worker; 'celery' tails every worker
+        # EXCEPT the PG-queue members — the complement of the 'pg-queue' alias
+        # (handled in the else-branch) — so the two transports' logs can be
+        # tailed separately. Same resolve-and-append body for both, single-sourced.
         for d in $(list_core_worker_dirs) $(list_pluggable_worker_dirs); do
-            local f
-            f=$(resolve_log_file "$d")
-            [[ -n "$f" ]] && log_files+=("$f")
-        done
-    elif [[ "$requested" == "$CELERY_SET" ]]; then
-        # Celery set logs = every worker EXCEPT the PG-queue members. Mirror of
-        # the 'pg-queue' alias below, so the two transports' logs can be tailed
-        # separately when both sets run side by side.
-        for d in $(list_core_worker_dirs) $(list_pluggable_worker_dirs); do
-            [[ "$d" == "$PG_QUEUE_CONSUMER_TYPE" || "$d" == "$PG_QUEUE_REAPER_TYPE" ]] && continue
+            if [[ "$requested" == "$CELERY_SET" && -n "${PG_QUEUE_MEMBERS[$d]:-}" ]]; then
+                continue
+            fi
             local f
             f=$(resolve_log_file "$d")
             [[ -n "$f" ]] && log_files+=("$f")

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -31,6 +31,10 @@ readonly PG_QUEUE_CONSUMER_TYPE="pg_queue_consumer"
 readonly PG_QUEUE_REAPER_TYPE="pg_queue_reaper"
 # Set alias that launches the whole PG-queue group (consumer + reaper) together.
 readonly PG_QUEUE_SET="pg-queue"
+# Log-tail alias for the Celery set: every worker EXCEPT the PG-queue members.
+# Mirrors PG_QUEUE_SET so the two transports' logs can be tailed separately
+# (-L celery vs -L pg-queue). Logs-only — the Celery set is *run* via 'all'.
+readonly CELERY_SET="celery"
 
 # Available workers
 declare -A WORKERS=(
@@ -163,7 +167,9 @@ OPTIONS:
     -r, --restart         Kill matching worker(s) then relaunch (with WORKER_TYPE,
                           restarts only that worker; without it, restarts all)
     -s, --status          Show status of running workers
-    -L, --logs [WORKER]   Live-tail worker log files (all if WORKER omitted)
+    -L, --logs [WORKER]   Live-tail worker log files (all if WORKER omitted).
+                          WORKER may also be a set: 'celery' (all but the
+                          PG-queue members) or 'pg-queue' (consumer + reaper).
     -C, --clear-logs      Delete worker .log files created by -d / 'all' runs
     -h, --help            Show this help message
 
@@ -199,6 +205,12 @@ EXAMPLES:
 
     # Live-tail all worker logs
     $0 -L
+
+    # Tail just the Celery set's logs (excludes the PG-queue workers)
+    $0 -L celery
+
+    # Tail just the PG-queue set's logs (consumer + reaper)
+    $0 -L pg-queue
 
     # Tail just one worker's log
     $0 -L general
@@ -434,6 +446,16 @@ tail_logs() {
 
     if [[ -z "$requested" || "$requested" == "all" ]]; then
         for d in $(list_core_worker_dirs) $(list_pluggable_worker_dirs); do
+            local f
+            f=$(resolve_log_file "$d")
+            [[ -n "$f" ]] && log_files+=("$f")
+        done
+    elif [[ "$requested" == "$CELERY_SET" ]]; then
+        # Celery set logs = every worker EXCEPT the PG-queue members. Mirror of
+        # the 'pg-queue' alias below, so the two transports' logs can be tailed
+        # separately when both sets run side by side.
+        for d in $(list_core_worker_dirs) $(list_pluggable_worker_dirs); do
+            [[ "$d" == "$PG_QUEUE_CONSUMER_TYPE" || "$d" == "$PG_QUEUE_REAPER_TYPE" ]] && continue
             local f
             f=$(resolve_log_file "$d")
             [[ -n "$f" ]] && log_files+=("$f")


### PR DESCRIPTION
## What & why

`./run-worker.sh -L pg-queue` already tails the PG-queue set's logs, but there was **no symmetric way to tail only the Celery set**. `-L` (no arg) tails **everything** — Celery **and** the PG-queue consumer/reaper — because `list_core_worker_dirs` includes the PG worker dirs. With both transports running side by side (the strangler-fig setup), the Celery logs get buried in PG-queue chatter.

This adds a **`-L celery`** log alias — the mirror of `-L pg-queue` — that tails every worker log **except** the PG-queue members (`pg_queue_consumer`, `pg_queue_reaper`).

Logs-only: the Celery set is still **run** via `all` (PG-queue is opt-in, never in `all`), so no run-path change is needed.

## Change
`workers/run-worker.sh` only:
- a `CELERY_SET="celery"` constant (mirrors `PG_QUEUE_SET`)
- a branch in `tail_logs()` that iterates core + pluggable dirs, skipping the two PG types
- usage text + examples

## Dev-test
With stub PG log files present:
- `-L` → **11** files (9 Celery + 2 PG)
- `-L celery` → **9** files (PG excluded) ✅
- `-L pg-queue` → **2** files (PG only) ✅

`bash -n run-worker.sh` clean.

## Notes
- Targets `feat/UN-3445-pg-queue-integration` (not `main`).
- Independent of the 9e seam PR (UN-3559 / #2062).
- Ticket: UN-3560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
