### PR TITLE
UN-3570 [FEAT] PG Queue 9e PR 3 — Flipt canary wiring for transport resolution

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -151,6 +151,14 @@ DB_SCHEMA = os.environ.get("DB_SCHEMA", "unstract")
 CELERY_BACKEND_DB_NAME = os.environ.get("CELERY_BACKEND_DB_NAME") or DB_NAME
 DEFAULT_ORGANIZATION = "default_org"
 FLIPT_BASE_URL = os.environ.get("FLIPT_BASE_URL", "http://localhost:9005")
+# 9e PG-queue transport master-gate (kill-switch). When not "true",
+# resolve_transport() never consults Flipt and every workflow execution rides
+# Celery — the instant global rollback AND the deploy-ordering safety (stays off
+# until PG consumers are running in the fleet). See
+# workers/queue_backend/pg_queue/9e-design.md §2.
+PG_QUEUE_TRANSPORT_ENABLED = CommonUtils.str_to_bool(
+    os.environ.get("PG_QUEUE_TRANSPORT_ENABLED", "False")
+)
 PLATFORM_HOST = os.environ.get("PLATFORM_SERVICE_HOST", "http://localhost")
 PLATFORM_PORT = os.environ.get("PLATFORM_SERVICE_PORT", 3001)
 PROMPT_HOST = os.environ.get("PROMPT_HOST", "http://localhost")

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -184,9 +184,11 @@ TOOL_REGISTRY_CONFIG_PATH="/data/tool_registry_config"
 # Flipt Service
 FLIPT_SERVICE_AVAILABLE=False
 
-# 9e PG-queue transport master-gate (kill-switch). Keep False until PG queue
-# consumers are running in the fleet; only then does the Flipt flag
-# `pg_queue_execution_enabled` take effect. Set False for instant rollback.
+# 9e PG-queue transport master-gate (kill-switch). Routing an execution onto the
+# PG queue requires ALL THREE: this gate True, FLIPT_SERVICE_AVAILABLE=True (else
+# the Flipt client returns False for every flag), and the Flipt flag
+# `pg_queue_execution_enabled` on. Keep False until PG queue consumers are running
+# in the fleet; set False for instant rollback.
 PG_QUEUE_TRANSPORT_ENABLED=False
 
 # File System Configuration for Workflow and API Execution

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -184,6 +184,11 @@ TOOL_REGISTRY_CONFIG_PATH="/data/tool_registry_config"
 # Flipt Service
 FLIPT_SERVICE_AVAILABLE=False
 
+# 9e PG-queue transport master-gate (kill-switch). Keep False until PG queue
+# consumers are running in the fleet; only then does the Flipt flag
+# `pg_queue_execution_enabled` take effect. Set False for instant rollback.
+PG_QUEUE_TRANSPORT_ENABLED=False
+
 # File System Configuration for Workflow and API Execution
 
 # Directory Prefixes for storing execution files

--- a/backend/workflow_manager/internal_api_views.py
+++ b/backend/workflow_manager/internal_api_views.py
@@ -323,10 +323,14 @@ def create_workflow_execution(request):
 
         # Resolve the transport this execution rides (9e). Decided once here, at
         # the creation chokepoint, and returned so the caller carries it in the
