### PR TITLE
[FIX] Revert djangorestframework 3.15.2 → 3.14.0 to unblock staging

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "cron-descriptor==1.4.0", # For cron string description
     "cryptography>=48.0.1",
     "django==4.2.30",
-    "djangorestframework==3.15.2",
+    "djangorestframework==3.14.0",
     "django-cors-headers==4.3.1",
     # Pinning django-celery-beat to avoid build issues
     "django-celery-beat==2.5.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -874,14 +874,15 @@ wheels = [
 
 [[package]]
 name = "djangorestframework"
-version = "3.15.2"
+version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ce/31482eb688bdb4e271027076199e1aa8d02507e530b6d272ab8b4481557c/djangorestframework-3.15.2.tar.gz", hash = "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad", size = 1067420, upload-time = "2024-06-19T07:59:32.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/53/5b2a002c5ebafd60dff1e1945a7d63dee40155830997439a9ba324f0fd50/djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8", size = 1055343, upload-time = "2022-09-22T11:38:44.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/b6/fa99d8f05eff3a9310286ae84c4059b08c301ae4ab33ae32e46e8ef76491/djangorestframework-3.15.2-py3-none-any.whl", hash = "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20", size = 1071235, upload-time = "2024-06-19T07:59:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4b/3b46c0914ba4b7546a758c35fdfa8e7f017fcbe7f23c878239e93623337a/djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08", size = 1062761, upload-time = "2022-09-22T11:38:41.825Z" },
 ]
 
 [[package]]
@@ -3740,7 +3741,7 @@ requires-dist = [
     { name = "django-log-request-id", specifier = ">=2.1.0" },
     { name = "django-redis", specifier = "==5.4.0" },
     { name = "django-tenants", specifier = "==3.5.0" },
-    { name = "djangorestframework", specifier = "==3.15.2" },
+    { name = "djangorestframework", specifier = "==3.14.0" },
     { name = "drf-standardized-errors", specifier = ">=0.12.6" },
     { name = "drf-yasg", specifier = ">=1.21.8" },
     { name = "google-cloud-recaptcha-enterprise", specifier = ">=1.28.2" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ hook-check-django-migrations = [
     "celery>=5.3.4",
     "cron-descriptor==1.4.0",
     "django==4.2.30",
-    "djangorestframework==3.15.2",
+    "djangorestframework==3.14.0",
     # Pinning django-celery-beat to avoid build issues
     "django-celery-beat==2.5.0",
     "django-cors-headers>=4.3.1",

--- a/uv.lock
+++ b/uv.lock
@@ -834,14 +834,15 @@ wheels = [
 
 [[package]]
 name = "djangorestframework"
-version = "3.15.2"
+version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ce/31482eb688bdb4e271027076199e1aa8d02507e530b6d272ab8b4481557c/djangorestframework-3.15.2.tar.gz", hash = "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad", size = 1067420, upload-time = "2024-06-19T07:59:32.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/53/5b2a002c5ebafd60dff1e1945a7d63dee40155830997439a9ba324f0fd50/djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8", size = 1055343, upload-time = "2022-09-22T11:38:44.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/b6/fa99d8f05eff3a9310286ae84c4059b08c301ae4ab33ae32e46e8ef76491/djangorestframework-3.15.2-py3-none-any.whl", hash = "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20", size = 1071235, upload-time = "2024-06-19T07:59:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4b/3b46c0914ba4b7546a758c35fdfa8e7f017fcbe7f23c878239e93623337a/djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08", size = 1062761, upload-time = "2022-09-22T11:38:41.825Z" },
 ]
 
 [[package]]
@@ -3892,7 +3893,7 @@ hook-check-django-migrations = [
     { name = "django-cors-headers", specifier = ">=4.3.1" },
     { name = "django-redis", specifier = "==5.4.0" },
     { name = "django-tenants", specifier = "==3.5.0" },
-    { name = "djangorestframework", specifier = "==3.15.2" },
+    { name = "djangorestframework", specifier = "==3.14.0" },
     { name = "drf-yasg", specifier = "==1.21.7" },
     { name = "psycopg2-binary", specifier = "==2.9.9" },
     { name = "python-dotenv", specifier = "==1.2.2" },


### PR DESCRIPTION
## What

Reverts **only** the `djangorestframework` bump (3.15.2 → 3.14.0) that landed in #2087. The other batched dependabot updates from that PR are untouched.

Files: `backend/pyproject.toml`, `pyproject.toml` (pins) + `backend/uv.lock`, `uv.lock` (re-resolved). Lock diff is the DRF version flip only — no other package added/removed.

## Why

DRF 3.15 auto-generates a `UniqueTogetherValidator` from model `UniqueConstraint`s, which forces **every** field in the constraint to `required=True` — including the server-set, nullable `organization` FK (`DefaultOrganizationMixin`). Clients never send `organization`, so adapter / connector / workflow / api-deployment creates started failing:

```
400 {"type":"validation_error","errors":[{"code":"required","attr":"organization"}]}
```

This broke the shared Playwright test setup (`createAdapters`) and cascaded into **146 staging failures on rc.342** (OSS v0.176.1). rc.341 (DRF 3.14, v0.176.0) was clean — 220/244. The DRF bump is the only relevant diff between them, and #2087 was a routine batched dependabot update (no CVE forcing 3.15).

## Follow-up (separate PR)

Reattempt the 3.15 upgrade deliberately: add a `get_unique_together_validators()` override to the shared serializer bases (`AuditSerializer` + `IntegrityErrorMixin`) to drop org-scoped auto-validators (restores 3.14 semantics; DB + `IntegrityErrorMixin` still enforce uniqueness), fix the cloud stragglers that inherit neither base (MRQ / subscription / agentic_table_settings), audit all ~20 org-scoped models, then cut its own RC + full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)