### PR TITLE
UN-3605 [GATED-FEAT] PG Queue — structure_tool executor RPC over Postgres (+ register executors in PG consumer)

### DIFF
--- a/backend/sample.env
+++ b/backend/sample.env
@@ -187,7 +187,7 @@ FLIPT_SERVICE_AVAILABLE=False
 # 9e PG-queue transport master-gate (kill-switch). Routing an execution onto the
 # PG queue requires ALL THREE: this gate True, FLIPT_SERVICE_AVAILABLE=True (else
 # the Flipt client returns False for every flag), and the Flipt flag
-# `pg_queue_execution_enabled` on. Keep False until PG queue consumers are running
+# `pg_queue_enabled` on. Keep False until PG queue consumers are running
 # in the fleet; set False for instant rollback.
 PG_QUEUE_TRANSPORT_ENABLED=False
 

--- a/workers/executor/tasks.py
+++ b/workers/executor/tasks.py
@@ -9,9 +9,11 @@ ExecutionOrchestrator, and returns an ExecutionResult dict.
 # decorators run before ``execute_extraction`` can be invoked. Coupling this to
 # the task module (not only the Celery ``executor/worker.py`` entrypoint) ensures
 # the registry is populated wherever the task is registered — in particular the PG
-# executor consumer (``pg_queue_consumer`` loads ``tasks.py`` but not
-# ``worker.py``), which would otherwise hit "No executor registered". Import is
-# idempotent (module cached), so the Celery path importing it twice is harmless.
+# executor consumer, which bootstraps via the root-worker import that loads
+# ``executor/tasks.py`` (this module) but NOT ``executor/worker.py`` where this
+# import historically lived; without it the consumer hits "No executor
+# registered". Import is idempotent (module cached), so the Celery entrypoint
+# importing it again is harmless.
 import executor.executors  # noqa: E402, F401
 from queue_backend import worker_task
 from shared.clients import UsageAPIClient

