### PR TITLE
UN-3606 [FIX] PG Queue — prefork the consumer so file batches + executor RPCs run in parallel

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -638,6 +638,17 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE=file_processing
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=file_processing,api_file_processing
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
+      # UN-3606: prefork N consumer children so file batches run in parallel (the
+      # PG analogue of the Celery worker's --concurrency). SKIP LOCKED distributes
+      # batches across children + replicas; a single execution is still capped by
+      # MAX_PARALLEL_FILE_BATCHES. Mirrors WORKER_FILE_PROCESSING_CONCURRENCY.
+      - WORKER_PG_QUEUE_CONSUMER_CONCURRENCY=${PG_FILEPROC_CONCURRENCY:-4}
+      # process_file_batch blocks on the executor RPC (up to EXECUTOR_RESULT_TIMEOUT,
+      # default 3600s). vt must exceed ONE batch's worst case (children run in
+      # parallel, not serially) or a long batch gets re-claimed mid-run; health-stale
+      # sits just above vt so a legitimately-long batch never trips the fleet probe.
+      - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_FILEPROC_VT_SECONDS:-3660}
+      - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_FILEPROC_HEALTH_STALE_SECONDS:-3720}
     labels:
       - traefik.enable=false
     volumes:
@@ -743,6 +754,12 @@ services:
       # double-spend, two runs racing the same reply_key) or killed by the probe.
       - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_EXECUTOR_VT_SECONDS:-3660}
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_EXECUTOR_HEALTH_STALE_SECONDS:-3720}
+      # UN-3606: prefork N executor children so concurrent file batches' executor
+      # RPCs run in parallel instead of serializing here. Without this the
+      # file-processing parallelism delivers no end-to-end speedup — the LLM
+      # extraction (the wall-clock-dominant work) is the bottleneck. Match the
+      # file-processing concurrency so N parallel files get N parallel executors.
+      - WORKER_PG_QUEUE_CONSUMER_CONCURRENCY=${PG_EXECUTOR_CONCURRENCY:-4}
       - CELERY_QUEUES_EXECUTOR=${CELERY_QUEUES_EXECUTOR:-celery_executor_legacy,celery_executor_agentic,celery_executor_agentic_table}
     labels:
       - traefik.enable=false