-        # dispatched task's payload — not persisted on the row. PR 1 always
-        # resolves "celery"; PR 3 wires Flipt (keyed on workflow/pipeline/org) in
-        # resolve_transport().
-        transport = resolve_transport()
+        # dispatched task's payload — not persisted on the row. Flipt (gated by
+        # the env master-switch) decides; fails closed to "celery".
+        transport = resolve_transport(
+            execution_id=str(execution.id),
+            organization_id=org_id,
+            workflow_id=str(workflow.id),
+            pipeline_id=data.get("pipeline_id"),
+        )
 
         return Response(
             {

--- a/backend/workflow_manager/workflow_v2/tests/test_transport.py
+++ b/backend/workflow_manager/workflow_v2/tests/test_transport.py
@@ -8,6 +8,7 @@ closed to Celery on any problem. These tests pin that contract.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.test import override_settings
 from unstract.core.data_models import (
     DEFAULT_WORKFLOW_TRANSPORT,
@@ -34,9 +35,35 @@ class TestWorkflowTransportEnum:
 
 
 class TestResolveTransport:
+    @pytest.fixture(autouse=True)
+    def _flipt_available(self, monkeypatch):
+        """The gate-ON path short-circuits to celery when Flipt is marked
+        unavailable; default it available so the flag-evaluation tests exercise
+        the real path. Individual tests override as needed."""
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "true")
+
     @override_settings(PG_QUEUE_TRANSPORT_ENABLED=False)
     def test_master_gate_off_never_consults_flipt(self):
         """Master-gate off → Celery, and Flipt is not even called."""
+        with patch(_FLIPT) as flipt:
+            result = resolve_transport(execution_id="e1", organization_id="org1")
+        assert result == WorkflowTransport.CELERY.value
+        flipt.assert_not_called()
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_missing_organization_forces_celery(self):
+        """No org context → can't segment safely → fail closed; Flipt not called
+        (str(None)/"" must never reach the Flipt org segment)."""
+        with patch(_FLIPT) as flipt:
+            result = resolve_transport(execution_id="e1", organization_id="")
+        assert result == WorkflowTransport.CELERY.value
+        flipt.assert_not_called()
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_gate_on_but_flipt_unavailable_forces_celery(self, monkeypatch):
+        """Gate ON + Flipt service unavailable → celery, loudly — not a silent
+        masquerade as a healthy 100%-celery canary."""
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "false")
         with patch(_FLIPT) as flipt:
             result = resolve_transport(execution_id="e1", organization_id="org1")
         assert result == WorkflowTransport.CELERY.value

--- a/backend/workflow_manager/workflow_v2/tests/test_transport.py
+++ b/backend/workflow_manager/workflow_v2/tests/test_transport.py
@@ -1,18 +1,27 @@
-"""Tests for the 9e transport-resolution seam.
+"""Tests for the 9e transport-resolution seam (PR 3 — Flipt canary wiring).
 
-PR 1 is the *inert* seam: ``resolve_transport`` always returns Celery, so the
-whole pipeline is byte-identical to today. These tests pin that contract so a
-future change (PR 3, Flipt wiring) can't silently flip the default.
+``resolve_transport`` is the single chokepoint that decides whether a new
+execution rides the legacy Celery transport or the Postgres queue. It is gated
+by an env master-switch and, when that is on, by a Flipt boolean flag; it fails
+closed to Celery on any problem. These tests pin that contract.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from unstract.core.data_models import (
     DEFAULT_WORKFLOW_TRANSPORT,
     WorkflowTransport,
     normalize_transport,
 )
-from workflow_manager.workflow_v2.transport import resolve_transport
+
+from workflow_manager.workflow_v2.transport import (
+    PG_QUEUE_FLAG_KEY,
+    resolve_transport,
+)
+
+# Where ``check_feature_flag_status`` is looked up (imported into the module).
+_FLIPT = "workflow_manager.workflow_v2.transport.check_feature_flag_status"
 
 
 class TestWorkflowTransportEnum:
@@ -25,14 +34,93 @@ class TestWorkflowTransportEnum:
 
 
 class TestResolveTransport:
-    def test_resolves_celery_in_pr1(self):
-        """PR 1: always Celery (inert seam, no inputs). PR 3 adds the
-        workflow/pipeline/org params + Flipt evaluation."""
-        assert resolve_transport() == WorkflowTransport.CELERY.value
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=False)
+    def test_master_gate_off_never_consults_flipt(self):
+        """Master-gate off → Celery, and Flipt is not even called."""
+        with patch(_FLIPT) as flipt:
+            result = resolve_transport(execution_id="e1", organization_id="org1")
+        assert result == WorkflowTransport.CELERY.value
+        flipt.assert_not_called()
 
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_gate_on_flipt_true_resolves_pg_queue(self):
+        with patch(_FLIPT, return_value=True):
+            result = resolve_transport(execution_id="e1", organization_id="org1")
+        assert result == WorkflowTransport.PG_QUEUE.value
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_gate_on_flipt_false_resolves_celery(self):
+        with patch(_FLIPT, return_value=False):
+            result = resolve_transport(execution_id="e1", organization_id="org1")
+        assert result == WorkflowTransport.CELERY.value
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_flipt_exception_fails_closed_to_celery(self):
+        """A Flipt outage must never break execution creation."""
+        with patch(_FLIPT, side_effect=RuntimeError("flipt down")):
+            result = resolve_transport(execution_id="e1", organization_id="org1")
+        assert result == WorkflowTransport.CELERY.value
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_passes_execution_id_as_entity_and_builds_context(self):
+        """entity_id = execution_id (sticky bucketing); context carries the
+        org/workflow/pipeline for segment rules.
+        """
+        with patch(_FLIPT, return_value=True) as flipt:
+            resolve_transport(
+                execution_id="exec-42",
+                organization_id="org1",
+                workflow_id="wf1",
+                pipeline_id="pl1",
+            )
+        flipt.assert_called_once_with(
+            flag_key=PG_QUEUE_FLAG_KEY,
+            entity_id="exec-42",
+            context={
+                "organization_id": "org1",
+                "workflow_id": "wf1",
+                "pipeline_id": "pl1",
+            },
+        )
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_non_string_ids_are_coerced_for_flipt(self):
+        """Callers pass UUID objects for the ids. Flipt's context is a gRPC
+        map<string,string> and entity_id must hash stably, so every value must
+        reach check_feature_flag_status as a plain str — otherwise the client
+        swallows the serialization error as False and silently forces celery.
+        Regression test for that exact dev-test finding.
+        """
+        import uuid
+
+        ex = uuid.UUID("8c091789-9dde-45e7-bb85-06f23fe120eb")
+        wf = uuid.UUID("ebed2834-c9fb-4b6c-8df3-9dd841f616bb")
+        pl = uuid.UUID("eaca3b0e-083a-4c75-8b25-85349d54145b")
+        with patch(_FLIPT, return_value=True) as flipt:
+            result = resolve_transport(
+                execution_id=ex, organization_id="org1", workflow_id=wf, pipeline_id=pl
+            )
+        assert result == WorkflowTransport.PG_QUEUE.value
+        _, kwargs = flipt.call_args
+        assert kwargs["entity_id"] == str(ex)
+        assert all(isinstance(v, str) for v in kwargs["context"].values())
+        assert kwargs["context"]["workflow_id"] == str(wf)
+        assert kwargs["context"]["pipeline_id"] == str(pl)
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
+    def test_context_omits_unset_optional_ids(self):
+        with patch(_FLIPT, return_value=True) as flipt:
+            resolve_transport(execution_id="exec-42", organization_id="org1")
+        _, kwargs = flipt.call_args
+        assert kwargs["context"] == {"organization_id": "org1"}
+
+    @override_settings(PG_QUEUE_TRANSPORT_ENABLED=True)
     def test_result_is_a_valid_transport_value(self):
         valid = {t.value for t in WorkflowTransport}