--- a/workers/executor/tasks.py
+++ b/workers/executor/tasks.py
@@ -5,6 +5,14 @@ ExecutionContext dict, runs the appropriate executor via
 ExecutionOrchestrator, and returns an ExecutionResult dict.
 """
 
+# Import the executor implementations so their ``@ExecutorRegistry.register``
+# decorators run before ``execute_extraction`` can be invoked. Coupling this to
+# the task module (not only the Celery ``executor/worker.py`` entrypoint) ensures
+# the registry is populated wherever the task is registered — in particular the PG
+# executor consumer (``pg_queue_consumer`` loads ``tasks.py`` but not
+# ``worker.py``), which would otherwise hit "No executor registered". Import is
+# idempotent (module cached), so the Celery path importing it twice is harmless.
+import executor.executors  # noqa: E402, F401
 from queue_backend import worker_task
 from shared.clients import UsageAPIClient
 from shared.enums.task_enums import TaskName

--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -25,12 +25,15 @@ from typing import Any
 from file_processing.worker import app
 from queue_backend import FairnessKey, worker_task
 from queue_backend.fairness import WorkloadType
+from queue_backend.pg_queue.executor_rpc import (
+    RoutingExecutionDispatcher,
+    get_executor_dispatcher,
+)
 from shared.enums.task_enums import TaskName
 from shared.infrastructure.context import StateStore
 
 from unstract.sdk1.constants import ToolEnv, UsageKwargs
 from unstract.sdk1.execution.context import ExecutionContext
-from unstract.sdk1.execution.dispatcher import ExecutionDispatcher
 from unstract.sdk1.execution.result import ExecutionResult
 
 logger = logging.getLogger(__name__)
@@ -276,7 +279,9 @@ def _execute_structure_tool_impl(params: dict) -> dict:
     )
 
     platform_helper = _create_platform_helper(shim, file_execution_id)
-    dispatcher = ExecutionDispatcher(celery_app=app)
+    # Gate-routed: PG executor RPC when pg_queue_enabled is on, else the unchanged
+    # Celery ExecutionDispatcher (zero-regression by construction — see executor_rpc).
+    dispatcher = get_executor_dispatcher(celery_app=app)
     fs = _get_file_storage()
 
     # ---- Step 2: Fetch tool metadata ----
@@ -675,7 +680,7 @@ def _run_agentic_extraction(
     input_file_path: str,
     output_dir_path: str,
     tool_instance_metadata: dict,
-    dispatcher: ExecutionDispatcher,
+    dispatcher: RoutingExecutionDispatcher,
     shim: Any,
     file_execution_id: str,
     execution_id: str,

--- a/workers/queue_backend/pg_queue/executor_rpc.py
+++ b/workers/queue_backend/pg_queue/executor_rpc.py
@@ -1,0 +1,282 @@
+"""Executor-RPC transport routing for the PG path — workers side (Phase 9, ③b-2).
+
+The workers-side twin of ``backend/pg_queue/executor_rpc.py``. The executor "RPC"
+is a synchronous request-reply: a caller (here, the ``structure_tool`` task in the
+file_processing worker) sends an ``ExecutionContext`` to the executor worker and
+blocks for the ``ExecutionResult``. The legacy transport is Celery — the SDK
+``ExecutionDispatcher`` (``send_task`` + ``AsyncResult.get``). This module adds a
+**parallel** Postgres transport that leaves Celery and the SDK completely
+untouched (no SDK edit, no change to the ``execute_extraction`` task or the Celery
+executor worker):
+
+- :class:`PgExecutionDispatcher` enqueues ``execute_extraction`` onto the PG queue
+  (via :class:`~queue_backend.pg_queue.client.PgQueueClient`) with a unique
+  ``reply_key`` and polls ``pg_task_result`` (via
+  :class:`~queue_backend.pg_queue.result_backend.PgResultBackend`) for the reply —
+  same ``.dispatch()`` contract as the SDK dispatcher (never raises;
+  failure/timeout → ``ExecutionResult.failure``). The already-running
+  ``worker-pg-executor`` consumer runs the task and writes the reply, so this side
+  only adds the enqueue + poll halves.
+- :func:`resolve_executor_transport` is the gate: master
+  ``PG_QUEUE_TRANSPORT_ENABLED`` (env, the workers analogue of the backend's
+  Django setting) then the **single** Flipt flag ``pg_queue_enabled`` — the same
+  flag the execution path uses, so one flip turns the whole PG-queue feature
+  on/off. Fails closed to Celery.
+- :class:`RoutingExecutionDispatcher` is what ``structure_tool`` gets from
+  :func:`get_executor_dispatcher`: ``dispatch()`` picks PG-vs-Celery **per call**
+  (read at dispatch time → flipping the flag is an instant, no-redeploy
+  rollout/rollback); ``dispatch_async`` / ``dispatch_with_callback`` always
+  delegate to Celery (the callback path is a later slice).
+
+Zero-regression: gate off ⇒ every method delegates to the unchanged Celery
+``ExecutionDispatcher`` and no ``pg_task_result`` row is created.
+
+TODO(shared): ``resolve_executor_transport`` and the reply_key/poll orchestration
+mirror the backend module almost verbatim — only the transport primitives differ
+(psycopg2 here vs Django ORM there). A later slice can lift the shared logic into
+``unstract.core`` so the gate/contract lives in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from unstract.core.data_models import PgTaskStatus
+from unstract.flags.feature_flag import check_feature_flag_status
+from unstract.sdk1.execution.dispatcher import ExecutionDispatcher
+from unstract.sdk1.execution.result import ExecutionResult
+
+from .client import PgQueueClient
+from .result_backend import PgResultBackend
+from .task_payload import to_payload
+
+if TYPE_CHECKING:
+    from unstract.sdk1.execution.context import ExecutionContext
+
+logger = logging.getLogger(__name__)
+
+# The single PG-queue rollout flag — same key the execution path and scheduler
+# read. Defined in backend/pg_queue/flags.py too; kept as a literal here because
+# workers can't import backend code (see TODO(shared) in the module docstring).
+PG_QUEUE_FLAG_KEY = "pg_queue_enabled"
+# Master kill-switch + deploy-ordering gate. The workers analogue of the backend's
+# ``settings.PG_QUEUE_TRANSPORT_ENABLED`` — read straight from the env here.
+_MASTER_GATE_ENV = "PG_QUEUE_TRANSPORT_ENABLED"
+
+_EXECUTE_TASK = "execute_extraction"
+# Mirror the SDK's queue-per-executor convention so the PG executor queue name
+# matches the Celery one (the worker-pg-executor consumer subscribes to these).
+_QUEUE_PREFIX = "celery_executor_"
+# Caller-side wait default — mirrors the SDK dispatcher (EXECUTOR_RESULT_TIMEOUT
+# env, else 3600s) so a PG-routed caller waits exactly as long as a Celery one.
+_DEFAULT_TIMEOUT_ENV = "EXECUTOR_RESULT_TIMEOUT"
+_DEFAULT_TIMEOUT = 3600
+
+
+def resolve_executor_transport(context: ExecutionContext) -> bool:
+    """True → route this executor dispatch over PG; False → Celery (default).
+
+    Mirrors the backend ``resolve_executor_transport``: master-gated by the
+    ``PG_QUEUE_TRANSPORT_ENABLED`` env, then the **single** ``pg_queue_enabled``
+    Flipt flag (shared across the whole PG-queue feature), bucketed per org.
+    **Fails closed to Celery** on a closed gate, a blind Flipt, or any error — so
+    the executor never silently loses its transport.
+    """
+    if os.environ.get(_MASTER_GATE_ENV, "false").lower() != "true":
+        return False
+    if os.environ.get("FLIPT_SERVICE_AVAILABLE", "false").lower() != "true":
+        logger.warning(
+            "resolve_executor_transport: gate ON but FLIPT_SERVICE_AVAILABLE != "
+            "true (Flipt blind); using Celery"
+        )
+        return False
+    org = getattr(context, "organization_id", None)
+    # %-bucket keyed on org; fall back to run_id so a context without an org still
+    # resolves deterministically (mirrors the backend resolver).
+    entity_id = str(org or getattr(context, "run_id", "") or "default")
+    flag_context = {"executor_name": str(context.executor_name)}
+    if org:
+        flag_context["organization_id"] = str(org)
+    try:
+        enabled = check_feature_flag_status(
+            flag_key=PG_QUEUE_FLAG_KEY, entity_id=entity_id, context=flag_context
+        )
+    except Exception:
+        logger.warning(
+            "resolve_executor_transport: Flipt check failed; using Celery",
+            exc_info=True,
+        )
+        return False
+    return bool(enabled)
+
+
+class PgExecutionDispatcher:
+    """PG request-reply executor dispatch — drop-in for ``ExecutionDispatcher.dispatch``.
+
+    Enqueues ``execute_extraction`` with a unique ``reply_key`` and blocks on
+    ``pg_task_result`` until the executor consumer records the result or the
+    timeout elapses. Honours the same contract as the SDK dispatcher: it never
+    raises and converts a timeout/failure into ``ExecutionResult.failure`` so
+    callers can branch on ``result.success`` identically on either transport.
+    """
+
+    def dispatch(
+        self,
+        context: ExecutionContext,
+        timeout: int | None = None,
+    ) -> ExecutionResult:
+        if timeout is None:
+            # Guard the env parse so a misconfigured EXECUTOR_RESULT_TIMEOUT can't
+            # raise out of dispatch() (the never-raises contract).
+            try:
+                timeout = int(os.environ.get(_DEFAULT_TIMEOUT_ENV, _DEFAULT_TIMEOUT))
+            except (TypeError, ValueError):
+                timeout = _DEFAULT_TIMEOUT
+        reply_key = str(uuid.uuid4())
+        queue = f"{_QUEUE_PREFIX}{context.executor_name}"
+        org = str(getattr(context, "organization_id", "") or "")
+        try:
+            self._enqueue(queue, context, reply_key, org)
+        except Exception as exc:
+            logger.exception(
+                "PG executor dispatch: enqueue failed (executor=%s run_id=%s)",
+                context.executor_name,
+                context.run_id,
+            )
+            return ExecutionResult.failure(error=f"{type(exc).__name__}: {exc}")
+        logger.info(
+            "PG executor dispatch: enqueued reply_key=%s queue=%s run_id=%s "
+            "timeout=%ss; waiting for result...",
+            reply_key,
+            queue,
+            context.run_id,
+            timeout,
+        )
+        try:
+            row = self._wait_for_result(reply_key, timeout)
+        except Exception as exc:
+            # Honour the never-raises contract even if the poll connection dies.
+            logger.exception(
+                "PG executor dispatch: wait failed (reply_key=%s run_id=%s)",
+                reply_key,
+                context.run_id,
+            )
+            return ExecutionResult.failure(error=f"{type(exc).__name__}: {exc}")
+        if row is None:
+            logger.warning(
+                "PG executor dispatch: TIMEOUT after %ss (reply_key=%s run_id=%s) — "
+                "the executor task may still be running",
+                timeout,
+                reply_key,
+                context.run_id,
+            )
+            return ExecutionResult.failure(
+                error=f"TimeoutError: executor reply not received within {timeout}s"
+            )
+        if (
+            row["status"] == PgTaskStatus.COMPLETED.value
+            and row.get("result") is not None
+        ):
+            try:
+                return ExecutionResult.from_dict(row["result"])
+            except Exception:
+                # A malformed completed row becomes a failure result, not a raise.
+                logger.exception(
+                    "PG executor dispatch: malformed completed result "
+                    "(reply_key=%s run_id=%s)",
+                    reply_key,
+                    context.run_id,
+                )
+                return ExecutionResult.failure(
+                    error=f"Malformed executor result for reply_key {reply_key}"
+                )
+        logger.warning(
+            "PG executor dispatch: executor reported failure (reply_key=%s "
+            "run_id=%s): %s",
+            reply_key,
+            context.run_id,
+            row.get("error") or "(no error)",
+        )
+        return ExecutionResult.failure(error=row.get("error") or "executor task failed")
+
+    @staticmethod
+    def _enqueue(
+        queue: str, context: ExecutionContext, reply_key: str, org_id: str
+    ) -> None:
+        """Enqueue the ``execute_extraction`` request-reply message.
+
+        A short-lived client owns its connection for just the insert (which
+        commits internally) so the message is durably visible to the
+        ``worker-pg-executor`` consumer before we begin polling — and no
+        connection is pinned for the whole (possibly long) RPC.
+        """
+        payload = to_payload(
+            _EXECUTE_TASK,
+            args=[context.to_dict()],
+            queue=queue,
+            reply_key=reply_key,
+        )
+        with PgQueueClient() as client:
+            client.send(queue, payload, org_id=org_id)
+
+    @staticmethod
+    def _wait_for_result(reply_key: str, timeout: float) -> dict[str, Any] | None:
+        """Poll ``pg_task_result`` until the row appears or *timeout* elapses.
+
+        Poll-based with capped backoff (PgBouncer-safe; no LISTEN/NOTIFY). The
+        backend owns one connection for the duration of the wait (one per
+        in-flight RPC; structure_tool dispatches are sequential) and closes it on
+        exit, so a long RPC never leaks a connection.
+        """
+        with PgResultBackend() as rb:
+            return rb.wait_for_result(reply_key, timeout)
+
+
+class RoutingExecutionDispatcher:
+    """Gate-routed executor dispatcher returned by :func:`get_executor_dispatcher`.
+
+    ``dispatch()`` chooses PG vs Celery per call (instant rollout/rollback);
+    ``dispatch_async`` / ``dispatch_with_callback`` always delegate to Celery —
+    the async/callback path stays on Celery until a later continuation slice.
+    Duck-typed against the SDK ``ExecutionDispatcher`` so call sites are unchanged.
+    """
+
+    def __init__(self, celery_app: object | None = None) -> None:
+        self._celery = ExecutionDispatcher(celery_app=celery_app)
+        self._pg = PgExecutionDispatcher()
+
+    def dispatch(
+        self,
+        context: ExecutionContext,
+        timeout: int | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> ExecutionResult:
+        if resolve_executor_transport(context):
+            logger.info(
+                "Executor RPC → PG transport (executor=%s run_id=%s)",
+                context.executor_name,
+                context.run_id,
+            )
+            # PG carries org/routing via the enqueue payload, not Celery headers,
+            # so the fairness headers are intentionally not forwarded here (parity
+            # with the backend executor RPC).
+            return self._pg.dispatch(context, timeout=timeout)
+        return self._celery.dispatch(context, timeout=timeout, headers=headers)
+
+    def dispatch_async(
+        self, context: ExecutionContext, headers: dict[str, Any] | None = None
+    ) -> str:
+        return self._celery.dispatch_async(context, headers=headers)
+
+    def dispatch_with_callback(self, context: ExecutionContext, **kwargs: Any) -> Any:
+        return self._celery.dispatch_with_callback(context, **kwargs)
+
+
+def get_executor_dispatcher(
+    celery_app: object | None = None,
+) -> RoutingExecutionDispatcher:
+    """Factory: the gate-routed executor dispatcher (PG when enabled, else Celery)."""
+    return RoutingExecutionDispatcher(celery_app=celery_app)

--- a/workers/queue_backend/pg_queue/executor_rpc.py
+++ b/workers/queue_backend/pg_queue/executor_rpc.py
@@ -127,13 +127,26 @@ class PgExecutionDispatcher:
         self,
         context: ExecutionContext,
         timeout: int | None = None,
+        headers: dict[str, Any] | None = None,
     ) -> ExecutionResult:
