### PR TITLE
UN-3563 [FEAT] PG Queue 9e PR 2c — live PG fan-out/barrier/callback (fire-and-forget)

### DIFF
--- a/unstract/core/src/unstract/core/data_models.py
+++ b/unstract/core/src/unstract/core/data_models.py
@@ -249,6 +249,17 @@ def normalize_transport(value: object, *, logger: Any = None, context: str = "")
         return DEFAULT_WORKFLOW_TRANSPORT
 
 
+def is_pg_transport(transport: str | None) -> bool:
+    """True if ``transport`` is the Postgres-queue transport.
+
+    Single source for "what counts as PG transport" — centralises the
+    ``== WorkflowTransport.PG_QUEUE.value`` comparison scattered across the
+    worker fan-out / barrier code, and the seam to extend if a second
+    PG-family transport is ever added.
+    """
+    return transport == WorkflowTransport.PG_QUEUE.value
+
+
 class FileListingResult:
     """Result of listing files from a source."""
 

--- a/workers/api-deployment/tasks.py
+++ b/workers/api-deployment/tasks.py
@@ -26,7 +26,13 @@ from shared.workflow.execution import WorkerExecutionContext, WorkflowOrchestrat
 from shared.workflow.execution.tool_validation import validate_workflow_tool_instances
 from worker import app
 
-from unstract.core.data_models import ExecutionStatus, FileHashData, WorkerFileData
+from unstract.core.data_models import (
+    DEFAULT_WORKFLOW_TRANSPORT,
+    ExecutionStatus,
+    FileHashData,
+    WorkerFileData,
+    normalize_transport,
+)
 from unstract.core.worker_models import ApiDeploymentResultStatus
 
 logger = WorkerLogger.get_logger(__name__)
@@ -683,6 +689,14 @@ def _run_workflow_api(
             org_id=str(schema_name),
             workload_type=WorkloadType.API,
         )
