### PR TITLE
UN-3566 [FEAT] PG Queue 9f — multi-queue consumer + named run-worker.sh PG roles

### DIFF
--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -70,7 +70,7 @@ class PgQueueConsumer:
 
     def __init__(
         self,
-        queue_name: str,
+        queue_names: list[str],
         *,
         client: PgQueueClient | None = None,
         app: Celery | None = None,
@@ -97,7 +97,13 @@ class PgQueueConsumer:
             raise ValueError(
                 f"backoff_max ({backoff_max}) must be >= poll_interval ({poll_interval})"
             )
-        self.queue_name = queue_name
+        if not queue_names:
+            raise ValueError("queue_names must be a non-empty list")
+        # One process can drain several queues (9f) — e.g. a file_processing
+        # consumer drains both file_processing and api_file_processing. Polled
+        # round-robin so the per-queue (queue_name, priority DESC, msg_id) dequeue
+        # index keeps its top-N efficiency and no queue starves another.
+        self.queue_names = queue_names
         self._client = client if client is not None else PgQueueClient()
         self._app = app if app is not None else current_app
         self.batch_size = batch_size
@@ -114,14 +120,19 @@ class PgQueueConsumer:
         self._last_poll_monotonic = time.monotonic()
 
     def poll_once(self) -> int:
-        """Claim + process one batch; returns the number of messages claimed."""
+        """Claim + process one batch per queue (round-robin); returns the total
+        number of messages claimed across all queues this cycle.
+        """
         self._last_poll_monotonic = time.monotonic()
-        messages = self._client.read(
-            self.queue_name, vt_seconds=self.vt_seconds, qty=self.batch_size
-        )
-        for message in messages:
-            self._handle(message)
-        return len(messages)
+        total = 0
+        for queue_name in self.queue_names:
+            messages = self._client.read(
+                queue_name, vt_seconds=self.vt_seconds, qty=self.batch_size
+            )
+            for message in messages:
+                self._handle(message)
+            total += len(messages)
+        return total
 
     def _handle(self, message: QueueMessage) -> None:
         payload = message.message
@@ -254,9 +265,9 @@ class PgQueueConsumer:
             name for name in self._app.tasks if not name.startswith("celery.")
         )
         logger.info(
-            "PG-queue consumer started (queue=%r, batch=%s, vt=%ss) — "
+            "PG-queue consumer started (queues=%r, batch=%s, vt=%ss) — "
             "%d application task(s) registered: %s",
-            self.queue_name,
+            self.queue_names,
             self.batch_size,
             self.vt_seconds,
             len(app_tasks),
@@ -278,7 +289,7 @@ class PgQueueConsumer:
             else:
                 time.sleep(backoff)
                 backoff = min(backoff * 2, self.backoff_max)
-        logger.info("PG-queue consumer stopped (queue=%r)", self.queue_name)
+        logger.info("PG-queue consumer stopped (queues=%r)", self.queue_names)
 
     def stop(self, *_: object) -> None:
         """Request a graceful stop after the current batch."""
@@ -294,6 +305,13 @@ class PgQueueConsumer:
                 "PG-queue consumer: signal handlers not installed (non-main "
                 "thread) — SIGTERM/SIGINT will not trigger graceful shutdown"
             )
+
+
+def _parse_queue_list(raw: str) -> list[str]:
+    """Comma-separated queue list (9f). A single value stays a one-element list,
+    so the pre-9f single-queue config remains valid.
+    """
+    return [q.strip() for q in raw.split(",") if q.strip()]
 
 
 def main() -> None:
@@ -315,7 +333,7 @@ def main() -> None:
             raise ValueError(f"Invalid {var}={raw!r}: {exc}") from exc
 
     consumer = PgQueueConsumer(
-        queue_name=_env("QUEUE", _DEFAULT_QUEUE, str),
+        queue_names=_env("QUEUE", [_DEFAULT_QUEUE], _parse_queue_list),
         batch_size=_env("BATCH", _DEFAULT_BATCH, int),
         vt_seconds=_env("VT_SECONDS", _DEFAULT_VT_SECONDS, int),
         poll_interval=_env("POLL_INTERVAL", _DEFAULT_POLL_INTERVAL, float),

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -100,10 +100,14 @@ class PgQueueConsumer:
         if not queue_names:
             raise ValueError("queue_names must be a non-empty list")
         # One process can drain several queues (9f) — e.g. a file_processing
-        # consumer drains both file_processing and api_file_processing. Polled
-        # round-robin so the per-queue (queue_name, priority DESC, msg_id) dequeue
-        # index keeps its top-N efficiency and no queue starves another.
-        self.queue_names = queue_names
+        # consumer drains both file_processing and api_file_processing. Each is
+        # read once per cycle in list order (poll_once): this prevents starvation
+        # (every queue gets a read each cycle) but does NOT equalize throughput —
+        # an always-full queue_names[0] claims its full batch and runs it before
+        # later queues. Copy + de-dup (order-preserving): a duplicate would
+        # double-read a queue per cycle, and storing the caller's list by
+        # reference would let a later mutation bypass the non-empty validation.
+        self.queue_names = list(dict.fromkeys(queue_names))
         self._client = client if client is not None else PgQueueClient()
         self._app = app if app is not None else current_app
         self.batch_size = batch_size
@@ -120,18 +124,30 @@ class PgQueueConsumer:
         self._last_poll_monotonic = time.monotonic()
 
     def poll_once(self) -> int:
-        """Claim + process one batch per queue (round-robin); returns the total
-        number of messages claimed across all queues this cycle.
+        """Claim + process one batch per queue (read once each, in list order);
+        returns the total number of messages claimed across all queues this cycle.
+
+        Each queue is isolated: a read/handle failure on one queue is logged and
+        skipped so the others still get their turn, and the work already done this
+        cycle still counts (so run() doesn't take the empty-queue backoff path
+        after a partial failure).
         """
         self._last_poll_monotonic = time.monotonic()
         total = 0
         for queue_name in self.queue_names:
-            messages = self._client.read(
-                queue_name, vt_seconds=self.vt_seconds, qty=self.batch_size
-            )
-            for message in messages:
-                self._handle(message)
-            total += len(messages)
+            try:
+                messages = self._client.read(
+                    queue_name, vt_seconds=self.vt_seconds, qty=self.batch_size
+                )
+                for message in messages:
+                    self._handle(message)
+                total += len(messages)
+            except Exception:
+                logger.exception(
+                    "PG-queue consumer: poll failed for queue %r; "
+                    "continuing with the other queues",
+                    queue_name,
+                )
         return total
 
     def _handle(self, message: QueueMessage) -> None:
@@ -309,9 +325,22 @@ class PgQueueConsumer:
 
 def _parse_queue_list(raw: str) -> list[str]:
     """Comma-separated queue list (9f). A single value stays a one-element list,
-    so the pre-9f single-queue config remains valid.
+    so the pre-9f single-queue config remains valid. Empty entries (a doubled or
+    trailing comma — almost always a config typo) are dropped with a warning so a
+    malformed list is diagnosable from the logs, not just by eyeballing.
     """
-    return [q.strip() for q in raw.split(",") if q.strip()]
+    parts = [q.strip() for q in raw.split(",")]
+    queues = [q for q in parts if q]
+    dropped = len(parts) - len(queues)
+    if dropped:
+        logger.warning(
+            "PG-queue consumer: dropped %d empty queue name(s) from "
+            "WORKER_PG_QUEUE_CONSUMER_QUEUE=%r → %r",
+            dropped,
+            raw,
+            queues,
+        )
+    return queues
 
 
 def main() -> None:

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -49,19 +49,25 @@ readonly PG_QUEUE_SET="pg-queue"
 # registry (api-deployment handles it as an API deployment; general routes by
 # workflow type), so one consumer can't serve both — they bind different queues.
 # fileproc/callback are multi-queue (one process drains both ETL + API queues).
+# Role-name constants — the literal lives in one place and is referenced across
+# PG_CONSUMER_ROLES / PG_QUEUE_MEMBERS / WORKERS.
+readonly PG_ROLE_ORCH_API="pg-orchestrator-api"
+readonly PG_ROLE_ORCH_GENERAL="pg-orchestrator-general"
+readonly PG_ROLE_FILEPROC="pg-fileproc"
+readonly PG_ROLE_CALLBACK="pg-callback"
 declare -rA PG_CONSUMER_ROLES=(
-    ["pg-orchestrator-api"]="api_deployment;celery_api_deployments"
-    ["pg-orchestrator-general"]="general;celery"
-    ["pg-fileproc"]="file_processing;file_processing,api_file_processing"
-    ["pg-callback"]="callback;file_processing_callback,api_file_processing_callback"
+    ["$PG_ROLE_ORCH_API"]="api_deployment;celery_api_deployments"
+    ["$PG_ROLE_ORCH_GENERAL"]="general;celery"
+    ["$PG_ROLE_FILEPROC"]="file_processing;file_processing,api_file_processing"
+    ["$PG_ROLE_CALLBACK"]="callback;file_processing_callback,api_file_processing_callback"
 )
 declare -rA PG_QUEUE_MEMBERS=(
     ["$PG_QUEUE_CONSUMER_TYPE"]=1
     ["$PG_QUEUE_REAPER_TYPE"]=1
-    ["pg-orchestrator-api"]=1
-    ["pg-orchestrator-general"]=1
-    ["pg-fileproc"]=1
-    ["pg-callback"]=1
+    ["$PG_ROLE_ORCH_API"]=1
+    ["$PG_ROLE_ORCH_GENERAL"]=1
+    ["$PG_ROLE_FILEPROC"]=1
+    ["$PG_ROLE_CALLBACK"]=1
 )
 # Log-tail alias for the Celery transport: every worker EXCEPT the PG-queue
 # members — the *complement* of the 'pg-queue' tail alias, so the two
@@ -95,10 +101,10 @@ declare -A WORKERS=(
     ["pg-consumer"]="$PG_QUEUE_CONSUMER_TYPE"
     # PG Queue named roles (9f) — coupled-pipeline consumers, queues + source
     # worker-type baked in. Run individually like any worker, or via the 'pg' set.
-    ["pg-orchestrator-api"]="pg-orchestrator-api"
-    ["pg-orchestrator-general"]="pg-orchestrator-general"
-    ["pg-fileproc"]="pg-fileproc"
-    ["pg-callback"]="pg-callback"
+    ["$PG_ROLE_ORCH_API"]="$PG_ROLE_ORCH_API"
+    ["$PG_ROLE_ORCH_GENERAL"]="$PG_ROLE_ORCH_GENERAL"
+    ["$PG_ROLE_FILEPROC"]="$PG_ROLE_FILEPROC"
+    ["$PG_ROLE_CALLBACK"]="$PG_ROLE_CALLBACK"
     # PG Queue reaper — leader-elected recovery loop (barrier-orphan sweep)
     ["reaper"]="$PG_QUEUE_REAPER_TYPE"
     ["pg-queue-reaper"]="$PG_QUEUE_REAPER_TYPE"

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -69,11 +69,11 @@ declare -rA PG_QUEUE_MEMBERS=(
     ["$PG_ROLE_FILEPROC"]=1
     ["$PG_ROLE_CALLBACK"]=1
 )
-# Log-tail alias for the Celery transport: every worker EXCEPT the PG-queue
-# members — the *complement* of the 'pg-queue' tail alias, so the two
-# transports' logs can be tailed separately (-L celery vs -L pg-queue).
-# Tail-only — there is no 'celery' run alias; this set is started via 'all',
-# which by design omits the opt-in PG-queue workers.
+# The Celery transport set: every worker EXCEPT the PG-queue members — the
+# *complement* of the 'pg-queue' set, so the two transports' logs can be tailed
+# separately (-L celery vs -L pg-queue). Since 9f, 'celery' is BOTH a -L tail
+# alias AND a run alias (WORKERS maps it to "all" → run_all_workers), symmetric
+# with 'pg'; 'all' remains its synonym. Either way it omits the opt-in PG workers.
 readonly CELERY_SET="celery"
 
 # Available workers
@@ -192,7 +192,7 @@ WORKER_TYPE:
     pg-orchestrator-api   Run the PG orchestrator consumer for API execs (celery_api_deployments)
     pg-orchestrator-general Run the PG orchestrator consumer for ETL/general execs (celery)
     pg-fileproc           Run the PG fan-out consumer (file_processing + api_file_processing)
-    pg-callback           Run the PG callback consumer (file_processing_callback + api_…_callback)
+    pg-callback           Run the PG callback consumer (file_processing_callback + api_file_processing_callback)
     reaper, pg-queue-reaper Run PG-queue reaper (leader-elected recovery; opt-in)
     pg, pg-queue          Run the whole PG-queue set (the 4 pipeline roles + reaper) together
     all, celery           Run the Celery worker set (all Celery workers; excludes the PG set)
@@ -840,7 +840,9 @@ run_worker() {
         # ("<type>;<queues>"); the generic pg-queue-consumer reads them from env
         # (default source worker = notification, the first migrated leaf task).
         if [[ -n "$pg_consumer_role" ]]; then
-            export WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE="${pg_consumer_role%%;*}"
+            # Plain assignment — the line below is the single export point (its
+            # :- default/override is load-bearing for the generic consumer path).
+            WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE="${pg_consumer_role%%;*}"
             queues="${pg_consumer_role#*;}"
         fi
         export WORKER_PG_QUEUE_CONSUMER_QUEUE="$queues"
@@ -875,9 +877,10 @@ run_worker() {
     # Change to appropriate directory
     # For pluggable workers, stay at workers root to allow module imports
     # For core workers, change to worker directory
-    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" || -n "${PG_CONSUMER_ROLES[$worker_type]:-}" ]]; then
+    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || -n "${PG_QUEUE_MEMBERS[$worker_type]:-}" ]]; then
         # Run from the workers root so `python -m pg_queue_consumer` /
-        # `python -m pg_queue_reaper` (and what they import) resolve.
+        # `python -m pg_queue_reaper` (and what they import) resolve. PG_QUEUE_MEMBERS
+        # is the single source of truth for "which workers are PG-queue members".
         cd "$WORKERS_DIR"
     else
         cd "$worker_dir"
@@ -973,7 +976,7 @@ run_all_workers() {
     fi
 }
 
-# Function to run the PG-queue worker set (consumer + reaper) together.
+# Function to run the PG-queue worker set (the 4 pipeline roles + reaper) together.
 # A set is multiple processes, so — like 'all' — it ALWAYS runs detached
 # (it ignores -d/--detach; there's no foreground form). The PG-queue counterpart
 # to 'all' (the Celery set): run both for a dual-transport (strangler-fig) setup.
@@ -986,8 +989,9 @@ run_pg_queue_set() {
     local concurrency=$2
     local pool_type=$3
 
-    # The set = the named pipeline consumer roles (9f) + the reaper. Each role is
-    # a multi-queue consumer covering ETL+API for its stage (fan-out / callback).
+    # The set = the named pipeline consumer roles (9f) + the reaper. The fan-out
+    # and callback roles are multi-queue (ETL+API); the two orchestrator roles
+    # each bind a single registry-specific queue (see PG_CONSUMER_ROLES).
     local members=("${!PG_CONSUMER_ROLES[@]}" "$PG_QUEUE_REAPER_TYPE")
     print_status $GREEN "Starting PG-queue set (${members[*]})..."
     local failed=0
@@ -1007,10 +1011,15 @@ run_pg_queue_set() {
         # Don't leave a survivor: a restart-on-failure relaunch would spawn a
         # second instance on top of it (a consumer would double-poll Postgres).
         # Kill all members (a crashed one is already gone → no-op). Same
-        # all-or-nothing discipline as the restart path.
+        # all-or-nothing discipline as the restart path — aggregate kill failures
+        # so a survivor (would double-poll Postgres) is surfaced, not silent.
+        local teardown_failed=0
         for worker in "${members[@]}"; do
-            kill_one_worker "$worker"
+            kill_one_worker "$worker" || teardown_failed=1
         done
+        if [[ $teardown_failed -ne 0 ]]; then
+            print_status $RED "PG-queue set: a member survived SIGKILL during teardown — check for a duplicate consumer double-polling Postgres"
+        fi
         show_status
         return 1
     fi
@@ -1148,8 +1157,12 @@ if [[ "$RESTART_MODE" == "true" ]]; then
         # consumer would double-poll Postgres. Mirrors kill_workers' discipline.
         print_status $BLUE "Restarting PG-queue set..."
         restart_failed=0
-        kill_one_worker "$PG_QUEUE_CONSUMER_TYPE" || restart_failed=1
-        kill_one_worker "$PG_QUEUE_REAPER_TYPE" || restart_failed=1
+        # Kill the SAME members run_pg_queue_set launches (the named roles +
+        # reaper) — not the generic consumer — or a survivor + relaunch would
+        # double-poll Postgres.
+        for pg_member in "${!PG_CONSUMER_ROLES[@]}" "$PG_QUEUE_REAPER_TYPE"; do
+            kill_one_worker "$pg_member" || restart_failed=1
+        done
         if [[ $restart_failed -ne 0 ]]; then
             print_status $RED "Cannot restart PG-queue set: a member survived SIGKILL; aborting to avoid duplicate processes"
             exit 1

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -36,9 +36,32 @@ readonly PG_QUEUE_SET="pg-queue"
 # pg-queue` complement correct by construction if a third member is ever added
 # (callers test membership via ${PG_QUEUE_MEMBERS[$dir]:-} instead of
 # hand-rolling the consumer/reaper pair).
+# 9f: named PG-queue consumer ROLES. Each is a multi-queue consumer (one process
+# draining several queues, mirroring the Celery file_processing/callback workers
+# that each cover ETL+API) with its source worker-type + queue list baked in — so
+# `./run-worker.sh -d pg-fileproc` needs no per-process env. Format:
+# "<source_worker_type>;<comma,separated,queues>". The role name is passed as argv
+# to `python -m pg_queue_consumer <role>` so pgrep (--status/-k/-r) tells the
+# co-running roles apart (they are otherwise identical processes).
+# The four coupled-pipeline stages, each a registry-bound consumer (mirroring the
+# Celery api-deployment / general / file_processing / callback workers). The two
+# orchestrator roles are split because async_execute_bin has DISTINCT impls per
+# registry (api-deployment handles it as an API deployment; general routes by
+# workflow type), so one consumer can't serve both — they bind different queues.
+# fileproc/callback are multi-queue (one process drains both ETL + API queues).
+declare -rA PG_CONSUMER_ROLES=(
+    ["pg-orchestrator-api"]="api_deployment;celery_api_deployments"
+    ["pg-orchestrator-general"]="general;celery"
+    ["pg-fileproc"]="file_processing;file_processing,api_file_processing"
+    ["pg-callback"]="callback;file_processing_callback,api_file_processing_callback"
+)
 declare -rA PG_QUEUE_MEMBERS=(
     ["$PG_QUEUE_CONSUMER_TYPE"]=1
     ["$PG_QUEUE_REAPER_TYPE"]=1
+    ["pg-orchestrator-api"]=1
+    ["pg-orchestrator-general"]=1
+    ["pg-fileproc"]=1
+    ["pg-callback"]=1
 )
 # Log-tail alias for the Celery transport: every worker EXCEPT the PG-queue
 # members — the *complement* of the 'pg-queue' tail alias, so the two
@@ -70,6 +93,12 @@ declare -A WORKERS=(
     ["pg-queue-consumer"]="$PG_QUEUE_CONSUMER_TYPE"
     ["$PG_QUEUE_CONSUMER_TYPE"]="$PG_QUEUE_CONSUMER_TYPE"
     ["pg-consumer"]="$PG_QUEUE_CONSUMER_TYPE"
+    # PG Queue named roles (9f) — coupled-pipeline consumers, queues + source
+    # worker-type baked in. Run individually like any worker, or via the 'pg' set.
+    ["pg-orchestrator-api"]="pg-orchestrator-api"
+    ["pg-orchestrator-general"]="pg-orchestrator-general"
+    ["pg-fileproc"]="pg-fileproc"
+    ["pg-callback"]="pg-callback"
     # PG Queue reaper — leader-elected recovery loop (barrier-orphan sweep)
     ["reaper"]="$PG_QUEUE_REAPER_TYPE"
     ["pg-queue-reaper"]="$PG_QUEUE_REAPER_TYPE"
@@ -149,9 +178,13 @@ WORKER_TYPE:
     scheduler, schedule   Run scheduler worker (scheduled pipeline tasks)
     executor              Run executor worker (extraction execution tasks)
     ide-callback          Run IDE callback worker (Prompt Studio post-execution callbacks)
-    pg-queue-consumer     Run PG-queue poll-loop consumer (opt-in; not part of 'all')
+    pg-queue-consumer     Run a generic PG-queue poll-loop consumer (env-configured; opt-in)
+    pg-orchestrator-api   Run the PG orchestrator consumer for API execs (celery_api_deployments)
+    pg-orchestrator-general Run the PG orchestrator consumer for ETL/general execs (celery)
+    pg-fileproc           Run the PG fan-out consumer (file_processing + api_file_processing)
+    pg-callback           Run the PG callback consumer (file_processing_callback + api_…_callback)
     reaper, pg-queue-reaper Run PG-queue reaper (leader-elected recovery; opt-in)
-    pg, pg-queue          Run the PG-queue set (consumer + reaper) together
+    pg, pg-queue          Run the whole PG-queue set (the 4 pipeline roles + reaper) together
     all                   Run all workers (in separate processes, includes auto-discovered pluggable workers)
 
 Note: Pluggable workers in pluggable_worker/ directory are automatically discovered and can be run by name.
@@ -383,7 +416,11 @@ get_worker_pids() {
     # `<type>-worker@host` process, so they have no `-worker` token to anchor on.
     # Match the module invocation instead (covers both the `uv run python` parent
     # and the `python -m` child). Keeps --status / -k / -r working for them.
-    if [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
+    if [[ -n "${PG_CONSUMER_ROLES[$worker_type]:-}" ]]; then
+        # 9f roles run as `python -m pg_queue_consumer <role>` — anchor on the
+        # role argv so co-running roles (and the generic consumer) don't collide.
+        pattern="-m[[:space:]]+${PG_QUEUE_CONSUMER_TYPE}[[:space:]]+${worker_type}([[:space:]]|\$)"
+    elif [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
         pattern="-m[[:space:]]+${worker_type}([[:space:]]|\$)"
     else
         pattern="[^[:alnum:]_]${worker_type}-worker(@|-)"
@@ -443,10 +480,15 @@ resolve_log_file() {
     local worker_dir=$1
     local core_path="$WORKERS_DIR/$worker_dir/$worker_dir.log"
     local pluggable_path="$WORKERS_DIR/pluggable_worker/$worker_dir/$worker_dir.log"
+    # 9f roles run from (and log under) the pg_queue_consumer launcher dir as
+    # "<role>.log", since they share that dir rather than having their own.
+    local role_path="$WORKERS_DIR/$PG_QUEUE_CONSUMER_TYPE/$worker_dir.log"
     if [[ -f "$core_path" ]]; then
         echo "$core_path"
     elif [[ -f "$pluggable_path" ]]; then
         echo "$pluggable_path"
+    elif [[ -n "${PG_CONSUMER_ROLES[$worker_dir]:-}" && -f "$role_path" ]]; then
+        echo "$role_path"
     fi
 }
 
@@ -477,8 +519,9 @@ tail_logs() {
             exit 1
         fi
         if [[ "$canonical" == "$PG_QUEUE_SET" ]]; then
-            # The set alias maps to no single dir — tail both member logs.
-            for d in "$PG_QUEUE_CONSUMER_TYPE" "$PG_QUEUE_REAPER_TYPE"; do
+            # The set alias maps to no single dir — tail every member's log
+            # (the named role consumers + the reaper).
+            for d in "${!PG_CONSUMER_ROLES[@]}" "$PG_QUEUE_REAPER_TYPE"; do
                 local member_log
                 member_log=$(resolve_log_file "$d")
                 [[ -n "$member_log" ]] && log_files+=("$member_log")
@@ -623,6 +666,10 @@ run_worker() {
     if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" ]]; then
         # Pluggable worker - use subdirectory
         worker_dir="$WORKERS_DIR/pluggable_worker/$worker_type"
+    elif [[ -n "${PG_CONSUMER_ROLES[$worker_type]:-}" ]]; then
+        # 9f role consumers share the pg_queue_consumer launcher dir (there is no
+        # per-role directory; the role only selects queues + source worker-type).
+        worker_dir="$WORKERS_DIR/$PG_QUEUE_CONSUMER_TYPE"
     else
         # Core worker - use root directory
         worker_dir="$WORKERS_DIR/$worker_type"
@@ -770,17 +817,24 @@ run_worker() {
     # PG queue consumer is a plain Python poll-loop (polls Postgres via
     # SKIP LOCKED, not a Celery/RabbitMQ worker) — override the celery command
     # with the bootstrapping launcher and route the queue via env.
-    if [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" ]]; then
+    pg_consumer_role="${PG_CONSUMER_ROLES[$worker_type]:-}"
+    if [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || -n "$pg_consumer_role" ]]; then
+        # A named 9f role bakes in its source worker-type + multi-queue list
+        # ("<type>;<queues>"); the generic pg-queue-consumer reads them from env
+        # (default source worker = notification, the first migrated leaf task).
+        if [[ -n "$pg_consumer_role" ]]; then
+            export WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE="${pg_consumer_role%%;*}"
+            queues="${pg_consumer_role#*;}"
+        fi
         export WORKER_PG_QUEUE_CONSUMER_QUEUE="$queues"
-        # The consumer registers ONE source worker's tasks (the launcher sets
-        # WORKER_TYPE from this before `import worker`). Default: notification —
-        # the worker that owns the first migrated leaf task,
-        # send_webhook_notification; override to drain another worker's queue.
         export WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE="${WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE:-notification}"
-        # Liveness HTTP server port (-p override wins, else the map default).
-        # Exported so the launcher's main() opts into the health server.
-        export WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT="${health_port:-${WORKER_HEALTH_PORTS[$worker_type]}}"
+        # Liveness HTTP server port (-p override wins, else the map default; roles
+        # have no map entry → empty → the launcher skips the health server).
+        export WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT="${health_port:-${WORKER_HEALTH_PORTS[$worker_type]:-}}"
         cmd_args=("uv" "run" "python" "-m" "$PG_QUEUE_CONSUMER_TYPE")
+        # Tag the process with the role name so pgrep (--status/-k/-r) can tell
+        # co-running roles apart — they are otherwise identical `python -m` procs.
+        [[ -n "$pg_consumer_role" ]] && cmd_args+=("$worker_type")
     fi
 
     # PG queue reaper — a leader-elected SQL recovery loop (no Celery, no task
@@ -804,7 +858,7 @@ run_worker() {
     # Change to appropriate directory
     # For pluggable workers, stay at workers root to allow module imports
     # For core workers, change to worker directory
-    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
+    if [[ -n "${PLUGGABLE_WORKERS[$worker_type]:-}" || "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" || -n "${PG_CONSUMER_ROLES[$worker_type]:-}" ]]; then
         # Run from the workers root so `python -m pg_queue_consumer` /
         # `python -m pg_queue_reaper` (and what they import) resolve.
         cd "$WORKERS_DIR"
@@ -915,9 +969,12 @@ run_pg_queue_set() {
     local concurrency=$2
     local pool_type=$3
 
-    print_status $GREEN "Starting PG-queue set (consumer + reaper)..."
+    # The set = the named pipeline consumer roles (9f) + the reaper. Each role is
+    # a multi-queue consumer covering ETL+API for its stage (fan-out / callback).
+    local members=("${!PG_CONSUMER_ROLES[@]}" "$PG_QUEUE_REAPER_TYPE")
+    print_status $GREEN "Starting PG-queue set (${members[*]})..."
     local failed=0
-    for worker in "$PG_QUEUE_CONSUMER_TYPE" "$PG_QUEUE_REAPER_TYPE"; do
+    for worker in "${members[@]}"; do
         print_status $BLUE "Starting $worker in background..."
         # A FOREGROUND subshell: run_worker (detach=true) nohup-backgrounds the
         # actual worker and returns 1 on an immediate crash-on-start — so the
@@ -931,11 +988,12 @@ run_pg_queue_set() {
     if [[ $failed -ne 0 ]]; then
         print_status $RED "PG-queue set: a member failed to start — tearing down the set (see logs above)"
         # Don't leave a survivor: a restart-on-failure relaunch would spawn a
-        # second instance on top of it (the consumer would double-poll Postgres).
-        # Kill both members (the crashed one is already gone → no-op). Same
+        # second instance on top of it (a consumer would double-poll Postgres).
+        # Kill all members (a crashed one is already gone → no-op). Same
         # all-or-nothing discipline as the restart path.
-        kill_one_worker "$PG_QUEUE_CONSUMER_TYPE"
-        kill_one_worker "$PG_QUEUE_REAPER_TYPE"
+        for worker in "${members[@]}"; do
+            kill_one_worker "$worker"
+        done
         show_status
         return 1
     fi

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -113,6 +113,10 @@ declare -A WORKERS=(
     ["$PG_QUEUE_SET"]="$PG_QUEUE_SET"
     ["pg"]="$PG_QUEUE_SET"
     ["all"]="all"
+    # 'celery' is a run alias for the Celery set (== 'all', which excludes the PG
+    # workers) — symmetric with 'pg'. Maps to "all" so it dispatches to
+    # run_all_workers and list_core_worker_dirs skips it (not a phantom dir).
+    ["$CELERY_SET"]="all"
 )
 
 # Pluggable workers will be auto-discovered at runtime
@@ -191,11 +195,11 @@ WORKER_TYPE:
     pg-callback           Run the PG callback consumer (file_processing_callback + api_…_callback)
     reaper, pg-queue-reaper Run PG-queue reaper (leader-elected recovery; opt-in)
     pg, pg-queue          Run the whole PG-queue set (the 4 pipeline roles + reaper) together
-    all                   Run all workers (in separate processes, includes auto-discovered pluggable workers)
+    all, celery           Run the Celery worker set (all Celery workers; excludes the PG set)
 
 Note: Pluggable workers in pluggable_worker/ directory are automatically discovered and can be run by name.
-Note: 'all' is the Celery worker set; 'pg-queue' is the PG-queue set. They are independent —
-      run both in parallel for a dual-transport (strangler-fig) setup.
+Note: 'all' (alias 'celery') is the Celery worker set; 'pg' ('pg-queue') is the PG-queue set. They are
+      independent — pass both (e.g. `-d all pg`) for a dual-transport (strangler-fig) setup.
 Note: pg-queue-consumer overrides: WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE (source worker whose
       tasks to load, default notification), WORKER_PG_QUEUE_CONSUMER_QUEUE (queue to poll),
       and WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT (liveness server port, default 8090).
@@ -1150,7 +1154,8 @@ if [[ "$RESTART_MODE" == "true" ]]; then
             print_status $RED "Cannot restart PG-queue set: a member survived SIGKILL; aborting to avoid duplicate processes"
             exit 1
         fi
-    elif [[ -n "$WORKER_TYPE" && "$WORKER_TYPE" != "all" ]]; then
+    elif [[ -n "$WORKER_TYPE" && "$WORKER_TYPE" != "all" && "${WORKERS[$WORKER_TYPE]:-}" != "all" ]]; then
+        # ('celery' maps to "all" → falls through to the restart-all branch below.)
         restart_target_dir="${WORKERS[$WORKER_TYPE]:-${PLUGGABLE_WORKERS[$WORKER_TYPE]:-}}"
         if [[ -z "$restart_target_dir" ]]; then
             print_status $RED "Error: Unknown worker type for restart: $WORKER_TYPE"
@@ -1216,7 +1221,8 @@ fi
 
 # Run each requested worker / set in turn.
 for wt in "${WORKER_TYPES[@]}"; do
-    if [[ "$wt" == "all" ]]; then
+    if [[ "${WORKERS[$wt]:-}" == "all" ]]; then
+        # 'all' and its synonym 'celery' (the Celery set, excludes PG workers).
         run_all_workers "$DETACH" "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE"
     elif [[ "${WORKERS[$wt]:-}" == "$PG_QUEUE_SET" ]]; then
         # The PG-queue set (pipeline roles + reaper). Always backgrounded (multiple

--- a/workers/run-worker.sh
+++ b/workers/run-worker.sh
@@ -227,6 +227,9 @@ EXAMPLES:
     # Run file processing worker in background
     $0 -d file
 
+    # Start BOTH transports in one shot (Celery set + PG set) — use -d so neither blocks
+    $0 -d all pg
+
     # Run with custom environment file
     $0 -e production.env all
 
@@ -421,7 +424,11 @@ get_worker_pids() {
         # role argv so co-running roles (and the generic consumer) don't collide.
         pattern="-m[[:space:]]+${PG_QUEUE_CONSUMER_TYPE}[[:space:]]+${worker_type}([[:space:]]|\$)"
     elif [[ "$worker_type" == "$PG_QUEUE_CONSUMER_TYPE" || "$worker_type" == "$PG_QUEUE_REAPER_TYPE" ]]; then
-        pattern="-m[[:space:]]+${worker_type}([[:space:]]|\$)"
+        # End-anchored so the GENERIC consumer doesn't also match the role
+        # consumers (which run as `... -m pg_queue_consumer <role>`); they have
+        # their own role-anchored pattern above. The reaper takes no role arg, so
+        # the same end anchor matches it cleanly.
+        pattern="-m[[:space:]]+${worker_type}[[:space:]]*\$"
     else
         pattern="[^[:alnum:]_]${worker_type}-worker(@|-)"
     fi
@@ -1014,6 +1021,10 @@ SHOW_STATUS=false
 LOGS_MODE=false
 CLEAR_LOGS_MODE=false
 RESTART_MODE=false
+# Multiple positional worker types may be given (e.g. `all pg` to start both the
+# Celery and PG sets in one shot). WORKER_TYPE stays the first for the
+# single-target paths (-r/validation); the launch path loops WORKER_TYPES.
+WORKER_TYPES=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -1079,11 +1090,15 @@ while [[ $# -gt 0 ]]; do
             exit 1
             ;;
         *)
-            WORKER_TYPE="$1"
+            WORKER_TYPES+=("$1")
             shift
             ;;
     esac
 done
+
+# First positional drives the single-target paths (-r, validation messages); the
+# launch path below iterates all of WORKER_TYPES.
+WORKER_TYPE="${WORKER_TYPES[0]:-}"
 
 # Handle special actions
 if [[ "$KILL_WORKERS" == "true" ]]; then
@@ -1143,11 +1158,16 @@ if [[ "$RESTART_MODE" == "true" ]]; then
     fi
 fi
 
-# Validate worker type
-if [[ -z "$WORKER_TYPE" ]]; then
-    print_status $RED "Error: Worker type is required"
-    usage
-    exit 1
+# A worker type is required. (restart-all set WORKER_TYPE=all without a positional
+# → seed WORKER_TYPES from it so the launch loop below has a target.)
+if [[ ${#WORKER_TYPES[@]} -eq 0 ]]; then
+    if [[ -n "$WORKER_TYPE" ]]; then
+        WORKER_TYPES=("$WORKER_TYPE")
+    else
+        print_status $RED "Error: Worker type is required"
+        usage
+        exit 1
+    fi
 fi
 
 # Load environment
@@ -1156,23 +1176,25 @@ load_env "$ENV_FILE"
 # Discover pluggable workers
 discover_pluggable_workers
 
-# Validate worker type (check both core and pluggable workers)
-if [[ -z "${WORKERS[$WORKER_TYPE]}" ]] && [[ -z "${PLUGGABLE_WORKERS[$WORKER_TYPE]}" ]]; then
-    print_status $RED "Error: Unknown worker type: $WORKER_TYPE"
-    print_status $BLUE "Available core workers: ${!WORKERS[*]}"
-    if [[ ${#PLUGGABLE_WORKERS[@]} -gt 0 ]]; then
-        # Show unique pluggable worker names (not aliases)
-        pluggable_names=""
-        for key in "${!PLUGGABLE_WORKERS[@]}"; do
-            value="${PLUGGABLE_WORKERS[$key]}"
-            if [[ "$key" == "$value" ]]; then
-                pluggable_names="$pluggable_names $value"
-            fi
-        done
-        print_status $BLUE "Available pluggable workers:$pluggable_names"
+# Validate every requested worker type (core or pluggable) up front.
+for wt in "${WORKER_TYPES[@]}"; do
+    if [[ -z "${WORKERS[$wt]:-}" && -z "${PLUGGABLE_WORKERS[$wt]:-}" ]]; then
+        print_status $RED "Error: Unknown worker type: $wt"
+        print_status $BLUE "Available core workers: ${!WORKERS[*]}"
+        if [[ ${#PLUGGABLE_WORKERS[@]} -gt 0 ]]; then
+            # Show unique pluggable worker names (not aliases)
+            pluggable_names=""
+            for key in "${!PLUGGABLE_WORKERS[@]}"; do
+                value="${PLUGGABLE_WORKERS[$key]}"
+                if [[ "$key" == "$value" ]]; then
+                    pluggable_names="$pluggable_names $value"
+                fi
+            done
+            print_status $BLUE "Available pluggable workers:$pluggable_names"
+        fi
+        exit 1
     fi
-    exit 1
-fi
+done
 
 # Validate environment
 validate_env
@@ -1180,19 +1202,24 @@ validate_env
 # Add PYTHONPATH for imports
 export PYTHONPATH="$WORKERS_DIR:${PYTHONPATH:-}"
 
-# Run the requested worker(s)
-if [[ "$WORKER_TYPE" == "all" ]]; then
-    run_all_workers "$DETACH" "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE"
-elif [[ "${WORKERS[$WORKER_TYPE]:-}" == "$PG_QUEUE_SET" ]]; then
-    # The PG-queue set (consumer + reaper). Always backgrounded (multiple procs).
-    # Propagate a member start-failure to the script exit code — the reaper has
-    # no health port, so this is the only programmatic startup signal.
-    run_pg_queue_set "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE" || exit 1
-else
-    # Resolve worker directory name from either WORKERS or PLUGGABLE_WORKERS
-    WORKER_DIR_NAME="${WORKERS[$WORKER_TYPE]}"
-    if [[ -z "$WORKER_DIR_NAME" ]]; then
-        WORKER_DIR_NAME="${PLUGGABLE_WORKERS[$WORKER_TYPE]}"
-    fi
-    run_worker "$WORKER_DIR_NAME" "$DETACH" "$LOG_LEVEL" "$CONCURRENCY" "$CUSTOM_QUEUES" "$HEALTH_PORT" "$POOL_TYPE" "$CUSTOM_HOSTNAME"
+# Multi-type launches (e.g. `all pg`) must be detached: a non-detached set
+# (run_all_workers) `wait`s on its background jobs and would block any later type.
+if [[ ${#WORKER_TYPES[@]} -gt 1 && "$DETACH" != "true" ]]; then
+    print_status $YELLOW "Multiple worker types given without -d/--detach: a foreground set will block the rest. Re-run with -d to start them all."
 fi
+
+# Run each requested worker / set in turn.
+for wt in "${WORKER_TYPES[@]}"; do
+    if [[ "$wt" == "all" ]]; then
+        run_all_workers "$DETACH" "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE"
+    elif [[ "${WORKERS[$wt]:-}" == "$PG_QUEUE_SET" ]]; then
+        # The PG-queue set (pipeline roles + reaper). Always backgrounded (multiple
+        # procs). Propagate a member start-failure to the script exit code — the
+        # reaper has no health port, so this is the only programmatic startup signal.
+        run_pg_queue_set "$LOG_LEVEL" "$CONCURRENCY" "$POOL_TYPE" || exit 1
+    else
+        # Resolve worker directory name from either WORKERS or PLUGGABLE_WORKERS
+        worker_dir_name="${WORKERS[$wt]:-${PLUGGABLE_WORKERS[$wt]}}"
+        run_worker "$worker_dir_name" "$DETACH" "$LOG_LEVEL" "$CONCURRENCY" "$CUSTOM_QUEUES" "$HEALTH_PORT" "$POOL_TYPE" "$CUSTOM_HOSTNAME"
+    fi
+done

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -54,7 +54,7 @@ class TestPollOnce:
     def test_runs_task_and_acks(self):
         client = MagicMock()
         client.read.return_value = [_msg(1, _ok_payload(3, 4))]
-        assert PgQueueConsumer("q", client=client).poll_once() == 1
+        assert PgQueueConsumer(["q"], client=client).poll_once() == 1
         assert _calls == [(3, 4)]  # task body ran
         client.delete.assert_called_once_with(1)  # acked
 
@@ -64,7 +64,7 @@ class TestPollOnce:
             _msg(2, {"task_name": "test_pg_consumer.boom", "args": [], "kwargs": {}})
         ]
         with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
-            PgQueueConsumer("q", client=client).poll_once()
+            PgQueueConsumer(["q"], client=client).poll_once()
         client.delete.assert_not_called()  # left for vt-expiry redelivery
         assert "failed" in caplog.text  # the cycling signal is logged
 
@@ -74,7 +74,7 @@ class TestPollOnce:
             _msg(3, {"task_name": "nope.nope", "args": [], "kwargs": {}})
         ]
         with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
-            PgQueueConsumer("q", client=client).poll_once()
+            PgQueueConsumer(["q"], client=client).poll_once()
         client.delete.assert_called_once_with(3)  # dropped, not redelivered
         assert "unknown task" in caplog.text
 
@@ -82,7 +82,7 @@ class TestPollOnce:
         client = MagicMock()
         client.read.return_value = [_msg(4, {"args": [], "kwargs": {}})]  # no task_name
         with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
-            PgQueueConsumer("q", client=client).poll_once()
+            PgQueueConsumer(["q"], client=client).poll_once()
         client.delete.assert_called_once_with(4)
         assert "missing task_name" in caplog.text  # distinct from "unknown task"
 
@@ -93,7 +93,7 @@ class TestPollOnce:
             _msg(5, {"task_name": "test_pg_consumer.boom"}, read_ct=6)
         ]
         with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
-            PgQueueConsumer("q", client=client, max_attempts=5).poll_once()
+            PgQueueConsumer(["q"], client=client, max_attempts=5).poll_once()
         client.delete.assert_called_once_with(5)  # dropped as poison
         assert "poison" in caplog.text
 
@@ -107,7 +107,7 @@ class TestPollOnce:
         client.read.return_value = [
             _msg(6, {"task_name": "t", "args": [1], "kwargs": {"k": "v"}, "fairness": fairness})
         ]
-        PgQueueConsumer("q", client=client, app=app).poll_once()
+        PgQueueConsumer(["q"], client=client, app=app).poll_once()
         kwargs = task.apply.call_args.kwargs
         assert kwargs["args"] == [1]
         assert kwargs["kwargs"] == {"k": "v"}
@@ -118,7 +118,7 @@ class TestPollOnce:
         client.delete.return_value = False  # row already gone (vt expired mid-run)
         client.read.return_value = [_msg(7, _ok_payload(1))]
         with caplog.at_level(logging.WARNING, logger="queue_backend.pg_queue.consumer"):
-            PgQueueConsumer("q", client=client).poll_once()
+            PgQueueConsumer(["q"], client=client).poll_once()
         assert "possible double-run" in caplog.text
 
     def test_multi_message_batch(self):
@@ -129,7 +129,7 @@ class TestPollOnce:
             _msg(12, {"task_name": "nope.nope"}),
             _msg(13, _ok_payload(2)),
         ]
-        assert PgQueueConsumer("q", client=client).poll_once() == 4
+        assert PgQueueConsumer(["q"], client=client).poll_once() == 4
         assert _calls == [(1, 0), (2, 0)]  # ok tasks ran in order
         deleted = {c.args[0] for c in client.delete.call_args_list}
         assert deleted == {10, 12, 13}  # ok acked + unknown dropped; boom NOT acked
@@ -137,7 +137,7 @@ class TestPollOnce:
     def test_empty_batch_acks_nothing(self):
         client = MagicMock()
         client.read.return_value = []
-        assert PgQueueConsumer("q", client=client).poll_once() == 0
+        assert PgQueueConsumer(["q"], client=client).poll_once() == 0
         client.delete.assert_not_called()
 
 
@@ -151,13 +151,13 @@ class TestConstruction:
             {"max_attempts": 0},
         ):
             with pytest.raises(ValueError):
-                PgQueueConsumer("q", client=MagicMock(), **kw)
+                PgQueueConsumer(["q"], client=MagicMock(), **kw)
 
     def test_rejects_backoff_max_below_poll_interval(self):
         # Otherwise backoff would shrink below poll_interval instead of growing.
         with pytest.raises(ValueError, match="backoff_max"):
             PgQueueConsumer(
-                "q", client=MagicMock(), poll_interval=0.5, backoff_max=0.1
+                ["q"], client=MagicMock(), poll_interval=0.5, backoff_max=0.1
             )
 
 
@@ -165,7 +165,7 @@ class TestRunLoop:
     def test_run_stops_gracefully(self, monkeypatch):
         client = MagicMock()
         client.read.return_value = []  # always empty → backoff path
-        consumer = PgQueueConsumer("q", client=client)
+        consumer = PgQueueConsumer(["q"], client=client)
         # First empty poll → sleep (patched to request stop) → loop exits.
         monkeypatch.setattr(
             "queue_backend.pg_queue.consumer.time.sleep", lambda _s: consumer.stop()
@@ -178,7 +178,7 @@ class TestRunLoop:
         # empty, empty, one message, empty → backoff doubles, resets, doubles.
         client.read.side_effect = [[], [], [_msg(1, _ok_payload(1))], []]
         consumer = PgQueueConsumer(
-            "q", client=client, poll_interval=0.1, backoff_max=0.25
+            ["q"], client=client, poll_interval=0.1, backoff_max=0.25
         )
         sleeps: list[float] = []
 
@@ -196,7 +196,7 @@ class TestRunLoop:
         client = MagicMock()
         # first poll raises (transient), then empty → loop must survive the raise.
         client.read.side_effect = [RuntimeError("blip"), []]
-        consumer = PgQueueConsumer("q", client=client)
+        consumer = PgQueueConsumer(["q"], client=client)
         sleeps: list[float] = []
 
         def _sleep(secs):
@@ -214,7 +214,7 @@ class TestRunLoop:
         from celery import Celery
 
         empty_app = Celery("empty-no-tasks")  # only celery.* built-ins
-        consumer = PgQueueConsumer("q", client=MagicMock(), app=empty_app)
+        consumer = PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)
         with pytest.raises(RuntimeError, match="no application tasks"):
             consumer.run(install_signals=False)
 
@@ -223,7 +223,7 @@ class TestRunLoop:
         # the module's @shared_task tasks registered, so the guard passes.
         client = MagicMock()
         client.read.return_value = []  # empty → loop sleeps → we stop it
-        consumer = PgQueueConsumer("q", client=client)
+        consumer = PgQueueConsumer(["q"], client=client)
         monkeypatch.setattr(
             "queue_backend.pg_queue.consumer.time.sleep", lambda _s: consumer.stop()
         )
@@ -238,7 +238,7 @@ class TestRunLoop:
         empty_app = Celery("empty-no-tasks")
         client = MagicMock()
         client.read.return_value = []
-        consumer = PgQueueConsumer("q", client=client, app=empty_app)
+        consumer = PgQueueConsumer(["q"], client=client, app=empty_app)
         monkeypatch.setattr(
             "queue_backend.pg_queue.consumer.time.sleep", lambda _s: consumer.stop()
         )
@@ -252,7 +252,7 @@ class TestRunLoop:
 
         empty_app = Celery("empty-no-tasks")
         assert (
-            PgQueueConsumer("q", client=MagicMock(), app=empty_app)._registered_task_count()
+            PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)._registered_task_count()
             == 0
         )
 
@@ -261,7 +261,7 @@ class TestRunLoop:
             return 1
 
         assert (
-            PgQueueConsumer("q", client=MagicMock(), app=empty_app)._registered_task_count()
+            PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)._registered_task_count()
             == 1
         )
 
@@ -273,7 +273,7 @@ class TestPollHeartbeat:
     def test_poll_once_refreshes_heartbeat(self):
         client = MagicMock()
         client.read.return_value = []
-        consumer = PgQueueConsumer("q", client=client)
+        consumer = PgQueueConsumer(["q"], client=client)
         # Simulate a long-idle consumer, then poll → heartbeat resets to ~now.
         consumer._last_poll_monotonic -= 120
         assert consumer.seconds_since_last_poll() > 100
@@ -286,7 +286,7 @@ class TestPollHeartbeat:
         # the probe. A bottom-of-poll stamp would pass test_poll_once_refreshes
         # but fail here.
         client = MagicMock()
-        consumer = PgQueueConsumer("q", client=client)
+        consumer = PgQueueConsumer(["q"], client=client)
         before = consumer._last_poll_monotonic
         seen: dict[str, float] = {}
         client.read.side_effect = lambda *a, **k: (
@@ -297,21 +297,21 @@ class TestPollHeartbeat:
         assert seen["during"] > before  # refreshed BEFORE read ran, not after
 
     def test_is_poll_stale_threshold(self):
-        consumer = PgQueueConsumer("q", client=MagicMock())
+        consumer = PgQueueConsumer(["q"], client=MagicMock())
         consumer._last_poll_monotonic -= 120  # last poll 120s ago
         assert consumer.is_poll_stale(60) is True  # past threshold → stale
         assert consumer.is_poll_stale(200) is False  # within threshold → fresh
 
     def test_fresh_consumer_is_not_stale(self):
         # Seeded at construction, so a just-started consumer reads healthy.
-        consumer = PgQueueConsumer("q", client=MagicMock())
+        consumer = PgQueueConsumer(["q"], client=MagicMock())
         assert consumer.is_poll_stale(60) is False
 
     def test_health_server_disabled_without_port(self):
         # No port configured → no server bound (opt-in).
         from queue_backend.pg_queue.consumer import _maybe_start_health_server
 
-        consumer = PgQueueConsumer("q", client=MagicMock())
+        consumer = PgQueueConsumer(["q"], client=MagicMock())
         assert _maybe_start_health_server(consumer, port=None, stale_after=60) is None
 
     def test_liveness_server_reports_200_then_503(self):
@@ -323,7 +323,7 @@ class TestPollHeartbeat:
 
         from queue_backend.pg_queue.consumer import LivenessServer
 
-        consumer = PgQueueConsumer("q", client=MagicMock())
+        consumer = PgQueueConsumer(["q"], client=MagicMock())
         server = LivenessServer(consumer, port=0, stale_after=60)
         server.start()
         try:
@@ -349,7 +349,7 @@ class TestPollHeartbeat:
 
         from queue_backend.pg_queue.consumer import LivenessServer
 
-        consumer = PgQueueConsumer("q", client=MagicMock())
+        consumer = PgQueueConsumer(["q"], client=MagicMock())
         server = LivenessServer(consumer, port=0, stale_after=60)
         server.start()
         try:
@@ -367,7 +367,7 @@ class TestPollHeartbeat:
     def test_double_start_is_rejected(self):
         from queue_backend.pg_queue.consumer import LivenessServer
 
-        server = LivenessServer(PgQueueConsumer("q", client=MagicMock()), port=0, stale_after=60)
+        server = LivenessServer(PgQueueConsumer(["q"], client=MagicMock()), port=0, stale_after=60)
         server.start()
         try:
             with pytest.raises(RuntimeError, match="already started"):
@@ -391,7 +391,7 @@ class TestConsumerIntegration:
                 queue_name,
                 to_payload("test_pg_consumer.ok", args=[5], kwargs={"y": 6}),
             )
-            claimed = PgQueueConsumer(queue_name, client=pg_client).poll_once()
+            claimed = PgQueueConsumer([queue_name], client=pg_client).poll_once()
             assert claimed == 1
             assert (5, 6) in _calls  # task actually executed off Postgres
             # Row was acked (deleted) — nothing left to claim.
@@ -402,6 +402,40 @@ class TestConsumerIntegration:
                     "DELETE FROM pg_queue_message WHERE queue_name = %s", (queue_name,)
                 )
             pg_client.conn.commit()
+
+
+class TestMultiQueue:
+    """9f: one consumer drains several queues round-robin."""
+
+    def test_round_robin_reads_each_queue_and_aggregates(self):
+        client = MagicMock()
+        # qa → 2 msgs, qb → 1 msg; poll_once returns the total across both.
+        client.read.side_effect = [
+            [_msg(1, _ok_payload(1)), _msg(2, _ok_payload(2))],
+            [_msg(3, _ok_payload(3))],
+        ]
+        claimed = PgQueueConsumer(["qa", "qb"], client=client).poll_once()
+        assert claimed == 3
+        # Read once per queue, in order.
+        assert [c.args[0] for c in client.read.call_args_list] == ["qa", "qb"]
+
+    def test_empty_queue_does_not_starve_the_others(self):
+        client = MagicMock()
+        client.read.side_effect = [[], [_msg(1, _ok_payload(1))]]
+        assert PgQueueConsumer(["empty", "busy"], client=client).poll_once() == 1
+
+    def test_rejects_empty_queue_list(self):
+        with pytest.raises(ValueError, match="queue_names"):
+            PgQueueConsumer([], client=MagicMock())
+
+
+def test_parse_queue_list():
+    from queue_backend.pg_queue.consumer import _parse_queue_list
+
+    assert _parse_queue_list("a") == ["a"]  # single value → one-element (back-compat)
+    assert _parse_queue_list("a,b,c") == ["a", "b", "c"]
+    assert _parse_queue_list(" a , b ,c ") == ["a", "b", "c"]  # whitespace stripped
+    assert _parse_queue_list("a,,b") == ["a", "b"]  # empties dropped
 
 
 if __name__ == "__main__":

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -428,6 +428,32 @@ class TestMultiQueue:
         with pytest.raises(ValueError, match="queue_names"):
             PgQueueConsumer([], client=MagicMock())
 
+    def test_one_queue_failing_does_not_abort_the_others(self):
+        """A read failure on one queue is isolated: the already-acked work this
+        cycle still counts (so run() doesn't take the empty backoff path), and
+        the failure doesn't propagate out of poll_once."""
+        client = MagicMock()
+        client.read.side_effect = [[_msg(1, _ok_payload(1))], RuntimeError("boom")]
+        claimed = PgQueueConsumer(["qa", "qb"], client=client).poll_once()
+        assert claimed == 1  # qa's message counted despite qb raising
+        assert _calls == [(1, 0)]  # qa task body ran
+        client.delete.assert_called_once_with(1)  # qa acked
+
+    def test_read_uses_batch_size_qty_per_queue(self):
+        client = MagicMock()
+        client.read.return_value = []
+        PgQueueConsumer(["qa", "qb"], client=client, batch_size=2).poll_once()
+        assert [c.kwargs["qty"] for c in client.read.call_args_list] == [2, 2]
+
+    def test_duplicate_queues_are_deduped(self):
+        """A duplicate (e.g. env "q,q") must not double-read the same queue."""
+        client = MagicMock()
+        client.read.return_value = []
+        consumer = PgQueueConsumer(["q", "q"], client=client)
+        assert consumer.queue_names == ["q"]
+        consumer.poll_once()
+        assert client.read.call_count == 1
+
 
 def test_parse_queue_list():
     from queue_backend.pg_queue.consumer import _parse_queue_list


### PR DESCRIPTION
## What

- **Multi-queue PG consumer:** `PgQueueConsumer` now takes `queue_names: list[str]` and polls them **round-robin** — one process can drain several queues (e.g. ETL + API fan-out) instead of one-process-per-queue.
- **Named PG roles in `run-worker.sh`:** the coupled pipeline's PG consumers are first-class, runnable **individually or as a set**, like the Celery workers — no per-process env.

## Why

- Running the PG pipeline meant launching 3–4 consumers each with hand-set `WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE` + `-q` + distinct `-p` (a repeated footgun). This makes `./run-worker.sh -d pg` (all) and `./run-worker.sh -d pg-fileproc` (individual) work just like `-d all` / `-d file`. Part of PG Queue Phase 9 (UN-3536), sub-task UN-3566.

## How

- **Consumer:** `queue_names` round-robin (`read()` per queue preserves the `(queue_name, priority DESC, msg_id)` index's top-N; no queue starves another). `WORKER_PG_QUEUE_CONSUMER_QUEUE` is comma-parsed; a single value stays a one-element list → **back-compat** with the existing leaf consumer.
- **Roles** (`PG_CONSUMER_ROLES`, `"<source_worker_type>;<queues>"`):
  - `pg-orchestrator-api` (api_deployment → `celery_api_deployments`) and `pg-orchestrator-general` (general → `celery`) — split because `async_execute_bin` has **distinct impls per registry** (api-deployment handles it as an API deployment; general routes by workflow type), so one consumer can't serve both.
  - `pg-fileproc` (file_processing → `file_processing,api_file_processing`) and `pg-callback` (callback → both callback queues) — **multi-queue**, one process each covering ETL + API.
  - The role name rides in argv (`python -m pg_queue_consumer <role>`) so `pgrep` (`-s`/`-k`/`-r`) distinguishes the otherwise-identical processes. Roles share the `pg_queue_consumer/` launcher dir; `resolve_log_file` + `-L pg` know the role log path.
- **`./run-worker.sh -d pg`** launches the 4 pipeline roles + reaper (mirrors `all`); `-s`/`-k`/`-r`/`-L` operate per role.

## Can this PR break any existing features?

- **No.** All changes are consumer-side ergonomics, gated off by the existing transport flag — no runtime change until PG consumers are run. The single-queue config still works (one-element list), so the existing leaf-webhook consumer and the `pg-queue-consumer` alias are unaffected. No schema/API change.

## Database Migrations

- None.

## Env Config

- None new. `WORKER_PG_QUEUE_CONSUMER_QUEUE` now accepts a comma-separated list (single value unchanged).

## Notes on Testing

- Unit: round-robin aggregation across queues; empty queue doesn't starve others; empty-list rejected; comma-parse incl. single-value back-compat. Existing consumer tests updated to the list arg.
- Dev-tested end-to-end: `./run-worker.sh -d pg` → `-s` shows the 4 roles + reaper RUNNING; an API execution drained **orchestrator-api → pg-fileproc (one process draining both `file_processing` and `api_file_processing`) → pg-callback → COMPLETED**; `-r pg-fileproc` restarted only that role (pg-callback PID unchanged).

## Related Issues

- UN-3536 (PG Queue Phase 9), sub-task UN-3566. Independent of the orchestrator-on-PG PR (#2072); the orchestrator roles here consume what that PR produces.

## Checklist

- [x] Appropriate PR title and description
- [x] Self-review performed
- [x] Tests added that prove the feature works
- [x] New and existing unit tests pass locally
- [x] Pre-commit passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)