--- a/workers/pg_queue_consumer/__main__.py
+++ b/workers/pg_queue_consumer/__main__.py
@@ -20,8 +20,6 @@ so the right worker type must be selected here.
 Launch via ``python -m pg_queue_consumer`` or ``./run-worker.sh pg-queue-consumer``.
 """
 
-import os
-
 
 def _bootstrap_and_run() -> None:
     # CONCURRENCY > 1 → run a prefork supervisor (UN-3606): N isolated consumer
@@ -43,12 +41,11 @@ def _bootstrap_and_run() -> None:
         return
 
     # Single-process path: select the source worker whose tasks back this
-    # consumer's queue. Must run BEFORE `import worker`, which reads WORKER_TYPE at
-    # import time. We overwrite (not setdefault) because the launcher's own
-    # WORKER_TYPE owns no tasks.
-    os.environ["WORKER_TYPE"] = os.environ.get(
-        "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
-    )
+    # consumer's queue (must run BEFORE `import worker`, which reads WORKER_TYPE at
+    # import time). Shared with the supervisor's children via _bootstrap.
+    from pg_queue_consumer._bootstrap import select_source_worker_type
+
+    select_source_worker_type()
 
     import worker  # noqa: F401 — side-effect: registers the source worker's tasks
     from queue_backend.pg_queue.consumer import main

--- a/workers/pg_queue_consumer/__main__.py
+++ b/workers/pg_queue_consumer/__main__.py
@@ -24,14 +24,28 @@ import os
 
 
 def _bootstrap_and_run() -> None:
-    # Select the source worker whose tasks back this consumer's queue. Must run
-    # BEFORE `import worker`, which reads WORKER_TYPE at import time. We overwrite
-    # (not setdefault) because the launcher's own WORKER_TYPE owns no tasks.
+    # CONCURRENCY > 1 → run a prefork supervisor (UN-3606): N isolated consumer
+    # children, the PG analogue of Celery --pool=prefork --concurrency=N. The
+    # supervisor forks the children (each does its OWN worker bootstrap, so no
+    # connections are inherited across the fork) and owns the single health port.
+    # CONCURRENCY = 1 (default) keeps the plain single-process path below,
+    # byte-identical to before the supervisor existed.
     #
     # Kept inside this guarded function (not at module scope) so the env mutation
     # and the heavy `import worker` bootstrap only happen on the `python -m`
     # entry — never as a side-effect if this module is imported by a test, IDE,
     # or type-checker walking `__main__` files.
+    from pg_queue_consumer.supervisor import concurrency_from_env, run_supervised
+
+    concurrency = concurrency_from_env()
+    if concurrency > 1:
+        run_supervised(concurrency)
+        return
+
+    # Single-process path: select the source worker whose tasks back this
+    # consumer's queue. Must run BEFORE `import worker`, which reads WORKER_TYPE at
+    # import time. We overwrite (not setdefault) because the launcher's own
+    # WORKER_TYPE owns no tasks.
     os.environ["WORKER_TYPE"] = os.environ.get(
         "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
     )

--- a/workers/pg_queue_consumer/_bootstrap.py
+++ b/workers/pg_queue_consumer/_bootstrap.py
@@ -1,0 +1,24 @@
+"""Shared bootstrap for the PG-queue consumer entrypoints.
+
+Both the single-process launcher (``__main__``) and the prefork supervisor's
+children must select the source worker type *before* ``import worker`` (which
+reads ``WORKER_TYPE`` at import time to register that type's tasks). Kept in a
+neutral module — not ``__main__`` — so ``supervisor`` can import it without
+triggering the ``python -m`` entry.
+"""
+
+import os
+
+
+def select_source_worker_type() -> None:
+    """Point ``WORKER_TYPE`` at the source worker whose tasks back this consumer.
+
+    Overwrites (not ``setdefault``): the launcher's own ``WORKER_TYPE`` is the
+    ``pg_queue_consumer`` pseudo-type, which owns no tasks — a plain ``import
+    worker`` would fall back to the ``general`` worker and drop every message as an
+    unknown task. Default ``notification`` (the worker owning the first migrated
+    leaf task). Must run before ``import worker``.
+    """
+    os.environ["WORKER_TYPE"] = os.environ.get(
+        "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
+    )

--- a/workers/pg_queue_consumer/supervisor.py
+++ b/workers/pg_queue_consumer/supervisor.py
@@ -121,8 +121,10 @@ class _Fleet:
         return self._n
 
     @property
-    def heartbeats(self):  # noqa: ANN201 — ctypes array, passed to forked children
-        """The shared heartbeat array (children write their own slot directly)."""
+    def heartbeats(self):  # noqa: ANN201
+        """The shared heartbeat array (a ctypes array, passed to forked children,
+        which write their own slot directly).
+        """
         return self._heartbeats
 
     def _validate(self, slot: int) -> None:
@@ -247,9 +249,11 @@ def _child_after_fork(slot: int, heartbeats) -> None:  # noqa: ANN001 (ctypes ar
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     try:
         _run_child(slot, heartbeats)
-    except BaseException:
+    except Exception:
         # A child that can't even start must not return into the supervisor loop
-        # (it would fork grandchildren). Log + hard exit.
+        # (it would fork grandchildren). Log + hard exit. Exception (not
+        # BaseException) is the realistic startup-failure surface here — import,
+        # connection, config; SystemExit/KeyboardInterrupt would exit anyway.
         logger.exception("PG-queue consumer: child slot=%s failed to run", slot)
         os._exit(1)
     os._exit(0)
@@ -264,11 +268,10 @@ def _try_fork_child(fleet: _Fleet, slot: int) -> bool:
     try:
         pid = os.fork()
     except OSError:
-        logger.error(
+        logger.exception(
             "PG-queue consumer: os.fork() failed for slot=%s (process/memory "
             "limit?) — will retry",
             slot,
-            exc_info=True,
         )
         return False
     if pid == 0:  # child — never returns

--- a/workers/pg_queue_consumer/supervisor.py
+++ b/workers/pg_queue_consumer/supervisor.py
@@ -182,8 +182,16 @@ class _Fleet:
     def is_crash_looping(self) -> bool:
         """True if any slot has died immediately ``_CRASH_LOOP_THRESHOLD`` times in
         a row — the signal that the heartbeat alone can't be trusted fresh.
+
+        Snapshots the values first (``tuple(...)`` is atomic under the GIL): this
+        runs in the liveness daemon thread (via :meth:`freshness`) while the main
+        thread mutates ``_consecutive_crashes`` in :meth:`schedule_restart`, so a
+        bare ``.values()`` iteration could raise "dictionary changed size during
+        iteration".
         """
-        return any(n >= _CRASH_LOOP_THRESHOLD for n in self._consecutive_crashes.values())
+        return any(
+            n >= _CRASH_LOOP_THRESHOLD for n in tuple(self._consecutive_crashes.values())
+        )
 
     def oldest_age(self) -> float:
         now = time.time()

--- a/workers/pg_queue_consumer/supervisor.py
+++ b/workers/pg_queue_consumer/supervisor.py
@@ -4,25 +4,32 @@ Forks ``WORKER_PG_QUEUE_CONSUMER_CONCURRENCY`` copies of the single-threaded
 :class:`~queue_backend.pg_queue.consumer.PgQueueConsumer` so multiple file
 batches run in parallel — the PG analogue of Celery's ``--pool=prefork
 --concurrency=N``. ``SELECT … FOR UPDATE SKIP LOCKED`` distributes work across the
-children (and across replicas): each child claims distinct rows, and the cap on a
-single execution is still ``MAX_PARALLEL_FILE_BATCHES`` (producer side). Total live
-parallelism = ``concurrency × replicas``; k8s HPA scales the replica count.
+children (and across replicas): each child claims distinct rows, a single
+execution is still capped by ``MAX_PARALLEL_FILE_BATCHES``, and total live
+parallelism = ``concurrency × replicas`` (k8s HPA scales the replica count).
 
 **Process model** (matches Celery prefork — the cloud-trusted choice): each child
 is a fully isolated process with its own DB connections and thread-local
 ``StateStore`` — no shared mutable state, no thread-safety surface. A child crash
-is isolated and re-forked by the supervisor; its in-flight message redelivers via
+is isolated and re-forked (rate-limited); its in-flight message redelivers via
 ``vt`` (at-least-once). The **consumer code is unchanged** — concurrency is purely
-a launch concern.
+a launch concern. ``CONCURRENCY = 1`` keeps the plain single-process ``main()``
+path (byte-identical to before this module existed).
 
 **Health**: the supervisor owns the single liveness port and reports the *fleet's*
 freshness — the staleness of the oldest-polling child (each child publishes its
 last-poll wall-time into a shared array). A child that dies is re-forked
-internally (transient); only a persistent failure (children that won't stay fresh)
-sustains 503 → pod restart. Children do not bind the port themselves.
+internally (transient); a child that **crash-loops** (dies immediately N times in
+a row, never reaching a real poll) forces the probe to 503 so k8s restarts the
+pod rather than the supervisor masking a wedged fleet with fresh-looking re-forks.
 
-Used only when ``CONCURRENCY > 1``; ``CONCURRENCY = 1`` keeps the plain
-single-process ``main()`` path (byte-identical to before this module existed).
+**Fork safety**: the initial fleet is forked while the parent is single-threaded.
+Re-forks happen after the liveness daemon thread exists; the only other thread is
+that probe (idle in ``select`` between requests, and CPython 3.12 re-inits the
+``logging`` locks across ``fork`` via ``os.register_at_fork``), and each child
+resets inherited signal handlers + does its own ``import worker`` before touching
+shared resources — so an inherited held lock or the parent's ``_on_term`` cannot
+wedge or mis-signal a child.
 """
 
 from __future__ import annotations
@@ -34,6 +41,10 @@ import os
 import signal
 import threading
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from queue_backend.pg_queue.liveness import LivenessServer
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +55,15 @@ _MAX_CONCURRENCY = 64
 # How often each child republishes its heartbeat, and the parent reaps + checks.
 _REPORT_INTERVAL_SECONDS = 1.0
 _MONITOR_INTERVAL_SECONDS = 1.0
-# Floor between a child's death and its re-fork — avoids a fork storm when a child
-# dies on startup every time (e.g. a bad migration); the gap lets logs/alerts fire.
+# Re-fork backoff floor and ceiling — a crash-looping child must not fork-storm.
 _RESTART_MIN_INTERVAL_SECONDS = 2.0
-# How long to wait for children to drain on shutdown before giving up the join.
+_RESTART_MAX_BACKOFF_SECONDS = 30.0
+# A child that stays up at least this long before exiting is a normal exit, not an
+# immediate crash — it resets the slot's consecutive-crash counter.
+_MIN_HEALTHY_UPTIME_SECONDS = 10.0
+# Consecutive immediate crashes after which the fleet probe is forced unhealthy.
+_CRASH_LOOP_THRESHOLD = 3
+# How long to wait per child for a graceful drain on shutdown before SIGKILL.
 _SHUTDOWN_GRACE_SECONDS = 30.0
 
 
@@ -77,43 +93,139 @@ def concurrency_from_env() -> int:
     return n
 
 
-def _oldest_child_age(heartbeats) -> float:  # noqa: ANN001 (ctypes array)
-    """Fleet staleness = seconds since the *oldest*-polling child last polled.
-
-    The supervisor's liveness verdict: if the worst child has stalled past the
-    threshold, the fleet probe goes 503. Empty fleet → 0 (fresh; nothing to judge).
+class _Fleet:
+    """Owns the per-slot child state — pid, last-fork, heartbeat, crash count and
+    pending-restart schedule — keeping them mutually consistent. Slots are
+    validated against ``[0, concurrency)`` so a stray key can't silently desync
+    the structures or ``IndexError`` the shared array.
     """
-    now = time.time()
-    return max((now - hb for hb in heartbeats), default=0.0)
+
+    def __init__(self, concurrency: int) -> None:
+        self._n = concurrency
+        # Shared, fork-inherited heartbeat slots (one last-poll wall-time per
+        # child). lock=False is safe: a slot is written either by the parent
+        # (seed, at construction, while no child owns it) OR by that child's
+        # heartbeat thread — never concurrently — and only read by the parent, so
+        # a torn double read just yields one stale sample that self-corrects.
+        self._heartbeats = multiprocessing.Array("d", concurrency, lock=False)
+        now = time.time()
+        for i in range(concurrency):
+            self._heartbeats[i] = now
+        self._pids: dict[int, int] = {}
+        self._last_fork: dict[int, float] = {}
+        self._consecutive_crashes: dict[int, int] = {}
+        self._restart_due: dict[int, float] = {}  # slot -> monotonic not-before
+
+    @property
+    def concurrency(self) -> int:
+        return self._n
+
+    @property
+    def heartbeats(self):  # noqa: ANN201 — ctypes array, passed to forked children
+        """The shared heartbeat array (children write their own slot directly)."""
+        return self._heartbeats
+
+    def _validate(self, slot: int) -> None:
+        if not 0 <= slot < self._n:
+            raise IndexError(f"slot {slot} out of range [0, {self._n})")
+
+    def record_fork(self, slot: int, pid: int) -> None:
+        """Mark ``slot`` alive under ``pid``; clears any pending restart. Note the
+        heartbeat is deliberately NOT reseeded here — a re-forked child must earn
+        freshness by actually polling, so a crash-looping slot ages instead of
+        looking perpetually fresh.
+        """
+        self._validate(slot)
+        self._pids[slot] = pid
+        self._last_fork[slot] = time.monotonic()
+        self._restart_due.pop(slot, None)
+
+    def reap(self, slot: int) -> float:
+        """Drop the slot's pid + last-fork together; return the child's uptime (s)."""
+        forked_at = self._last_fork.pop(slot, time.monotonic())
+        self._pids.pop(slot, None)
+        return time.monotonic() - forked_at
+
+    def schedule_restart(self, slot: int, uptime: float) -> int:
+        """Record the exit and set the re-fork not-before; return the consecutive
+        immediate-crash count. A child that ran healthily before exiting resets the
+        counter; an immediate death increments it and backs the restart off
+        (capped) so a crash loop can't fork-storm.
+        """
+        if uptime < _MIN_HEALTHY_UPTIME_SECONDS:
+            n = self._consecutive_crashes.get(slot, 0) + 1
+        else:
+            n = 0  # ran fine, then exited — not a crash loop
+        self._consecutive_crashes[slot] = n
+        backoff = min(
+            _RESTART_MIN_INTERVAL_SECONDS * max(1, n), _RESTART_MAX_BACKOFF_SECONDS
+        )
+        self._restart_due[slot] = time.monotonic() + backoff
+        return n
+
+    def due_restarts(self) -> list[int]:
+        """Slots whose re-fork backoff has elapsed (oldest schedule first)."""
+        now = time.monotonic()
+        return sorted(s for s, due in self._restart_due.items() if due <= now)
+
+    def consecutive_crashes(self, slot: int) -> int:
+        return self._consecutive_crashes.get(slot, 0)
+
+    def alive_items(self) -> list[tuple[int, int]]:
+        return list(self._pids.items())
+
+    def alive_count(self) -> int:
+        return len(self._pids)
+
+    def is_crash_looping(self) -> bool:
+        """True if any slot has died immediately ``_CRASH_LOOP_THRESHOLD`` times in
+        a row — the signal that the heartbeat alone can't be trusted fresh.
+        """
+        return any(n >= _CRASH_LOOP_THRESHOLD for n in self._consecutive_crashes.values())
+
+    def oldest_age(self) -> float:
+        now = time.time()
+        return max((now - hb for hb in self._heartbeats), default=0.0)
+
+    def freshness(self) -> float:
+        """Liveness verdict source: a crash-looping fleet is force-stale (``inf``)
+        so the probe trips 503 even if a just-constructed child briefly looked
+        fresh; otherwise the oldest child's staleness (catches a wedged-alive
+        child).
+        """
+        return float("inf") if self.is_crash_looping() else self.oldest_age()
 
 
 def _run_child(slot: int, heartbeats) -> None:  # noqa: ANN001 (ctypes array)
-    """Child entry: bootstrap the worker app, then run one consumer forever.
+    """Build one consumer and run it forever, publishing its heartbeat.
 
     The worker import (and any connections it opens) happens HERE, in the child —
     never inherited across the fork — so each process owns its own connections.
-    A daemon thread publishes the consumer's last-poll wall-time into
+    A *guarded* daemon thread publishes the consumer's last-poll wall-time into
     ``heartbeats[slot]`` for the supervisor's fleet liveness.
     """
