### PR TITLE
UN-3561 [FEAT] PG Queue 9e PR 2a — live-PG-pipeline inert foundation (dispatch backend override + barrier decrement core)

### DIFF
--- a/workers/queue_backend/dispatch.py
+++ b/workers/queue_backend/dispatch.py
@@ -1,11 +1,12 @@
 """Transport-agnostic task dispatch.
 
-Routes each task to its transport via :func:`select_backend`:
+Routes each task to its transport via :func:`resolve_backend` (which applies a
+per-call ``backend`` override, else defers to :func:`select_backend`):
 
 - **Celery** (default) — a thin pass-through to ``current_app.send_task``.
-- **PG Queue** — when a task is opted into ``WORKER_PG_QUEUE_ENABLED_TASKS``,
-  the task is serialised and enqueued to ``pg_queue_message`` (9b); the PG
-  consumer (9c) drains and runs it.
+- **PG Queue** — when a task is opted into ``WORKER_PG_QUEUE_ENABLED_TASKS``
+  (or pinned via a ``backend=`` override), the task is serialised and enqueued
+  to ``pg_queue_message`` (9b); the PG consumer (9c) drains and runs it.
 
 The default (empty allow-list) routes everything to Celery, so dispatch is
 unchanged unless an operator explicitly opts a task in.
@@ -130,6 +131,12 @@ def _enqueue_pg(
         # true regardless of send outcome, so a first-dispatch failure
         # (DB down / unmigrated) must not suppress the one announcement.
         # INFO so it survives a default log config; once-per-task bounds it.
+        # NOTE: keyed on task name only, not on *why* it routed to PG. If a name
+        # is first PG-routed via a ``backend=`` override and the operator later
+        # adds it to the allow-list, the allow-list cutover won't re-announce
+        # (already in the set). Benign given the usage split (override = pipeline
+        # headers, allow-list = leaf tasks, so no overlap expected); the
+        # allow-list config itself is still announced by _log_allow_list_once.
         _pg_routing_logged.add(task_name)
         logger.info(
             "PG-queue: routing task=%r to Postgres (queue=%r). Requires the "

--- a/workers/queue_backend/dispatch.py
+++ b/workers/queue_backend/dispatch.py
@@ -30,7 +30,7 @@ from celery import current_app
 from .fairness import DEFAULT_PRIORITY, FairnessKey
 from .handle import DispatchHandle
 from .pg_queue import PgQueueClient, to_payload
-from .routing import QueueBackend, select_backend
+from .routing import QueueBackend, resolve_backend
 
 logger = logging.getLogger(__name__)
 
@@ -85,19 +85,21 @@ def dispatch(
     path / serialised into the message on the PG path. Pass ``None`` for
     non-workflow worker tasks.
 
-    ``backend`` is a per-call transport override. When ``None`` (the default,
-    and every call site today) the transport is the env allow-list decision
-    via :func:`select_backend` — behaviour is unchanged. When set, it wins
-    over the allow-list: this is the seam the execution-level PG pipeline (9e
-    PR 2c) uses to route a whole execution's header/callback dispatches onto
-    PG without opting their task *names* into ``WORKER_PG_QUEUE_ENABLED_TASKS``
-    (the allow-list is for leaf tasks; the coupled pipeline's migration unit is
-    the execution, carried in the payload — see ``routing.py``). The override
-    only forces the *transport*; it does not bypass ``_enqueue_pg``'s no-silent-
-    fallback contract.
+    ``backend`` is a per-call transport override (see
+    :func:`~queue_backend.routing.resolve_backend` for the precedence). When
+    ``None`` (the default, and every call site today) the transport is the env
+    allow-list decision via ``select_backend`` — behaviour is unchanged. When
+    set, it wins over the allow-list: this is the seam the execution-level PG
+    pipeline (9e PR 2c) uses to route a whole execution's header/callback
+    dispatches onto PG without opting their task *names* into
+    ``WORKER_PG_QUEUE_ENABLED_TASKS``. (The allow-list is for *leaf* tasks; the
+    coupled pipeline's migration unit is the whole execution — its transport is
+    resolved once at creation and travels on the execution's task kwargs onto
+    ``WorkflowContextData.transport``, see ``queue_backend/pg_queue/
+    9e-design.md``.) The override only forces the *transport*; it does not
+    bypass ``_enqueue_pg``'s no-silent-fallback contract.
     """