+        # Transport rides in via the dispatched task's kwargs (PR 1 seam); the
+        # fan-out honours it (PG path → fire-and-forget PgBarrier). Fail-closed
+        # to celery on any unrecognised value.
+        transport = normalize_transport(
+            kwargs.get("transport", DEFAULT_WORKFLOW_TRANSPORT),
+            logger=logger,
+            context=f" [exec:{execution_id}]",
+        )
         result = WorkflowOrchestrationUtils.create_chord_execution(
             batch_tasks=batch_tasks,
             callback_task_name="process_batch_callback_api",
@@ -694,6 +708,7 @@ def _run_workflow_api(
             callback_queue=file_processing_callback_queue,
             app_instance=app,
             fairness=api_fairness,
+            transport=transport,
         )
 
         if result is None:

--- a/workers/file_processing/tasks.py
+++ b/workers/file_processing/tasks.py
@@ -11,6 +11,7 @@ import time
 from typing import Any
 
 from queue_backend import worker_task
+from queue_backend.pg_barrier import run_batch_with_barrier
 
 # Import shared worker infrastructure
 from shared.api import InternalAPIClient
@@ -222,25 +223,14 @@ def _enhance_batch_with_mrq_flags(
         )
 
 
-def _process_file_batch_core(
-    task_instance, file_batch_data: dict[str, Any]
+def _run_batch_stages(
+    task_instance, file_batch_data: dict[str, Any], celery_task_id: str
 ) -> dict[str, Any]:
-    """Core implementation of file batch processing.
+    """The actual batch work (validate → setup → pre-create → process → compile).
 
-    This function contains the actual processing logic that both the new task
-    and Django compatibility task will use.
-
-    Args:
-        task_instance: The Celery task instance (self)
-        file_batch_data: Dictionary that will be converted to FileBatchData dataclass
-
-    Returns:
-        Dictionary with successful_files and failed_files counts
+    Transport-agnostic: identical on the Celery chord path and the PG
+    fire-and-forget path. Returns the JSON-serialisable batch result.
     """
-    celery_task_id = (
-        task_instance.request.id if hasattr(task_instance, "request") else "unknown"
-    )
-
     # Step 1: Validate and parse input data
     batch_data = _validate_and_parse_batch_data(file_batch_data)
 
@@ -260,6 +250,44 @@ def _process_file_batch_core(
     return _compile_batch_result(context)
 
 
+def _process_file_batch_core(
+    task_instance,
+    file_batch_data: dict[str, Any],
+    barrier_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Core implementation of file batch processing.
+
+    This function contains the actual processing logic that both the new task
+    and Django compatibility task will use.
+
+    Args:
+        task_instance: The Celery task instance (self)
+        file_batch_data: Dictionary that will be converted to FileBatchData dataclass
+        barrier_context: Present only on the 9e PG fire-and-forget path — carries
+            ``execution_id`` / ``batch_index`` / ``callback_descriptor`` so the
+            batch claims its slot and runs the barrier decrement in-body (a
+            PG-consumed task fires no Celery ``.link``). ``None`` on the Celery
+            chord path, where the chord ``.link`` drives the decrement instead.
+
+    Returns:
+        Dictionary with successful_files and failed_files counts
+    """
+    celery_task_id = (
+        task_instance.request.id if hasattr(task_instance, "request") else "unknown"
+    )
+
+    if barrier_context is None:
+        # Celery chord path — the chord's .link runs the decrement after this.
+        return _run_batch_stages(task_instance, file_batch_data, celery_task_id)
+
+    # PG fire-and-forget path — claim the batch (idempotent on redelivery), run
+    # the stages, then decrement the barrier in-body / self-chain the callback.
+    return run_batch_with_barrier(
+        barrier_context,
+        lambda: _run_batch_stages(task_instance, file_batch_data, celery_task_id),
+    )
+
+
 @worker_task(
     bind=True,
     name=TaskName.PROCESS_FILE_BATCH,
@@ -272,18 +300,26 @@ def _process_file_batch_core(
     # Timeout inherited from global Celery config (FILE_PROCESSING_TASK_TIME_LIMIT env var)
 )
 @monitor_performance
-def process_file_batch(self, file_batch_data: dict[str, Any]) -> dict[str, Any]:
-    """Process a batch of files in parallel using Celery.
+def process_file_batch(
+    self,
+    file_batch_data: dict[str, Any],
+    _barrier_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Process a batch of files in parallel.
 
     This is the main task entry point for new workers.
 
     Args:
         file_batch_data: Dictionary that will be converted to FileBatchData dataclass
+        _barrier_context: Injected only when this task is dispatched onto the PG
+            queue (9e fire-and-forget path) by ``PgBarrier`` — carries the barrier
+            coordination context (``execution_id`` / ``batch_index`` /
+            ``callback_descriptor``). Absent on the Celery chord path.
 
     Returns:
         Dictionary with successful_files and failed_files counts
     """
-    return _process_file_batch_core(self, file_batch_data)
+    return _process_file_batch_core(self, file_batch_data, _barrier_context)
 
 
 def _validate_and_parse_batch_data(file_batch_data: dict[str, Any]) -> FileBatchData:

--- a/workers/file_processing/tasks.py
+++ b/workers/file_processing/tasks.py
@@ -224,12 +224,14 @@ def _enhance_batch_with_mrq_flags(
 
 
 def _run_batch_stages(
-    task_instance, file_batch_data: dict[str, Any], celery_task_id: str
+    file_batch_data: dict[str, Any], celery_task_id: str
 ) -> dict[str, Any]:
     """The actual batch work (validate → setup → pre-create → process → compile).
 
     Transport-agnostic: identical on the Celery chord path and the PG
-    fire-and-forget path. Returns the JSON-serialisable batch result.
+    fire-and-forget path. The task instance isn't needed here — its only use
+    (deriving ``celery_task_id``) happens in the caller. Returns the
+    JSON-serialisable batch result.
     """
     # Step 1: Validate and parse input data
     batch_data = _validate_and_parse_batch_data(file_batch_data)
@@ -278,13 +280,13 @@ def _process_file_batch_core(
 
     if barrier_context is None:
         # Celery chord path — the chord's .link runs the decrement after this.
-        return _run_batch_stages(task_instance, file_batch_data, celery_task_id)
+        return _run_batch_stages(file_batch_data, celery_task_id)
 
     # PG fire-and-forget path — claim the batch (idempotent on redelivery), run
     # the stages, then decrement the barrier in-body / self-chain the callback.
     return run_batch_with_barrier(
         barrier_context,
-        lambda: _run_batch_stages(task_instance, file_batch_data, celery_task_id),
+        lambda: _run_batch_stages(file_batch_data, celery_task_id),
     )
 
 

--- a/workers/file_processing/tasks.py
+++ b/workers/file_processing/tasks.py
@@ -11,6 +11,7 @@ import time
 from typing import Any
 
 from queue_backend import worker_task
+from queue_backend.barrier import BarrierContext
 from queue_backend.pg_barrier import run_batch_with_barrier
 
 # Import shared worker infrastructure
@@ -255,7 +256,7 @@ def _run_batch_stages(
 def _process_file_batch_core(
     task_instance,
     file_batch_data: dict[str, Any],
-    barrier_context: dict[str, Any] | None = None,
+    barrier_context: BarrierContext | None = None,
 ) -> dict[str, Any]:
     """Core implementation of file batch processing.
 
@@ -305,7 +306,7 @@ def _process_file_batch_core(
 def process_file_batch(
     self,
     file_batch_data: dict[str, Any],
-    _barrier_context: dict[str, Any] | None = None,
+    _barrier_context: BarrierContext | None = None,
 ) -> dict[str, Any]:
     """Process a batch of files in parallel.
 

--- a/workers/general/tasks.py
+++ b/workers/general/tasks.py
@@ -710,6 +710,7 @@ def _execute_general_workflow(
                 execution_mode=execution_mode,
                 use_file_history=use_file_history,
                 organization_id=api_client.organization_id,
+                transport=transport,
                 **kwargs,
             )
 
@@ -764,6 +765,7 @@ def _orchestrate_file_processing_general(
     execution_mode: tuple | None,
     use_file_history: bool,
     organization_id: str,
+    transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     **kwargs: dict[str, Any],
 ) -> dict[str, Any]:
     """Orchestrate file processing for general workflows using the same pattern as API worker.
@@ -957,6 +959,7 @@ def _orchestrate_file_processing_general(
                 org_id=organization_id,
                 workload_type=WorkloadType.NON_API,
             ),
+            transport=transport,
         )
 
         if not result:

--- a/workers/general/tasks.py
+++ b/workers/general/tasks.py
@@ -56,6 +56,7 @@ from unstract.core.data_models import (
     FileBatchData,
     FileHashData,
     WorkerFileData,
+    normalize_transport,
 )
 
 # Import common workflow utilities
@@ -487,6 +488,12 @@ def _execute_general_workflow(
         Execution result
     """
     start_time = time.time()
+
+    # Fail-closed coercion, for parity with the api/scheduler workers (which run
+    # normalize_transport at their entry): a typo'd transport degrades to Celery
+    # with a warning rather than silently routing onto an unknown substrate. The
+    # coerced value feeds both WorkflowContextData and the fan-out below.
+    transport = normalize_transport(transport, logger=logger)
 
     logger.info("Executing general workflow logic for ETL/TASK workflow")
 

--- a/workers/queue_backend/barrier.py
+++ b/workers/queue_backend/barrier.py
@@ -94,11 +94,29 @@ class CallbackDescriptor(TypedDict):
     kwargs: dict[str, Any]
     queue: str
     fairness_headers: dict[str, Any] | None
-    # 9e: transport the aggregating callback is fired on when the barrier
-    # completes. Absent / ``None`` → legacy Celery dispatch (``current_app``
-    # ``.apply_async`` — the ``.link`` path). ``"pg_queue"`` → the fire-and-forget
-    # PG path self-chains the callback via ``dispatch(backend=PG)``.
-    backend: NotRequired[str | None]
+    # 9e: the WorkflowTransport the aggregating callback is fired on when the
+    # barrier completes. Absent / ``None`` → legacy Celery dispatch
+    # (``current_app.apply_async`` — the ``.link`` path). ``"pg_queue"`` → the
+    # fire-and-forget PG path self-chains the callback via dispatch onto PG.
+    # Named ``transport`` (a WorkflowTransport value, e.g. ``"pg_queue"``) — NOT
+    # ``backend``, to avoid confusion with ``QueueBackend`` (``"pg"``).
+    transport: NotRequired[str | None]
+
+
+class BarrierContext(TypedDict):
+    """Per-batch barrier coordination injected into a PG-dispatched header task.
+
+    The 9e fire-and-forget sibling of :class:`CallbackDescriptor`, and typed for
+    the same reason: it crosses producer → PG-queue → consumer, so the contract
+    is pinned here to catch a typo/rename at the type layer rather than as a
+    remote ``KeyError`` mid-batch. Carried as the ``_barrier_context`` kwarg on
+    ``process_file_batch`` so the consumer can claim its slot and run the barrier
+    decrement in-body (a PG-consumed task fires no Celery ``.link``).
+    """
+
+    execution_id: str
+    batch_index: int
+    callback_descriptor: CallbackDescriptor
 
 
 class Barrier(Protocol):

--- a/workers/queue_backend/barrier.py
+++ b/workers/queue_backend/barrier.py
@@ -36,9 +36,11 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Protocol, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, Protocol, TypedDict
 
 from celery import chord
+
+from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT
 
 from .fairness import FairnessKey
 from .handle import BarrierHandle
@@ -92,6 +94,11 @@ class CallbackDescriptor(TypedDict):
     kwargs: dict[str, Any]
     queue: str
     fairness_headers: dict[str, Any] | None
+    # 9e: transport the aggregating callback is fired on when the barrier
+    # completes. Absent / ``None`` → legacy Celery dispatch (``current_app``
+    # ``.apply_async`` — the ``.link`` path). ``"pg_queue"`` → the fire-and-forget
+    # PG path self-chains the callback via ``dispatch(backend=PG)``.
+    backend: NotRequired[str | None]
 
 
 class Barrier(Protocol):
@@ -112,8 +119,14 @@ class Barrier(Protocol):
         callback_queue: str,
         app_instance: Any,
         fairness: FairnessKey | None = None,
+        transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     ) -> BarrierHandle | None:
         """Enqueue ``header_tasks`` and a single callback to fire on completion.
+
+        ``transport`` is the per-execution transport (9e). Only ``PgBarrier``
+        acts on it (``pg_queue`` → fire-and-forget PG fan-out instead of Celery
+        ``.link``); the Celery/Redis substrates accept it for Protocol parity
+        and ignore it (they are only ever reached on the ``celery`` transport).
 
         ``None`` is the **sole signal** that no work was enqueued — it
         is returned exclusively when ``header_tasks`` is empty. Any
@@ -166,8 +179,10 @@ class CeleryChordBarrier:
         callback_queue: str,
         app_instance: Any,
         fairness: FairnessKey | None = None,
+        transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     ) -> BarrierHandle | None:
         """See :class:`Barrier.enqueue`."""
+        del transport  # Celery chord is only reached on the celery transport.
         # Empty-header guard goes FIRST so a zero-task run skips
         # signature construction / fairness serialisation entirely.
         # Any failure in those paths is now constrained to the

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -318,45 +318,14 @@ class PgBarrier:
                     (execution_id,),
                 )
 
-            link_signature = barrier_pg_decr_and_check.s(
+            self._dispatch_headers(
+                header_tasks,
+                is_pg=is_pg,
                 execution_id=execution_id,
                 callback_descriptor=callback_descriptor,
+                fairness=fairness,
+                fairness_headers=fairness_headers,
             )
-            link_error_signature = barrier_pg_abort.s(execution_id=execution_id)
-            for i, task in enumerate(header_tasks):
-                try:
-                    if is_pg:
-                        self._dispatch_header_pg(
-                            task, i, execution_id, callback_descriptor, fairness
-                        )
-                    else:
-                        cloned = task.clone()
-                        if fairness_headers:
-                            cloned.set(headers=fairness_headers)
-                        cloned.link(link_signature)
-                        cloned.link_error(link_error_signature)
-                        cloned.apply_async()
-                except Exception:
-                    # Mid-loop dispatch failure: i of N never reached the queue,
-                    # so the counter can't reach 0. Delete the row so an in-flight
-                    # decrement (link or in-body) finds no row and cleans up;
-                    # re-raise so the caller marks the workflow ERROR.
-                    with contextlib.suppress(Exception):
-                        _delete_barrier(execution_id)
-                    if is_pg:
-                        # On the PG path, headers dispatched before i may already
-                        # have run + committed a claim_batch marker. With the
-                        # barrier row gone, their in-flight barrier_pg_abort is a
-                        # no-op (already_aborted) and never reaches the clear
-                        # inside it — so reclaim the markers here directly.
-                        with contextlib.suppress(Exception):
-                            clear_execution_batches(execution_id)
-                    logger.exception(
-                        f"[exec:{execution_id}] header dispatch failed at task "
-                        f"{i}/{len(header_tasks)}; barrier row deleted to prevent "
-                        f"spurious callback fires from the orphan tasks."
-                    )
-                    raise
 
             logger.info(
                 f"Barrier enqueued via PgBarrier ({transport}) — "
@@ -374,6 +343,56 @@ class PgBarrier:
                 f"header_tasks={len(header_tasks)})"
             )
             raise
+
+    def _dispatch_headers(
+        self,
+        header_tasks: list[Signature],
+        *,
+        is_pg: bool,
+        execution_id: str,
+        callback_descriptor: CallbackDescriptor,
+        fairness: FairnessKey | None,
+        fairness_headers: dict[str, Any] | None,
+    ) -> None:
+        """Dispatch the N header tasks, one transport or the other.
+
+        PG path (``is_pg``) → fire-and-forget onto the PG queue via
+        :meth:`_dispatch_header_pg` (no ``.link``). Celery path → ``.link`` /
+        ``.link_error`` chord-style. On any mid-loop dispatch failure, ``i`` of N
+        never reached the queue so the counter can't reach 0 — delete the barrier
+        row (and, on the PG path, reclaim dedup markers an earlier header may have
+        committed, since the in-flight ``barrier_pg_abort`` is a no-op once the row
+        is gone) so an in-flight decrement finds nothing, then re-raise.
+        """
+        link_signature = barrier_pg_decr_and_check.s(
+            execution_id=execution_id, callback_descriptor=callback_descriptor
+        )
+        link_error_signature = barrier_pg_abort.s(execution_id=execution_id)
+        for i, task in enumerate(header_tasks):
+            try:
+                if is_pg:
+                    self._dispatch_header_pg(
+                        task, i, execution_id, callback_descriptor, fairness
+                    )
+                else:
+                    cloned = task.clone()
+                    if fairness_headers:
+                        cloned.set(headers=fairness_headers)
+                    cloned.link(link_signature)
+                    cloned.link_error(link_error_signature)
+                    cloned.apply_async()
+            except Exception:
+                with contextlib.suppress(Exception):
+                    _delete_barrier(execution_id)
+                if is_pg:
+                    with contextlib.suppress(Exception):
+                        clear_execution_batches(execution_id)
+                logger.exception(
+                    f"[exec:{execution_id}] header dispatch failed at task "
+                    f"{i}/{len(header_tasks)}; barrier row deleted to prevent "
+                    f"spurious callback fires from the orphan tasks."
+                )
+                raise
 
     @staticmethod
     def _dispatch_header_pg(

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -724,9 +724,13 @@ def run_batch_with_barrier(
       ``skipped_redelivery`` and never re-runs the batch — the barrier hangs to
       ``expires_at``. (Claiming before the work avoids re-processing on the common
       redelivery case at the cost of this crash window.)
-    - A failure *after* ``remaining`` hits 0 and the callback is committed but
-      before/at the callback enqueue: the decrement is committed, so redelivery is
-      blocked, and the abort here removes the row without the callback having run.
+    - A hard crash *between* the decrement committing (``remaining`` → 0) and the
+      callback enqueue completing: the decrement is committed (so redelivery is
+      blocked by the marker) but the process is gone before the callback is
+      enqueued and before any in-body abort can run, so the ``pg_barrier_state``
+      row survives to ``expires_at`` with no callback ever fired. (A *software*
+      callback-dispatch failure here is NOT this window — that's catchable and is
+      torn down by step 3's wrap above.)
 
     For both, the **reaper** (sweep stranded ``pg_barrier_state``, mark the
     execution ERROR / re-drive, reclaim ``pg_batch_dedup``) is the recovery net;

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -60,12 +60,14 @@ import contextlib
 import json
 import logging
 import threading
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import psycopg2
 import psycopg2.extensions
+
+from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, WorkflowTransport
 
 from .barrier import CallbackDescriptor, barrier_ttl_seconds
 from .decorator import worker_task
@@ -197,15 +199,26 @@ class PgBarrier:
         callback_queue: str,
         app_instance: Any,
         fairness: FairnessKey | None = None,
+        transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     ) -> BarrierHandle | None:
         """See :class:`queue_backend.barrier.Barrier.enqueue`.
 
         Empty ``header_tasks`` → ``None`` (caller owns the zero-files contract);
         any substrate failure raises. ``app_instance`` is accepted for Protocol
-        parity but unused — the callback is built inside the link task via
-        ``current_app`` so it runs against the worker's app.
+        parity but unused.
+
+        ``transport`` selects the fan-out mode (9e):
+
+        - ``celery`` (default, the ``WORKER_BARRIER_BACKEND=pg`` legacy path):
+          header tasks are Celery-dispatched with ``.link(barrier_pg_decr_and_check)``
+          / ``.link_error(barrier_pg_abort)``; the link drives the decrement.
+        - ``pg_queue`` (the fire-and-forget path): header tasks are dispatched onto
+          the PG queue (``dispatch(backend=PG)``) with a ``_barrier_context`` kwarg
+          carrying ``execution_id`` / ``batch_index`` / ``callback_descriptor`` —
+          a PG-consumed task fires no ``.link``, so it claims its batch and runs
+          the decrement in-body, self-chaining the callback at ``remaining`` → 0.
         """
-        del app_instance  # Protocol parity; callback built in the link task.
+        del app_instance  # Protocol parity; callback dispatched by the decrement.
         if not header_tasks:
             logger.info(
                 f"[exec:{callback_kwargs.get('execution_id')}] "
@@ -223,6 +236,7 @@ class PgBarrier:
             )
         execution_id = str(execution_id)
 
+        is_pg = transport == WorkflowTransport.PG_QUEUE.value
         try:
             fairness_headers = fairness.as_header() if fairness else None
             callback_descriptor: CallbackDescriptor = {
@@ -231,6 +245,10 @@ class PgBarrier:
                 "queue": callback_queue,
                 "fairness_headers": fairness_headers,
             }
+            if is_pg:
+                # The decrement (run in-body on the PG path) reads this to
+                # self-chain the callback onto PG rather than Celery.
+                callback_descriptor["backend"] = WorkflowTransport.PG_QUEUE.value
             ttl_seconds = barrier_ttl_seconds()
 
             with _cursor() as cur:
@@ -249,6 +267,15 @@ class PgBarrier:
                     "  created_at = now(), expires_at = EXCLUDED.expires_at",
                     (execution_id, len(header_tasks), ttl_seconds),
                 )
+                # Reset per-batch dedup markers from a prior run reusing this
+                # execution_id, ATOMICALLY with the barrier reset. Without this a
+                # re-enqueue would leave stale markers → every in-body claim_batch
+                # returns False → all batches skip → barrier hangs to expiry.
+                # (No-op pre-PR-2c: nothing writes pg_batch_dedup yet.)
+                cur.execute(
+                    "DELETE FROM pg_batch_dedup WHERE execution_id = %s",
+                    (execution_id,),
+                )
 
             link_signature = barrier_pg_decr_and_check.s(
                 execution_id=execution_id,
@@ -257,30 +284,35 @@ class PgBarrier:
             link_error_signature = barrier_pg_abort.s(execution_id=execution_id)
             for i, task in enumerate(header_tasks):
                 try:
-                    cloned = task.clone()
-                    if fairness_headers:
-                        cloned.set(headers=fairness_headers)
-                    cloned.link(link_signature)
-                    cloned.link_error(link_error_signature)
-                    cloned.apply_async()
+                    if is_pg:
+                        self._dispatch_header_pg(
+                            task, i, execution_id, callback_descriptor, fairness
+                        )
+                    else:
+                        cloned = task.clone()
+                        if fairness_headers:
+                            cloned.set(headers=fairness_headers)
+                        cloned.link(link_signature)
+                        cloned.link_error(link_error_signature)
+                        cloned.apply_async()
                 except Exception:
-                    # Mid-loop dispatch failure: i of N never reached the broker,
-                    # so the counter can't reach 0. Delete the row so in-flight
-                    # links' decrement finds no row and cleans up; re-raise so the
-                    # caller marks the workflow ERROR.
+                    # Mid-loop dispatch failure: i of N never reached the queue,
+                    # so the counter can't reach 0. Delete the row so an in-flight
+                    # decrement (link or in-body) finds no row and cleans up;
+                    # re-raise so the caller marks the workflow ERROR.
                     with contextlib.suppress(Exception):
                         _delete_barrier(execution_id)
                     logger.exception(
-                        f"[exec:{execution_id}] apply_async failed at task "
+                        f"[exec:{execution_id}] header dispatch failed at task "
                         f"{i}/{len(header_tasks)}; barrier row deleted to prevent "
-                        f"spurious callback fires from the orphan tasks' links."
+                        f"spurious callback fires from the orphan tasks."
                     )
                     raise
 
             logger.info(
-                f"Barrier enqueued via PgBarrier — exec_id={execution_id}, "
-                f"header_tasks={len(header_tasks)}, callback={callback_task_name}, "
-                f"queue={callback_queue}"
+                f"Barrier enqueued via PgBarrier ({transport}) — "
+                f"exec_id={execution_id}, header_tasks={len(header_tasks)}, "
+                f"callback={callback_task_name}, queue={callback_queue}"
             )
             return _PgBarrierHandle(id=execution_id)
 
@@ -293,6 +325,90 @@ class PgBarrier:
                 f"header_tasks={len(header_tasks)})"
             )
             raise
+
+    @staticmethod
+    def _dispatch_header_pg(
+        task: Signature,
+        batch_index: int,
+        execution_id: str,
+        callback_descriptor: CallbackDescriptor,
+        fairness: FairnessKey | None,
+    ) -> None:
+        """Dispatch one header task onto the PG queue (fire-and-forget mode).
+
+        Unpacks the Celery ``Signature`` (the fan-out built it as
+        ``app.signature(name, args=[batch], queue=...)``) and re-dispatches it via
+        ``dispatch(backend=PG)`` with a ``_barrier_context`` kwarg. The PG consumer
+        runs the task; it claims ``(execution_id, batch_index)`` and runs the
+        decrement in-body (no ``.link``). ``fairness`` carries org/priority onto
+        the row exactly as the bare-dispatch sites do.
+        """
+        # Local import to avoid an import cycle (dispatch/routing pull in queue
+        # plumbing that imports the barrier package).
+        from .dispatch import dispatch
+        from .routing import QueueBackend
+
+        header_kwargs = dict(task.kwargs or {})
+        header_kwargs["_barrier_context"] = {
+            "execution_id": execution_id,
+            "batch_index": batch_index,
+            "callback_descriptor": callback_descriptor,
+        }
+        dispatch(
+            task.task,
+            args=list(task.args or ()),
+            kwargs=header_kwargs,
+            queue=task.options.get("queue"),
+            fairness=fairness,
+            backend=QueueBackend.PG,
+        )
+
+
+def _fire_barrier_callback(
+    callback_descriptor: CallbackDescriptor, all_results: list[Any]
+) -> str:
+    """Dispatch the aggregating callback when the barrier completes; return its id.
+
+    Two transports, selected by the descriptor's ``backend`` marker:
+
+    - ``"pg_queue"`` (9e fire-and-forget PG path): self-chain the callback onto
+      the PG queue via ``dispatch(backend=PG)`` — no Celery, so the whole
+      execution stays off the broker. (The callback rides default priority; the
+      barrier's fan-out fairness has already been applied to the header tasks.)
+    - absent / anything else (legacy ``.link`` path): dispatch via
+      ``current_app.signature(...).apply_async()`` — byte-identical to pre-9e,
+      preserving the ``fairness_headers`` the producer attached.
+    """
+    if callback_descriptor.get("backend") == WorkflowTransport.PG_QUEUE.value:
+        # Local imports: avoid an import cycle (dispatch/routing pull in queue
+        # plumbing) and keep the Celery path free of the PG dispatch deps.
+        from .dispatch import dispatch
+        from .routing import QueueBackend
+
+        handle = dispatch(
+            callback_descriptor["task_name"],
+            args=[all_results],
+            kwargs=callback_descriptor["kwargs"],
+            queue=callback_descriptor["queue"],
+            backend=QueueBackend.PG,
+        )
+        return str(handle.id)
+
+    from celery import current_app
+
+    # Build the callback-signature kwargs explicitly (headers only when truthy) —
+    # matching CeleryChordBarrier's idiom, no spurious headers=None.
+    signature_kwargs: dict[str, Any] = {
+        "args": [all_results],
+        "kwargs": callback_descriptor["kwargs"],
+        "queue": callback_descriptor["queue"],
+    }
+    if callback_descriptor.get("fairness_headers"):
+        signature_kwargs["headers"] = callback_descriptor["fairness_headers"]
+    callback_signature = current_app.signature(
+        callback_descriptor["task_name"], **signature_kwargs
+    )
+    return str(callback_signature.apply_async().id)
 
 
 def _barrier_pg_decrement(
@@ -321,8 +437,6 @@ def _barrier_pg_decrement(
     mid-transaction (see the guard below). The Celery wrapper additionally pins
     ``max_retries=0``; an orphaned barrier is bounded by ``expires_at`` instead.
     """
-    from celery import current_app
-
     # Enforce the "own committed transaction" contract loudly. A caller that
     # invokes this inside an already-open transaction on the shared thread-local
     # connection would hold the row lock across the call and let the outer txn's
@@ -406,35 +520,27 @@ def _barrier_pg_decrement(
         return {"status": "abandoned", "remaining": remaining}
 
     # remaining == 0: we are the last task. psycopg2 decodes the jsonb array to
-    # a Python list already — no per-element json.loads needed. Build the kwargs
-    # explicitly (headers only when truthy) — clearer than an inline ** spread,
-    # matching CeleryChordBarrier's idiom.
-    signature_kwargs: dict[str, Any] = {
-        "args": [all_results],
-        "kwargs": callback_descriptor["kwargs"],
-        "queue": callback_descriptor["queue"],
-    }
-    if callback_descriptor.get("fairness_headers"):
-        signature_kwargs["headers"] = callback_descriptor["fairness_headers"]
-    callback_signature = current_app.signature(
-        callback_descriptor["task_name"], **signature_kwargs
-    )
-    # Dispatch FIRST; delete the row only after dispatch succeeds, so a callback
-    # apply_async failure leaves the row (and its expiry) in place rather than
-    # stranding the execution with no state and no recovery path.
-    callback_result = callback_signature.apply_async()
-    # The post-dispatch delete must not mask the successful dispatch: the callback
-    # already fired, so a delete error here is logged (not raised) — the row
-    # lingers until expiry rather than re-running the callback. No double-fire is
-    # possible: this is the last decrement (remaining hit 0) and max_retries=0, so
-    # the link task is never replayed.
+    # a Python list already — no per-element json.loads needed.
+    #
+    # Dispatch the callback FIRST; delete the row only after dispatch succeeds, so
+    # a callback dispatch failure leaves the row (and its expiry) in place rather
+    # than stranding the execution with no state and no recovery path. No
+    # double-fire is possible: this is the last decrement (remaining hit 0) and
+    # max_retries=0, so the task is never replayed.
+    callback_id = _fire_barrier_callback(callback_descriptor, all_results)
+    # Post-dispatch cleanup is best-effort: the callback already fired, so a
+    # failure here is logged (not raised) — the rows linger until reclaim rather
+    # than re-running the callback. Clear the per-batch dedup markers too (their
+    # job is done once the barrier completes); a leftover marker is bounded by
+    # the future dedup-orphan sweep, never re-runs anything.
     try:
         _delete_barrier(execution_id)
+        clear_execution_batches(execution_id)
     except Exception:
         logger.exception(
             f"[exec:{execution_id}] Barrier callback dispatched "
-            f"(callback_task_id={callback_result.id}) but the post-dispatch row "
-            f"delete failed — row will be reclaimed at expiry. Callback NOT "
+            f"(callback_task_id={callback_id}) but the post-dispatch cleanup "
+            f"failed — rows will be reclaimed by expiry/sweep. Callback NOT "
             f"re-run (max_retries=0)."
         )
 
@@ -442,11 +548,11 @@ def _barrier_pg_decrement(
         f"[exec:{execution_id}] Barrier complete — fired callback "
         f"{callback_descriptor['task_name']} on {callback_descriptor['queue']} "
         f"with {len(all_results)} aggregated results "
-        f"(callback_task_id={callback_result.id})"
+        f"(callback_task_id={callback_id})"
     )
     return {
         "status": "complete",
-        "callback_task_id": callback_result.id,
+        "callback_task_id": callback_id,
         "aggregated_count": len(all_results),
     }
 
@@ -510,8 +616,70 @@ def barrier_pg_abort(
         # Another failure already aborted this execution (or it's already gone).
         return {"status": "already_aborted", "execution_id": execution_id}
 
+    # We won the abort: reclaim the per-batch dedup markers too (best-effort —
+    # the barrier is already torn down). A leftover marker would otherwise linger
+    # until the future dedup-orphan sweep; it can never re-run anything.
+    with contextlib.suppress(Exception):
+        clear_execution_batches(execution_id)
+
     logger.error(
         f"[exec:{execution_id}] PgBarrier aborted — a header task failed; "
         f"barrier state cleaned up (aggregating callback will not fire)."
     )
     return {"status": "aborted", "execution_id": execution_id}
+
+
+def run_batch_with_barrier(
+    barrier_context: dict[str, Any], work_fn: Callable[[], dict[str, Any]]
+) -> dict[str, Any]:
+    """Run a fire-and-forget PG-path batch under the barrier protocol (9e PR 2c).
+
+    A PG-consumed header task fires no Celery ``.link``, so the barrier
+    coordination runs in-body here, given the ``_barrier_context`` that
+    :meth:`PgBarrier._dispatch_header_pg` injected (``execution_id`` /
+    ``batch_index`` / ``callback_descriptor``):
+
+    1. **Claim** ``(execution_id, batch_index)``. A redelivery (at-least-once
+       queue) finds the marker already set → returns a no-op result WITHOUT
+       re-running the work or re-decrementing — exactly-once decrement.
+    2. **Run** ``work_fn()`` (the batch). On exception there is no ``.link_error``,
+       so tear the barrier down in-body via :func:`barrier_pg_abort` (mirrors the
+       chord path's failure semantic — the callback won't fire) and re-raise.
+    3. **Decrement** the barrier with the batch result; the task that drives
+       ``remaining`` → 0 self-chains the aggregating callback onto PG.
+
+    ``work_fn`` must return the JSON-serialisable batch result (the same dict the
+    Celery chord path returns), since the decrement appends it to the barrier's
+    aggregated results that the callback receives.
+    """
+    execution_id = str(barrier_context["execution_id"])
+    batch_index = int(barrier_context["batch_index"])
+
+    if not claim_batch(execution_id, batch_index):
+        logger.info(
+            f"[exec:{execution_id}] batch {batch_index} already claimed — "
+            f"redelivery, skipping (barrier already decremented for this batch)."
+        )
+        return {
+            "status": "skipped_redelivery",
+            "execution_id": execution_id,
+            "batch_index": batch_index,
+        }
+
+    try:
+        result = work_fn()
+    except Exception:
+        with contextlib.suppress(Exception):
+            barrier_pg_abort(execution_id=execution_id)
+        logger.exception(
+            f"[exec:{execution_id}] batch {batch_index} failed — barrier torn "
+            f"down in-body (no .link_error on the PG path); execution fails fast."
+        )
+        raise
+
+    _barrier_pg_decrement(
+        result,
+        execution_id=execution_id,
+        callback_descriptor=barrier_context["callback_descriptor"],
+    )
+    return result

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -67,9 +67,13 @@ from typing import TYPE_CHECKING, Any
 import psycopg2
 import psycopg2.extensions
 
-from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, WorkflowTransport
+from unstract.core.data_models import (
+    DEFAULT_WORKFLOW_TRANSPORT,
+    WorkflowTransport,
+    is_pg_transport,
+)
 
-from .barrier import CallbackDescriptor, barrier_ttl_seconds
+from .barrier import BarrierContext, CallbackDescriptor, barrier_ttl_seconds
 from .decorator import worker_task
 from .fairness import FairnessKey
 from .handle import BarrierHandle
@@ -139,8 +143,8 @@ def claim_batch(execution_id: str, batch_index: int) -> bool:
     batch resolve to exactly one ``True`` (the row's existence is the token) with
     no race.
 
-    Inert in 9e PR 2b — wired into ``process_file_batch`` (claim at batch start)
-    in PR 2c, alongside the in-body decrement. The companion
+    Called on the in-body PG path from :func:`run_batch_with_barrier` (claim at
+    batch start), alongside the in-body decrement. The companion
     :func:`clear_execution_batches` reclaims the markers at barrier finalise.
     """
     with _cursor() as cur:
@@ -166,11 +170,43 @@ def clear_execution_batches(execution_id: str) -> int:
     0). Uses the ``(execution_id, batch_index)`` constraint index (``execution_id``
     leading) for the lookup.
 
-    Inert in 9e PR 2b — wired into the barrier-finalise path in PR 2c.
+    Called from the barrier-finalise + abort paths.
     """
     with _cursor() as cur:
         cur.execute("DELETE FROM pg_batch_dedup WHERE execution_id = %s", (execution_id,))
         return cur.rowcount
+
+
+def _dispatch_pg(
+    task_name: str,
+    *,
+    args: list[Any] | None = None,
+    kwargs: dict[str, Any] | None = None,
+    queue: str | None,
+    fairness: FairnessKey | None = None,
+) -> Any:
+    """Enqueue a task onto the PG queue (the one place that owns the cycle-avoiding
+    local imports + the ``backend=QueueBackend.PG`` argument).
+
+    Both the header fan-out (:meth:`PgBarrier._dispatch_header_pg`) and the
+    self-chained callback (:func:`_fire_barrier_callback`) route through here.
+    Returns the ``dispatch`` handle. ``queue`` is required (may be ``None`` only
+    if the caller has already logged the fallback) — a ``None`` queue makes
+    ``dispatch`` fall back to its default PG queue.
+    """
+    # Local import: dispatch/routing pull in queue plumbing that imports the
+    # barrier package — importing at module load would be a cycle.
+    from .dispatch import dispatch
+    from .routing import QueueBackend
+
+    return dispatch(
+        task_name,
+        args=args,
+        kwargs=kwargs,
+        queue=queue,
+        fairness=fairness,
+        backend=QueueBackend.PG,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -236,7 +272,7 @@ class PgBarrier:
             )
         execution_id = str(execution_id)
 
-        is_pg = transport == WorkflowTransport.PG_QUEUE.value
+        is_pg = is_pg_transport(transport)
         try:
             fairness_headers = fairness.as_header() if fairness else None
             callback_descriptor: CallbackDescriptor = {
@@ -248,7 +284,7 @@ class PgBarrier:
             if is_pg:
                 # The decrement (run in-body on the PG path) reads this to
                 # self-chain the callback onto PG rather than Celery.
-                callback_descriptor["backend"] = WorkflowTransport.PG_QUEUE.value
+                callback_descriptor["transport"] = WorkflowTransport.PG_QUEUE.value
             ttl_seconds = barrier_ttl_seconds()
 
             with _cursor() as cur:
@@ -271,7 +307,7 @@ class PgBarrier:
                 # execution_id, ATOMICALLY with the barrier reset. Without this a
                 # re-enqueue would leave stale markers → every in-body claim_batch
                 # returns False → all batches skip → barrier hangs to expiry.
-                # (No-op pre-PR-2c: nothing writes pg_batch_dedup yet.)
+                # (Markers are written by claim_batch() on the in-body PG path.)
                 cur.execute(
                     "DELETE FROM pg_batch_dedup WHERE execution_id = %s",
                     (execution_id,),
@@ -337,30 +373,36 @@ class PgBarrier:
         """Dispatch one header task onto the PG queue (fire-and-forget mode).
 
         Unpacks the Celery ``Signature`` (the fan-out built it as
-        ``app.signature(name, args=[batch], queue=...)``) and re-dispatches it via
-        ``dispatch(backend=PG)`` with a ``_barrier_context`` kwarg. The PG consumer
-        runs the task; it claims ``(execution_id, batch_index)`` and runs the
-        decrement in-body (no ``.link``). ``fairness`` carries org/priority onto
-        the row exactly as the bare-dispatch sites do.
+        ``app.signature(name, kwargs={batch_files, batch_index, total_batches},
+        queue=...)`` — the batch payload is in ``kwargs``) and re-dispatches it via
+        :func:`_dispatch_pg` with an added ``_barrier_context`` kwarg. The PG
+        consumer runs the task; it claims ``(execution_id, batch_index)`` and runs
+        the decrement in-body (no ``.link``). ``fairness`` carries org/priority
+        onto the row exactly as the bare-dispatch sites do.
         """
-        # Local import to avoid an import cycle (dispatch/routing pull in queue
-        # plumbing that imports the barrier package).
-        from .dispatch import dispatch
-        from .routing import QueueBackend
-
-        header_kwargs = dict(task.kwargs or {})
-        header_kwargs["_barrier_context"] = {
+        barrier_context: BarrierContext = {
             "execution_id": execution_id,
             "batch_index": batch_index,
             "callback_descriptor": callback_descriptor,
         }
-        dispatch(
+        header_kwargs = dict(task.kwargs or {})
+        header_kwargs["_barrier_context"] = barrier_context
+        queue = task.options.get("queue")
+        if queue is None:
+            # The fan-out always sets a queue; a missing one would silently route
+            # to dispatch's default PG queue (off the intended file-processing
+            # queue), so surface it rather than let it slip by.
+            logger.warning(
+                f"[exec:{execution_id}] header task {task.task!r} (batch "
+                f"{batch_index}) has no queue option — falling back to the default "
+                f"PG queue; the consumer for the intended queue won't see it."
+            )
+        _dispatch_pg(
             task.task,
             args=list(task.args or ()),
             kwargs=header_kwargs,
-            queue=task.options.get("queue"),
+            queue=queue,
             fairness=fairness,
-            backend=QueueBackend.PG,
         )
 
 
@@ -369,28 +411,22 @@ def _fire_barrier_callback(
 ) -> str:
     """Dispatch the aggregating callback when the barrier completes; return its id.
 
-    Two transports, selected by the descriptor's ``backend`` marker:
+    Two transports, selected by the descriptor's ``transport`` marker:
 
     - ``"pg_queue"`` (9e fire-and-forget PG path): self-chain the callback onto
-      the PG queue via ``dispatch(backend=PG)`` — no Celery, so the whole
-      execution stays off the broker. (The callback rides default priority; the
-      barrier's fan-out fairness has already been applied to the header tasks.)
+      the PG queue via :func:`_dispatch_pg` — no Celery, so the whole execution
+      stays off the broker. (The callback rides default priority; the barrier's
+      fan-out fairness has already been applied to the header tasks.)
     - absent / anything else (legacy ``.link`` path): dispatch via
       ``current_app.signature(...).apply_async()`` — byte-identical to pre-9e,
       preserving the ``fairness_headers`` the producer attached.
     """
-    if callback_descriptor.get("backend") == WorkflowTransport.PG_QUEUE.value:
-        # Local imports: avoid an import cycle (dispatch/routing pull in queue
-        # plumbing) and keep the Celery path free of the PG dispatch deps.
-        from .dispatch import dispatch
-        from .routing import QueueBackend
-
-        handle = dispatch(
+    if is_pg_transport(callback_descriptor.get("transport")):
+        handle = _dispatch_pg(
             callback_descriptor["task_name"],
             args=[all_results],
             kwargs=callback_descriptor["kwargs"],
             queue=callback_descriptor["queue"],
-            backend=QueueBackend.PG,
         )
         return str(handle.id)
 
@@ -530,18 +566,25 @@ def _barrier_pg_decrement(
     callback_id = _fire_barrier_callback(callback_descriptor, all_results)
     # Post-dispatch cleanup is best-effort: the callback already fired, so a
     # failure here is logged (not raised) — the rows linger until reclaim rather
-    # than re-running the callback. Clear the per-batch dedup markers too (their
-    # job is done once the barrier completes); a leftover marker is bounded by
-    # the future dedup-orphan sweep, never re-runs anything.
+    # than re-running the callback. The two cleanups are independent so one
+    # failing doesn't skip the other and each names what failed: the barrier row
+    # is reclaimed by expiry, the dedup markers by the (PR-3-blocking) dedup-orphan
+    # sweep — neither re-runs anything (this is the last decrement, max_retries=0).
     try:
         _delete_barrier(execution_id)
+    except Exception:
+        logger.exception(
+            f"[exec:{execution_id}] Barrier callback dispatched "
+            f"(callback_task_id={callback_id}) but deleting the pg_barrier_state "
+            f"row failed — reclaimed at expiry. Callback NOT re-run."
+        )
+    try:
         clear_execution_batches(execution_id)
     except Exception:
         logger.exception(
             f"[exec:{execution_id}] Barrier callback dispatched "
-            f"(callback_task_id={callback_id}) but the post-dispatch cleanup "
-            f"failed — rows will be reclaimed by expiry/sweep. Callback NOT "
-            f"re-run (max_retries=0)."
+            f"(callback_task_id={callback_id}) but clearing pg_batch_dedup markers "
+            f"failed — reclaimed by the dedup-orphan sweep. Callback NOT re-run."
         )
 
     logger.info(
@@ -629,8 +672,30 @@ def barrier_pg_abort(
     return {"status": "aborted", "execution_id": execution_id}
 
 
+def _abort_barrier_in_body(execution_id: str, *, reason: str) -> None:
+    """Tear the barrier down from the in-body PG path (no ``.link_error`` here).
+
+    Best-effort: a batch failure and a DB failure are correlated, so the abort
+    itself can fail — that's logged (not swallowed silently) so a stuck barrier
+    isn't masked by a misleading "torn down" message. A failed teardown bottoms
+    out at the barrier's ``expires_at`` and is reclaimed by the reaper.
+    """
+    try:
+        barrier_pg_abort(execution_id=execution_id)
+        logger.error(
+            f"[exec:{execution_id}] {reason} — barrier teardown attempted in-body "
+            f"(no .link_error on the PG path); aggregating callback won't fire."
+        )
+    except Exception:
+        logger.exception(
+            f"[exec:{execution_id}] {reason} AND the in-body barrier teardown "
+            f"itself failed — barrier will hang until expiry and be reclaimed by "
+            f"the reaper (max_retries=0, no replay)."
+        )
+
+
 def run_batch_with_barrier(
-    barrier_context: dict[str, Any], work_fn: Callable[[], dict[str, Any]]
+    barrier_context: BarrierContext, work_fn: Callable[[], dict[str, Any]]
 ) -> dict[str, Any]:
     """Run a fire-and-forget PG-path batch under the barrier protocol (9e PR 2c).
 
@@ -642,11 +707,30 @@ def run_batch_with_barrier(
     1. **Claim** ``(execution_id, batch_index)``. A redelivery (at-least-once
        queue) finds the marker already set → returns a no-op result WITHOUT
        re-running the work or re-decrementing — exactly-once decrement.
-    2. **Run** ``work_fn()`` (the batch). On exception there is no ``.link_error``,
-       so tear the barrier down in-body via :func:`barrier_pg_abort` (mirrors the
-       chord path's failure semantic — the callback won't fire) and re-raise.
+    2. **Run** ``work_fn()`` (the batch).
     3. **Decrement** the barrier with the batch result; the task that drives
        ``remaining`` → 0 self-chains the aggregating callback onto PG.
+
+    Steps 2 *and* 3 are wrapped: any catchable failure (work error, the decrement
+    guard / DB error, or the last-batch callback dispatch failing) tears the
+    barrier down in-body via :func:`barrier_pg_abort` and re-raises, so it fails
+    fast instead of hanging to expiry — mirroring the chord path's ``.link_error``.
+
+    **Strand windows the reaper must cover (NOT catchable here — hard merge
+    dependency for enabling the flag in PR 3, see the module / PgBatchDedup docs):**
+
+    - A hard crash / SIGKILL / visibility-timeout expiry *during* ``work_fn()``
+      leaves the dedup marker committed (claim is step 1), so redelivery returns
+      ``skipped_redelivery`` and never re-runs the batch — the barrier hangs to
+      ``expires_at``. (Claiming before the work avoids re-processing on the common
+      redelivery case at the cost of this crash window.)
+    - A failure *after* ``remaining`` hits 0 and the callback is committed but
+      before/at the callback enqueue: the decrement is committed, so redelivery is
+      blocked, and the abort here removes the row without the callback having run.
+
+    For both, the **reaper** (sweep stranded ``pg_barrier_state``, mark the
+    execution ERROR / re-drive, reclaim ``pg_batch_dedup``) is the recovery net;
+    it must be live before PR 3 flips ``pg_queue_execution_enabled``.
 
     ``work_fn`` must return the JSON-serialisable batch result (the same dict the
     Celery chord path returns), since the decrement appends it to the barrier's
@@ -666,20 +750,18 @@ def run_batch_with_barrier(
             "batch_index": batch_index,
         }
 
+    # Wrap BOTH the work and the decrement: a decrement-side failure (the
+    # open-transaction guard, a json/DB error, or the last-batch callback dispatch
+    # raising) must also tear the barrier down, else the marker is committed,
+    # redelivery is blocked, and the barrier strands to expiry.
     try:
         result = work_fn()
-    except Exception:
-        with contextlib.suppress(Exception):
-            barrier_pg_abort(execution_id=execution_id)
-        logger.exception(
-            f"[exec:{execution_id}] batch {batch_index} failed — barrier torn "
-            f"down in-body (no .link_error on the PG path); execution fails fast."
+        _barrier_pg_decrement(
+            result,
+            execution_id=execution_id,
+            callback_descriptor=barrier_context["callback_descriptor"],
         )
+    except Exception:
+        _abort_barrier_in_body(execution_id, reason=f"batch {batch_index} failed")
         raise
-
-    _barrier_pg_decrement(
-        result,
-        execution_id=execution_id,
-        callback_descriptor=barrier_context["callback_descriptor"],
-    )
     return result

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -75,7 +75,12 @@ from unstract.core.data_models import (
 
 from .barrier import BarrierContext, CallbackDescriptor, barrier_ttl_seconds
 from .decorator import worker_task
-from .fairness import FairnessKey
+from .fairness import (
+    DEFAULT_PRIORITY,
+    FAIRNESS_HEADER_NAME,
+    FairnessKey,
+    WorkloadType,
+)
 from .handle import BarrierHandle
 from .pg_queue.connection import create_pg_connection
 
@@ -338,6 +343,14 @@ class PgBarrier:
                     # re-raise so the caller marks the workflow ERROR.
                     with contextlib.suppress(Exception):
                         _delete_barrier(execution_id)
+                    if is_pg:
+                        # On the PG path, headers dispatched before i may already
+                        # have run + committed a claim_batch marker. With the
+                        # barrier row gone, their in-flight barrier_pg_abort is a
+                        # no-op (already_aborted) and never reaches the clear
+                        # inside it — so reclaim the markers here directly.
+                        with contextlib.suppress(Exception):
+                            clear_execution_batches(execution_id)
                     logger.exception(
                         f"[exec:{execution_id}] header dispatch failed at task "
                         f"{i}/{len(header_tasks)}; barrier row deleted to prevent "
@@ -406,6 +419,27 @@ class PgBarrier:
         )
 
 
+def _fairness_from_headers(
+    fairness_headers: dict[str, Any] | None,
+) -> FairnessKey | None:
+    """Reconstruct a :class:`FairnessKey` from the stored ``x-fairness-key`` header.
+
+    The descriptor carries the wire-shape headers (``FairnessKey.as_header()``),
+    but the PG dispatch path wants the ``FairnessKey`` itself (``dispatch`` writes
+    ``org_id`` + ``pipeline_priority`` onto the row). Reconstructing keeps the PG
+    callback at the producer's org/priority — parity with the Celery path, which
+    applies the headers directly. ``None`` when the producer attached no key.
+    """
+    payload = (fairness_headers or {}).get(FAIRNESS_HEADER_NAME)
+    if not payload:
+        return None
+    return FairnessKey(
+        org_id=payload.get("org_id"),
+        workload_type=WorkloadType(payload["workload_type"]),
+        pipeline_priority=payload.get("pipeline_priority", DEFAULT_PRIORITY),
+    )
+
+
 def _fire_barrier_callback(
     callback_descriptor: CallbackDescriptor, all_results: list[Any]
 ) -> str:
@@ -414,9 +448,10 @@ def _fire_barrier_callback(
     Two transports, selected by the descriptor's ``transport`` marker:
 
     - ``"pg_queue"`` (9e fire-and-forget PG path): self-chain the callback onto
-      the PG queue via :func:`_dispatch_pg` — no Celery, so the whole execution
-      stays off the broker. (The callback rides default priority; the barrier's
-      fan-out fairness has already been applied to the header tasks.)
+      the PG queue via :func:`_dispatch_pg`, carrying the producer's fairness
+      (reconstructed from the stored headers) so the callback rides the same
+      org/priority as the Celery path — no Celery, so the whole execution stays
+      off the broker.
     - absent / anything else (legacy ``.link`` path): dispatch via
       ``current_app.signature(...).apply_async()`` — byte-identical to pre-9e,
       preserving the ``fairness_headers`` the producer attached.
@@ -427,6 +462,7 @@ def _fire_barrier_callback(
             args=[all_results],
             kwargs=callback_descriptor["kwargs"],
             queue=callback_descriptor["queue"],
+            fairness=_fairness_from_headers(callback_descriptor.get("fairness_headers")),
         )
         return str(handle.id)
 

--- a/workers/queue_backend/redis_barrier.py
+++ b/workers/queue_backend/redis_barrier.py
@@ -69,6 +69,7 @@ from typing import TYPE_CHECKING, Any
 from celery.canvas import Signature
 
 from unstract.core.cache.redis_client import create_redis_client
+from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT
 
 from .barrier import (
     _DEFAULT_BARRIER_TTL_SECONDS,
@@ -313,10 +314,13 @@ class RedisDecrBarrier:
         callback_queue: str,
         app_instance: Any,
         fairness: FairnessKey | None = None,
+        transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     ) -> BarrierHandle | None:
         """See :class:`queue_backend.barrier.Barrier.enqueue`.
 
-        Mirrors ``CeleryChordBarrier.enqueue`` semantics:
+        ``transport`` is accepted for Protocol parity and ignored — the Redis
+        barrier is the Celery-transport fan-in substrate (the PG transport uses
+        ``PgBarrier``'s fire-and-forget mode). Mirrors ``CeleryChordBarrier``:
 
         - Empty ``header_tasks`` → ``None`` (caller handles the
           zero-files contract); no Redis keys touched.
@@ -337,7 +341,7 @@ class RedisDecrBarrier:
         """
         # Explicit ``del`` documents the Protocol-parity intent and
         # satisfies static linters' unused-parameter check.
-        del app_instance
+        del app_instance, transport
         if not header_tasks:
             execution_id = callback_kwargs.get("execution_id")
             pipeline_id = callback_kwargs.get("pipeline_id")

--- a/workers/shared/workflow/execution/orchestration_utils.py
+++ b/workers/shared/workflow/execution/orchestration_utils.py
@@ -10,6 +10,9 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from queue_backend import BarrierHandle, FairnessKey, get_barrier
+from queue_backend.pg_barrier import PgBarrier
+
+from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, WorkflowTransport
 
 from ...enums import FileDestinationType, PipelineType
 from ...enums.worker_enums import QueueName
@@ -17,16 +20,29 @@ from ...infrastructure.logging import WorkerLogger
 
 if TYPE_CHECKING:
     from celery.canvas import Signature
+    from queue_backend import Barrier
 
 logger = WorkerLogger.get_logger(__name__)
 
 # Single ``Barrier`` instance reused across all
-# ``WorkflowOrchestrationUtils.create_chord_execution`` calls. The
-# substrate is selected at module-import (worker startup) time by the
-# ``WORKER_BARRIER_BACKEND`` env var (default ``chord``). Flag flips
-# require a pod restart — same posture as every other ``WORKER_*``
-# env in the codebase.
+# ``WorkflowOrchestrationUtils.create_chord_execution`` calls on the **celery**
+# transport. The substrate is selected at module-import (worker startup) time by
+# the ``WORKER_BARRIER_BACKEND`` env var (default ``chord``). Flag flips require a
+# pod restart — same posture as every other ``WORKER_*`` env in the codebase.
 _BARRIER = get_barrier()
+
+
+def _barrier_for_transport(transport: str) -> Barrier:
+    """Pick the fan-in substrate for a per-execution transport (9e).
+
+    The ``pg_queue`` transport always coordinates on Postgres — it uses a fresh
+    :class:`PgBarrier` in its fire-and-forget mode regardless of
+    ``WORKER_BARRIER_BACKEND`` (the env-selected singleton is the *celery*-transport
+    substrate, which may be ``chord``). Every other transport uses that singleton.
+    """
+    if transport == WorkflowTransport.PG_QUEUE.value:
+        return PgBarrier()
+    return _BARRIER
 
 
 class WorkflowOrchestrationUtils:
@@ -41,6 +57,7 @@ class WorkflowOrchestrationUtils:
         app_instance: Any,
         *,
         fairness: FairnessKey | None = None,
+        transport: str = DEFAULT_WORKFLOW_TRANSPORT,
     ) -> BarrierHandle | None:
         """Standardized fan-out + callback pattern (Phase 6 ``Barrier``).
 
@@ -71,13 +88,14 @@ class WorkflowOrchestrationUtils:
             parent that direct pipeline status updates should be
             handled instead.
         """
-        return _BARRIER.enqueue(
+        return _barrier_for_transport(transport).enqueue(
             batch_tasks,
             callback_task_name=callback_task_name,
             callback_kwargs=callback_kwargs,
             callback_queue=callback_queue,
             app_instance=app_instance,
             fairness=fairness,
+            transport=transport,
         )
 
     @staticmethod

--- a/workers/shared/workflow/execution/orchestration_utils.py
+++ b/workers/shared/workflow/execution/orchestration_utils.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from queue_backend import BarrierHandle, FairnessKey, get_barrier
 from queue_backend.pg_barrier import PgBarrier
 
-from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, WorkflowTransport
+from unstract.core.data_models import DEFAULT_WORKFLOW_TRANSPORT, is_pg_transport
 
 from ...enums import FileDestinationType, PipelineType
 from ...enums.worker_enums import QueueName
@@ -40,7 +40,7 @@ def _barrier_for_transport(transport: str) -> Barrier:
     ``WORKER_BARRIER_BACKEND`` (the env-selected singleton is the *celery*-transport
     substrate, which may be ``chord``). Every other transport uses that singleton.
     """
-    if transport == WorkflowTransport.PG_QUEUE.value:
+    if is_pg_transport(transport):
         return PgBarrier()
     return _BARRIER
 

--- a/workers/tests/test_barrier.py
+++ b/workers/tests/test_barrier.py
@@ -392,6 +392,8 @@ class TestOrchestrationUtilsRoutesThroughSingleton:
                 fairness=fairness,
             )
 
+        # Default transport (celery) → the env-selected singleton, with the
+        # per-execution transport threaded through to the substrate (9e).
         mock_barrier.enqueue.assert_called_once_with(
             batch,
             callback_task_name="process_batch_callback_api",
@@ -399,6 +401,40 @@ class TestOrchestrationUtilsRoutesThroughSingleton:
             callback_queue="api_file_processing_callback",
             app_instance=app_mock,
             fairness=fairness,
+            transport="celery",
+        )
+
+    def test_pg_queue_transport_bypasses_singleton_for_pgbarrier(self):
+        # 9e: a pg_queue execution must coordinate on Postgres regardless of
+        # WORKER_BARRIER_BACKEND, so it uses a fresh PgBarrier — NOT the (possibly
+        # chord) singleton. Pin that the singleton's enqueue is never called.
+        from shared.workflow.execution import orchestration_utils
+        from shared.workflow.execution.orchestration_utils import (
+            WorkflowOrchestrationUtils,
+        )
+
+        app_mock = MagicMock(name="celery_app")
+        batch = [MagicMock(name="h1")]
+
+        with (
+            patch.object(orchestration_utils, "_BARRIER") as mock_singleton,
+            patch.object(orchestration_utils, "PgBarrier") as mock_pgbarrier_cls,
+        ):
+            WorkflowOrchestrationUtils.create_chord_execution(
+                batch_tasks=batch,
+                callback_task_name="process_batch_callback",
+                callback_kwargs={"execution_id": "exec-pg"},
+                callback_queue="general",
+                app_instance=app_mock,
+                transport="pg_queue",
+            )
+
+        mock_singleton.enqueue.assert_not_called()  # NOT the env singleton
+        mock_pgbarrier_cls.assert_called_once_with()  # a fresh PgBarrier
+        mock_pgbarrier_cls.return_value.enqueue.assert_called_once()
+        assert (
+            mock_pgbarrier_cls.return_value.enqueue.call_args.kwargs["transport"]
+            == "pg_queue"
         )
 
 

--- a/workers/tests/test_chord_callback_boundary.py
+++ b/workers/tests/test_chord_callback_boundary.py
@@ -767,5 +767,45 @@ class TestRealConsumerTolerance:
         assert aggregated["batches_processed"] == 2
 
 
+class TestProcessFileBatchTransportRouting:
+    """9e PR 2c: ``_process_file_batch_core`` routes by ``barrier_context`` —
+    Celery chord path runs the stages directly (the chord ``.link`` decrements);
+    the PG path wraps them in ``run_batch_with_barrier`` (in-body claim + decrement).
+    """
+
+    def test_celery_path_runs_stages_directly(self, monkeypatch):
+        from file_processing import tasks as tasks_mod
+
+        monkeypatch.setattr(tasks_mod, "_run_batch_stages", lambda *a: {"r": "celery"})
+        barrier_calls = []
+        monkeypatch.setattr(
+            tasks_mod,
+            "run_batch_with_barrier",
+            lambda *a, **k: barrier_calls.append(1),
+        )
+        out = tasks_mod._process_file_batch_core(MagicMock(), {"fb": 1}, None)
+        assert out == {"r": "celery"}
+        assert barrier_calls == []  # barrier path NOT taken on the celery transport
+
+    def test_pg_path_routes_through_barrier(self, monkeypatch):
+        from file_processing import tasks as tasks_mod
+
+        monkeypatch.setattr(tasks_mod, "_run_batch_stages", lambda *a: {"r": "work"})
+        captured = {}
+
+        def fake_run_batch_with_barrier(ctx, work_fn):
+            captured["ctx"] = ctx
+            return {"via": "barrier", "work": work_fn()}
+
+        monkeypatch.setattr(
+            tasks_mod, "run_batch_with_barrier", fake_run_batch_with_barrier
+        )
+        ctx = {"execution_id": "e", "batch_index": 0, "callback_descriptor": {}}
+        out = tasks_mod._process_file_batch_core(MagicMock(), {"fb": 1}, ctx)
+        assert captured["ctx"] is ctx
+        assert out["via"] == "barrier"
+        assert out["work"] == {"r": "work"}  # work_fn runs the real stages
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -613,6 +613,36 @@ class TestPgFireAndForgetMode:
         assert mock_dispatch.call_args.kwargs["backend"] is QueueBackend.PG
         assert mock_dispatch.call_args.kwargs["args"] == [[{"r": 1}]]
 
+    def test_fire_barrier_callback_pg_carries_fairness(self):
+        # greptile: the PG callback must ride the producer's org/priority (parity
+        # with the Celery path), reconstructed from the stored fairness_headers.
+        descriptor = {
+            **_CALLBACK,
+            "transport": "pg_queue",
+            "fairness_headers": {
+                FAIRNESS_HEADER_NAME: {
+                    "org_id": "org-9",
+                    "workload_type": "api",
+                    "pipeline_priority": 8,
+                }
+            },
+        }
+        with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
+            mock_dispatch.return_value = MagicMock(id="pg-cb")
+            _fire_barrier_callback(descriptor, [{"r": 1}])
+        fairness = mock_dispatch.call_args.kwargs["fairness"]
+        assert fairness is not None
+        assert fairness.org_id == "org-9"
+        assert fairness.pipeline_priority == 8
+
+    def test_fire_barrier_callback_pg_without_fairness_passes_none(self):
+        # No producer key → None (dispatch writes neutral defaults), not a crash.
+        descriptor = {**_CALLBACK, "transport": "pg_queue"}  # fairness_headers None
+        with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
+            mock_dispatch.return_value = MagicMock(id="pg-cb")
+            _fire_barrier_callback(descriptor, [{"r": 1}])
+        assert mock_dispatch.call_args.kwargs["fairness"] is None
+
     def test_fire_barrier_callback_legacy_uses_celery(self):
         # No backend marker → the .link-mode Celery dispatch (unchanged).
         with patch("celery.current_app.signature") as sig:
@@ -689,12 +719,15 @@ class TestPgFireAndForgetMode:
                 run_batch_with_barrier(ctx, lambda: {"ok": 1})
         assert _row(barrier_db, "exec-decfail") is None  # barrier torn down
 
-    def test_pg_mid_loop_dispatch_failure_deletes_row(self, barrier_db):
+    def test_pg_mid_loop_dispatch_failure_deletes_row_and_clears_dedup(self, barrier_db):
         # The PG-branch counterpart of test_mid_loop_dispatch_failure_deletes_row:
-        # a header PG-dispatch failure mid fan-out deletes the barrier row so an
-        # in-flight in-body decrement finds no row and cleans up.
+        # a header PG-dispatch failure mid fan-out deletes the barrier row AND
+        # reclaims dedup markers (greptile #2069) — an already-claimed earlier
+        # header's marker would otherwise orphan, since the in-flight abort is a
+        # no-op once the barrier row is gone.
         with barrier_db.cursor() as cur:
             cur.execute("DELETE FROM pg_batch_dedup")
+        claim_batch("exec-midfail", 0)  # an earlier header already claimed its slot
         with patch(
             "queue_backend.dispatch.dispatch",
             side_effect=[MagicMock(id="1"), RuntimeError("broker down")],
@@ -709,6 +742,12 @@ class TestPgFireAndForgetMode:
                     transport="pg_queue",
                 )
         assert _row(barrier_db, "exec-midfail") is None  # row deleted on failure
+        with barrier_db.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pg_batch_dedup WHERE execution_id = %s",
+                ("exec-midfail",),
+            )
+            assert cur.fetchone()[0] == 0  # markers reclaimed, not orphaned
 
 
 if __name__ == "__main__":

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -24,10 +24,24 @@ from queue_backend.handle import BarrierHandle
 from queue_backend.pg_barrier import (
     PgBarrier,
     _barrier_pg_decrement,
+    _fire_barrier_callback,
     barrier_pg_abort,
     barrier_pg_decr_and_check,
+    claim_batch,
+    run_batch_with_barrier,
 )
 from queue_backend.pg_queue.connection import create_pg_connection
+from queue_backend.routing import QueueBackend
+
+
+def _pg_header(task_name="process_file_batch", args=None, queue="file_processing"):
+    """A Celery-Signature-shaped stub for the PG-fan-out path (.task/.args/.kwargs/.options)."""
+    sig = MagicMock(name="pg_header_signature")
+    sig.task = task_name
+    sig.args = args if args is not None else [{"file": "f1"}]
+    sig.kwargs = {}
+    sig.options = {"queue": queue}
+    return sig
 
 _CALLBACK = {
     "task_name": "process_batch_callback_api",
@@ -476,6 +490,142 @@ class TestDbConstraint:
                     "(execution_id, remaining, results, created_at, expires_at) "
                     "VALUES ('bad', 1, '[]'::jsonb, now(), now())"  # expires == created
                 )
+
+
+class TestPgFireAndForgetMode:
+    """9e PR 2c — PgBarrier's ``transport="pg_queue"`` fire-and-forget path:
+    headers dispatched onto PG (no ``.link``), in-body claim + decrement, callback
+    self-chained onto PG, and dedup-marker cleanup at enqueue/finalise/abort.
+    """
+
+    def test_enqueue_pg_mode_dispatches_headers_via_pg_with_context(self, barrier_db):
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        headers = [_pg_header(), _pg_header()]
+        with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
+            PgBarrier().enqueue(
+                headers,
+                callback_task_name="process_batch_callback",
+                callback_kwargs={"execution_id": "exec-pg"},
+                callback_queue="general",
+                app_instance=None,
+                transport="pg_queue",
+            )
+        assert mock_dispatch.call_count == 2  # one per header, no .link
+        # Each header carries its _barrier_context (incl. its batch_index) + the
+        # callback descriptor marked backend=pg_queue, dispatched backend=PG.
+        for i, call in enumerate(mock_dispatch.call_args_list):
+            assert call.kwargs["backend"] is QueueBackend.PG
+            ctx = call.kwargs["kwargs"]["_barrier_context"]
+            assert ctx["execution_id"] == "exec-pg"
+            assert ctx["batch_index"] == i
+            assert ctx["callback_descriptor"]["backend"] == "pg_queue"
+
+    def test_enqueue_pg_mode_clears_stale_dedup_on_reuse(self, barrier_db):
+        # greptile #2068: a re-enqueue with the same execution_id must wipe prior
+        # dedup markers atomically with the barrier reset, else every claim_batch
+        # returns False and the barrier hangs.
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        claim_batch("exec-reuse", 0)
+        claim_batch("exec-reuse", 1)
+        with patch("queue_backend.dispatch.dispatch"):
+            PgBarrier().enqueue(
+                [_pg_header()],
+                callback_task_name="process_batch_callback",
+                callback_kwargs={"execution_id": "exec-reuse"},
+                callback_queue="general",
+                app_instance=None,
+                transport="pg_queue",
+            )
+        with barrier_db.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pg_batch_dedup WHERE execution_id = %s",
+                ("exec-reuse",),
+            )
+            assert cur.fetchone()[0] == 0  # stale markers wiped by the UPSERT block
+
+    def test_run_batch_with_barrier_first_delivery_runs_and_decrements(self, barrier_db):
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-fd", 2)
+        ctx = {
+            "execution_id": "exec-fd",
+            "batch_index": 0,
+            "callback_descriptor": _CALLBACK,
+        }
+        work = MagicMock(return_value={"ok": 1})
+        out = run_batch_with_barrier(ctx, work)
+        work.assert_called_once()
+        assert out == {"ok": 1}
+        remaining, results = _row(barrier_db, "exec-fd")
+        assert remaining == 1
+        assert results == [{"ok": 1}]
+
+    def test_run_batch_with_barrier_redelivery_skips_work_and_decrement(self, barrier_db):
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-re", 2)
+        claim_batch("exec-re", 0)  # batch already claimed → this is a redelivery
+        ctx = {
+            "execution_id": "exec-re",
+            "batch_index": 0,
+            "callback_descriptor": _CALLBACK,
+        }
+        work = MagicMock(return_value={"ok": 1})
+        out = run_batch_with_barrier(ctx, work)
+        work.assert_not_called()  # no reprocessing
+        assert out["status"] == "skipped_redelivery"
+        remaining, _ = _row(barrier_db, "exec-re")
+        assert remaining == 2  # NOT decremented again
+
+    def test_run_batch_with_barrier_exception_aborts_barrier(self, barrier_db):
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-err", 2)
+        ctx = {
+            "execution_id": "exec-err",
+            "batch_index": 0,
+            "callback_descriptor": _CALLBACK,
+        }
+
+        def boom():
+            raise RuntimeError("batch failed")
+
+        with pytest.raises(RuntimeError, match="batch failed"):
+            run_batch_with_barrier(ctx, boom)
+        # No .link_error on the PG path → torn down in-body (mirror chord abort).
+        assert _row(barrier_db, "exec-err") is None
+
+    def test_fire_barrier_callback_pg_self_chains_via_dispatch(self):
+        descriptor = {**_CALLBACK, "backend": "pg_queue"}
+        with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
+            mock_dispatch.return_value = MagicMock(id="pg-cb-1")
+            cb_id = _fire_barrier_callback(descriptor, [{"r": 1}])
+        assert cb_id == "pg-cb-1"
+        assert mock_dispatch.call_args.kwargs["backend"] is QueueBackend.PG
+        assert mock_dispatch.call_args.kwargs["args"] == [[{"r": 1}]]
+
+    def test_fire_barrier_callback_legacy_uses_celery(self):
+        # No backend marker → the .link-mode Celery dispatch (unchanged).
+        with patch("celery.current_app.signature") as sig:
+            sig.return_value.apply_async.return_value = MagicMock(id="celery-cb")
+            cb_id = _fire_barrier_callback(_CALLBACK, [{"r": 1}])
+        assert cb_id == "celery-cb"
+        sig.assert_called_once()
+
+    def test_abort_clears_dedup_markers(self, barrier_db):
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-ab", 2)
+        claim_batch("exec-ab", 0)
+        barrier_pg_abort(execution_id="exec-ab")
+        with barrier_db.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pg_batch_dedup WHERE execution_id = %s",
+                ("exec-ab",),
+            )
+            assert cur.fetchone()[0] == 0
 
 
 if __name__ == "__main__":

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -725,12 +725,24 @@ class TestPgFireAndForgetMode:
         # reclaims dedup markers (greptile #2069) — an already-claimed earlier
         # header's marker would otherwise orphan, since the in-flight abort is a
         # no-op once the barrier row is gone.
+        #
+        # The marker must be claimed AFTER enqueue's UPSERT block (which wipes
+        # stale markers for this execution_id) — else the assertion would pass on
+        # the UPSERT, not the mid-loop clear under test. So the first dispatch
+        # call claims it (a fast consumer on the PG path), the second fails.
         with barrier_db.cursor() as cur:
             cur.execute("DELETE FROM pg_batch_dedup")
-        claim_batch("exec-midfail", 0)  # an earlier header already claimed its slot
+
+        def dispatch_side_effect(*args, **kwargs):
+            if not dispatch_side_effect.claimed:
+                dispatch_side_effect.claimed = True
+                claim_batch("exec-midfail", 0)  # marker created post-UPSERT
+                return MagicMock(id="1")
+            raise RuntimeError("broker down")
+
+        dispatch_side_effect.claimed = False
         with patch(
-            "queue_backend.dispatch.dispatch",
-            side_effect=[MagicMock(id="1"), RuntimeError("broker down")],
+            "queue_backend.dispatch.dispatch", side_effect=dispatch_side_effect
         ):
             with pytest.raises(RuntimeError, match="broker down"):
                 PgBarrier().enqueue(
@@ -747,7 +759,9 @@ class TestPgFireAndForgetMode:
                 "SELECT count(*) FROM pg_batch_dedup WHERE execution_id = %s",
                 ("exec-midfail",),
             )
-            assert cur.fetchone()[0] == 0  # markers reclaimed, not orphaned
+            # The marker existed post-UPSERT and was removed by the mid-loop
+            # clear_execution_batches under test (not by the UPSERT reset).
+            assert cur.fetchone()[0] == 0
 
 
 if __name__ == "__main__":

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -501,10 +501,15 @@ class TestPgFireAndForgetMode:
     def test_enqueue_pg_mode_dispatches_headers_via_pg_with_context(self, barrier_db):
         with barrier_db.cursor() as cur:
             cur.execute("DELETE FROM pg_batch_dedup")
-        headers = [_pg_header(), _pg_header()]
+        # A header with a pre-existing kwarg, real args, and a queue — to prove
+        # the Signature→dispatch unpacking preserves all three (a dropped args or
+        # queue would silently process an empty/misrouted batch).
+        h0 = _pg_header(args=[{"file": "f0"}], queue="api_file_processing")
+        h0.kwargs = {"pre_existing": "keep"}
+        h1 = _pg_header(args=[{"file": "f1"}], queue="api_file_processing")
         with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
             PgBarrier().enqueue(
-                headers,
+                [h0, h1],
                 callback_task_name="process_batch_callback",
                 callback_kwargs={"execution_id": "exec-pg"},
                 callback_queue="general",
@@ -512,14 +517,16 @@ class TestPgFireAndForgetMode:
                 transport="pg_queue",
             )
         assert mock_dispatch.call_count == 2  # one per header, no .link
-        # Each header carries its _barrier_context (incl. its batch_index) + the
-        # callback descriptor marked backend=pg_queue, dispatched backend=PG.
         for i, call in enumerate(mock_dispatch.call_args_list):
             assert call.kwargs["backend"] is QueueBackend.PG
+            assert call.kwargs["args"] == [{"file": f"f{i}"}]  # args preserved
+            assert call.kwargs["queue"] == "api_file_processing"  # queue preserved
             ctx = call.kwargs["kwargs"]["_barrier_context"]
             assert ctx["execution_id"] == "exec-pg"
             assert ctx["batch_index"] == i
-            assert ctx["callback_descriptor"]["backend"] == "pg_queue"
+            assert ctx["callback_descriptor"]["transport"] == "pg_queue"
+        # The pre-existing kwarg on h0 survives alongside the injected context.
+        assert mock_dispatch.call_args_list[0].kwargs["kwargs"]["pre_existing"] == "keep"
 
     def test_enqueue_pg_mode_clears_stale_dedup_on_reuse(self, barrier_db):
         # greptile #2068: a re-enqueue with the same execution_id must wipe prior
@@ -598,7 +605,7 @@ class TestPgFireAndForgetMode:
         assert _row(barrier_db, "exec-err") is None
 
     def test_fire_barrier_callback_pg_self_chains_via_dispatch(self):
-        descriptor = {**_CALLBACK, "backend": "pg_queue"}
+        descriptor = {**_CALLBACK, "transport": "pg_queue"}
         with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
             mock_dispatch.return_value = MagicMock(id="pg-cb-1")
             cb_id = _fire_barrier_callback(descriptor, [{"r": 1}])
@@ -626,6 +633,82 @@ class TestPgFireAndForgetMode:
                 ("exec-ab",),
             )
             assert cur.fetchone()[0] == 0
+
+    def test_last_batch_self_chains_callback_to_pg_and_cleans_up(self, barrier_db):
+        # The PR's core promise, end to end: the batch that drives remaining → 0
+        # self-chains the aggregating callback onto PG (backend=PG, args=[results])
+        # and clears both the barrier row and the dedup markers.
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-last", 1)  # this batch is the last → remaining → 0
+        descriptor = {
+            "task_name": "process_batch_callback_api",
+            "kwargs": {"execution_id": "exec-last"},
+            "queue": "api_file_processing_callback",
+            "fairness_headers": None,
+            "transport": "pg_queue",
+        }
+        ctx = {
+            "execution_id": "exec-last",
+            "batch_index": 0,
+            "callback_descriptor": descriptor,
+        }
+        with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
+            mock_dispatch.return_value = MagicMock(id="pg-cb")
+            out = run_batch_with_barrier(ctx, lambda: {"successful_files": 1})
+        assert out == {"successful_files": 1}
+        # callback self-chained onto PG with the aggregated results
+        assert mock_dispatch.call_args.kwargs["backend"] is QueueBackend.PG
+        assert mock_dispatch.call_args.args[0] == "process_batch_callback_api"
+        assert mock_dispatch.call_args.kwargs["args"] == [[{"successful_files": 1}]]
+        # barrier row + dedup markers cleaned up at finalise
+        assert _row(barrier_db, "exec-last") is None
+        with barrier_db.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pg_batch_dedup WHERE execution_id = %s",
+                ("exec-last",),
+            )
+            assert cur.fetchone()[0] == 0
+
+    def test_decrement_failure_aborts_barrier(self, barrier_db):
+        # #69: a decrement-side failure (after the work succeeded) must tear the
+        # barrier down in-body — else the dedup marker is committed, redelivery is
+        # blocked, and the barrier strands to expiry.
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-decfail", 2)
+        ctx = {
+            "execution_id": "exec-decfail",
+            "batch_index": 0,
+            "callback_descriptor": _CALLBACK,
+        }
+        with patch.object(
+            pg_barrier, "_barrier_pg_decrement", side_effect=RuntimeError("decr boom")
+        ):
+            with pytest.raises(RuntimeError, match="decr boom"):
+                run_batch_with_barrier(ctx, lambda: {"ok": 1})
+        assert _row(barrier_db, "exec-decfail") is None  # barrier torn down
+
+    def test_pg_mid_loop_dispatch_failure_deletes_row(self, barrier_db):
+        # The PG-branch counterpart of test_mid_loop_dispatch_failure_deletes_row:
+        # a header PG-dispatch failure mid fan-out deletes the barrier row so an
+        # in-flight in-body decrement finds no row and cleans up.
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        with patch(
+            "queue_backend.dispatch.dispatch",
+            side_effect=[MagicMock(id="1"), RuntimeError("broker down")],
+        ):
+            with pytest.raises(RuntimeError, match="broker down"):
+                PgBarrier().enqueue(
+                    [_pg_header(), _pg_header()],
+                    callback_task_name="process_batch_callback",
+                    callback_kwargs={"execution_id": "exec-midfail"},
+                    callback_queue="general",
+                    app_instance=None,
+                    transport="pg_queue",
+                )
+        assert _row(barrier_db, "exec-midfail") is None  # row deleted on failure
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Third slice of **9e PR 2**, after **2a** (#2067) + **2b** (#2068). This is the **live switch**: it wires the coupled pipeline's **fan-out → barrier → callback** onto the PG queue for a `transport=="pg_queue"` execution (fire-and-forget self-chaining — no Celery chord / `.link`).

## Non-regressive by construction

`resolve_transport()` still returns `"celery"` (PR 3 wires Flipt), so the **entire PG branch is present-but-unreachable** — the default path is byte-identical. The flag `pg_queue_execution_enabled` stays **off** and is **not consumed by any code** until PR 3.

## Scope = hybrid

2c migrates the **fan-out → barrier → callback** (the at-least-once core). The orchestrator task (`async_execute_bin`) stays on Celery; routing it onto PG (wholly-off-Celery) is a follow-up (**2d**).

## How it works (on `transport=="pg_queue"`)

- `Barrier` Protocol + Celery/Redis impls accept (and ignore) a `transport` param; `CallbackDescriptor` gains an optional `backend` marker.
- `create_chord_execution` routes `pg_queue` to a **fresh `PgBarrier()`** — bypassing the `WORKER_BARRIER_BACKEND` singleton (the celery substrate), so the transport selects the substrate.
- `PgBarrier.enqueue` fire-and-forget mode: each header dispatched via `dispatch(backend=PG)` with an injected `_barrier_context {execution_id, batch_index, callback_descriptor}` (no `.link`); the UPSERT block also clears `pg_batch_dedup` (the reuse-reset flagged in 2b review — `@greptile-apps` #2068).
- `process_file_batch(_barrier_context=None)`: the PG path runs `run_batch_with_barrier` — **claim** the batch (idempotent on redelivery), run the work, **decrement** the barrier in-body; the task that drives `remaining → 0` **self-chains the callback** onto PG via `dispatch(backend=PG)`. Exceptions tear the barrier down in-body (mirrors the chord `.link_error`). `clear_execution_batches` runs at finalise and abort.

## Mixed-version / rolling-deploy safety

Three layers:
1. **Defaults** — new params (`transport`, `_barrier_context`) have safe defaults, so an old payload on a new worker falls back to celery/legacy.
2. **`transport` absorbed by old workers** — orchestrator tasks + the callback have `**kwargs`, so a pre-version worker swallows an unknown `transport` (no `TypeError`).
3. **`_barrier_context` never reaches a Celery/old worker** — injected only on the `pg_queue` path, which is gated off until PR 3 and routes only to the PG consumer (this code). That's *why* `process_file_batch` keeps an explicit param, not a `**kwargs` swallow.

**Operational rule** (naturally enforced by flag-default-off + separate PR): deploy 2c everywhere **before** PR 3 flips `pg_queue_execution_enabled`.

## Tests

- **+8 PgBarrier fire-and-forget**: header PG-dispatch + `_barrier_context` injection, reuse-clear, `run_batch_with_barrier` first/redelivery/exception, callback PG-vs-celery, abort-clears-dedup.
- **+2 orchestration routing**: `pg_queue` → fresh `PgBarrier` (not the singleton); celery → singleton with `transport` threaded.
- **+2 `process_file_batch` routing**: `_barrier_context` None → chord stages, set → `run_batch_with_barrier`.
- Each test file green alone; `ruff` clean.

## Dev-test (end-to-end, forced `pg_queue`)

The coupled pipeline ran **end-to-end on Postgres, fire-and-forget, twice, clean teardown**:
`process_file_batch` claimed + ran on a PG consumer → in-body barrier decrement → `remaining=0` → callback self-chained onto the PG callback queue → ran on a second PG consumer → execution **COMPLETED**. `pg_barrier_state` and `pg_batch_dedup` both empty afterward (finalise cleanup verified). No chord, no `.link`.

## Base

Targets the long-lived `feat/UN-3445-pg-queue-integration` integration branch (**not** `main`). Stacked on 2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