-    # Same source-worker selection the single-process launcher does (see
-    # pg_queue_consumer/__main__.py): overwrite WORKER_TYPE before importing
-    # ``worker``, which reads it at import time to register the right tasks.
-    os.environ["WORKER_TYPE"] = os.environ.get(
-        "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
-    )
+    from pg_queue_consumer._bootstrap import select_source_worker_type
+
+    select_source_worker_type()  # set WORKER_TYPE before importing worker
     import worker  # noqa: F401 — side-effect: registers the source worker's tasks
     from queue_backend.pg_queue.consumer import build_consumer_from_env
 
     consumer = build_consumer_from_env()
-    heartbeats[slot] = time.time()  # seed fresh before the first poll
 
     def _publish_heartbeat() -> None:
         # last-poll wall-time = now − (seconds since last poll). Frozen while a
         # task runs (the consumer stamps its heartbeat at the top of poll_once),
         # so a child stuck on a too-long task goes stale exactly as the single
-        # consumer does — the supervisor then sees it via the shared slot.
+        # consumer does. Guarded so a transient error (e.g. teardown during
+        # shutdown) logs loudly and the loop continues instead of dying silently
+        # and false-staling a healthy child.
         while True:
-            heartbeats[slot] = time.time() - consumer.seconds_since_last_poll()
+            try:
+                heartbeats[slot] = time.time() - consumer.seconds_since_last_poll()
+            except Exception:
+                logger.exception(
+                    "PG-queue consumer: heartbeat publish failed for slot=%s", slot
+                )
             time.sleep(_REPORT_INTERVAL_SECONDS)
 
     threading.Thread(target=_publish_heartbeat, daemon=True, name=f"pg-hb-{slot}").start()
@@ -121,44 +233,98 @@ def _run_child(slot: int, heartbeats) -> None:  # noqa: ANN001 (ctypes array)
     consumer.run()
 
 
-def run_supervised(concurrency: int) -> None:
-    """Fork ``concurrency`` consumer children and supervise them until SIGTERM.
+def _child_after_fork(slot: int, heartbeats) -> None:  # noqa: ANN001 (ctypes array)
+    """Child side of the fork: reset inherited state, run, hard-exit on failure.
 
-    Forks the initial fleet while the parent is still single-threaded (safe), then
-    starts the liveness server and the reap/restart loop.
+    Resets the supervisor's signal handlers to ``SIG_DFL`` *immediately* — until
+    ``consumer.run()`` installs its own, a SIGTERM arriving in the fork→run window
+    (which spans the slow ``import worker`` bootstrap) must NOT fire the parent's
+    ``_on_term`` closure in the child (it captured a stale ``children`` dict and
+    would signal sibling pids). ``SIG_DFL`` = terminate, the correct disposition
+    for a not-yet-running child.
     """
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        _run_child(slot, heartbeats)
+    except BaseException:
+        # A child that can't even start must not return into the supervisor loop
+        # (it would fork grandchildren). Log + hard exit.
+        logger.exception("PG-queue consumer: child slot=%s failed to run", slot)
+        os._exit(1)
+    os._exit(0)
+
+
+def _try_fork_child(fleet: _Fleet, slot: int) -> bool:
+    """Fork one child for ``slot``. Returns False (without raising) if ``os.fork``
+    fails — EAGAIN (RLIMIT_NPROC) / ENOMEM are realistic under heavy-child load —
+    so the caller can fail fast (initial fleet) or leave the slot for the next
+    monitor tick (re-fork path) instead of an uncaught crash taking the fleet down.
+    """
+    try:
+        pid = os.fork()
+    except OSError:
+        logger.error(
+            "PG-queue consumer: os.fork() failed for slot=%s (process/memory "
+            "limit?) — will retry",
+            slot,
+            exc_info=True,
+        )
+        return False
+    if pid == 0:  # child — never returns
+        _child_after_fork(slot, fleet.heartbeats)
+    fleet.record_fork(slot, pid)
+    logger.info("PG-queue consumer: forked child slot=%s pid=%s", slot, pid)
+    return True
+
+
+def _reap_dead(fleet: _Fleet, stopping: threading.Event) -> None:
+    """Reap exited children and schedule their re-fork (unless shutting down)."""
+    for slot, pid in fleet.alive_items():
+        try:
+            reaped, _status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            reaped = pid  # already reaped elsewhere — treat as gone
+        if reaped == 0:
+            continue  # still alive
+        uptime = fleet.reap(slot)
+        if stopping.is_set():
+            continue  # do not resurrect during shutdown
+        crashes = fleet.schedule_restart(slot, uptime)
+        level = logging.ERROR if crashes >= _CRASH_LOOP_THRESHOLD else logging.WARNING
+        logger.log(
+            level,
+            "PG-queue consumer: child slot=%s pid=%s exited after %.1fs "
+            "(consecutive immediate crashes=%s) — re-fork scheduled",
+            slot,
+            pid,
+            uptime,
+            crashes,
+        )
+
+
+def _restart_due_children(fleet: _Fleet, stopping: threading.Event) -> None:
+    """Re-fork the slots whose backoff has elapsed — non-blocking (the backoff is
+    a scheduled not-before, not an in-loop sleep), and re-checking ``stopping``
+    each iteration so a SIGTERM mid-cycle can't spawn a fresh child into shutdown.
+    """
+    for slot in fleet.due_restarts():
+        if stopping.is_set():
+            return
+        # On success record_fork clears the pending restart; on fork failure the
+        # slot stays due and is retried next tick.
+        _try_fork_child(fleet, slot)
+
+
+def run_supervised(concurrency: int) -> None:
+    """Fork ``concurrency`` consumer children and supervise them until SIGTERM."""
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
 
-    # Shared, fork-inherited heartbeat slots (one wall-time per child). No lock:
-    # each slot has a single writer (its child) and one reader (the parent); a
-    # torn double read just yields one stale sample, self-correcting next tick.
-    heartbeats = multiprocessing.Array("d", concurrency, lock=False)
-    now = time.time()
-    for i in range(concurrency):
-        heartbeats[i] = now
-
-    children: dict[int, int] = {}  # slot -> pid
-    last_fork: dict[int, float] = {}  # slot -> monotonic time of last fork
+    fleet = _Fleet(concurrency)
     stopping = threading.Event()
 
-    def _fork_child(slot: int) -> None:
-        heartbeats[slot] = time.time()  # reset freshness for the new child
-        pid = os.fork()
-        if pid == 0:  # child
-            try:
-                _run_child(slot, heartbeats)
-            except BaseException:
-                # Last-resort: a child that can't even start must not return into
-                # the supervisor loop (it would fork grandchildren). Log + hard exit.
-                logger.exception("PG-queue consumer: child slot=%s failed to run", slot)
-                os._exit(1)
-            os._exit(0)
-        children[slot] = pid
-        last_fork[slot] = time.monotonic()
-        logger.info("PG-queue consumer: forked child slot=%s pid=%s", slot, pid)
-
     def _signal_children(sig: int) -> None:
-        for pid in list(children.values()):
+        for _slot, pid in fleet.alive_items():
             with contextlib.suppress(ProcessLookupError):
                 os.kill(pid, sig)
 
@@ -166,7 +332,7 @@ def run_supervised(concurrency: int) -> None:
         logger.info(
             "PG-queue consumer supervisor: signal %s — stopping %d child(ren)",
             signum,
-            len(children),
+            fleet.alive_count(),
         )
         stopping.set()
         _signal_children(signal.SIGTERM)
@@ -175,95 +341,81 @@ def run_supervised(concurrency: int) -> None:
     signal.signal(signal.SIGINT, _on_term)
 
     # Fork the initial fleet while single-threaded (before the liveness thread).
+    # A fork failure here is fatal + actionable rather than a half-started fleet.
     for slot in range(concurrency):
-        _fork_child(slot)
+        if not _try_fork_child(fleet, slot):
+            stopping.set()
+            _signal_children(signal.SIGTERM)
+            _join_children(fleet, _SHUTDOWN_GRACE_SECONDS)
+            raise RuntimeError(
+                f"PG-queue consumer: os.fork() failed starting child {slot}/"
+                f"{concurrency} — reduce WORKER_PG_QUEUE_CONSUMER_CONCURRENCY or "
+                "raise the process/memory limit"
+            )
 
-    def _fleet_freshness() -> float:
-        # Fleet age = the oldest child's staleness; if any child stalls past the
-        # threshold the probe goes 503. A just-(re)forked child is seeded fresh.
-        return _oldest_child_age(heartbeats)
-
-    def _extra_status() -> dict[str, object]:
-        return {"alive_children": len(children), "concurrency": concurrency}
-
-    health = _maybe_start_supervisor_health(_fleet_freshness, _extra_status)
-
+    health = _maybe_start_supervisor_health(fleet)
     try:
         while not stopping.is_set():
-            _reap_and_restart(children, last_fork, stopping, _fork_child)
-            time.sleep(_MONITOR_INTERVAL_SECONDS)
+            _reap_dead(fleet, stopping)
+            _restart_due_children(fleet, stopping)
+            stopping.wait(_MONITOR_INTERVAL_SECONDS)  # responsive to SIGTERM
     finally:
         stopping.set()
         _signal_children(signal.SIGTERM)
-        _join_children(children, _SHUTDOWN_GRACE_SECONDS)
+        _join_children(fleet, _SHUTDOWN_GRACE_SECONDS)
         if health is not None:
             health.stop()
         logger.info("PG-queue consumer supervisor: stopped")
 
 
-def _reap_and_restart(
-    children: dict[int, int],
-    last_fork: dict[int, float],
-    stopping: threading.Event,
-    fork_child,  # noqa: ANN001 (Callable[[int], None])
-) -> None:
-    """Reap any exited children; re-fork them (rate-limited) unless shutting down."""
-    for slot, pid in list(children.items()):
+def _wait_for_exit(pid: int, deadline: float) -> bool:
+    """Poll ``pid`` until it exits or ``deadline`` (monotonic) passes. True if it
+    exited (or was already reaped).
+    """
+    while time.monotonic() < deadline:
         try:
             reaped, _status = os.waitpid(pid, os.WNOHANG)
         except ChildProcessError:
-            reaped = pid  # already reaped elsewhere — treat as gone
-        if reaped == 0:
-            continue  # still alive
-        del children[slot]
-        if stopping.is_set():
+            return True
+        if reaped != 0:
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _join_children(fleet: _Fleet, grace_seconds: float) -> None:
+    """Wait up to ``grace_seconds`` *per child* for a graceful drain; SIGKILL +
+    reap any straggler. The budget is per-child (not a single shared deadline) so
+    one slow-draining child can't starve the others of their grace.
+    """
+    for slot, pid in fleet.alive_items():
+        if _wait_for_exit(pid, time.monotonic() + grace_seconds):
             continue
-        elapsed = time.monotonic() - last_fork.get(slot, 0.0)
-        if elapsed < _RESTART_MIN_INTERVAL_SECONDS:
-            time.sleep(_RESTART_MIN_INTERVAL_SECONDS - elapsed)
         logger.warning(
-            "PG-queue consumer: child slot=%s pid=%s exited — restarting", slot, pid
+            "PG-queue consumer: child slot=%s pid=%s did not stop in %ss — SIGKILL",
+            slot,
+            pid,
+            grace_seconds,
         )
-        fork_child(slot)
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+        with contextlib.suppress(ChildProcessError):
+            os.waitpid(pid, 0)
 
 
-def _join_children(children: dict[int, int], grace_seconds: float) -> None:
-    """Wait up to ``grace_seconds`` for children to exit; SIGKILL stragglers."""
-    deadline = time.monotonic() + grace_seconds
-    for slot, pid in list(children.items()):
-        remaining = deadline - time.monotonic()
-        waited = False
-        while remaining > 0:
-            try:
-                reaped, _status = os.waitpid(pid, os.WNOHANG)
-            except ChildProcessError:
-                waited = True
-                break
-            if reaped != 0:
-                waited = True
-                break
-            time.sleep(0.1)
-            remaining = deadline - time.monotonic()
-        if not waited:
-            logger.warning(
-                "PG-queue consumer: child slot=%s pid=%s did not stop in %ss — "
-                "SIGKILL",
-                slot,
-                pid,
-                grace_seconds,
-            )
-            with contextlib.suppress(ProcessLookupError):
-                os.kill(pid, signal.SIGKILL)
-            with contextlib.suppress(ChildProcessError):
-                os.waitpid(pid, 0)
-
-
-def _maybe_start_supervisor_health(freshness_fn, extra_status_fn):  # noqa: ANN001,ANN201
+def _maybe_start_supervisor_health(fleet: _Fleet) -> LivenessServer | None:
     """Start the fleet liveness server when a port is configured; else None.
 