-    resolved = backend if backend is not None else select_backend(task_name)
-    if resolved is QueueBackend.PG:
+    if resolve_backend(task_name, backend) is QueueBackend.PG:
         return _enqueue_pg(task_name, args, kwargs, queue, fairness)
 
     headers = fairness.as_header() if fairness is not None else None

--- a/workers/queue_backend/dispatch.py
+++ b/workers/queue_backend/dispatch.py
@@ -77,14 +77,27 @@ def dispatch(
     kwargs: Mapping[str, Any] | None = None,
     queue: str | None = None,
     fairness: FairnessKey | None = None,
+    backend: QueueBackend | None = None,
 ) -> DispatchHandle:
     """Enqueue a task by name onto its selected transport.
 
     ``fairness`` is attached as the ``x-fairness-key`` header on the Celery
     path / serialised into the message on the PG path. Pass ``None`` for
     non-workflow worker tasks.
+
+    ``backend`` is a per-call transport override. When ``None`` (the default,
+    and every call site today) the transport is the env allow-list decision
+    via :func:`select_backend` — behaviour is unchanged. When set, it wins
+    over the allow-list: this is the seam the execution-level PG pipeline (9e
+    PR 2c) uses to route a whole execution's header/callback dispatches onto
+    PG without opting their task *names* into ``WORKER_PG_QUEUE_ENABLED_TASKS``
+    (the allow-list is for leaf tasks; the coupled pipeline's migration unit is
+    the execution, carried in the payload — see ``routing.py``). The override
+    only forces the *transport*; it does not bypass ``_enqueue_pg``'s no-silent-
+    fallback contract.
     """
-    if select_backend(task_name) is QueueBackend.PG:
+    resolved = backend if backend is not None else select_backend(task_name)
+    if resolved is QueueBackend.PG:
         return _enqueue_pg(task_name, args, kwargs, queue, fairness)
 
     headers = fairness.as_header() if fairness is not None else None

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -65,6 +65,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import psycopg2
+import psycopg2.extensions
 
 from .barrier import CallbackDescriptor, barrier_ttl_seconds
 from .decorator import worker_task