+        # ``headers`` is accepted (and ignored) for substitutability with the SDK
+        # ``ExecutionDispatcher.dispatch`` / ``RoutingExecutionDispatcher.dispatch``
+        # shapes — the PG path carries org/routing via the enqueue payload, not
+        # Celery headers, so fairness headers are intentionally not forwarded.
         if timeout is None:
             # Guard the env parse so a misconfigured EXECUTOR_RESULT_TIMEOUT can't
             # raise out of dispatch() (the never-raises contract).
             try:
                 timeout = int(os.environ.get(_DEFAULT_TIMEOUT_ENV, _DEFAULT_TIMEOUT))
             except (TypeError, ValueError):
+                # Don't swallow silently — an operator who fat-fingers the value
+                # would otherwise wait the 3600s default with no signal.
+                logger.warning(
+                    "PG executor dispatch: invalid %s=%r; falling back to %ss",
+                    _DEFAULT_TIMEOUT_ENV,
+                    os.environ.get(_DEFAULT_TIMEOUT_ENV),
+                    _DEFAULT_TIMEOUT,
+                )
                 timeout = _DEFAULT_TIMEOUT
         reply_key = str(uuid.uuid4())
         queue = f"{_QUEUE_PREFIX}{context.executor_name}"
@@ -166,6 +179,14 @@ class PgExecutionDispatcher:
             )
             return ExecutionResult.failure(error=f"{type(exc).__name__}: {exc}")
         if row is None:
+            # On timeout the executor task may still be running on the consumer;
+            # it will write its outcome under this reply_key, but we've already
+            # given up reading it (the reaper retention-sweeps the orphan row). If
+            # the workflow engine retries the file execution, it re-dispatches with
+            # a FRESH reply_key — so two executor tasks for the same file can
+            # overlap (double LLM spend / duplicate writes). De-duping that belongs
+            # at the file-execution layer, not here; this transport stays at-least-
+            # once + caller-timeout by design.
             logger.warning(
                 "PG executor dispatch: TIMEOUT after %ss (reply_key=%s run_id=%s) — "
                 "the executor task may still be running",
@@ -176,14 +197,19 @@ class PgExecutionDispatcher:
             return ExecutionResult.failure(
                 error=f"TimeoutError: executor reply not received within {timeout}s"
             )
+        # ``.get`` (not ``[...]``) so a result row missing ``status`` can't raise
+        # out of dispatch() — the never-raises contract must not depend on the
+        # producer always writing every key.
         if (
-            row["status"] == PgTaskStatus.COMPLETED.value
+            row.get("status") == PgTaskStatus.COMPLETED.value
             and row.get("result") is not None
         ):
             try:
                 return ExecutionResult.from_dict(row["result"])
-            except Exception:
+            except Exception as exc:
                 # A malformed completed row becomes a failure result, not a raise.
+                # Surface the parse cause (like the enqueue/wait paths) so a UI
+                # reading result.error isn't left with an opaque message.
                 logger.exception(
                     "PG executor dispatch: malformed completed result "
                     "(reply_key=%s run_id=%s)",
@@ -191,7 +217,10 @@ class PgExecutionDispatcher:
                     context.run_id,
                 )
                 return ExecutionResult.failure(
-                    error=f"Malformed executor result for reply_key {reply_key}"
+                    error=(
+                        f"Malformed executor result ({type(exc).__name__}) "
+                        f"for reply_key {reply_key}"
+                    )
                 )
         logger.warning(
             "PG executor dispatch: executor reported failure (reply_key=%s "
@@ -227,9 +256,14 @@ class PgExecutionDispatcher:
         """Poll ``pg_task_result`` until the row appears or *timeout* elapses.
 
         Poll-based with capped backoff (PgBouncer-safe; no LISTEN/NOTIFY). The
-        backend owns one connection for the duration of the wait (one per
-        in-flight RPC; structure_tool dispatches are sequential) and closes it on
-        exit, so a long RPC never leaks a connection.
+        backend owns one connection for the duration of the wait and closes it on
+        exit, so a long RPC never leaks a connection. The pin is bounded: a
+        file_processing worker runs ``--pool=prefork`` with
+        ``WORKER_FILE_PROCESSING_CONCURRENCY`` (default 4) processes, and each
+        dispatches sequentially, so at most ~concurrency connections are held for
+        up to ``EXECUTOR_RESULT_TIMEOUT``. (The backend twin instead releases via
+        ``close_old_connections`` between polls; if file_processing concurrency is
+        raised materially, do the same here.)
         """
         with PgResultBackend() as rb:
             return rb.wait_for_result(reply_key, timeout)

--- a/workers/queue_backend/pg_queue/task_payload.py
+++ b/workers/queue_backend/pg_queue/task_payload.py
@@ -32,12 +32,23 @@ def to_payload(
     kwargs: Mapping[str, Any] | None = None,
     queue: str | None = None,
     fairness: FairnessKey | None = None,
+    reply_key: str | None = None,
 ) -> TaskPayload:
-    """Build the JSON-serialisable task payload for the PG queue."""
-    return TaskPayload(
+    """Build the JSON-serialisable task payload for the PG queue.
+
+    ``reply_key`` marks a **request-reply** dispatch (the executor RPC on PG):
+    the executor consumer writes the task's result/error to ``pg_task_result``
+    under it for the blocking caller to poll. Omitted = fire-and-forget.
+    """
+    payload = TaskPayload(
         task_name=task_name,
         args=list(args) if args is not None else [],
         kwargs=dict(kwargs) if kwargs is not None else {},
         queue=queue,
         fairness=fairness.to_dict() if fairness is not None else None,
     )
+    # Only set for request-reply dispatches — keeps fire-and-forget rows
+    # byte-identical to before this field existed (mirrors the backend producer).
+    if reply_key is not None:
+        payload["reply_key"] = reply_key
+    return payload

--- a/workers/sample.env
+++ b/workers/sample.env
@@ -473,3 +473,11 @@ FLIPT_SERVICE_AVAILABLE=False
 EVALUATION_SERVER_IP=unstract-flipt
 EVALUATION_SERVER_PORT=9005
 PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+
+# PG-queue transport master-gate (kill-switch), worker side. Mirrors the backend's
+# PG_QUEUE_TRANSPORT_ENABLED: the file_processing worker reads it to route the
+# structure_tool executor RPC onto the PG queue. Routing onto PG requires ALL
+# THREE: this gate True, FLIPT_SERVICE_AVAILABLE=True, and the Flipt flag
+# `pg_queue_enabled` on. Keep False until the worker-pg-executor consumer is
+# running in the fleet; set False for instant rollback.
+PG_QUEUE_TRANSPORT_ENABLED=False

--- a/workers/tests/test_dispatch_pg.py
+++ b/workers/tests/test_dispatch_pg.py
@@ -66,6 +66,15 @@ class TestToPayload:
         # Must round-trip through JSON (it's stored in a JSONB column).
         json.dumps(to_payload("t", args=[1], kwargs={"a": "b"}, fairness=fairness))
 
+    def test_reply_key_set_when_passed(self):
+        # The request-reply marker (executor RPC): the consumer keys the result
+        # row on it; a drop/mis-key would make the caller block until timeout.
+        assert to_payload("t", reply_key="rk")["reply_key"] == "rk"
+
+    def test_reply_key_omitted_when_absent(self):
+        # Fire-and-forget rows stay byte-identical to before the field existed.
+        assert "reply_key" not in to_payload("t")
+
 
 # --- Integration: dispatch() lands a decodable row in pg_queue_message ---
 # Uses the shared ``pg_client`` fixture from conftest.py.

--- a/workers/tests/test_executor_registration.py
+++ b/workers/tests/test_executor_registration.py
@@ -1,0 +1,46 @@
+"""Regression: the executor registry must be populated by importing the task module.
+
+The PG executor consumer (``pg_queue_consumer``) bootstraps a worker by importing
+the source worker's ``tasks.py`` — it does NOT import ``executor/worker.py`` (the
+Celery entrypoint that historically held ``import executor.executors``). So if the
+``@ExecutorRegistry.register`` side-effect import lives only in ``worker.py``, the
+PG executor runs ``execute_extraction`` against an EMPTY registry and every
+extraction fails with ``No executor registered with name 'legacy'. Available:
+(none)``.
+
+This is pinned in a fresh interpreter that imports ONLY ``executor.tasks`` (exactly
+what the PG consumer does), so import caching from the rest of the suite can't mask
+a regression.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def test_importing_executor_tasks_registers_executors():
+    """Importing executor.tasks alone must register the bundled executors.
+
+    Mirrors the PG-queue consumer's bootstrap (tasks.py, not worker.py). A fresh
+    subprocess avoids the suite's other imports pre-populating the registry.
+    """
+    code = (
+        "import executor.tasks\n"
+        "from unstract.sdk1.execution.registry import ExecutorRegistry\n"
+        "reg = getattr(ExecutorRegistry, '_registry', {})\n"
+        "assert 'legacy' in reg, f'registry empty/missing legacy: {sorted(reg)}'\n"
+        "print('OK', sorted(reg))\n"
+    )
+    env = {**os.environ, "WORKER_TYPE": "executor"}
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    assert result.returncode == 0, (
+        f"executor.tasks import did not register executors.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout

--- a/workers/tests/test_executor_rpc.py
+++ b/workers/tests/test_executor_rpc.py
@@ -1,0 +1,248 @@
+"""Tests for the workers-side executor-RPC transport routing (Phase 9, ③b-2).
+
+DB-free: the env gate / Flipt / the enqueue + poll halves are mocked. Pins the
+gate's fail-closed matrix and — the load-bearing zero-regression property — that
+with the gate off ``RoutingExecutionDispatcher`` delegates EVERY mode to the
+unchanged Celery ``ExecutionDispatcher`` and never touches the PG path. Mirrors
+``backend/pg_queue/tests/test_executor_rpc.py`` (the backend twin) adapted to the
+worker primitives: an env master-gate instead of a Django setting, and the result
+row is a plain ``dict`` (``PgResultBackend``) instead of a Django model.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from queue_backend.pg_queue.executor_rpc import (
+    PgExecutionDispatcher,
+    RoutingExecutionDispatcher,
+    resolve_executor_transport,
+)
+
+_MOD = "queue_backend.pg_queue.executor_rpc"
+
+
+def _completed(result: dict) -> dict:
+    return {"status": "completed", "result": result, "error": ""}
+
+
+def _ok_result() -> dict:
+    return {"success": True, "data": {"x": 1}, "metadata": {}, "error": None}
+
+
+class TestPgExecutionDispatcherDispatch:
+    """The load-bearing contract: never raises; timeout/failure → failure result.
+
+    DB-free — the ``_enqueue`` and ``_wait_for_result`` halves are mocked.
+    """
+
+    @staticmethod
+    def _ctx() -> MagicMock:
+        c = MagicMock()
+        c.executor_name = "legacy"
+        c.run_id = "r"
+        c.organization_id = "o"
+        c.to_dict.return_value = {"run_id": "r"}
+        return c
+
+    def test_enqueue_failure_returns_failure_not_raise(self):
+        with patch.object(
+            PgExecutionDispatcher, "_enqueue", side_effect=RuntimeError("db down")
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        assert res.success is False
+        assert "RuntimeError" in res.error
+
+    def test_wait_failure_returns_failure_not_raise(self):
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(
+                PgExecutionDispatcher,
+                "_wait_for_result",
+                side_effect=RuntimeError("conn died"),
+            ),
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        assert res.success is False
+        assert "RuntimeError" in res.error
+
+    def test_timeout_returns_failure(self):
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(PgExecutionDispatcher, "_wait_for_result", return_value=None),
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=3)
+        assert res.success is False
+        assert "within 3s" in res.error
+
+    def test_completed_row_returns_result(self):
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(
+                PgExecutionDispatcher,
+                "_wait_for_result",
+                return_value=_completed(_ok_result()),
+            ),
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        assert res.success is True
+
+    def test_failed_row_returns_error(self):
+        row = {"status": "failed", "result": None, "error": "boom"}
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(PgExecutionDispatcher, "_wait_for_result", return_value=row),
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        assert res.success is False
+        assert res.error == "boom"
+
+    def test_failed_row_empty_error_falls_back(self):
+        row = {"status": "failed", "result": None, "error": ""}
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(PgExecutionDispatcher, "_wait_for_result", return_value=row),
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        assert res.success is False
+        assert "executor task failed" in res.error
+
+    def test_completed_but_result_none_is_failure(self):
+        row = {"status": "completed", "result": None, "error": ""}
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(PgExecutionDispatcher, "_wait_for_result", return_value=row),
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        assert res.success is False
+
+    def test_malformed_completed_row_is_failure_not_raise(self):
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(
+                PgExecutionDispatcher,
+                "_wait_for_result",
+                return_value=_completed({"bad": "shape"}),
+            ),
+        ):
+            res = PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        assert res.success is False
+        assert "Malformed" in res.error
+
+    def test_timeout_none_reads_env_then_default(self, monkeypatch):
+        monkeypatch.setenv("EXECUTOR_RESULT_TIMEOUT", "42")
+        seen = {}
+
+        def fake_wait(reply_key, timeout):
+            seen["timeout"] = timeout
+            return None
+
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(
+                PgExecutionDispatcher, "_wait_for_result", side_effect=fake_wait
+            ),
+        ):
+            # No explicit timeout arg → falls back to the env/default.
+            PgExecutionDispatcher().dispatch(self._ctx())
+        assert seen["timeout"] == 42
+
+    def test_timeout_none_bad_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("EXECUTOR_RESULT_TIMEOUT", "not-an-int")
+        seen = {}
+
+        def fake_wait(reply_key, timeout):
+            seen["timeout"] = timeout
+            return None
+
+        with (
+            patch.object(PgExecutionDispatcher, "_enqueue"),
+            patch.object(
+                PgExecutionDispatcher, "_wait_for_result", side_effect=fake_wait
+            ),
+        ):
+            PgExecutionDispatcher().dispatch(self._ctx())  # must not raise
+        assert seen["timeout"] == 3600  # _DEFAULT_TIMEOUT
+
+
+def _ctx(org: str | None = "org1") -> MagicMock:
+    c = MagicMock()
+    c.executor_name = "legacy"
+    c.run_id = "run-1"
+    c.organization_id = org
+    return c
+
+
+class TestResolveExecutorTransport:
+    def test_master_gate_off_is_celery(self, monkeypatch):
+        monkeypatch.delenv("PG_QUEUE_TRANSPORT_ENABLED", raising=False)
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "true")
+        with patch(f"{_MOD}.check_feature_flag_status") as flag:
+            assert resolve_executor_transport(_ctx()) is False
+            flag.assert_not_called()  # gate off → Flipt never consulted
+
+    def test_flipt_unavailable_is_celery(self, monkeypatch):
+        monkeypatch.setenv("PG_QUEUE_TRANSPORT_ENABLED", "true")
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "false")
+        with patch(f"{_MOD}.check_feature_flag_status") as flag:
+            assert resolve_executor_transport(_ctx()) is False
+            flag.assert_not_called()
+
+    def test_flag_true_is_pg_keyed_on_org(self, monkeypatch):
+        monkeypatch.setenv("PG_QUEUE_TRANSPORT_ENABLED", "true")
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "true")
+        with patch(
+            f"{_MOD}.check_feature_flag_status", return_value=True
+        ) as flag:
+            assert resolve_executor_transport(_ctx("orgX")) is True
+            assert flag.call_args.kwargs["entity_id"] == "orgX"
+            # The single shared PG-queue flag (not a per-subsystem flag).
+            assert flag.call_args.kwargs["flag_key"] == "pg_queue_enabled"
+
+    def test_flag_false_is_celery(self, monkeypatch):
+        monkeypatch.setenv("PG_QUEUE_TRANSPORT_ENABLED", "true")
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "true")
+        with patch(f"{_MOD}.check_feature_flag_status", return_value=False):
+            assert resolve_executor_transport(_ctx()) is False
+
+    def test_flipt_error_fails_closed_to_celery(self, monkeypatch):
+        monkeypatch.setenv("PG_QUEUE_TRANSPORT_ENABLED", "true")
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "true")
+        with patch(
+            f"{_MOD}.check_feature_flag_status", side_effect=RuntimeError("down")
+        ):
+            assert resolve_executor_transport(_ctx()) is False
+
+
+class TestRoutingZeroRegression:
+    @staticmethod
+    def _build():
+        # Patch both sub-dispatchers at construction; the instances are captured
+        # in __init__ so they remain mocked after the context exits.
+        with (
+            patch(f"{_MOD}.ExecutionDispatcher") as celery_cls,
+            patch(f"{_MOD}.PgExecutionDispatcher") as pg_cls,
+        ):
+            dispatcher = RoutingExecutionDispatcher(celery_app="app")
+        return dispatcher, celery_cls.return_value, pg_cls.return_value
+
+    def test_gate_off_dispatch_uses_celery_only(self):
+        dispatcher, celery, pg = self._build()
+        with patch(f"{_MOD}.resolve_executor_transport", return_value=False):
+            dispatcher.dispatch(_ctx())
+        celery.dispatch.assert_called_once()
+        pg.dispatch.assert_not_called()  # the zero-regression guarantee
+
+    def test_gate_on_dispatch_uses_pg(self):
+        dispatcher, celery, pg = self._build()
+        with patch(f"{_MOD}.resolve_executor_transport", return_value=True):
+            dispatcher.dispatch(_ctx())
+        pg.dispatch.assert_called_once()
+        celery.dispatch.assert_not_called()
+
+    def test_async_and_callback_always_celery(self):
+        """The callback/async path stays on Celery regardless of the gate (a later slice)."""
+        dispatcher, celery, pg = self._build()
+        dispatcher.dispatch_async(_ctx())
+        dispatcher.dispatch_with_callback(_ctx(), on_success=None)
+        celery.dispatch_async.assert_called_once()
+        celery.dispatch_with_callback.assert_called_once()
+        pg.dispatch.assert_not_called()