-    Reuses the same env knobs as the single-process consumer
-    (``WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT`` / ``_HEALTH_STALE_SECONDS``) so the
-    pod's probe is unchanged — only the freshness source differs (fleet vs one loop).
+    Reuses the single-process consumer's env knobs (``..._HEALTH_PORT`` /
+    ``..._HEALTH_STALE_SECONDS``) and the same HTTP contract (``/health`` →
+    200/503), so the k8s probe config is unchanged. The JSON body differs
+    (``check="pg_queue_fleet"``, age key ``oldest_child_seconds_since_poll``) since
+    the freshness source is the fleet's oldest child, not one poll loop.
+
+    A bind failure does not abort the consumer (it must keep draining the queue),
+    but ``EADDRINUSE`` usually signals a real config bug, so it's logged at error;
+    either way ``liveness_probe_bound: false`` is surfaced in the status payload so
+    the degradation is observable.
     """
     from queue_backend.pg_queue.consumer import (
         _DEFAULT_HEALTH_STALE_SECONDS,
@@ -271,36 +423,52 @@ def _maybe_start_supervisor_health(freshness_fn, extra_status_fn):  # noqa: ANN0
     )
     from queue_backend.pg_queue.liveness import LivenessServer
 
-    port = consumer_env("HEALTH_PORT", None, int)
+    port: int | None = consumer_env("HEALTH_PORT", None, int)
     if port is None:
         logger.info("PG-queue consumer supervisor: HEALTH_PORT unset — liveness disabled")
         return None
     stale_after = consumer_env(
         "HEALTH_STALE_SECONDS", _DEFAULT_HEALTH_STALE_SECONDS, float
     )
+
+    def _extra_status() -> dict[str, object]:
+        return {
+            "alive_children": fleet.alive_count(),
+            "concurrency": fleet.concurrency,
+            "crash_looping": fleet.is_crash_looping(),
+            "liveness_probe_bound": True,
+        }
+
     server = LivenessServer(
-        freshness_fn=freshness_fn,
+        freshness_fn=fleet.freshness,
         stale_after=stale_after,
         port=port,
         check_name="pg_queue_fleet",
         age_key="oldest_child_seconds_since_poll",
-        extra_status_fn=extra_status_fn,
+        extra_status_fn=_extra_status,
         thread_name="pg-supervisor-liveness",
         log_label="pg-queue supervisor",
     )
     try:
         server.start()
-    except OSError:
-        logger.exception(
-            "PG-queue consumer supervisor: liveness could not bind :%s — "
+    except OSError as exc:
+        import errno
+
+        level = logging.ERROR if exc.errno == errno.EADDRINUSE else logging.WARNING
+        logger.log(
+            level,
+            "PG-queue consumer supervisor: liveness could not bind :%s (%s) — "
             "continuing WITHOUT a probe",
             port,
+            exc.strerror or exc,
+            exc_info=True,
         )
         return None
     logger.info(
         "PG-queue consumer supervisor: fleet liveness on :%s/health (stale after "
-        "%ss, concurrency live)",
+        "%ss, %d children)",
         server.bound_port,
         stale_after,
+        fleet.concurrency,
     )
     return server

--- a/workers/pg_queue_consumer/supervisor.py
+++ b/workers/pg_queue_consumer/supervisor.py
@@ -1,0 +1,306 @@
+"""Prefork supervisor for the PG-queue consumer (UN-3606).
+
+Forks ``WORKER_PG_QUEUE_CONSUMER_CONCURRENCY`` copies of the single-threaded
+:class:`~queue_backend.pg_queue.consumer.PgQueueConsumer` so multiple file
+batches run in parallel — the PG analogue of Celery's ``--pool=prefork
+--concurrency=N``. ``SELECT … FOR UPDATE SKIP LOCKED`` distributes work across the
+children (and across replicas): each child claims distinct rows, and the cap on a
+single execution is still ``MAX_PARALLEL_FILE_BATCHES`` (producer side). Total live
+parallelism = ``concurrency × replicas``; k8s HPA scales the replica count.
+
+**Process model** (matches Celery prefork — the cloud-trusted choice): each child
+is a fully isolated process with its own DB connections and thread-local
+``StateStore`` — no shared mutable state, no thread-safety surface. A child crash
+is isolated and re-forked by the supervisor; its in-flight message redelivers via
+``vt`` (at-least-once). The **consumer code is unchanged** — concurrency is purely
+a launch concern.
+
+**Health**: the supervisor owns the single liveness port and reports the *fleet's*
+freshness — the staleness of the oldest-polling child (each child publishes its
+last-poll wall-time into a shared array). A child that dies is re-forked
+internally (transient); only a persistent failure (children that won't stay fresh)
+sustains 503 → pod restart. Children do not bind the port themselves.
+
+Used only when ``CONCURRENCY > 1``; ``CONCURRENCY = 1`` keeps the plain
+single-process ``main()`` path (byte-identical to before this module existed).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import multiprocessing
+import os
+import signal
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONCURRENCY = 1
+# Fork-bomb backstop for a fat-fingered env (a single machine can't usefully run
+# hundreds of heavy file-processing children anyway — scale replicas instead).
+_MAX_CONCURRENCY = 64
+# How often each child republishes its heartbeat, and the parent reaps + checks.
+_REPORT_INTERVAL_SECONDS = 1.0
+_MONITOR_INTERVAL_SECONDS = 1.0
+# Floor between a child's death and its re-fork — avoids a fork storm when a child
+# dies on startup every time (e.g. a bad migration); the gap lets logs/alerts fire.
+_RESTART_MIN_INTERVAL_SECONDS = 2.0
+# How long to wait for children to drain on shutdown before giving up the join.
+_SHUTDOWN_GRACE_SECONDS = 30.0
+
+
+def concurrency_from_env() -> int:
+    """Parse ``WORKER_PG_QUEUE_CONSUMER_CONCURRENCY`` (default 1, clamped to a sane
+    max). 1 → the single-process path; >1 → the prefork supervisor.
+    """
+    raw = os.environ.get("WORKER_PG_QUEUE_CONSUMER_CONCURRENCY")
+    if raw is None or raw == "":
+        return _DEFAULT_CONCURRENCY
+    try:
+        n = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid WORKER_PG_QUEUE_CONSUMER_CONCURRENCY={raw!r}: {exc}"
+        ) from exc
+    if n < 1:
+        raise ValueError(f"WORKER_PG_QUEUE_CONSUMER_CONCURRENCY must be >= 1, got {n}")
+    if n > _MAX_CONCURRENCY:
+        logger.warning(
+            "WORKER_PG_QUEUE_CONSUMER_CONCURRENCY=%s exceeds the %s cap; clamping "
+            "(scale replicas for more parallelism, not one fat process)",
+            n,
+            _MAX_CONCURRENCY,
+        )
+        n = _MAX_CONCURRENCY
+    return n
+
+
+def _oldest_child_age(heartbeats) -> float:  # noqa: ANN001 (ctypes array)
+    """Fleet staleness = seconds since the *oldest*-polling child last polled.
+
+    The supervisor's liveness verdict: if the worst child has stalled past the
+    threshold, the fleet probe goes 503. Empty fleet → 0 (fresh; nothing to judge).
+    """
+    now = time.time()
+    return max((now - hb for hb in heartbeats), default=0.0)
+
+
+def _run_child(slot: int, heartbeats) -> None:  # noqa: ANN001 (ctypes array)
+    """Child entry: bootstrap the worker app, then run one consumer forever.
+
+    The worker import (and any connections it opens) happens HERE, in the child —
+    never inherited across the fork — so each process owns its own connections.
+    A daemon thread publishes the consumer's last-poll wall-time into
+    ``heartbeats[slot]`` for the supervisor's fleet liveness.
+    """
+    # Same source-worker selection the single-process launcher does (see
+    # pg_queue_consumer/__main__.py): overwrite WORKER_TYPE before importing
+    # ``worker``, which reads it at import time to register the right tasks.
+    os.environ["WORKER_TYPE"] = os.environ.get(
+        "WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE", "notification"
+    )
+    import worker  # noqa: F401 — side-effect: registers the source worker's tasks
+    from queue_backend.pg_queue.consumer import build_consumer_from_env
+
+    consumer = build_consumer_from_env()
+    heartbeats[slot] = time.time()  # seed fresh before the first poll
+
+    def _publish_heartbeat() -> None:
+        # last-poll wall-time = now − (seconds since last poll). Frozen while a
+        # task runs (the consumer stamps its heartbeat at the top of poll_once),
+        # so a child stuck on a too-long task goes stale exactly as the single
+        # consumer does — the supervisor then sees it via the shared slot.
+        while True:
+            heartbeats[slot] = time.time() - consumer.seconds_since_last_poll()
+            time.sleep(_REPORT_INTERVAL_SECONDS)
+
+    threading.Thread(target=_publish_heartbeat, daemon=True, name=f"pg-hb-{slot}").start()
+    # consumer.run() installs its own SIGTERM/SIGINT handlers → graceful stop.
+    consumer.run()
+
+
+def run_supervised(concurrency: int) -> None:
+    """Fork ``concurrency`` consumer children and supervise them until SIGTERM.
+
+    Forks the initial fleet while the parent is still single-threaded (safe), then
+    starts the liveness server and the reap/restart loop.
+    """
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+    # Shared, fork-inherited heartbeat slots (one wall-time per child). No lock:
+    # each slot has a single writer (its child) and one reader (the parent); a
+    # torn double read just yields one stale sample, self-correcting next tick.
+    heartbeats = multiprocessing.Array("d", concurrency, lock=False)
+    now = time.time()
+    for i in range(concurrency):
+        heartbeats[i] = now
+
+    children: dict[int, int] = {}  # slot -> pid
+    last_fork: dict[int, float] = {}  # slot -> monotonic time of last fork
+    stopping = threading.Event()
+
+    def _fork_child(slot: int) -> None:
+        heartbeats[slot] = time.time()  # reset freshness for the new child
+        pid = os.fork()
+        if pid == 0:  # child
+            try:
+                _run_child(slot, heartbeats)
+            except BaseException:
+                # Last-resort: a child that can't even start must not return into
+                # the supervisor loop (it would fork grandchildren). Log + hard exit.
+                logger.exception("PG-queue consumer: child slot=%s failed to run", slot)
+                os._exit(1)
+            os._exit(0)
+        children[slot] = pid
+        last_fork[slot] = time.monotonic()
+        logger.info("PG-queue consumer: forked child slot=%s pid=%s", slot, pid)
+
+    def _signal_children(sig: int) -> None:
+        for pid in list(children.values()):
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(pid, sig)
+
+    def _on_term(signum: int, _frame: object) -> None:
+        logger.info(
+            "PG-queue consumer supervisor: signal %s — stopping %d child(ren)",
+            signum,
+            len(children),
+        )
+        stopping.set()
+        _signal_children(signal.SIGTERM)
+
+    signal.signal(signal.SIGTERM, _on_term)
+    signal.signal(signal.SIGINT, _on_term)
+
+    # Fork the initial fleet while single-threaded (before the liveness thread).
+    for slot in range(concurrency):
+        _fork_child(slot)
+
+    def _fleet_freshness() -> float:
+        # Fleet age = the oldest child's staleness; if any child stalls past the
+        # threshold the probe goes 503. A just-(re)forked child is seeded fresh.
+        return _oldest_child_age(heartbeats)
+
+    def _extra_status() -> dict[str, object]:
+        return {"alive_children": len(children), "concurrency": concurrency}
+
+    health = _maybe_start_supervisor_health(_fleet_freshness, _extra_status)
+
+    try:
+        while not stopping.is_set():
+            _reap_and_restart(children, last_fork, stopping, _fork_child)
+            time.sleep(_MONITOR_INTERVAL_SECONDS)
+    finally:
+        stopping.set()
+        _signal_children(signal.SIGTERM)
+        _join_children(children, _SHUTDOWN_GRACE_SECONDS)
+        if health is not None:
+            health.stop()
+        logger.info("PG-queue consumer supervisor: stopped")
+
+
+def _reap_and_restart(
+    children: dict[int, int],
+    last_fork: dict[int, float],
+    stopping: threading.Event,
+    fork_child,  # noqa: ANN001 (Callable[[int], None])
+) -> None:
+    """Reap any exited children; re-fork them (rate-limited) unless shutting down."""
+    for slot, pid in list(children.items()):
+        try:
+            reaped, _status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            reaped = pid  # already reaped elsewhere — treat as gone
+        if reaped == 0:
+            continue  # still alive
+        del children[slot]
+        if stopping.is_set():
+            continue
+        elapsed = time.monotonic() - last_fork.get(slot, 0.0)
+        if elapsed < _RESTART_MIN_INTERVAL_SECONDS:
+            time.sleep(_RESTART_MIN_INTERVAL_SECONDS - elapsed)
+        logger.warning(
+            "PG-queue consumer: child slot=%s pid=%s exited — restarting", slot, pid
+        )
+        fork_child(slot)
+
+
+def _join_children(children: dict[int, int], grace_seconds: float) -> None:
+    """Wait up to ``grace_seconds`` for children to exit; SIGKILL stragglers."""
+    deadline = time.monotonic() + grace_seconds
+    for slot, pid in list(children.items()):
+        remaining = deadline - time.monotonic()
+        waited = False
+        while remaining > 0:
+            try:
+                reaped, _status = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                waited = True
+                break
+            if reaped != 0:
+                waited = True
+                break
+            time.sleep(0.1)
+            remaining = deadline - time.monotonic()
+        if not waited:
+            logger.warning(
+                "PG-queue consumer: child slot=%s pid=%s did not stop in %ss — "
+                "SIGKILL",
+                slot,
+                pid,
+                grace_seconds,
+            )
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)
+            with contextlib.suppress(ChildProcessError):
+                os.waitpid(pid, 0)
+
+
+def _maybe_start_supervisor_health(freshness_fn, extra_status_fn):  # noqa: ANN001,ANN201
+    """Start the fleet liveness server when a port is configured; else None.
+
+    Reuses the same env knobs as the single-process consumer
+    (``WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT`` / ``_HEALTH_STALE_SECONDS``) so the
+    pod's probe is unchanged — only the freshness source differs (fleet vs one loop).
+    """
+    from queue_backend.pg_queue.consumer import (
+        _DEFAULT_HEALTH_STALE_SECONDS,
+        consumer_env,
+    )
+    from queue_backend.pg_queue.liveness import LivenessServer
+
+    port = consumer_env("HEALTH_PORT", None, int)
+    if port is None:
+        logger.info("PG-queue consumer supervisor: HEALTH_PORT unset — liveness disabled")
+        return None
+    stale_after = consumer_env(
+        "HEALTH_STALE_SECONDS", _DEFAULT_HEALTH_STALE_SECONDS, float
+    )
+    server = LivenessServer(
+        freshness_fn=freshness_fn,
+        stale_after=stale_after,
+        port=port,
+        check_name="pg_queue_fleet",
+        age_key="oldest_child_seconds_since_poll",
+        extra_status_fn=extra_status_fn,
+        thread_name="pg-supervisor-liveness",
+        log_label="pg-queue supervisor",
+    )
+    try:
+        server.start()
+    except OSError:
+        logger.exception(
+            "PG-queue consumer supervisor: liveness could not bind :%s — "
+            "continuing WITHOUT a probe",
+            port,
+        )
+        return None
+    logger.info(
+        "PG-queue consumer supervisor: fleet liveness on :%s/health (stale after "
+        "%ss, concurrency live)",
+        server.bound_port,
+        stale_after,
+    )
+    return server

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -427,36 +427,50 @@ def _parse_queue_list(raw: str) -> list[str]:
     return queues
 
 