@@ -261,16 +262,37 @@ def _barrier_pg_decrement(
 
     - the Celery ``link`` callback :func:`barrier_pg_decr_and_check` (today's
       only caller, behaviour unchanged); and
-    - the 9e PR 2c PG-consumed pipeline path, which calls this directly in the
-      header task's body — a PG-consumed task fires no ``.link``, so the
-      decrement must run in-body (fire-and-forget self-chaining).
+    - the 9e PR 2c PG-consumed pipeline path, which will call this directly in
+      the header task's body — a PG-consumed task fires no ``.link``, so the
+      decrement must run in-body.
 
-    Callers MUST run each decrement in its own committed transaction (one call
-    = one ``_cursor()`` txn here) and MUST NOT retry it: a replay re-runs the
-    decrement and corrupts the count. The Celery wrapper enforces this with
+    Callers MUST run each decrement in its own committed transaction (the
+    decrement ``UPDATE`` runs in its own ``_cursor()`` txn) and MUST NOT retry
+    it: a replay re-runs the decrement and corrupts the count. This is enforced
+    loudly, not just in prose — entry raises if the shared connection is already
+    mid-transaction (see the guard below). The Celery wrapper additionally pins
     ``max_retries=0``; an orphaned barrier is bounded by ``expires_at`` instead.
     """
     from celery import current_app
+
+    # Enforce the "own committed transaction" contract loudly. A caller that
+    # invokes this inside an already-open transaction on the shared thread-local
+    # connection would hold the row lock across the call and let the outer txn's
+    # commit boundary replay the decrement — corrupting ``remaining`` and
+    # breaking the exactly-one-sees-zero serialisation, surfacing only as a
+    # barrier hung until ``expires_at`` (~6h). The Celery ``.link`` path always
+    # enters idle (``_cursor`` commits after every use); the 2c in-body caller
+    # must too. (Tests inject an autocommit connection → always idle → no trip.)
+    if (
+        _get_conn().get_transaction_status()
+        != psycopg2.extensions.TRANSACTION_STATUS_IDLE
+    ):
+        raise RuntimeError(
+            f"[exec:{execution_id}] _barrier_pg_decrement entered with an open "
+            f"transaction on the shared connection — each decrement MUST run in "
+            f"its own committed transaction (see this function's docstring). "
+            f"Refusing to proceed to avoid corrupting the barrier counter."
+        )
 
     try:
         # No default=str — a non-JSON-safe leaf must fail loudly here (it would

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -246,20 +246,29 @@ class PgBarrier:
             raise
 
 
-@worker_task(name="barrier_pg_decr_and_check", max_retries=0)
-def barrier_pg_decr_and_check(
+def _barrier_pg_decrement(
     result: Any,
     *,
     execution_id: str,
     callback_descriptor: CallbackDescriptor,
 ) -> dict[str, Any]:
-    """Per-task ``link`` callback for :class:`PgBarrier`.
+    """Atomic barrier decrement + last-task callback fire (substrate core).
 
-    Atomically appends this task's result and decrements ``remaining``. The
-    single task that drives ``remaining`` to 0 dispatches the aggregating
-    callback (then deletes the row). ``max_retries=0`` — a Celery retry would
-    replay the decrement and corrupt the count; an orphaned barrier is bounded
-    by ``expires_at`` instead.
+    Appends this task's result and decrements ``remaining`` in one atomic
+    statement; the single caller that drives ``remaining`` to 0 dispatches the
+    aggregating callback (then deletes the row). This is the plain, in-body-
+    callable core shared by two entry points:
+
+    - the Celery ``link`` callback :func:`barrier_pg_decr_and_check` (today's
+      only caller, behaviour unchanged); and
+    - the 9e PR 2c PG-consumed pipeline path, which calls this directly in the
+      header task's body — a PG-consumed task fires no ``.link``, so the
+      decrement must run in-body (fire-and-forget self-chaining).
+
+    Callers MUST run each decrement in its own committed transaction (one call
+    = one ``_cursor()`` txn here) and MUST NOT retry it: a replay re-runs the
+    decrement and corrupts the count. The Celery wrapper enforces this with
+    ``max_retries=0``; an orphaned barrier is bounded by ``expires_at`` instead.
     """
     from celery import current_app
 
@@ -370,6 +379,25 @@ def barrier_pg_decr_and_check(
         "callback_task_id": callback_result.id,
         "aggregated_count": len(all_results),
     }
+
+
+@worker_task(name="barrier_pg_decr_and_check", max_retries=0)
+def barrier_pg_decr_and_check(
+    result: Any,
+    *,
+    execution_id: str,
+    callback_descriptor: CallbackDescriptor,
+) -> dict[str, Any]:
+    """Per-task ``link`` callback for :class:`PgBarrier` (Celery entry point).
+
+    Thin ``@worker_task`` wrapper around :func:`_barrier_pg_decrement` so the
+    decrement logic stays callable in-body (no ``.link``) on the PG-consumed
+    pipeline path (9e PR 2c). ``max_retries=0`` — a Celery retry would replay
+    the decrement and corrupt the count (see the core's contract).
+    """
+    return _barrier_pg_decrement(
+        result, execution_id=execution_id, callback_descriptor=callback_descriptor
+    )
 
 
 @worker_task(name="barrier_pg_abort", max_retries=0)

--- a/workers/queue_backend/routing.py
+++ b/workers/queue_backend/routing.py
@@ -36,8 +36,9 @@ consult this allow-list." Until then, only enable *leaf* tasks here.
 **Scaffold posture.** This module only makes the routing *decision*.
 In the current phase there is no PG consumer, so ``dispatch()`` still
 sends PG-selected tasks via Celery (the decision is observable in logs
-but inert). ``select_backend()`` is the seam where the real PG dispatch
-lands in a later phase.
+but inert). ``resolve_backend()`` (which wraps the ``select_backend()``
+allow-list with the per-call override) is the seam where the real PG
+dispatch lands in a later phase.
 
 **Observability.** Because the gate is silent-by-construction (a
 misrouted task still runs on Celery), the only signals are logs, emitted

--- a/workers/queue_backend/routing.py
+++ b/workers/queue_backend/routing.py
@@ -132,3 +132,23 @@ def select_backend(task_name: str) -> QueueBackend:
     if task_name in allow_list:
         return QueueBackend.PG
     return QueueBackend.CELERY