--- a/workers/tests/test_executor_rpc.py
+++ b/workers/tests/test_executor_rpc.py
@@ -211,6 +211,60 @@ class TestResolveExecutorTransport:
         ):
             assert resolve_executor_transport(_ctx()) is False
 
+    def test_org_less_context_buckets_on_run_id(self, monkeypatch):
+        """No org → entity_id falls back to run_id and org is absent from context.
+
+        Guards the org-less bucketing so cross-org/run-only contexts resolve
+        deterministically instead of shipping a bogus "None" org.
+        """
+        monkeypatch.setenv("PG_QUEUE_TRANSPORT_ENABLED", "true")
+        monkeypatch.setenv("FLIPT_SERVICE_AVAILABLE", "true")
+        with patch(
+            f"{_MOD}.check_feature_flag_status", return_value=True
+        ) as flag:
+            assert resolve_executor_transport(_ctx(org=None)) is True
+        assert flag.call_args.kwargs["entity_id"] == "run-1"
+        assert "organization_id" not in flag.call_args.kwargs["context"]
+
+
+class TestPgExecutionDispatcherEnqueueWiring:
+    """The actual PG-transport wiring: queue name, payload shape, org_id.
+
+    These are the *only* routing/identity carried on the PG path (Celery headers
+    are dropped), so a bug here misroutes or breaks org-fairness. ``to_payload``
+    runs for real; only ``PgQueueClient`` and the wait are mocked.
+    """
+
+    @staticmethod
+    def _ctx():
+        c = MagicMock()
+        c.executor_name = "legacy"
+        c.run_id = "r"
+        c.organization_id = "org9"
+        c.to_dict.return_value = {"run_id": "r"}
+        return c
+
+    def test_enqueue_sends_queue_payload_and_org(self):
+        client = MagicMock()
+        client.__enter__.return_value = client  # `with PgQueueClient() as c` → c is client
+        with (
+            patch(f"{_MOD}.PgQueueClient", return_value=client),
+            patch.object(
+                PgExecutionDispatcher,
+                "_wait_for_result",
+                return_value=_completed(_ok_result()),
+            ),
+        ):
+            PgExecutionDispatcher().dispatch(self._ctx(), timeout=5)
+        client.send.assert_called_once()
+        args, kwargs = client.send.call_args
+        queue_arg, payload_arg = args[0], args[1]
+        assert queue_arg == "celery_executor_legacy"
+        assert kwargs["org_id"] == "org9"
+        assert payload_arg["task_name"] == "execute_extraction"
+        assert payload_arg["args"] == [{"run_id": "r"}]
+        assert payload_arg["reply_key"]  # request-reply marker present (a uuid)
+
 
 class TestRoutingZeroRegression:
     @staticmethod