-        assert resolve_transport() in valid
+        with patch(_FLIPT, return_value=True):
+            assert (
+                resolve_transport(execution_id="e1", organization_id="org1") in valid
+            )
 
 
 class TestNormalizeTransport:

--- a/backend/workflow_manager/workflow_v2/transport.py
+++ b/backend/workflow_manager/workflow_v2/transport.py
@@ -52,7 +52,7 @@ PG_QUEUE_FLAG_KEY = "pg_queue_execution_enabled"
 def resolve_transport(
     *,
     execution_id: str | UUID,
-    organization_id: str | UUID,
+    organization_id: str | UUID | None,
     workflow_id: str | UUID | None = None,
     pipeline_id: str | UUID | None = None,
 ) -> str:
@@ -69,8 +69,9 @@ def resolve_transport(
             execution is resolved exactly once).
         organization_id: The org's string identifier
             (``Organization.organization_id`` — the ``X-Organization-ID`` header
-            value, *not* the DB pk). Carried in the Flipt ``context`` for per-org
-            segment rollouts.
+            value, *not* the DB pk). May be ``None`` on the helper path
+            (``StateStore`` not populated) → resolves to celery. Carried in the
+            Flipt ``context`` for per-org segment rollouts.
         workflow_id: Optional, carried in ``context`` for future segment rules.
         pipeline_id: Optional, carried in ``context`` for future segment rules.
 