+
+
+def resolve_backend(task_name: str, override: QueueBackend | None) -> QueueBackend:
+    """Resolve the transport for a dispatch, applying the per-call override.
+
+    The single home for the override-wins-else-allow-list precedence so the
+    rule reads in one place (and ``dispatch()`` plus the 9e PR 2c call sites
+    share it):
+
+    - ``override`` is ``None`` → defer to :func:`select_backend` (the env
+      allow-list) — the behaviour of every call site today.
+    - ``override`` is a :class:`QueueBackend` → it wins. This is how the
+      execution-level PG pipeline pins a whole execution's header/callback
+      dispatches to one transport regardless of the per-task allow-list (the
+      allow-list is for *leaf* tasks; the coupled pipeline's migration unit is
+      the execution).
+
+    Never raises — both branches resolve to a valid :class:`QueueBackend`.
+    """
+    return override if override is not None else select_backend(task_name)

--- a/workers/tests/test_dispatch_pg.py
+++ b/workers/tests/test_dispatch_pg.py
@@ -19,6 +19,7 @@ from queue_backend import dispatch
 from queue_backend.fairness import FairnessKey, WorkloadType
 from queue_backend.pg_queue import to_payload
 from queue_backend.routing import _ENABLED_TASKS_ENV_VAR as ENABLED_TASKS_ENV
+from queue_backend.routing import QueueBackend
 
 # ``queue_backend.dispatch`` the attribute is the function (shadows the
 # submodule) — import the module explicitly to reach its globals.
@@ -109,6 +110,62 @@ class TestDispatchEnqueueIntegration:
             dispatch("some_task", args=["x"], queue="general")
         mock_app.send_task.assert_called_once()
         mock_get.assert_not_called()
+
+
+class TestDispatchBackendOverride:
+    """The per-call ``backend=`` override (9e PR 2a inert foundation).
+
+    When set it wins over the ``WORKER_PG_QUEUE_ENABLED_TASKS`` allow-list, so
+    the execution-level PG pipeline can route a whole execution's headers /
+    callback onto PG without opting their task *names* in. ``None`` (default)
+    preserves the allow-list decision exactly — every call site today.
+    """
+
+    def test_override_pg_forces_pg_without_allow_list(self, monkeypatch):
+        # Task name NOT in the (empty) allow-list → select_backend says Celery;
+        # the explicit override must still route it to PG.
+        captured: dict = {}
+
+        class _Client:
+            def send(self, queue_name, payload, **kwargs):
+                captured.update(queue=queue_name, payload=payload, **kwargs)
+                return 11
+
+        monkeypatch.setattr(dispatch_mod, "_get_pg_client", lambda: _Client())
+        with patch("queue_backend.dispatch.current_app") as mock_app:
+            handle = dispatch(
+                "pipeline_header", queue="general", backend=QueueBackend.PG
+            )
+        mock_app.send_task.assert_not_called()
+        assert handle.id == "11"
+        assert captured["payload"]["task_name"] == "pipeline_header"
+
+    def test_override_celery_forces_celery_despite_allow_list(self, monkeypatch):
+        # Task name IS opted into PG, but the override pins it back to Celery.
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "pipeline_header")
+        with (
+            patch("queue_backend.dispatch.current_app") as mock_app,
+            patch("queue_backend.dispatch._get_pg_client") as mock_get,
+        ):
+            dispatch("pipeline_header", queue="general", backend=QueueBackend.CELERY)
+        mock_app.send_task.assert_called_once()
+        mock_get.assert_not_called()
+
+    def test_default_none_preserves_allow_list_decision(self, monkeypatch):
+        # No override → allow-list decides. Opted-in name → PG.
+        captured: dict = {}
+
+        class _Client:
+            def send(self, queue_name, payload, **kwargs):
+                captured.update(queue=queue_name)
+                return 5
+
+        monkeypatch.setenv(ENABLED_TASKS_ENV, "leaf_task")
+        monkeypatch.setattr(dispatch_mod, "_get_pg_client", lambda: _Client())
+        with patch("queue_backend.dispatch.current_app") as mock_app:
+            handle = dispatch("leaf_task", queue="general")
+        mock_app.send_task.assert_not_called()
+        assert handle.id == "5"
 
 
 class TestDispatchPriorityWiring:

--- a/workers/tests/test_dispatch_pg.py
+++ b/workers/tests/test_dispatch_pg.py
@@ -167,6 +167,32 @@ class TestDispatchBackendOverride:
         mock_app.send_task.assert_not_called()
         assert handle.id == "5"
 