@@ -224,18 +278,24 @@ class TestRoutingZeroRegression:
             dispatcher = RoutingExecutionDispatcher(celery_app="app")
         return dispatcher, celery_cls.return_value, pg_cls.return_value
 
-    def test_gate_off_dispatch_uses_celery_only(self):
+    def test_gate_off_forwards_timeout_and_headers_to_celery(self):
+        """Zero-regression: gate off → Celery gets timeout AND headers unchanged."""
         dispatcher, celery, pg = self._build()
+        ctx = _ctx()
+        hdrs = {"x-fairness-key": {"org_id": "o"}}
         with patch(f"{_MOD}.resolve_executor_transport", return_value=False):
-            dispatcher.dispatch(_ctx())
-        celery.dispatch.assert_called_once()
+            dispatcher.dispatch(ctx, timeout=9, headers=hdrs)
+        celery.dispatch.assert_called_once_with(ctx, timeout=9, headers=hdrs)
         pg.dispatch.assert_not_called()  # the zero-regression guarantee
 
-    def test_gate_on_dispatch_uses_pg(self):
+    def test_gate_on_passes_timeout_to_pg_and_drops_headers(self):
+        """Gate on → PG gets the timeout but NOT the Celery headers (intentional)."""
         dispatcher, celery, pg = self._build()