+def consumer_env(suffix: str, default: _T, cast: Callable[[str], _T]) -> _T:
+    """Read ``WORKER_PG_QUEUE_CONSUMER_<suffix>`` with a typed default.
+
+    Preserves the default's type through to PgQueueConsumer's typed ``__init__``
+    (a bare ``type`` would erase it). On a bad value, fail with the offending var
+    name instead of a context-free ``int('abc')`` ValueError. Treats empty-string
+    as unset (an empty HEALTH_PORT must hit the clean opt-out, not ``int("")``).
+    Module-level (not nested in ``main``) so the prefork supervisor reads the same
+    knobs the single-process path does.
+    """
+    var = f"WORKER_PG_QUEUE_CONSUMER_{suffix}"
+    raw = os.getenv(var)
+    if raw is None or raw == "":
+        return default
+    try:
+        return cast(raw)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid {var}={raw!r}: {exc}") from exc
+
+
+def build_consumer_from_env() -> PgQueueConsumer:
+    """Construct a :class:`PgQueueConsumer` from the ``WORKER_PG_QUEUE_CONSUMER_*``
+    env. Shared by ``main`` (single process) and the prefork supervisor's children,
+    so every consumer instance is configured identically.
+    """
+    return PgQueueConsumer(
+        queue_names=consumer_env("QUEUE", [_DEFAULT_QUEUE], _parse_queue_list),
+        batch_size=consumer_env("BATCH", _DEFAULT_BATCH, int),
+        vt_seconds=consumer_env("VT_SECONDS", _DEFAULT_VT_SECONDS, int),
+        poll_interval=consumer_env("POLL_INTERVAL", _DEFAULT_POLL_INTERVAL, float),
+        backoff_max=consumer_env("BACKOFF_MAX", _DEFAULT_BACKOFF_MAX, float),
+        max_attempts=consumer_env("MAX_ATTEMPTS", _DEFAULT_MAX_ATTEMPTS, int),
+    )
+
+
 def main() -> None:
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
-
-    def _env(suffix: str, default: _T, cast: Callable[[str], _T]) -> _T:
-        # Preserve the default's type through to PgQueueConsumer's typed
-        # __init__ (a bare `type` would erase it). On a bad value, fail with the
-        # offending var name instead of a context-free `int('abc')` ValueError.
-        var = f"WORKER_PG_QUEUE_CONSUMER_{suffix}"
-        raw = os.getenv(var)
-        # Treat empty-string as unset: an empty HEALTH_PORT (e.g. a run-worker.sh
-        # fallback resolving empty) must hit the clean opt-out, not int("") crash.
-        if raw is None or raw == "":
-            return default
-        try:
-            return cast(raw)
-        except (ValueError, TypeError) as exc:
-            raise ValueError(f"Invalid {var}={raw!r}: {exc}") from exc
-
-    consumer = PgQueueConsumer(
-        queue_names=_env("QUEUE", [_DEFAULT_QUEUE], _parse_queue_list),
-        batch_size=_env("BATCH", _DEFAULT_BATCH, int),
-        vt_seconds=_env("VT_SECONDS", _DEFAULT_VT_SECONDS, int),
-        poll_interval=_env("POLL_INTERVAL", _DEFAULT_POLL_INTERVAL, float),
-        backoff_max=_env("BACKOFF_MAX", _DEFAULT_BACKOFF_MAX, float),
-        max_attempts=_env("MAX_ATTEMPTS", _DEFAULT_MAX_ATTEMPTS, int),
-    )
+    consumer = build_consumer_from_env()
     health_server = _maybe_start_health_server(
         consumer,
-        port=_env("HEALTH_PORT", None, int),
-        stale_after=_env("HEALTH_STALE_SECONDS", _DEFAULT_HEALTH_STALE_SECONDS, float),
+        port=consumer_env("HEALTH_PORT", None, int),
+        stale_after=consumer_env(
+            "HEALTH_STALE_SECONDS", _DEFAULT_HEALTH_STALE_SECONDS, float
+        ),
     )
     try:
         consumer.run()

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -465,9 +465,12 @@ def build_consumer_from_env() -> PgQueueConsumer:
 def main() -> None:
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
     consumer = build_consumer_from_env()