+    def test_override_path_carries_fairness_to_row(self, monkeypatch):
+        # The override's whole purpose is to route an *execution's* dispatches —
+        # exactly the ones that carry a FairnessKey. The org/priority plumbing
+        # must work identically on the override path (not just the allow-list
+        # path), so a regression dropping fairness here would otherwise pass.
+        captured: dict = {}
+
+        class _Client:
+            def send(self, queue_name, payload, **kwargs):
+                captured.update(queue=queue_name, **kwargs)
+                return 13
+
+        monkeypatch.setattr(dispatch_mod, "_get_pg_client", lambda: _Client())
+        fairness = FairnessKey(
+            org_id="o", workload_type=WorkloadType.API, pipeline_priority=8
+        )
+        with patch("queue_backend.dispatch.current_app"):
+            dispatch(
+                "pipeline_header",
+                queue="general",
+                fairness=fairness,
+                backend=QueueBackend.PG,
+            )
+        assert captured["priority"] == 8
+        assert captured["org_id"] == "o"
+
 
 class TestDispatchPriorityWiring:
     """dispatch() carries fairness.pipeline_priority onto the PG row (mocked)."""

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -350,9 +350,25 @@ class TestDecrementCoreExtraction:
         assert remaining == 2
         assert results == [{"f": 1}]
 