@@ -105,8 +106,9 @@ def resolve_transport(
     # FliptClient returns False for ALL flags when the service is marked
     # unavailable — indistinguishable from "rollout says no". Surface it loudly so
     # a blind Flipt under an ON gate doesn't masquerade as a healthy 100%-Celery
-    # canary. (Mirrors FliptClient's own FLIPT_SERVICE_AVAILABLE env read.)
-    if os.environ.get("FLIPT_SERVICE_AVAILABLE", "false").strip().lower() != "true":
+    # canary. Parse exactly as FliptClient does (``.lower()``, no ``.strip()``)
+    # so the two can never disagree on a value like ``" true"``.
+    if os.environ.get("FLIPT_SERVICE_AVAILABLE", "false").lower() != "true":
         logger.warning(
             "resolve_transport: gate ON but FLIPT_SERVICE_AVAILABLE != true "
             "(Flipt is blind) for execution %s; forcing celery",

--- a/backend/workflow_manager/workflow_v2/transport.py
+++ b/backend/workflow_manager/workflow_v2/transport.py
@@ -12,6 +12,9 @@ PR 3 (this change) replaces PR 1's hardwired Celery with a Flipt evaluation:
 
   master-gate (env) → Flipt boolean (``pg_queue_execution_enabled``) → transport
 
+Routing onto PG needs **all three** of: the env master-gate on, Flipt reachable
+(``FLIPT_SERVICE_AVAILABLE=true``), and the flag enabled for this execution.
+
 - **Master-gate** (``settings.PG_QUEUE_TRANSPORT_ENABLED``, default off): until
   ops flips it on, Flipt is never consulted and every execution rides Celery.
   This is both the instant global kill-switch *and* the deploy-ordering safety —
@@ -21,17 +24,24 @@ PR 3 (this change) replaces PR 1's hardwired Celery with a Flipt evaluation:
   never re-bucket mid-flight); ``context`` carries org/workflow/pipeline for
   segment rules. The flag contract is fixed in 9e-design §2.
 - **Fail-closed to Celery**: a Flipt outage must never break execution creation,
-  mirroring ``normalize_transport`` on the read side.
+  mirroring ``normalize_transport`` on the read side. The gate-ON path logs its
+  decision so a "gate on but still all Celery" situation (e.g. a blind Flipt)
+  is visible rather than silent.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 
 from unstract.core.data_models import WorkflowTransport
 from unstract.flags.feature_flag import check_feature_flag_status
+
+if TYPE_CHECKING:
+    from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
@@ -41,49 +51,84 @@ PG_QUEUE_FLAG_KEY = "pg_queue_execution_enabled"
 
 def resolve_transport(
     *,
-    execution_id: str,
-    organization_id: str,
-    workflow_id: str | None = None,
-    pipeline_id: str | None = None,
+    execution_id: str | UUID,
+    organization_id: str | UUID,
+    workflow_id: str | UUID | None = None,
+    pipeline_id: str | UUID | None = None,
 ) -> str:
     """Resolve the transport for a new workflow execution.
+
+    The id parameters are typed ``str | UUID`` because callers pass either
+    (e.g. the view path pre-coerces with ``str(...)``, the helper path passes
+    raw UUIDs). Coercion to the wire types Flipt needs is kept internal here so
+    callers never have to know about it.
 
     Args:
         execution_id: The execution's id. Used as the Flipt ``entity_id`` so the
             percentage rollout buckets per execution and stays sticky (one
             execution is resolved exactly once).
-        organization_id: Owning org's public identifier. Carried in the Flipt
-            ``context`` for per-org segment rollouts.
+        organization_id: The org's string identifier
+            (``Organization.organization_id`` — the ``X-Organization-ID`` header
+            value, *not* the DB pk). Carried in the Flipt ``context`` for per-org
+            segment rollouts.
         workflow_id: Optional, carried in ``context`` for future segment rules.
         pipeline_id: Optional, carried in ``context`` for future segment rules.
 
     Returns:
         A :class:`WorkflowTransport` value string — ``"pg_queue"`` only when the
-        master-gate is on *and* Flipt says yes for this execution; ``"celery"``
-        otherwise (including any Flipt error — fail-closed).
+        master-gate is on, Flipt is reachable, and Flipt says yes for this
+        execution; ``"celery"`` otherwise (including any error — fail-closed).
     """
     celery = WorkflowTransport.CELERY.value
 
     # Master-gate: until ops sets PG_QUEUE_TRANSPORT_ENABLED=true, never consult
     # Flipt — every execution rides Celery (kill-switch + deploy-ordering safety).
+    # Intentionally unlogged: this is the steady state for every execution while
+    # the gate is off, so a log here would be pure noise.
     if not settings.PG_QUEUE_TRANSPORT_ENABLED:
         return celery
 
-    # Flipt's context is a gRPC map<string,string>; callers pass UUID objects
-    # for the ids, so coerce every value to str. A non-str value makes the
-    # client's serialization fail and check_feature_flag_status swallow it as
-    # False — silently forcing celery. entity_id is str-coerced for the same
-    # reason (and so the %-rollout hash is stable across str/UUID call sites).
+    # Gate is ON (canary/rollout). From here the decision is logged so a
+    # "gate on but everything still Celery" situation cannot hide.
+
+    # No org context → per-org segment matching can't be trusted (str(None) would
+    # ship a bogus "None" org into the Flipt context and mis-segment). The view
+    # path validates the header non-None, but the helper path reads it from
+    # StateStore, which can be empty. Fail closed rather than mis-bucket.
+    if not organization_id:
+        logger.warning(
+            "resolve_transport: no organization_id for execution %s; forcing celery",
+            execution_id,
+        )
+        return celery
+
+    # FliptClient returns False for ALL flags when the service is marked
+    # unavailable — indistinguishable from "rollout says no". Surface it loudly so
+    # a blind Flipt under an ON gate doesn't masquerade as a healthy 100%-Celery
+    # canary. (Mirrors FliptClient's own FLIPT_SERVICE_AVAILABLE env read.)
+    if os.environ.get("FLIPT_SERVICE_AVAILABLE", "false").strip().lower() != "true":
+        logger.warning(
+            "resolve_transport: gate ON but FLIPT_SERVICE_AVAILABLE != true "
+            "(Flipt is blind) for execution %s; forcing celery",
+            execution_id,
+        )
+        return celery
+
+    # Flipt's context is a gRPC map<string,string>; callers pass UUID objects for
+    # the ids, so coerce every value to str. A non-str value makes the client's
+    # serialization fail and check_feature_flag_status swallow it as False —
+    # silently forcing celery. entity_id is str-coerced for the same reason (and
+    # so the %-rollout hash is stable across str/UUID call sites).
     context = {"organization_id": str(organization_id)}
     if workflow_id:
         context["workflow_id"] = str(workflow_id)
     if pipeline_id:
         context["pipeline_id"] = str(pipeline_id)
 
-    # Defense in depth: check_feature_flag_status already swallows errors and
-    # returns False, but the design mandates an explicit fail-closed wrap here so
-    # a future change to that helper (or an import-time fault) can never let a
-    # Flipt problem break execution creation.
+    # Defense in depth: check_feature_flag_status already wraps its body in
+    # try/except → False, but an explicit fail-closed wrap here keeps a future
+    # change to that helper from ever letting a Flipt problem break execution
+    # creation.
     try:
         enabled = check_feature_flag_status(
             flag_key=PG_QUEUE_FLAG_KEY,
@@ -99,4 +144,11 @@ def resolve_transport(
         )
         return celery
 
-    return WorkflowTransport.PG_QUEUE.value if enabled else celery
+    result = WorkflowTransport.PG_QUEUE.value if enabled else celery
+    logger.info(
+        "resolve_transport: execution %s resolved to %s (flipt enabled=%s)",
+        execution_id,
+        result,
+        enabled,
+    )
+    return result

--- a/backend/workflow_manager/workflow_v2/transport.py
+++ b/backend/workflow_manager/workflow_v2/transport.py
@@ -8,33 +8,95 @@ in the dispatched task's payload (see ``workers/queue_backend/pg_queue/
 row: the payload is the single carrier, durable for PG via the queue row's
 JSONB, and the giant shared table is never migrated for this work.
 
-PR 1 (this seam) hardwires the result to Celery, so behaviour is byte-identical
-to today. PR 3 replaces the body with a Flipt evaluation (percentage rollout via
-``entity_id`` hashing + per-org segment via ``context``), wrapped by an env
-kill-switch and failing closed to Celery.
+PR 3 (this change) replaces PR 1's hardwired Celery with a Flipt evaluation:
+
+  master-gate (env) → Flipt boolean (``pg_queue_execution_enabled``) → transport
+
+- **Master-gate** (``settings.PG_QUEUE_TRANSPORT_ENABLED``, default off): until
+  ops flips it on, Flipt is never consulted and every execution rides Celery.
+  This is both the instant global kill-switch *and* the deploy-ordering safety —
+  the flag stays inert until PG consumers are actually running in the fleet.
+- **Flipt** decides per-execution: ``entity_id = execution_id`` drives the
+  percentage-rollout hashing (an execution resolves exactly once, so it can
+  never re-bucket mid-flight); ``context`` carries org/workflow/pipeline for
+  segment rules. The flag contract is fixed in 9e-design §2.
+- **Fail-closed to Celery**: a Flipt outage must never break execution creation,
+  mirroring ``normalize_transport`` on the read side.
 """
 
 from __future__ import annotations
 
+import logging
+
+from django.conf import settings
+
 from unstract.core.data_models import WorkflowTransport
+from unstract.flags.feature_flag import check_feature_flag_status
+
+logger = logging.getLogger(__name__)
+
+# The fixed Flipt flag contract (9e-design §2): Boolean, default false.
+PG_QUEUE_FLAG_KEY = "pg_queue_execution_enabled"
 
 
-def resolve_transport() -> str:
+def resolve_transport(
+    *,
+    execution_id: str,
+    organization_id: str,
+    workflow_id: str | None = None,
+    pipeline_id: str | None = None,
+) -> str:
     """Resolve the transport for a new workflow execution.
 
-    Returns:
-        The transport value (a :class:`WorkflowTransport` value string).
+    Args:
+        execution_id: The execution's id. Used as the Flipt ``entity_id`` so the
+            percentage rollout buckets per execution and stays sticky (one
+            execution is resolved exactly once).
+        organization_id: Owning org's public identifier. Carried in the Flipt
+            ``context`` for per-org segment rollouts.
+        workflow_id: Optional, carried in ``context`` for future segment rules.
+        pipeline_id: Optional, carried in ``context`` for future segment rules.
 
-    Note:
-        PR 1 always returns ``"celery"`` and takes no arguments (the inert seam
-        needs no inputs). PR 3 reintroduces ``workflow_id`` / ``pipeline_id`` /
-        ``organization_id`` parameters when it wires Flipt here — percentage
-        rollout via ``entity_id`` hashing + per-org segment via ``context`` —
-        and updates the two call sites (``internal_api_views`` view and
-        ``workflow_helper.execute_workflow_async``). PR 3 must wrap the Flipt
-        evaluation in ``try/except`` and fall back to
-        ``WorkflowTransport.CELERY.value`` (fail-closed), so a Flipt outage can
-        never break execution creation — mirroring ``normalize_transport`` on
-        the read side.
+    Returns:
+        A :class:`WorkflowTransport` value string — ``"pg_queue"`` only when the
+        master-gate is on *and* Flipt says yes for this execution; ``"celery"``
+        otherwise (including any Flipt error — fail-closed).
     """
-    return WorkflowTransport.CELERY.value
+    celery = WorkflowTransport.CELERY.value
+
+    # Master-gate: until ops sets PG_QUEUE_TRANSPORT_ENABLED=true, never consult
+    # Flipt — every execution rides Celery (kill-switch + deploy-ordering safety).
+    if not settings.PG_QUEUE_TRANSPORT_ENABLED:
+        return celery
+
+    # Flipt's context is a gRPC map<string,string>; callers pass UUID objects
+    # for the ids, so coerce every value to str. A non-str value makes the
+    # client's serialization fail and check_feature_flag_status swallow it as
+    # False — silently forcing celery. entity_id is str-coerced for the same
+    # reason (and so the %-rollout hash is stable across str/UUID call sites).
+    context = {"organization_id": str(organization_id)}
+    if workflow_id:
+        context["workflow_id"] = str(workflow_id)
+    if pipeline_id:
+        context["pipeline_id"] = str(pipeline_id)
+
+    # Defense in depth: check_feature_flag_status already swallows errors and
+    # returns False, but the design mandates an explicit fail-closed wrap here so
+    # a future change to that helper (or an import-time fault) can never let a
+    # Flipt problem break execution creation.
+    try:
+        enabled = check_feature_flag_status(
+            flag_key=PG_QUEUE_FLAG_KEY,
+            entity_id=str(execution_id),
+            context=context,
+        )
+    except Exception:
+        logger.warning(
+            "resolve_transport: Flipt evaluation failed for execution %s; "
+            "falling back to Celery",
+            execution_id,
+            exc_info=True,
+        )
+        return celery
+
+    return WorkflowTransport.PG_QUEUE.value if enabled else celery

--- a/backend/workflow_manager/workflow_v2/workflow_helper.py
+++ b/backend/workflow_manager/workflow_v2/workflow_helper.py
@@ -510,17 +510,22 @@ class WorkflowHelper:
             log_events_id = StateStore.get(Common.LOG_EVENTS_ID)
             # Resolve the transport this execution rides (9e) and carry it in the
             # task payload — the pipeline reads it to stay on one transport
-            # end-to-end. PR 1 always resolves "celery" (no behaviour change).
+            # end-to-end. Flipt (gated by the env master-switch) decides; fails
+            # closed to "celery".
             #
             # NOTE (deliberate, two resolution sites): transport is resolved here
             # for the API/manual/async paths and separately in
             # internal_api_views.create_workflow_execution for the scheduler
             # path. These are DISTINCT entry paths — never a double-resolution of
-            # the same execution — so today they cannot diverge. PR 3 makes each
-            # an independent Flipt evaluation; before then, both must be funnelled
-            # through a single per-execution chokepoint (so a percentage re-roll
-            # can't split one execution across transports). Tracked for PR 3.
-            transport = resolve_transport()
+            # the same execution. entity_id is execution_id, so each execution
+            # buckets exactly once and can't split across transports even if the
+            # rollout % is re-rolled between the two sites.
+            transport = resolve_transport(
+                execution_id=execution_id,
+                organization_id=org_schema,
+                workflow_id=workflow_id,
+                pipeline_id=pipeline_id,
+            )
             async_execution: AsyncResult = celery_app.send_task(
                 "async_execute_bin",
                 args=[


### PR DESCRIPTION
## What

- `resolve_transport()` now makes a real decision instead of always returning Celery: an **env master-gate** (`PG_QUEUE_TRANSPORT_ENABLED`, default off) → when on, a **Flipt boolean flag** (`pg_queue_execution_enabled`) → fail-closed to Celery on any error.
- Wired at **both** execution-creation chokepoints: `internal_api_views.create_workflow_execution` (scheduler path) and `workflow_helper.execute_workflow_async` (API / manual / async path).
- New setting `PG_QUEUE_TRANSPORT_ENABLED` + a `sample.env` entry.

## Why

- This is the on/off switch for the 9e PG-queue pipeline. PR 1 left `resolve_transport` hardwired to Celery; this PR lets a **new** execution be canary-routed onto Postgres while everything else stays on Celery. Part of PG Queue Phase 9 (UN-3536), sub-task UN-3570.

## How

- **Master-gate** (env, default off): until ops turns it on, Flipt is never consulted and every execution rides Celery. Doubles as the instant kill-switch and the deploy-ordering safety (inert until PG consumers are deployed).
- **entity_id = execution_id** → per-execution percentage-rollout stickiness. The decision is resolved once at creation and carried in the task payload, so an in-flight execution never re-buckets.
- **context** carries org / workflow / pipeline ids for Flipt segment rules. All values are `str`-coerced: callers pass UUID objects, and a non-string value in Flipt's gRPC `map<string,string>` context is swallowed by the client as `False`, silently forcing Celery (found and fixed during dev-test).
- Decision mirrors `normalize_transport` on the read side: fail-closed.

## Can this PR break any existing features?

- **No.** Behaviour is byte-identical to today while `PG_QUEUE_TRANSPORT_ENABLED` is off (the default) — the gate returns Celery before Flipt is even consulted. Even with the gate on, the Flipt flag defaults to off, and any Flipt error falls back to Celery. The flag must not be enabled in production until PG consumers are deployed (deploy-ordering safety, enforced by the default-off env gate).

## Database Migrations

- None.

## Env Config

- New: `PG_QUEUE_TRANSPORT_ENABLED` (default `False`). When not `true`, transport resolution never consults Flipt and every execution rides Celery — kill-switch + deploy-ordering safety.
- Existing `FLIPT_SERVICE_AVAILABLE` / `EVALUATION_SERVER_IP` / `EVALUATION_SERVER_PORT` already gate Flipt availability (client fails closed to `False`).

## Notes on Testing

- Unit: 15 cases in `test_transport.py` — gate off (Flipt not consulted), gate on + flag true → pg_queue, flag false → celery, Flipt exception → fail-closed, entity_id/context shape, optional-id omission, and a UUID-coercion regression test.
- Dev-tested end-to-end against a running stack:
  - Gate OFF: API deployment runs fully on Celery; `pg_barrier_state` / `pg_batch_dedup` untouched; COMPLETED.
  - Gate ON + flag at 100%: real API deployment routes through the PG consumers (PgBarrier → decrement remaining=0 → callback) to COMPLETED with clean teardown.
  - Live-Flipt decision matrix: gate off / flag on / Flipt unavailable → celery / pg_queue / celery.

## Related Issues

- UN-3536 (PG Queue Phase 9 — transport engine), sub-task UN-3570.
- Follow-ups (separate sub-tasks): 2d orchestrator-on-PG; UN-3566 multi-queue consumer ergonomics.

## Checklist

- [x] Appropriate PR title and description
- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Tests added that prove the feature works
- [x] New and existing unit tests pass locally
- [x] Pre-commit passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)