+        ctx = _ctx()
         with patch(f"{_MOD}.resolve_executor_transport", return_value=True):
-            dispatcher.dispatch(_ctx())
-        pg.dispatch.assert_called_once()
+            dispatcher.dispatch(ctx, timeout=7, headers={"x-fairness-key": {"o": 1}})
+        pg.dispatch.assert_called_once_with(ctx, timeout=7)
+        assert "headers" not in pg.dispatch.call_args.kwargs
         celery.dispatch.assert_not_called()
 
     def test_async_and_callback_always_celery(self):

--- a/workers/tests/test_structure_tool_task.py
+++ b/workers/tests/test_structure_tool_task.py
@@ -17,8 +17,11 @@ site forwards it".
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
+from file_processing import structure_tool_task as st
 from file_processing.structure_tool_task import _fairness_headers
 from queue_backend.fairness import WorkloadType
 
@@ -48,6 +51,41 @@ class TestFairnessHeaders:
         wire = _fairness_headers("org-1")
         assert wire["x-fairness-key"]["workload_type"] == WorkloadType.NON_API.value
         assert wire["x-fairness-key"]["workload_type"] != WorkloadType.API.value
+
+
+class TestDispatcherFactory:
+    """Pin the call-site swap this PR makes: the impl builds its dispatcher via
+    ``get_executor_dispatcher(celery_app=app)`` (the gate-routed dispatcher), not
+    the raw SDK ``ExecutionDispatcher``. A mis-import or wrong arg would otherwise
+    silently bypass the PG routing with nothing failing.
+    """
+
+    @staticmethod
+    def _params() -> dict:
+        return {
+            "organization_id": "org1",
+            "file_execution_id": "fe1",
+            "tool_instance_metadata": {},
+            "platform_service_api_key": "sk",
+            "input_file_path": "/in/f.pdf",
+            "output_dir_path": "/out",
+            "source_file_name": "f.pdf",
+            "execution_data_dir": "/data",
+        }
+
+    def test_impl_builds_dispatcher_via_factory_with_app(self):
+        # Stub everything up to (and just past) the dispatcher construction, then
+        # raise to stop before the heavy tool-metadata work runs.
+        with (
+            patch("executor.executor_tool_shim.ExecutorToolShim"),
+            patch.object(st, "_create_platform_helper"),
+            patch.object(st, "_get_file_storage"),
+            patch.object(st, "get_executor_dispatcher") as factory,
+            patch.object(st, "_fetch_tool_metadata", side_effect=RuntimeError("stop")),
+        ):
+            with pytest.raises(RuntimeError, match="stop"):
+                st._execute_structure_tool_impl(self._params())
+        factory.assert_called_once_with(celery_app=st.app)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Routes the in-workflow **structure_tool** executor dispatch onto the Postgres executor RPC when the single `pg_queue_enabled` flag is on; Celery otherwise (**zero-regression by construction**). Next slice after UN-3603 (prompt-studio blocking path). Gated off by default; lands on the PG-queue integration branch (not main).