-    def test_worker_task_delegates_to_core(self):
-        # The Celery entry point must forward verbatim to the core — same result,
-        # same args — so the link path and the in-body path can never diverge.
+    def test_worker_task_produces_same_decrement_as_core(self, barrier_db):
+        # The real no-drift guard: the wrapper, run against a real seeded row,
+        # must produce the SAME observable decrement as a direct core call
+        # (mirror of test_core_runs_the_decrement_in_body). Unlike the mocked
+        # forwarding test below, this would catch a renamed/reordered core param
+        # — the core is NOT mocked away.
+        _seed(barrier_db, "exec-wrap", 3)
+        out = barrier_pg_decr_and_check(
+            {"f": 1}, execution_id="exec-wrap", callback_descriptor=_CALLBACK
+        )
+        assert out["status"] == "pending"
+        remaining, results = _row(barrier_db, "exec-wrap")
+        assert remaining == 2
+        assert results == [{"f": 1}]
+
+    def test_worker_task_forwards_kwargs_verbatim(self):
+        # Complements the real-row test above by pinning the keyword-forwarding
+        # contract explicitly: the wrapper passes result + execution_id +
+        # callback_descriptor straight through, returning the core's result.
         sentinel = {"status": "pending", "remaining": 9}
         with patch.object(
             pg_barrier, "_barrier_pg_decrement", return_value=sentinel
@@ -364,6 +380,24 @@ class TestDecrementCoreExtraction:
         core.assert_called_once_with(
             {"f": 1}, execution_id="exec-d", callback_descriptor=_CALLBACK
         )
+
+    def test_open_transaction_on_shared_conn_raises(self):
+        # The in-body contract is enforced loudly: a caller that enters with an
+        # already-open transaction on the shared connection is rejected before
+        # any decrement runs (would otherwise corrupt 'remaining' and hang the
+        # barrier to expiry). Guards the 2c in-body caller.
+        import psycopg2.extensions
+
+        conn = MagicMock()
+        conn.get_transaction_status.return_value = (
+            psycopg2.extensions.TRANSACTION_STATUS_INTRANS
+        )
+        with patch.object(pg_barrier, "_get_conn", return_value=conn):
+            with pytest.raises(RuntimeError, match="own committed transaction"):
+                _barrier_pg_decrement(
+                    {"f": 1}, execution_id="exec-tx", callback_descriptor=_CALLBACK
+                )
+        conn.cursor.assert_not_called()  # rejected before touching the DB
 
 
 class TestAbort:

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -23,6 +23,7 @@ from queue_backend.fairness import FAIRNESS_HEADER_NAME, FairnessKey, WorkloadTy
 from queue_backend.handle import BarrierHandle
 from queue_backend.pg_barrier import (
     PgBarrier,
+    _barrier_pg_decrement,
     barrier_pg_abort,
     barrier_pg_decr_and_check,
 )
@@ -323,6 +324,46 @@ class TestDecrAndCheck:
 
     def test_registered_under_canonical_name(self):
         assert barrier_pg_decr_and_check.name == "barrier_pg_decr_and_check"
+
+
+class TestDecrementCoreExtraction:
+    """The decrement logic lives in a plain ``_barrier_pg_decrement`` core so the
+    9e PR 2c PG-consumed path can call it in-body (a PG-consumed task fires no
+    ``.link``). The Celery ``@worker_task`` is a thin delegator; both paths must
+    share one implementation (no drift). (Inert in 2a — no PG caller yet.)
+    """
+
+    def test_core_is_a_plain_callable_not_a_celery_task(self):
+        # A ``@worker_task`` exposes ``.name`` / ``.delay``; the in-body core
+        # must not, or callers could accidentally re-dispatch instead of running.
+        assert not hasattr(_barrier_pg_decrement, "name")
+        assert not hasattr(_barrier_pg_decrement, "delay")
+
+    def test_core_runs_the_decrement_in_body(self, barrier_db):
+        # Called directly (no Celery), the core performs the atomic decrement.
+        _seed(barrier_db, "exec-core", 3)
+        out = _barrier_pg_decrement(
+            {"f": 1}, execution_id="exec-core", callback_descriptor=_CALLBACK
+        )
+        assert out["status"] == "pending"
+        remaining, results = _row(barrier_db, "exec-core")
+        assert remaining == 2
+        assert results == [{"f": 1}]
+
+    def test_worker_task_delegates_to_core(self):
+        # The Celery entry point must forward verbatim to the core — same result,
+        # same args — so the link path and the in-body path can never diverge.
+        sentinel = {"status": "pending", "remaining": 9}
+        with patch.object(
+            pg_barrier, "_barrier_pg_decrement", return_value=sentinel
+        ) as core:
+            out = barrier_pg_decr_and_check(
+                {"f": 1}, execution_id="exec-d", callback_descriptor=_CALLBACK
+            )
+        assert out is sentinel
+        core.assert_called_once_with(
+            {"f": 1}, execution_id="exec-d", callback_descriptor=_CALLBACK
+        )
 
 
 class TestAbort:


### PR DESCRIPTION
## What

First slice of **9e PR 2** (the live PG execution pipeline), split into **2a → 2b → 2c**. This is **2a, the inert foundation** — the two seams the live switch (2c) consumes, each with **zero behaviour change on the default path**.

### 1. `dispatch(backend=...)` — per-call transport override
`dispatch()` gains an optional `backend: QueueBackend | None = None`:
- `None` (the default, and **every call site today**) → transport is the env allow-list decision via `select_backend()` — **byte-identical** to today.
- Set → it **wins over the allow-list**. This is the seam the execution-level PG pipeline (2c) uses to route a whole execution's header/callback dispatches onto PG **without** opting their task *names* into `WORKER_PG_QUEUE_ENABLED_TASKS`. The allow-list is for *leaf* tasks; the coupled pipeline's migration unit is the *execution* (carried in the payload — see `routing.py`).

### 2. Extract `_barrier_pg_decrement(...)` core
The decrement logic moves out of the `@worker_task barrier_pg_decr_and_check` into a plain `_barrier_pg_decrement(...)` function; the `@worker_task` becomes a thin **delegator**. The plain core is what 2c calls **in-body** on the PG-consumed path — a PG-consumed task fires no Celery `.link`, so the decrement must run in-body (fire-and-forget self-chaining). Behaviour for the existing Celery `.link` path is unchanged (the wrapper forwards verbatim).

## Why it's inert

- Default barrier backend is `chord` → **Celery executions never import the `PgBarrier` module**, so the extraction is invisible to them.
- **No call site passes `backend=`** → the Celery dispatch path is byte-identical.
- Net behaviour change: **NONE**. Transport threading into the fan-out fns + the live `transport=="pg_queue"` switch land in **2c** (threading an unused param earlier just trips S1172); per-batch idempotency lands in **2b**.

## Tests

- **dispatch backend-override** (3): PG-forces-PG-without-allow-list, Celery-forces-Celery-despite-allow-list, default-None-preserves-allow-list.
- **decrement-core extraction** (3): core is a plain callable (not a Celery task), runs the decrement in-body against real PG, and the `@worker_task` delegates verbatim.
- Full `test_pg_barrier` (33) + `test_dispatch_pg` (10) + barrier/routing (53) suites green; `ruff` clean.
- Worker-app bootstrap verified clean under `WORKER_BARRIER_BACKEND=pg`: both barrier tasks registered under canonical names, `get_barrier()` → `PgBarrier`.

## Base

Targets the long-lived `feat/UN-3445-pg-queue-integration` integration branch (**not** `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
