### PR TITLE
[FIX] Keep DRF 3.15.2 safe for org-scoped serializers (drop server-set uniqueness)

### DIFF
--- a/backend/adapter_processor_v2/tests/test_org_uniqueness.py
+++ b/backend/adapter_processor_v2/tests/test_org_uniqueness.py
@@ -1,0 +1,50 @@
+"""DRF 3.15 org-uniqueness regression guard.
+
+DRF 3.15 derives ``required=True`` and ``UniqueTogetherValidator``s from a
+model's multi-field ``UniqueConstraint``s. ``AdapterInstance`` has an
+org-scoped constraint (``adapter_name``, ``adapter_type``, ``organization``),
+where ``organization`` is set server-side and never sent by clients. Without
+``DropServerSetUniquenessMixin``, the serializer marks ``organization`` as
+required and every create 400s. These tests pin that behaviour; no test
+database is required (serializer field/validator setup only).
+"""
+
+from __future__ import annotations
+
+import os
+
+import django
+from django.apps import apps
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings.test")
+if not apps.ready:
+    django.setup()
+
+from adapter_processor_v2.serializers import AdapterInstanceSerializer  # noqa: E402
+from utils.serializer.org_uniqueness import (  # noqa: E402
+    SERVER_SET_UNIQUENESS_FIELDS,
+)
+
+
+def test_organization_not_required_on_create_serializer():
+    serializer = AdapterInstanceSerializer()
+    assert serializer.fields["organization"].required is False
+
+
+def test_server_set_fields_absent_from_uniqueness_required_kwargs():
+    serializer = AdapterInstanceSerializer()
+    field_names = list(serializer.fields)
+    declared_fields = serializer._declared_fields
+    extra_kwargs, _hidden = serializer.get_uniqueness_extra_kwargs(
+        field_names, declared_fields, {}
+    )
+    required_fields = {
+        name for name, kwargs in extra_kwargs.items() if kwargs.get("required")
+    }
+    assert not (required_fields & SERVER_SET_UNIQUENESS_FIELDS)
+
+
+def test_no_unique_together_validator_over_server_set_fields():
+    serializer = AdapterInstanceSerializer()
+    for validator in serializer.get_unique_together_validators():
+        assert not (set(validator.fields) & SERVER_SET_UNIQUENESS_FIELDS)

--- a/backend/backend/serializers.py
+++ b/backend/backend/serializers.py
@@ -1,11 +1,12 @@
 from typing import Any
 
 from rest_framework.serializers import ModelSerializer
+from utils.serializer.org_uniqueness import DropServerSetUniquenessMixin
 
 from backend.constants import RequestKey
 
 
-class AuditSerializer(ModelSerializer):
+class AuditSerializer(DropServerSetUniquenessMixin, ModelSerializer):
     def create(self, validated_data: dict[str, Any]) -> Any:
         request = self.context.get(RequestKey.REQUEST)
         if request:

--- a/backend/utils/serializer/integrity_error_mixin.py
+++ b/backend/utils/serializer/integrity_error_mixin.py
@@ -2,11 +2,12 @@ import logging
 
 from django.db import IntegrityError
 from rest_framework.exceptions import ValidationError
+from utils.serializer.org_uniqueness import DropServerSetUniquenessMixin
 
 logger = logging.getLogger(__name__)
 
 
-class IntegrityErrorMixin:
+class IntegrityErrorMixin(DropServerSetUniquenessMixin):
     """Mixin to handle IntegrityError across multiple serializers for unique
     constraint violations.
     """