+    # Annotate the int|None result so the intent ("a port, or None when unset") is
+    # declared rather than recovered from the generic widening over default=None.
+    port: int | None = consumer_env("HEALTH_PORT", None, int)
     health_server = _maybe_start_health_server(
         consumer,
-        port=consumer_env("HEALTH_PORT", None, int),
+        port=port,
         stale_after=consumer_env(
             "HEALTH_STALE_SECONDS", _DEFAULT_HEALTH_STALE_SECONDS, float
         ),

--- a/workers/sample.env
+++ b/workers/sample.env
@@ -481,3 +481,12 @@ PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 # `pg_queue_enabled` on. Keep False until the worker-pg-executor consumer is
 # running in the fleet; set False for instant rollback.
 PG_QUEUE_TRANSPORT_ENABLED=False
+
+# PG-queue consumer prefork concurrency (UN-3606). >1 makes the consumer launcher
+# fork N isolated consumer children — the PG analogue of Celery's prefork
+# --concurrency, so file batches run in parallel. SKIP LOCKED distributes work
+# across children AND replicas; a single execution is still capped by
+# MAX_PARALLEL_FILE_BATCHES, and total live parallelism = concurrency x replicas
+# (k8s HPA scales replicas). 1 = single process (default). Set per consumer; for
+# the file-processing consumer it mirrors WORKER_FILE_PROCESSING_CONCURRENCY.
+# WORKER_PG_QUEUE_CONSUMER_CONCURRENCY=1

--- a/workers/tests/test_pg_consumer_supervisor.py
+++ b/workers/tests/test_pg_consumer_supervisor.py
@@ -67,7 +67,7 @@ class TestFleet:
         f.record_fork(0, 111)
         assert f.alive_items() == [(0, 111)] and f.alive_count() == 1
         uptime = f.reap(0)
-        assert uptime >= 0.0
+        assert uptime >= 0  # a non-negative monotonic duration
         assert f.alive_count() == 0  # pid + last_fork dropped together
 
     def test_slot_out_of_range_raises(self):
@@ -99,10 +99,12 @@ class TestFleet:
         assert n == 0 and f.is_crash_looping() is False
 
     def test_freshness_is_inf_when_crash_looping(self):
+        import math
+
         f = _Fleet(1)
         for _ in range(_CRASH_LOOP_THRESHOLD):
             f.schedule_restart(0, uptime=0.1)
-        assert f.freshness() == float("inf")
+        assert math.isinf(f.freshness())
 
     def test_freshness_is_oldest_age_when_healthy(self):
         f = _Fleet(2)

--- a/workers/tests/test_pg_consumer_supervisor.py
+++ b/workers/tests/test_pg_consumer_supervisor.py
@@ -1,0 +1,116 @@
+"""Tests for the PG-queue consumer prefork supervisor (UN-3606).
+
+DB-free / fork-free: the env knob, the fleet-liveness staleness calc, and the
+reap/restart loop are exercised in isolation (``os.waitpid`` mocked) so the suite
+stays fast and deterministic — no real children, no worker bootstrap.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pg_queue_consumer.supervisor import (
+    _MAX_CONCURRENCY,
+    _oldest_child_age,
+    _reap_and_restart,
+    concurrency_from_env,
+)
+
+_MOD = "pg_queue_consumer.supervisor"
+_ENV = "WORKER_PG_QUEUE_CONSUMER_CONCURRENCY"
+
+
+class TestConcurrencyFromEnv:
+    def test_unset_defaults_to_one(self, monkeypatch):
+        monkeypatch.delenv(_ENV, raising=False)
+        assert concurrency_from_env() == 1
+
+    def test_empty_defaults_to_one(self, monkeypatch):
+        monkeypatch.setenv(_ENV, "")
+        assert concurrency_from_env() == 1
+
+    def test_valid_value(self, monkeypatch):
+        monkeypatch.setenv(_ENV, "4")
+        assert concurrency_from_env() == 4
+
+    def test_clamped_to_max(self, monkeypatch):
+        monkeypatch.setenv(_ENV, str(_MAX_CONCURRENCY + 50))
+        assert concurrency_from_env() == _MAX_CONCURRENCY
+
+    def test_zero_raises(self, monkeypatch):
+        monkeypatch.setenv(_ENV, "0")
+        with pytest.raises(ValueError, match=">= 1"):
+            concurrency_from_env()
+
+    def test_negative_raises(self, monkeypatch):
+        monkeypatch.setenv(_ENV, "-3")
+        with pytest.raises(ValueError, match=">= 1"):
+            concurrency_from_env()
+
+    def test_non_int_raises(self, monkeypatch):
+        monkeypatch.setenv(_ENV, "abc")
+        with pytest.raises(ValueError, match="Invalid"):
+            concurrency_from_env()
+
+
+class TestOldestChildAge:
+    def test_fresh_fleet_is_near_zero(self):
+        now = time.time()
+        assert _oldest_child_age([now, now, now]) < 1.0
+
+    def test_returns_oldest(self):
+        now = time.time()
+        # One child polled 100s ago — that's the fleet's staleness.
+        age = _oldest_child_age([now, now - 100, now - 5])
+        assert 99 < age < 102
+
+    def test_empty_fleet_is_zero(self):
+        assert _oldest_child_age([]) == 0.0
+
+
+class TestReapAndRestart:
+    """The supervisor's recovery loop: dead children re-fork; the rest are left."""
+
+    @staticmethod
+    def _old(slot: int) -> dict:
+        # last_fork well in the past so the rate-limit sleep is skipped.
+        return {slot: time.monotonic() - 1000.0}
+
+    def test_dead_child_is_restarted(self):
+        children = {0: 111}
+        fork_child = MagicMock()
+        stopping = threading.Event()
+        with patch(f"{_MOD}.os.waitpid", return_value=(111, 0)):  # exited
+            _reap_and_restart(children, self._old(0), stopping, fork_child)
+        fork_child.assert_called_once_with(0)
+        assert 0 not in children  # removed before re-fork
+
+    def test_live_child_is_left_alone(self):
+        children = {0: 111}
+        fork_child = MagicMock()
+        stopping = threading.Event()
+        with patch(f"{_MOD}.os.waitpid", return_value=(0, 0)):  # still alive
+            _reap_and_restart(children, self._old(0), stopping, fork_child)
+        fork_child.assert_not_called()
+        assert children == {0: 111}  # untouched
+
+    def test_dead_child_not_restarted_while_stopping(self):
+        children = {0: 111}
+        fork_child = MagicMock()
+        stopping = threading.Event()
+        stopping.set()  # graceful shutdown in progress
+        with patch(f"{_MOD}.os.waitpid", return_value=(111, 0)):
+            _reap_and_restart(children, self._old(0), stopping, fork_child)
+        fork_child.assert_not_called()  # do NOT resurrect during shutdown
+        assert 0 not in children  # but still reaped
+
+    def test_already_reaped_child_is_restarted(self):
+        """waitpid raising ChildProcessError (already reaped) is treated as gone."""
+        children = {0: 111}
+        fork_child = MagicMock()
+        stopping = threading.Event()
+        with patch(f"{_MOD}.os.waitpid", side_effect=ChildProcessError()):
+            _reap_and_restart(children, self._old(0), stopping, fork_child)
+        fork_child.assert_called_once_with(0)

--- a/workers/tests/test_pg_consumer_supervisor.py
+++ b/workers/tests/test_pg_consumer_supervisor.py
@@ -1,20 +1,30 @@
 """Tests for the PG-queue consumer prefork supervisor (UN-3606).
 
-DB-free / fork-free: the env knob, the fleet-liveness staleness calc, and the
-reap/restart loop are exercised in isolation (``os.waitpid`` mocked) so the suite
-stays fast and deterministic — no real children, no worker bootstrap.
+DB-free / fork-free: the env knob, the ``_Fleet`` bookkeeping, the reap/restart
+scheduling, the join+SIGKILL escalation and the fork/health guards are exercised in
+isolation (``os.*`` mocked) so the suite stays fast and deterministic — no real
+children, no worker bootstrap, no signals installed.
 """
 
+import errno
 import threading
 import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pg_queue_consumer import supervisor as sup
 from pg_queue_consumer.supervisor import (
+    _CRASH_LOOP_THRESHOLD,
     _MAX_CONCURRENCY,
-    _oldest_child_age,
-    _reap_and_restart,
+    _MIN_HEALTHY_UPTIME_SECONDS,
+    _Fleet,
+    _child_after_fork,
+    _join_children,
+    _reap_dead,
+    _restart_due_children,
+    _try_fork_child,
+    _wait_for_exit,
     concurrency_from_env,
 )
 
@@ -39,13 +49,9 @@ class TestConcurrencyFromEnv:
         monkeypatch.setenv(_ENV, str(_MAX_CONCURRENCY + 50))
         assert concurrency_from_env() == _MAX_CONCURRENCY
 
-    def test_zero_raises(self, monkeypatch):
-        monkeypatch.setenv(_ENV, "0")
-        with pytest.raises(ValueError, match=">= 1"):
-            concurrency_from_env()
-
-    def test_negative_raises(self, monkeypatch):
-        monkeypatch.setenv(_ENV, "-3")
+    @pytest.mark.parametrize("bad", ["0", "-3"])
+    def test_below_one_raises(self, monkeypatch, bad):
+        monkeypatch.setenv(_ENV, bad)
         with pytest.raises(ValueError, match=">= 1"):
             concurrency_from_env()
 
@@ -55,62 +61,214 @@ class TestConcurrencyFromEnv:
             concurrency_from_env()
 
 
-class TestOldestChildAge:
-    def test_fresh_fleet_is_near_zero(self):
-        now = time.time()
-        assert _oldest_child_age([now, now, now]) < 1.0
+class TestFleet:
+    def test_record_and_reap_keep_structures_consistent(self):
+        f = _Fleet(2)
+        f.record_fork(0, 111)
+        assert f.alive_items() == [(0, 111)] and f.alive_count() == 1
+        uptime = f.reap(0)
+        assert uptime >= 0.0
+        assert f.alive_count() == 0  # pid + last_fork dropped together
 
-    def test_returns_oldest(self):
-        now = time.time()
-        # One child polled 100s ago — that's the fleet's staleness.
-        age = _oldest_child_age([now, now - 100, now - 5])
-        assert 99 < age < 102
+    def test_slot_out_of_range_raises(self):
+        f = _Fleet(2)
+        with pytest.raises(IndexError):
+            f.record_fork(5, 111)
 
-    def test_empty_fleet_is_zero(self):
-        assert _oldest_child_age([]) == 0.0
+    def test_record_fork_does_not_reseed_heartbeat(self):
+        # The crash-loop fix: a re-fork must NOT refresh the slot, or a child that
+        # never polls looks perpetually fresh.
+        f = _Fleet(1)
+        f._heartbeats[0] = time.time() - 500  # an aged slot
+        f.record_fork(0, 111)
+        assert f.oldest_age() > 400  # still aged, not reset to ~0
+
+    def test_immediate_crash_increments_then_loops(self):
+        f = _Fleet(1)
+        for i in range(1, _CRASH_LOOP_THRESHOLD + 1):
+            n = f.schedule_restart(0, uptime=0.1)  # died immediately
+            assert n == i
+        assert f.is_crash_looping() is True
+
+    def test_healthy_uptime_resets_crash_counter(self):
+        f = _Fleet(1)
+        f.schedule_restart(0, uptime=0.1)
+        f.schedule_restart(0, uptime=0.1)
+        assert f.consecutive_crashes(0) == 2
+        n = f.schedule_restart(0, uptime=_MIN_HEALTHY_UPTIME_SECONDS + 1)
+        assert n == 0 and f.is_crash_looping() is False
+
+    def test_freshness_is_inf_when_crash_looping(self):
+        f = _Fleet(1)
+        for _ in range(_CRASH_LOOP_THRESHOLD):
+            f.schedule_restart(0, uptime=0.1)
+        assert f.freshness() == float("inf")
+
+    def test_freshness_is_oldest_age_when_healthy(self):
+        f = _Fleet(2)
+        f._heartbeats[1] = time.time() - 100
+        assert 99 < f.freshness() < 102
+
+    def test_due_restarts_respects_backoff(self, monkeypatch):
+        f = _Fleet(1)
+        clock = [1000.0]
+        monkeypatch.setattr(f"{_MOD}.time.monotonic", lambda: clock[0])
+        f.schedule_restart(0, uptime=0.1)  # backoff scheduled in the future
+        assert f.due_restarts() == []  # not yet due
+        clock[0] += 100.0  # well past any backoff
+        assert f.due_restarts() == [0]
 
 
-class TestReapAndRestart:
-    """The supervisor's recovery loop: dead children re-fork; the rest are left."""
-
-    @staticmethod
-    def _old(slot: int) -> dict:
-        # last_fork well in the past so the rate-limit sleep is skipped.
-        return {slot: time.monotonic() - 1000.0}
-
-    def test_dead_child_is_restarted(self):
-        children = {0: 111}
-        fork_child = MagicMock()
+class TestReapDead:
+    def test_dead_child_reaped_and_rescheduled(self):
+        f = _Fleet(1)
+        f.record_fork(0, 111)
         stopping = threading.Event()
         with patch(f"{_MOD}.os.waitpid", return_value=(111, 0)):  # exited
-            _reap_and_restart(children, self._old(0), stopping, fork_child)
-        fork_child.assert_called_once_with(0)
-        assert 0 not in children  # removed before re-fork
+            _reap_dead(f, stopping)
+        assert f.alive_count() == 0
+        assert f.due_restarts() in ([], [0])  # scheduled (maybe backed off)
+        assert f.consecutive_crashes(0) >= 1  # counted (immediate death)
 
-    def test_live_child_is_left_alone(self):
-        children = {0: 111}
-        fork_child = MagicMock()
-        stopping = threading.Event()
-        with patch(f"{_MOD}.os.waitpid", return_value=(0, 0)):  # still alive
-            _reap_and_restart(children, self._old(0), stopping, fork_child)
-        fork_child.assert_not_called()
-        assert children == {0: 111}  # untouched
+    def test_live_child_left_alone(self):
+        f = _Fleet(1)
+        f.record_fork(0, 111)
+        with patch(f"{_MOD}.os.waitpid", return_value=(0, 0)):  # alive
+            _reap_dead(f, threading.Event())
+        assert f.alive_items() == [(0, 111)]
 
-    def test_dead_child_not_restarted_while_stopping(self):
-        children = {0: 111}
-        fork_child = MagicMock()
+    def test_not_rescheduled_while_stopping(self):
+        f = _Fleet(1)
+        f.record_fork(0, 111)
         stopping = threading.Event()
-        stopping.set()  # graceful shutdown in progress
+        stopping.set()
         with patch(f"{_MOD}.os.waitpid", return_value=(111, 0)):
-            _reap_and_restart(children, self._old(0), stopping, fork_child)
-        fork_child.assert_not_called()  # do NOT resurrect during shutdown
-        assert 0 not in children  # but still reaped
+            _reap_dead(f, stopping)
+        assert f.alive_count() == 0  # reaped
+        assert f.due_restarts() == []  # but NOT scheduled for restart
 
-    def test_already_reaped_child_is_restarted(self):
-        """waitpid raising ChildProcessError (already reaped) is treated as gone."""
-        children = {0: 111}
-        fork_child = MagicMock()
-        stopping = threading.Event()
+    def test_already_reaped_is_treated_gone(self):
+        f = _Fleet(1)
+        f.record_fork(0, 111)
         with patch(f"{_MOD}.os.waitpid", side_effect=ChildProcessError()):
-            _reap_and_restart(children, self._old(0), stopping, fork_child)
-        fork_child.assert_called_once_with(0)
+            _reap_dead(f, threading.Event())
+        assert f.alive_count() == 0
+
+
+class TestRestartDueChildren:
+    def test_due_slot_is_reforked(self):
+        f = _Fleet(1)
+        f.schedule_restart(0, uptime=0.1)
+        with (
+            patch(f"{_MOD}.time.monotonic", return_value=1e9),  # everything due
+            patch(f"{_MOD}._try_fork_child") as fork,
+        ):
+            _restart_due_children(f, threading.Event())
+        fork.assert_called_once_with(f, 0)
+
+    def test_stopping_blocks_refork(self):
+        f = _Fleet(1)
+        f.schedule_restart(0, uptime=0.1)
+        stopping = threading.Event()
+        stopping.set()
+        with (
+            patch(f"{_MOD}.time.monotonic", return_value=1e9),
+            patch(f"{_MOD}._try_fork_child") as fork,
+        ):
+            _restart_due_children(f, stopping)
+        fork.assert_not_called()  # no fresh child spawned into shutdown
+
+
+class TestTryForkChild:
+    def test_fork_oserror_returns_false_and_does_not_record(self):
+        f = _Fleet(1)
+        with patch(f"{_MOD}.os.fork", side_effect=OSError(errno.EAGAIN, "again")):
+            assert _try_fork_child(f, 0) is False
+        assert f.alive_count() == 0  # slot left for the next monitor tick
+
+    def test_parent_records_child(self):
+        f = _Fleet(1)
+        with patch(f"{_MOD}.os.fork", return_value=222):  # parent sees child pid
+            assert _try_fork_child(f, 0) is True
+        assert f.alive_items() == [(0, 222)]
+
+
+class TestChildAfterFork:
+    def test_resets_signals_and_exits_zero_on_clean_run(self):
+        with (
+            patch(f"{_MOD}.signal.signal") as sig,
+            patch(f"{_MOD}._run_child"),
+            patch(f"{_MOD}.os._exit", side_effect=SystemExit) as exit_,
+        ):
+            with pytest.raises(SystemExit):
+                _child_after_fork(0, MagicMock())
+        # SIGTERM + SIGINT reset to default before running.
+        assert sig.call_count == 2
+        exit_.assert_called_once_with(0)
+
+    def test_hard_exits_one_when_run_raises(self):
+        with (
+            patch(f"{_MOD}.signal.signal"),
+            patch(f"{_MOD}._run_child", side_effect=RuntimeError("boom")),
+            patch(f"{_MOD}.os._exit", side_effect=SystemExit) as exit_,
+        ):
+            with pytest.raises(SystemExit):
+                _child_after_fork(0, MagicMock())
+        exit_.assert_called_once_with(1)
+
+
+class TestWaitForExit:
+    def test_true_when_child_exits(self):
+        with patch(f"{_MOD}.os.waitpid", return_value=(111, 0)):
+            assert _wait_for_exit(111, time.monotonic() + 5) is True
+
+    def test_true_when_already_reaped(self):
+        with patch(f"{_MOD}.os.waitpid", side_effect=ChildProcessError()):
+            assert _wait_for_exit(111, time.monotonic() + 5) is True
+
+    def test_false_when_deadline_passes(self):
+        with patch(f"{_MOD}.os.waitpid", return_value=(0, 0)):  # never exits
+            assert _wait_for_exit(111, time.monotonic() - 1) is False  # already past
+
+
+class TestJoinChildren:
+    def test_clean_exit_no_sigkill(self):
+        f = _Fleet(1)
+        f.record_fork(0, 111)
+        with (
+            patch(f"{_MOD}._wait_for_exit", return_value=True),
+            patch(f"{_MOD}.os.kill") as kill,
+        ):
+            _join_children(f, grace_seconds=5)
+        kill.assert_not_called()
+
+    def test_straggler_is_sigkilled_and_reaped(self):
+        f = _Fleet(1)
+        f.record_fork(0, 111)
+        with (
+            patch(f"{_MOD}._wait_for_exit", return_value=False),  # never drained
+            patch(f"{_MOD}.os.kill") as kill,
+            patch(f"{_MOD}.os.waitpid") as waitpid,
+        ):
+            _join_children(f, grace_seconds=5)
+        import signal as _signal
+
+        kill.assert_called_once_with(111, _signal.SIGKILL)
+        waitpid.assert_called_once_with(111, 0)
+
+
+class TestSupervisorHealth:
+    def test_no_port_returns_none(self, monkeypatch):
+        monkeypatch.delenv("WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT", raising=False)
+        assert sup._maybe_start_supervisor_health(_Fleet(1)) is None
+
+    def test_bind_error_is_swallowed(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT", "8090")
+        server = MagicMock()
+        server.start.side_effect = OSError(errno.EADDRINUSE, "in use")
+        # LivenessServer is imported locally inside the function → patch its source.
+        with patch(
+            "queue_backend.pg_queue.liveness.LivenessServer", return_value=server
+        ):
+            # Must not propagate — the consumer keeps draining without a probe.
+            assert sup._maybe_start_supervisor_health(_Fleet(1)) is None


### PR DESCRIPTION
## Problem

On the PG transport, a multi-file ETL processed files **serially** (the ramp blocker). `worker-pg-fileproc` was a single `batch=1` consumer, so the orchestrator's parallel batches drained one at a time — Celery runs them concurrently via `--pool=prefork --concurrency`. The **same** single-consumer bottleneck on `worker-pg-executor` serialized the `execute_extraction` RPCs (the LLM extraction), so even parallel file fan-out gained nothing end-to-end.

Evidence (2-file ETL): flag OFF (Celery) → both file executions created at the same instant; flag ON (PG, before this fix) → file-2 created only after file-1 **completed**.

## Fix — a prefork supervisor for the PG-queue consumer launcher

The PG analogue of Celery `--pool=prefork --concurrency=N`.

- **`supervisor.py` (new):** when `WORKER_PG_QUEUE_CONSUMER_CONCURRENCY > 1`, fork **N isolated consumer children** (each does its own worker bootstrap, so no connections are inherited across the fork), **monitor + re-fork** dead children, and own a **single fleet-liveness** endpoint (503 when the oldest child stalls past the threshold). `SELECT … FOR UPDATE SKIP LOCKED` distributes batches across children **and** replicas; a single execution is still capped by `MAX_PARALLEL_FILE_BATCHES`; total live parallelism = `concurrency × replicas` (k8s HPA scales replicas).
- **The consumer code is unchanged** — each child is the current single-threaded `PgQueueConsumer.run()`; concurrency is purely a launch concern. `CONCURRENCY=1` (default) keeps the byte-identical single-process path → every other PG consumer is non-regressive.
- **`consumer.py`:** extract `build_consumer_from_env()` / `consumer_env()` so children and `main()` build identical consumers.
- **`docker-compose`:** `CONCURRENCY=4` on **both** `worker-pg-fileproc` and `worker-pg-executor` (mirrors `WORKER_FILE_PROCESSING_CONCURRENCY`). Also raise their `VT_SECONDS` to 3660 — `process_file_batch`/`execute_extraction` block on the executor up to 3600s, so the prior `vt=30` default would re-claim a long batch mid-run (latent **double-run**); health-stale sits just above `vt`.

## Why processes (not threads)

Matches Celery prefork — the cloud-trusted model. Full process isolation (own DB connections + thread-local `StateStore`, no shared-state/thread-safety surface), a crash is contained and re-forked, and its in-flight message redelivers via `vt` (at-least-once). The workload is I/O-bound so the GIL is moot, but cloud runs prefork specifically to avoid thread issues — so the PG consumer does too.

## Tests

`workers/tests/test_pg_consumer_supervisor.py` — env-knob parse/clamp/validation, fleet-staleness calc, and the reap/restart matrix (dead → re-fork, live → left alone, shutdown → not resurrected, already-reaped → handled). The fork/signal/health-port integration is validated live (below) rather than with flaky in-process fork tests.

## Dev-tested end-to-end (gated, running stack)

- 4 `worker-pg-fileproc` + 4 `worker-pg-executor` children fork; fleet health green; killing a child → supervisor re-forks it.
- A 2-file ETL now runs **fully parallel**: both file executions created/completed together, and **both `execute_extraction` RPCs overlap on separate executor children** — ~25s vs ~42s when the executor was serial.

## Out of scope

Continuation/callback path and Celery decommission are later slices; the shared executor-RPC de-dup is UN-3607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)