## Changes

- **`workers/queue_backend/pg_queue/executor_rpc.py` (new)** — workers twin of the backend module on worker primitives:
  - `resolve_executor_transport` — master `PG_QUEUE_TRANSPORT_ENABLED` env, then the single `pg_queue_enabled` Flipt flag; **fail-closed to Celery**.
  - `PgExecutionDispatcher` — enqueue `execute_extraction` with a unique `reply_key` via `PgQueueClient`, poll `PgResultBackend.wait_for_result`; **never raises** (timeout/failure → `ExecutionResult.failure`).
  - `RoutingExecutionDispatcher` — per-call gate routing; `dispatch_async`/`dispatch_with_callback` stay on Celery (later slice). `get_executor_dispatcher` factory.
- **`to_payload`** gains an optional `reply_key` (request-reply marker; fire-and-forget rows stay byte-identical).
- **`structure_tool_task`** swaps its dispatcher factory to `get_executor_dispatcher`; the 3 blocking dispatch call sites are unchanged.
- **Fix (latent gap exposed by this slice):** the PG executor consumer registered **no executors** — `No executor registered with name 'legacy'`. The `@ExecutorRegistry.register` side-effect import lived only in the Celery `executor/worker.py`, but the PG consumer bootstraps via `executor/tasks.py`. Importing `executor.executors` from `executor/tasks.py` means any worker registering `execute_extraction` (Celery **or** PG) has the executors — also fixes the prompt-studio PG path from UN-3603.
- **`sample.env`** — document the worker-side `PG_QUEUE_TRANSPORT_ENABLED` gate; fix a stale `pg_queue_execution_enabled` → `pg_queue_enabled` doc reference.

## Zero-regression

Gate off → `resolve_executor_transport` returns before any Flipt call → `RoutingExecutionDispatcher` delegates to the unchanged SDK `ExecutionDispatcher` (Celery). No `pg_task_result` row. Flipping the flag is an instant, no-redeploy rollout/rollback (read per dispatch).

## Tests

- `workers/tests/test_executor_rpc.py` — gate fail-closed matrix, zero-regression routing (gate off → Celery delegate, no enqueue), never-raises dispatch cases.
- `workers/tests/test_executor_registration.py` — subprocess regression asserting that importing `executor.tasks` alone registers the executors (mirrors the PG consumer bootstrap).

## Dev-tested end-to-end (gated, running stack)

- **Flag ON** → `Executor RPC → PG transport` logged → `execute_extraction` runs on `worker-pg-executor` → `pg_task_result` `completed` rows (reply_keys match) → file executions + workflow **COMPLETED**.
- **Flag OFF** → Celery executor path, no `pg_task_result` row.

## Out of scope (separate follow-ups)

- `worker-pg-fileproc` single-consumer serializes multi-file fan-out on the PG path (own ticket).
- Continuation/callback path and Celery decommission are later slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)