--- a/backend/utils/serializer/org_uniqueness.py
+++ b/backend/utils/serializer/org_uniqueness.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+# Fields injected server-side (outside the request body) by mixins such as
+# DefaultOrganizationMixin / AuditSerializer; clients never supply them.
+SERVER_SET_UNIQUENESS_FIELDS = frozenset({"organization", "created_by", "modified_by"})
+
+
+class DropServerSetUniquenessMixin:
+    """Restore DRF 3.14 behaviour for server-set uniqueness fields.
+
+    DRF 3.15 derives ``required=True`` and ``UniqueTogetherValidator``s from a
+    model's multi-field ``UniqueConstraint``s (3.14 only looked at
+    ``unique_together``). For org-scoped constraints that include server-set
+    fields, that wrongly forces clients to POST ``organization`` and 400s every
+    create/update. Strip those fields from both halves of the uniqueness
+    machinery. The DB ``UniqueConstraint``s still enforce real duplicates, and
+    ``IntegrityErrorMixin`` still surfaces them as clean validation errors.
+    """
+
+    def get_uniqueness_extra_kwargs(
+        self,
+        field_names: Any,
+        declared_fields: Any,
+        extra_kwargs: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_kwargs, hidden_fields = super().get_uniqueness_extra_kwargs(
+            field_names, declared_fields, extra_kwargs
+        )
+        for field in SERVER_SET_UNIQUENESS_FIELDS:
+            extra_kwargs.pop(field, None)
+            hidden_fields.pop(field, None)
+        return extra_kwargs, hidden_fields
+
+    def get_unique_together_validators(self) -> list[Any]:
+        return [
+            validator
+            for validator in super().get_unique_together_validators()
+            if not (set(getattr(validator, "fields", ())) & SERVER_SET_UNIQUENESS_FIELDS)
+        ]


### PR DESCRIPTION
## What

Add `DropServerSetUniquenessMixin` (`backend/utils/serializer/org_uniqueness.py`) and apply it to `AuditSerializer` and `IntegrityErrorMixin` so create/update endpoints stop 400ing under `djangorestframework==3.15.2`.

**Supersedes the DRF 3.14 revert #2090** — this keeps 3.15.2 (and its CVE-2024-21520 XSS patch) while removing the regression that revert was working around.

## Why

DRF 3.15 extended `ModelSerializer.get_uniqueness_extra_kwargs()` and `get_unique_together_validators()` to derive uniqueness from a model's multi-field `UniqueConstraint`s — not just `Meta.unique_together` as in 3.14. Models using `DefaultOrganizationMixin` carry org-scoped constraints (e.g. `AdapterInstance.unique_organization_adapter` over `adapter_name, adapter_type, organization`). `organization` is a nullable FK set **server-side** in `DefaultOrganizationMixin.save()` via `UserContext` and is never sent by clients.

Under 3.15 this made serializers (notably `fields="__all__"`) mark `organization` `required=True` **and** build a `UniqueTogetherValidator` whose `enforce_required_fields` also demands it. Result: create/update 400 with `{"attr":"organization","code":"required"}` across adapters, connectors, workflows, api-deployments, prompt-studio, etc. (this is what broke ~146 staging tests).

Both DRF methods had to be neutralized: for `AdapterInstance` the `required` kwarg test passes but the `UniqueTogetherValidator` is the active 400 path — a validator-only or kwargs-only fix would be insufficient.

## How

`DropServerSetUniquenessMixin` strips `organization`/`created_by`/`modified_by` from **both** the uniqueness `extra_kwargs`/hidden-fields and the unique-together validators, restoring 3.14 behaviour. DB `UniqueConstraint`s + `IntegrityErrorMixin` still enforce and cleanly surface real duplicate errors.

Applied with minimal churn:
- `AuditSerializer` gains the mixin — covers all OSS create serializers (adapter/connector/workflow/api/prompt-studio/platform-api, all `fields="__all__"`).
- `IntegrityErrorMixin` gains the mixin — cloud serializers that import it (e.g. `AgenticProjectSerializer`, `LookupDefinitionSerializer`) inherit the fix for free. Serializers inheriting both (`WorkflowSerializer`, `PipelineSerializer`, `APIDeploymentSerializer`, `CustomToolSerializer`) get it once via MRO (verified — harmless).

### Coverage audit

| Model | Constraint | Serializer | Covered via |
|---|---|---|---|
| AdapterInstance | (adapter_name, adapter_type, organization) | AdapterInstanceSerializer/BaseAdapterSerializer (`__all__`) | AuditSerializer |
| ConnectorInstance | (connector_name, organization) | ConnectorInstanceSerializer (`__all__`) | AuditSerializer |
| Workflow | (workflow_name, organization) | WorkflowSerializer (`__all__`) | AuditSerializer + IntegrityErrorMixin |
| Pipeline | (pipeline_name, organization) | PipelineSerializer (`__all__`) | AuditSerializer + IntegrityErrorMixin |
| APIDeployment | (api_name, organization) | APIDeploymentSerializer (`__all__`) | AuditSerializer + IntegrityErrorMixin |
| CustomTool | (tool_name, organization) | CustomToolSerializer (`__all__`) | AuditSerializer + IntegrityErrorMixin |
| PlatformApiKey | (name, organization) | PlatformApiKeyCreate/UpdateSerializer | AuditSerializer (organization not in fields → already safe) |
| Tag, OrganizationMember, OrganizationGroup, EventMetrics* | org-scoped | plain ModelSerializer | **Not affected** — `organization` not in serializer fields, so DRF skips the constraint (issuperset check fails) |
| Configuration | (organization, key) | (no DRF serializer — internal API) | n/a |

No OSS writable serializer over an org-scoped multi-field constraint was left uncovered.

## Can this PR break any existing features

No. The mixin only removes uniqueness *machinery* for server-set fields that clients never supply anyway; DB `UniqueConstraint`s remain authoritative and `IntegrityErrorMixin` still returns clean validation errors on real duplicates. This restores the exact pre-3.15 (3.14) serializer behaviour for these fields.

## Database Migrations

None.

## Env Config

None.

## Related Issues or PRs

Supersedes #2090 (DRF 3.14 revert). Cloud counterpart: `Zipstack/unstract-cloud#fix/drf-315-org-uniqueness`.

## Dependencies Versions

No change — keeps `djangorestframework==3.15.2`.

## Notes on Testing

Added `backend/adapter_processor_v2/tests/test_org_uniqueness.py` (3 tests): asserts `AdapterInstanceSerializer().fields["organization"].required is False`, that no server-set field appears in the uniqueness `required` extra_kwargs, and that no `UniqueTogetherValidator` covers a server-set field. Verified the tests FAIL without the mixin (the `(adapter_name, adapter_type, organization)` validator reappears) and PASS with it, under DRF 3.15.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)