### PR TITLE
UN-3608 [FEAT] PG Queue 9i — executor async/callback path on PG (self-chained continuations)

### DIFF
--- a/backend/pg_queue/executor_rpc.py
+++ b/backend/pg_queue/executor_rpc.py
@@ -41,7 +41,8 @@ from django.db import close_old_connections
 from pg_queue.flags import PG_QUEUE_FLAG_KEY
 from pg_queue.models import PgTaskResult
 from pg_queue.producer import enqueue_task
-from unstract.core.data_models import ContinuationSpec, PgTaskStatus
+from unstract.core.data_models import PgTaskStatus
+from unstract.core.execution_dispatch import DispatchHandle, signature_to_continuation
 from unstract.flags.feature_flag import check_feature_flag_status
 from unstract.sdk1.execution.dispatcher import ExecutionDispatcher
 from unstract.sdk1.execution.result import ExecutionResult
@@ -63,46 +64,6 @@ _DEFAULT_TIMEOUT_ENV = "EXECUTOR_RESULT_TIMEOUT"
 _DEFAULT_TIMEOUT = 3600
 _POLL_INITIAL_SECONDS = 0.2
 _POLL_MAX_SECONDS = 2.0
-
-
-class _DispatchHandle:
-    """Minimal duck-type of Celery ``AsyncResult`` for the PG callback path.
-
-    ``dispatch_with_callback`` callers read only ``.id`` (to return the task id
-    in the HTTP 202 response); they must NOT call ``.get()`` — the result arrives
-    via the self-chained callback (WebSocket), not by polling here. Exposing just
-    ``.id`` lets a PG dispatch return the same shape the call sites already use.
-    """
-
-    __slots__ = ("id",)
-
-    def __init__(self, task_id: str) -> None:
-        self.id = task_id
-
-
-def _signature_to_spec(sig: Any | None) -> ContinuationSpec | None:
-    """Translate a Celery ``Signature`` to a serialisable continuation spec.
-
-    Reads only the three attributes PG self-chaining needs — task name, kwargs,
-    target queue — so the prompt-studio call sites keep passing
-    ``signature(name, kwargs=..., queue=...)`` unchanged; only the PG branch
-    translates. ``None`` (no callback for that outcome) passes through. A
-    signature without a queue is a configuration error: PG routes by the row's
-    queue and must not silently default it, so we fail fast.
-    """
-    if sig is None:
-        return None
-    queue = (getattr(sig, "options", None) or {}).get("queue")
-    if not queue:
-        raise ValueError(
-            f"callback signature {getattr(sig, 'task', sig)!r} has no queue; "
-            "PG self-chaining routes by the row's queue and cannot default it"
-        )
-    return ContinuationSpec(
-        task_name=sig.task,
-        kwargs=dict(getattr(sig, "kwargs", None) or {}),
-        queue=queue,
-    )
 
 
 def resolve_executor_transport(context: ExecutionContext) -> bool:
@@ -263,7 +224,7 @@ class PgExecutionDispatcher:
         on_error: Any | None = None,
         task_id: str | None = None,
         headers: dict[str, Any] | None = None,
-    ) -> _DispatchHandle:
+    ) -> DispatchHandle:
         """Fire-and-forget enqueue with self-chained callbacks (§5 model).
 
         The PG analogue of the SDK ``dispatch_with_callback``: instead of Celery
@@ -271,15 +232,15 @@ class PgExecutionDispatcher:
         on-error Celery ``Signature``s are translated to serialisable
         :class:`ContinuationSpec`s and carried in the payload. After the executor
         consumer runs ``execute_extraction`` it self-chains the matching
-        continuation onto the callback queue. Returns a :class:`_DispatchHandle`
+        continuation onto the callback queue. Returns a :class:`DispatchHandle`
         exposing ``.id`` (== ``task_id``) so call sites read the task id exactly
         as on the Celery path. ``headers`` is accepted and ignored.
         """
         task_id = task_id or str(uuid.uuid4())
         queue = f"{_QUEUE_PREFIX}{context.executor_name}"
         org = getattr(context, "organization_id", "") or ""
-        success_spec = _signature_to_spec(on_success)
-        error_spec = _signature_to_spec(on_error)
+        success_spec = signature_to_continuation(on_success)
+        error_spec = signature_to_continuation(on_error)
         enqueue_task(
             task_name=_EXECUTE_TASK,
             queue=queue,
@@ -298,7 +259,7 @@ class PgExecutionDispatcher:
             success_spec["task_name"] if success_spec else None,
             error_spec["task_name"] if error_spec else None,
         )
-        return _DispatchHandle(task_id)
+        return DispatchHandle(task_id)
 
     @staticmethod
     def _wait_for_result(reply_key: str, timeout: float) -> PgTaskResult | None:

--- a/backend/pg_queue/executor_rpc.py
+++ b/backend/pg_queue/executor_rpc.py
@@ -41,7 +41,7 @@ from django.db import close_old_connections
 from pg_queue.flags import PG_QUEUE_FLAG_KEY
 from pg_queue.models import PgTaskResult
 from pg_queue.producer import enqueue_task
-from unstract.core.data_models import PgTaskStatus
+from unstract.core.data_models import ContinuationSpec, PgTaskStatus
 from unstract.flags.feature_flag import check_feature_flag_status
 from unstract.sdk1.execution.dispatcher import ExecutionDispatcher
 from unstract.sdk1.execution.result import ExecutionResult
@@ -63,6 +63,46 @@ _DEFAULT_TIMEOUT_ENV = "EXECUTOR_RESULT_TIMEOUT"
 _DEFAULT_TIMEOUT = 3600
 _POLL_INITIAL_SECONDS = 0.2
 _POLL_MAX_SECONDS = 2.0
+
+
+class _DispatchHandle:
+    """Minimal duck-type of Celery ``AsyncResult`` for the PG callback path.
+
+    ``dispatch_with_callback`` callers read only ``.id`` (to return the task id
+    in the HTTP 202 response); they must NOT call ``.get()`` — the result arrives
+    via the self-chained callback (WebSocket), not by polling here. Exposing just
+    ``.id`` lets a PG dispatch return the same shape the call sites already use.
+    """
+
+    __slots__ = ("id",)
+
+    def __init__(self, task_id: str) -> None:
+        self.id = task_id
+
+
+def _signature_to_spec(sig: Any | None) -> ContinuationSpec | None:
+    """Translate a Celery ``Signature`` to a serialisable continuation spec.
+
+    Reads only the three attributes PG self-chaining needs — task name, kwargs,
+    target queue — so the prompt-studio call sites keep passing
+    ``signature(name, kwargs=..., queue=...)`` unchanged; only the PG branch
+    translates. ``None`` (no callback for that outcome) passes through. A
+    signature without a queue is a configuration error: PG routes by the row's
+    queue and must not silently default it, so we fail fast.
+    """
+    if sig is None:
+        return None
+    queue = (getattr(sig, "options", None) or {}).get("queue")
+    if not queue:
+        raise ValueError(
+            f"callback signature {getattr(sig, 'task', sig)!r} has no queue; "
+            "PG self-chaining routes by the row's queue and cannot default it"
+        )
+    return ContinuationSpec(
+        task_name=sig.task,
+        kwargs=dict(getattr(sig, "kwargs", None) or {}),
+        queue=queue,
+    )
 
 
 def resolve_executor_transport(context: ExecutionContext) -> bool:
@@ -186,6 +226,80 @@ class PgExecutionDispatcher:
         )
         return ExecutionResult.failure(error=row.error or "executor task failed")
 
+    def dispatch_async(
+        self, context: ExecutionContext, headers: dict[str, Any] | None = None
+    ) -> str:
+        """Fire-and-forget enqueue of ``execute_extraction``; returns the task id.
+
+        The PG analogue of the SDK ``dispatch_async``: no ``reply_key``, no
+        callback, no blocking. There is no PG ``AsyncResult`` backend, so a caller
+        that needs the outcome uses :meth:`dispatch_with_callback` (a self-chained
+        continuation), not polling on this id. ``headers`` is accepted and ignored
+        (PG carries routing in the payload). Enqueue failures propagate — parity
+        with the SDK, which lets a broker error out of ``dispatch_async``.
+        """
+        task_id = str(uuid.uuid4())
+        queue = f"{_QUEUE_PREFIX}{context.executor_name}"
+        org = getattr(context, "organization_id", "") or ""
+        enqueue_task(
+            task_name=_EXECUTE_TASK,
+            queue=queue,
+            args=[context.to_dict()],
+            org_id=str(org),
+            task_id=task_id,
+        )
+        logger.info(
+            "PG executor dispatch_async: enqueued task_id=%s queue=%s run_id=%s",
+            task_id,
+            queue,
+            context.run_id,
+        )
+        return task_id
+
+    def dispatch_with_callback(
+        self,
+        context: ExecutionContext,
+        on_success: Any | None = None,
+        on_error: Any | None = None,
+        task_id: str | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> _DispatchHandle:
+        """Fire-and-forget enqueue with self-chained callbacks (§5 model).
+
+        The PG analogue of the SDK ``dispatch_with_callback``: instead of Celery
+        ``link`` / ``link_error`` (which the broker fires), the on-success /
+        on-error Celery ``Signature``s are translated to serialisable
+        :class:`ContinuationSpec`s and carried in the payload. After the executor
+        consumer runs ``execute_extraction`` it self-chains the matching
+        continuation onto the callback queue. Returns a :class:`_DispatchHandle`
+        exposing ``.id`` (== ``task_id``) so call sites read the task id exactly
+        as on the Celery path. ``headers`` is accepted and ignored.
+        """
+        task_id = task_id or str(uuid.uuid4())
+        queue = f"{_QUEUE_PREFIX}{context.executor_name}"
+        org = getattr(context, "organization_id", "") or ""
+        success_spec = _signature_to_spec(on_success)
+        error_spec = _signature_to_spec(on_error)
+        enqueue_task(
+            task_name=_EXECUTE_TASK,
+            queue=queue,
+            args=[context.to_dict()],
+            org_id=str(org),
+            on_success=success_spec,
+            on_error=error_spec,
+            task_id=task_id,
+        )
+        logger.info(
+            "PG executor dispatch_with_callback: enqueued task_id=%s queue=%s "
+            "run_id=%s on_success=%s on_error=%s",
+            task_id,
+            queue,
+            context.run_id,
+            success_spec["task_name"] if success_spec else None,
+            error_spec["task_name"] if error_spec else None,
+        )
+        return _DispatchHandle(task_id)
+
     @staticmethod
     def _wait_for_result(reply_key: str, timeout: float) -> PgTaskResult | None:
         """Poll ``pg_task_result`` until the row appears or *timeout* elapses.
@@ -216,10 +330,10 @@ class PgExecutionDispatcher:
 class RoutingExecutionDispatcher:
     """Gate-routed executor dispatcher returned by ``_get_dispatcher()``.
 
-    ``dispatch()`` chooses PG vs Celery per call (instant rollout/rollback);
-    ``dispatch_async`` / ``dispatch_with_callback`` always delegate to Celery —
-    the async/callback path stays on Celery until a later continuation slice.
-    Duck-typed against the SDK ``ExecutionDispatcher`` so call sites are unchanged.
+    Every mode chooses PG vs Celery per call (instant rollout/rollback):
+    ``dispatch()`` (request-reply), ``dispatch_async`` (fire-and-forget) and
+    ``dispatch_with_callback`` (self-chained callbacks). Duck-typed against the SDK
+    ``ExecutionDispatcher`` so call sites are unchanged.
     """
 
     def __init__(self, celery_app: object | None = None) -> None:
@@ -246,10 +360,32 @@ class RoutingExecutionDispatcher:
     def dispatch_async(
         self, context: ExecutionContext, headers: dict[str, Any] | None = None
     ) -> str:
+        if resolve_executor_transport(context):
+            return self._pg.dispatch_async(context)
         return self._celery.dispatch_async(context, headers=headers)
 
-    def dispatch_with_callback(self, context: ExecutionContext, **kwargs: Any) -> Any:
-        return self._celery.dispatch_with_callback(context, **kwargs)
+    def dispatch_with_callback(
+        self,
+        context: ExecutionContext,
+        on_success: Any | None = None,
+        on_error: Any | None = None,
+        task_id: str | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> Any:
+        if resolve_executor_transport(context):
+            return self._pg.dispatch_with_callback(
+                context,
+                on_success=on_success,
+                on_error=on_error,
+                task_id=task_id,
+            )
+        return self._celery.dispatch_with_callback(
+            context,
+            on_success=on_success,
+            on_error=on_error,
+            task_id=task_id,
+            headers=headers,
+        )
 
 
 def get_executor_dispatcher(

--- a/backend/pg_queue/producer.py
+++ b/backend/pg_queue/producer.py
@@ -83,8 +83,14 @@ def enqueue_task(
     (``dispatch_with_callback``): the executor consumer self-chains the matching
     continuation after the task runs. ``task_id`` is the dispatch id prepended to
     ``on_error`` as the failed id (Celery ``link_error`` parity). Mutually
-    exclusive with ``reply_key``.
+    exclusive with ``reply_key`` — passing both is rejected (the consumer checks
+    ``reply_key`` first and would silently drop the callback).
     """
+    if reply_key is not None and (on_success is not None or on_error is not None):
+        raise ValueError(
+            "reply_key (request-reply) and on_success/on_error (callback) are "
+            "mutually exclusive"
+        )
     if not FAIRNESS_MIN_PRIORITY <= priority <= FAIRNESS_MAX_PRIORITY:
         raise ValueError(
             f"priority out of range "
@@ -102,10 +108,13 @@ def enqueue_task(
     # byte-identical to before these fields existed.
     if reply_key is not None:
         message["reply_key"] = reply_key
+    # Continuation specs carry a nested callback ``kwargs`` dict that may hold a
+    # UUID/datetime — coerce like ``args``/``kwargs`` above, else the JSONField
+    # insert raises at dispatch time (caller-visible).
     if on_success is not None:
-        message["on_success"] = on_success
+        message["on_success"] = _json_safe(on_success)
     if on_error is not None:
-        message["on_error"] = on_error
+        message["on_error"] = _json_safe(on_error)
     if task_id is not None:
         message["task_id"] = task_id
     # Mirror the worker _enqueue_pg path: log the failure with breadcrumbs before

--- a/backend/pg_queue/producer.py
+++ b/backend/pg_queue/producer.py
@@ -25,6 +25,7 @@ from unstract.core.data_models import (
     FAIRNESS_DEFAULT_PRIORITY,
     FAIRNESS_MAX_PRIORITY,
     FAIRNESS_MIN_PRIORITY,
+    ContinuationSpec,
     FairnessPayload,
     TaskPayload,
 )
@@ -63,6 +64,9 @@ def enqueue_task(
     priority: int = DEFAULT_PRIORITY,
     fairness: FairnessPayload | None = None,
     reply_key: str | None = None,
+    on_success: ContinuationSpec | None = None,
+    on_error: ContinuationSpec | None = None,
+    task_id: str | None = None,
 ) -> int:
     """Enqueue a task onto the PG queue; returns the new ``msg_id``.
 
@@ -74,6 +78,12 @@ def enqueue_task(
     ``reply_key`` marks a **request-reply** dispatch (the executor RPC on PG):
     the executor consumer writes the task's result/error to ``pg_task_result``
     under it for the blocking caller to poll. Omitted = fire-and-forget.
+
+    ``on_success`` / ``on_error`` mark an **async/callback** dispatch
+    (``dispatch_with_callback``): the executor consumer self-chains the matching
+    continuation after the task runs. ``task_id`` is the dispatch id prepended to
+    ``on_error`` as the failed id (Celery ``link_error`` parity). Mutually
+    exclusive with ``reply_key``.
     """
     if not FAIRNESS_MIN_PRIORITY <= priority <= FAIRNESS_MAX_PRIORITY:
         raise ValueError(
@@ -88,10 +98,16 @@ def enqueue_task(
         "queue": pg_queue,
         "fairness": fairness,
     }
-    # Only set for request-reply dispatches — keeps fire-and-forget rows
-    # byte-identical to before this field existed.
+    # Each optional key is set only when present — keeps fire-and-forget rows
+    # byte-identical to before these fields existed.
     if reply_key is not None:
         message["reply_key"] = reply_key
+    if on_success is not None:
+        message["on_success"] = on_success
+    if on_error is not None:
+        message["on_error"] = on_error
+    if task_id is not None:
+        message["task_id"] = task_id
     # Mirror the worker _enqueue_pg path: log the failure with breadcrumbs before
     # it propagates, so a DB/constraint/serialization error isn't mislabeled by
     # the caller's broad handler.

--- a/backend/pg_queue/tests/test_executor_rpc.py
+++ b/backend/pg_queue/tests/test_executor_rpc.py
@@ -8,11 +8,9 @@ Celery ``ExecutionDispatcher`` and never touches the PG path.
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pg_queue.executor_rpc import (
     PgExecutionDispatcher,
     RoutingExecutionDispatcher,
-    _signature_to_spec,
     resolve_executor_transport,
 )
 
@@ -247,30 +245,6 @@ class TestRoutingZeroRegression:
         assert "headers" not in pg.dispatch_with_callback.call_args.kwargs
         celery.dispatch_async.assert_not_called()
         celery.dispatch_with_callback.assert_not_called()
-
-
-class TestSignatureToSpec:
-    """Celery ``Signature`` → serialisable continuation spec (the §5 wire-form)."""
-
-    def test_none_passes_through(self):
-        assert _signature_to_spec(None) is None
-
-    def test_translates_task_kwargs_and_queue(self):
-        sig = MagicMock(
-            task="ide_prompt_complete",
-            kwargs={"callback_kwargs": {"room": "r1"}},
-            options={"queue": "ide_callback"},
-        )
-        assert _signature_to_spec(sig) == {
-            "task_name": "ide_prompt_complete",
-            "kwargs": {"callback_kwargs": {"room": "r1"}},
-            "queue": "ide_callback",
-        }
-
-    def test_missing_queue_fails_fast(self):
-        sig = MagicMock(task="ide_prompt_complete", kwargs={}, options={})
-        with pytest.raises(ValueError, match="no queue"):
-            _signature_to_spec(sig)
 
 
 class TestPgAsyncCallbackWiring:

--- a/backend/pg_queue/tests/test_executor_rpc.py
+++ b/backend/pg_queue/tests/test_executor_rpc.py
@@ -276,11 +276,13 @@ class TestPgAsyncCallbackWiring:
     def test_dispatch_with_callback_carries_continuations(self):
         on_s = MagicMock(
             task="ide_prompt_complete",
+            args=(),
             kwargs={"callback_kwargs": {"room": "r1"}},
             options={"queue": "ide_callback"},
         )
         on_e = MagicMock(
             task="ide_prompt_error",
+            args=(),
             kwargs={"callback_kwargs": {"room": "r1"}},
             options={"queue": "ide_callback"},
         )

--- a/backend/pg_queue/tests/test_executor_rpc.py
+++ b/backend/pg_queue/tests/test_executor_rpc.py
@@ -8,9 +8,11 @@ Celery ``ExecutionDispatcher`` and never touches the PG path.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pg_queue.executor_rpc import (
     PgExecutionDispatcher,
     RoutingExecutionDispatcher,
+    _signature_to_spec,
     resolve_executor_transport,
 )
 
@@ -221,11 +223,104 @@ class TestRoutingZeroRegression:
         pg.dispatch.assert_called_once()
         celery.dispatch.assert_not_called()
 
-    def test_async_and_callback_always_celery(self):
-        """The callback/async path stays on Celery regardless of the gate (a later slice)."""
+    def test_async_and_callback_stay_celery_when_gate_off(self):
+        """Zero-regression: gate off → async/callback delegate to Celery unchanged."""
         dispatcher, celery, pg = self._build()
-        dispatcher.dispatch_async(_ctx())
-        dispatcher.dispatch_with_callback(_ctx(), on_success=None)
+        with patch(f"{_MOD}.resolve_executor_transport", return_value=False):
+            dispatcher.dispatch_async(_ctx(), headers={"h": 1})
+            dispatcher.dispatch_with_callback(_ctx(), on_success="s", on_error="e")
         celery.dispatch_async.assert_called_once()
         celery.dispatch_with_callback.assert_called_once()
-        pg.dispatch.assert_not_called()
+        pg.dispatch_async.assert_not_called()
+        pg.dispatch_with_callback.assert_not_called()
+
+    def test_async_and_callback_route_to_pg_when_gated(self):
+        """Gate on (③c) → async/callback take the PG self-chained path."""
+        dispatcher, celery, pg = self._build()
+        with patch(f"{_MOD}.resolve_executor_transport", return_value=True):
+            dispatcher.dispatch_async(_ctx())
+            dispatcher.dispatch_with_callback(
+                _ctx(), on_success="s", on_error="e", task_id="t"
+            )
+        pg.dispatch_async.assert_called_once()
+        pg.dispatch_with_callback.assert_called_once()
+        assert "headers" not in pg.dispatch_with_callback.call_args.kwargs
+        celery.dispatch_async.assert_not_called()
+        celery.dispatch_with_callback.assert_not_called()
+
+
+class TestSignatureToSpec:
+    """Celery ``Signature`` → serialisable continuation spec (the §5 wire-form)."""
+
+    def test_none_passes_through(self):
+        assert _signature_to_spec(None) is None
+
+    def test_translates_task_kwargs_and_queue(self):
+        sig = MagicMock(
+            task="ide_prompt_complete",
+            kwargs={"callback_kwargs": {"room": "r1"}},
+            options={"queue": "ide_callback"},
+        )
+        assert _signature_to_spec(sig) == {
+            "task_name": "ide_prompt_complete",
+            "kwargs": {"callback_kwargs": {"room": "r1"}},
+            "queue": "ide_callback",
+        }
+
+    def test_missing_queue_fails_fast(self):
+        sig = MagicMock(task="ide_prompt_complete", kwargs={}, options={})
+        with pytest.raises(ValueError, match="no queue"):
+            _signature_to_spec(sig)
+
+
+class TestPgAsyncCallbackWiring:
+    """PG fire-and-forget + self-chained-callback enqueue shapes (``enqueue_task``
+    mocked). Pins that the async path carries NO reply_key and the callback path
+    carries the translated continuations + the tracking task_id.
+    """
+
+    @staticmethod
+    def _ctx():
+        c = MagicMock()
+        c.executor_name = "legacy"
+        c.run_id = "r"
+        c.organization_id = "org9"
+        c.to_dict.return_value = {"run_id": "r", "organization_id": "org9"}
+        return c
+
+    def test_dispatch_async_is_fire_and_forget(self):
+        with patch(f"{_MOD}.enqueue_task") as enq:
+            task_id = PgExecutionDispatcher().dispatch_async(self._ctx())
+        kwargs = enq.call_args.kwargs
+        assert kwargs["task_name"] == "execute_extraction"
+        assert kwargs["queue"] == "celery_executor_legacy"
+        assert kwargs["org_id"] == "org9"
+        assert kwargs["task_id"] == task_id
+        assert "reply_key" not in kwargs
+        assert "on_success" not in kwargs
+
+    def test_dispatch_with_callback_carries_continuations(self):
+        on_s = MagicMock(
+            task="ide_prompt_complete",
+            kwargs={"callback_kwargs": {"room": "r1"}},
+            options={"queue": "ide_callback"},
+        )
+        on_e = MagicMock(
+            task="ide_prompt_error",
+            kwargs={"callback_kwargs": {"room": "r1"}},
+            options={"queue": "ide_callback"},
+        )
+        with patch(f"{_MOD}.enqueue_task") as enq:
+            handle = PgExecutionDispatcher().dispatch_with_callback(
+                self._ctx(), on_success=on_s, on_error=on_e, task_id="tid-7"
+            )
+        assert handle.id == "tid-7"  # call sites read .id off the handle
+        kwargs = enq.call_args.kwargs
+        assert kwargs["on_success"] == {
+            "task_name": "ide_prompt_complete",
+            "kwargs": {"callback_kwargs": {"room": "r1"}},
+            "queue": "ide_callback",
+        }
+        assert kwargs["on_error"]["task_name"] == "ide_prompt_error"
+        assert kwargs["task_id"] == "tid-7"
+        assert "reply_key" not in kwargs

--- a/backend/pg_queue/tests/test_producer.py
+++ b/backend/pg_queue/tests/test_producer.py
@@ -111,3 +111,33 @@ class TestEnqueueTask:
             model.objects.create.side_effect = RuntimeError("db down")
             with pytest.raises(RuntimeError):
                 producer.enqueue_task(task_name="t", queue="celery")
+
+    def test_reply_key_and_callback_mutually_exclusive(self):
+        spec = {"task_name": "cb", "kwargs": {}, "queue": "ide_callback"}
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            producer.enqueue_task(
+                task_name="execute_extraction",
+                queue="celery_executor_legacy",
+                reply_key="rk",
+                on_success=spec,
+            )
+
+    def test_continuation_specs_are_json_coerced(self):
+        # A callback's kwargs can carry a UUID/datetime → must be coerced like
+        # args/kwargs, else the JSONField insert raises at dispatch (caller-visible).
+        uid = uuid.UUID("ebed2834-c9fb-4b6c-8df3-9dd841f616bb")
+        spec = {
+            "task_name": "ide_prompt_complete",
+            "kwargs": {"callback_kwargs": {"doc_id": uid}},
+            "queue": "ide_callback",
+        }
+        with patch(_MODEL) as model:
+            model.objects.create.return_value = MagicMock(msg_id=1)
+            producer.enqueue_task(
+                task_name="execute_extraction",
+                queue="celery_executor_legacy",
+                on_success=spec,
+                task_id="t1",
+            )
+        msg = model.objects.create.call_args.kwargs["message"]
+        assert msg["on_success"]["kwargs"]["callback_kwargs"]["doc_id"] == str(uid)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -800,6 +800,12 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=ide_callback
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
       - WORKER_PG_QUEUE_CONSUMER_CONCURRENCY=${PG_IDE_CALLBACK_CONCURRENCY:-2}
+      # Callbacks are sub-second (ws emit + small API writes), so nowhere near the
+      # executor's 1h limit — but set the visibility timeout above a slow internal
+      # API write (backend under load) so a sibling replica can't re-claim mid-run
+      # and double-emit. Health-stale sits above it. Overridable per-env.
+      - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${PG_IDE_CALLBACK_VT_SECONDS:-120}
+      - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${PG_IDE_CALLBACK_HEALTH_STALE_SECONDS:-180}
     labels:
       - traefik.enable=false
     volumes:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -770,6 +770,44 @@ services:
     profiles:
       - pg-queue
 
+  # IDE callback consumer (③c) — drains the ``ide_callback`` queue the executor
+  # self-chains onto for async/callback dispatch (Prompt Studio run/index/extract,
+  # lookups). Registers the ide_callback worker's tasks (ide_prompt_complete,
+  # ide_index_complete, extraction_complete, …). Dark until dispatch_with_callback
+  # routes to PG (flag on); the Celery ``worker-ide-callback`` still serves the
+  # Celery path. Callbacks are lightweight (ws emit + small API writes), so a
+  # modest concurrency suffices; scale via replicas (SKIP LOCKED) under load.
+  worker-pg-ide-callback:
+    image: unstract/worker-unified:${VERSION}
+    container_name: unstract-worker-pg-ide-callback
+    restart: unless-stopped
+    command: ["pg-queue-consumer"]
+    ports:
+      - "8100:8090"
+    env_file:
+      - ../workers/.env
+      - ./essentials.env
+    depends_on:
+      - db
+      - redis
+      - platform-service
+    environment:
+      - ENVIRONMENT=development
+      - APPLICATION_NAME=unstract-worker-pg-ide-callback
+      - WORKER_BARRIER_BACKEND=pg
+      - WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE=ide_callback
+      - WORKER_PG_QUEUE_CONSUMER_QUEUE=ide_callback
+      - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
+      - WORKER_PG_QUEUE_CONSUMER_CONCURRENCY=${PG_IDE_CALLBACK_CONCURRENCY:-2}
+    labels:
+      - traefik.enable=false
+    volumes:
+      - ./workflow_data:/data
+      - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
+      - prompt_studio_data:/app/prompt-studio-data
+    profiles:
+      - pg-queue
+
   # Reaper / orchestrator — leader-elected loop. Run exactly ONE instance (it
   # elects a single leader via pg_orchestrator_lock; extra replicas idle as
   # standby). Besides barrier-orphan recovery it runs the PG scheduler tick

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -773,10 +773,11 @@ services:
   # IDE callback consumer (③c) — drains the ``ide_callback`` queue the executor
   # self-chains onto for async/callback dispatch (Prompt Studio run/index/extract,
   # lookups). Registers the ide_callback worker's tasks (ide_prompt_complete,
-  # ide_index_complete, extraction_complete, …). Dark until dispatch_with_callback
-  # routes to PG (flag on); the Celery ``worker-ide-callback`` still serves the
-  # Celery path. Callbacks are lightweight (ws emit + small API writes), so a
-  # modest concurrency suffices; scale via replicas (SKIP LOCKED) under load.
+  # ide_index_complete, extraction_complete, …). Idle (receives no work) until
+  # dispatch_with_callback routes to PG (i.e. the gating flag is on); the Celery
+  # ``worker-ide-callback`` still serves the Celery path. No broker dependency:
+  # these callbacks only do API writes + ws emits, never an onward Celery dispatch.
+  # Lightweight, so a modest concurrency suffices; scale via replicas (SKIP LOCKED).
   worker-pg-ide-callback:
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-pg-ide-callback

--- a/unstract/core/src/unstract/core/data_models.py
+++ b/unstract/core/src/unstract/core/data_models.py
@@ -311,8 +311,9 @@ class ContinuationSpec(TypedDict):
     the prompt-studio call sites keep passing Celery ``Signature``s unchanged and
     the dispatcher translates them only on the PG branch.
 
-    The consumer prepends the chained argument the callback expects (the executor
-    result dict on success, the dispatch ``task_id`` on error) before ``kwargs`` —
+    The consumer passes the chained value the callback expects (the executor
+    result dict on success, the dispatch ``task_id`` on error) as the callback's
+    first positional arg, alongside the spec's ``kwargs`` as a distinct mapping —
     mirroring how Celery's ``link`` prepends the parent task's return value.
     """
 

--- a/unstract/core/src/unstract/core/data_models.py
+++ b/unstract/core/src/unstract/core/data_models.py
@@ -298,6 +298,29 @@ class FairnessPayload(TypedDict):
     pipeline_priority: int
 
 
+class ContinuationSpec(TypedDict):
+    """A self-chained continuation — the PG wire-form of a Celery ``Signature``.
+
+    The async/callback executor path (``dispatch_with_callback``) attaches an
+    ``on_success`` / ``on_error`` callback. Celery carries these as ``link`` /
+    ``link_error`` signatures the broker fires automatically; PG has no such
+    broker mechanism, so the executor consumer **self-chains** instead — after it
+    runs ``execute_extraction`` it enqueues this continuation onto ``queue`` (the
+    §5 fire-and-forget model). ``task_name`` / ``kwargs`` / ``queue`` are exactly
+    the three fields read off a ``signature(task_name, kwargs=..., queue=...)`` so
+    the prompt-studio call sites keep passing Celery ``Signature``s unchanged and
+    the dispatcher translates them only on the PG branch.
+
+    The consumer prepends the chained argument the callback expects (the executor
+    result dict on success, the dispatch ``task_id`` on error) before ``kwargs`` —
+    mirroring how Celery's ``link`` prepends the parent task's return value.
+    """
+
+    task_name: str
+    kwargs: dict[str, Any]
+    queue: str
+
+
 class TaskPayload(TypedDict):
     """The ``message`` JSONB of a task row in ``pg_queue_message``.
 
@@ -331,6 +354,15 @@ class TaskPayload(TypedDict):
     queue: str | None
     fairness: FairnessPayload | None
     reply_key: NotRequired[str]
+    # Async/callback dispatch (``dispatch_with_callback``). Mutually exclusive with
+    # ``reply_key``: request-reply (blocking) sets ``reply_key``; fire-and-forget
+    # with callbacks sets these continuations. The executor consumer self-chains
+    # whichever applies after the task runs. ``task_id`` is the dispatch id the
+    # caller tracks (== Celery's task id); the consumer prepends it as the failed
+    # id to ``on_error`` (parity with Celery ``link_error``).
+    on_success: NotRequired[ContinuationSpec]
+    on_error: NotRequired[ContinuationSpec]
+    task_id: NotRequired[str]
 
 
 class PgTaskStatus(str, Enum):

--- a/unstract/core/src/unstract/core/execution_dispatch.py
+++ b/unstract/core/src/unstract/core/execution_dispatch.py
@@ -1,0 +1,61 @@
+"""Transport-agnostic helpers for the executor-RPC dispatchers.
+
+The PG executor dispatch lives in two near-identical mirrors — backend (Django
+ORM) and workers (psycopg2) ``pg_queue/executor_rpc.py`` — because neither
+codebase can import the other and there is no shared home for the transport logic
+yet (the SDK is transport-agnostic by contract, and ``unstract.sdk1`` →
+``unstract.core`` would be circular). Retiring that mirror wholesale is tracked
+as a follow-up (a dedicated shared executor-RPC package).
+
+These two helpers, however, are the genuinely **transport-agnostic** pieces of
+the async/callback path: they have no Django / psycopg / SDK dependency. So they
+live here in ``unstract.core`` (alongside :class:`ContinuationSpec`, the wire
+type one of them produces) and BOTH mirrors import them — removing that slice of
+the duplication today rather than waiting for the full package.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .data_models import ContinuationSpec
+
+
+class DispatchHandle:
+    """Minimal duck-type of Celery ``AsyncResult`` for the PG callback path.
+
+    ``dispatch_with_callback`` callers read only ``.id`` (to return the task id in
+    the HTTP 202 response); they must NOT call ``.get()`` — the result arrives via
+    the self-chained callback (WebSocket), not by polling here. Exposing just
+    ``.id`` lets a PG dispatch return the same shape the call sites already use.
+    """
+
+    __slots__ = ("id",)
+
+    def __init__(self, task_id: str) -> None:
+        self.id = task_id
+
+
+def signature_to_continuation(sig: Any | None) -> ContinuationSpec | None:
+    """Translate a Celery ``Signature`` to a serialisable continuation spec.
+
+    Reads only the three attributes PG self-chaining needs — task name, kwargs,
+    target queue — so the prompt-studio call sites keep passing
+    ``signature(name, kwargs=..., queue=...)`` unchanged; only the PG branch
+    translates. ``None`` (no callback for that outcome) passes through. A signature
+    without a queue is a configuration error: PG routes by the row's queue and must
+    not silently default it, so we fail fast.
+    """
+    if sig is None:
+        return None
+    queue = (getattr(sig, "options", None) or {}).get("queue")
+    if not queue:
+        raise ValueError(
+            f"callback signature {getattr(sig, 'task', sig)!r} has no queue; "
+            "PG self-chaining routes by the row's queue and cannot default it"
+        )
+    return ContinuationSpec(
+        task_name=sig.task,
+        kwargs=dict(getattr(sig, "kwargs", None) or {}),
+        queue=queue,
+    )

--- a/unstract/core/src/unstract/core/execution_dispatch.py
+++ b/unstract/core/src/unstract/core/execution_dispatch.py
@@ -48,14 +48,28 @@ def signature_to_continuation(sig: Any | None) -> ContinuationSpec | None:
     """
     if sig is None:
         return None
+    task = getattr(sig, "task", None)
+    if not task:
+        raise ValueError(
+            "callback signature has no task name; PG self-chaining cannot enqueue "
+            "it (it would be dropped downstream as a malformed payload)"
+        )
     queue = (getattr(sig, "options", None) or {}).get("queue")
     if not queue:
         raise ValueError(
-            f"callback signature {getattr(sig, 'task', sig)!r} has no queue; "
-            "PG self-chaining routes by the row's queue and cannot default it"
+            f"callback signature {task!r} has no queue; PG self-chaining routes "
+            "by the row's queue and cannot default it"
+        )
+    # ContinuationSpec carries no positional args (the consumer prepends the one
+    # chained value). A signature with its own positional args would run with a
+    # different arg list on PG than on Celery — fail fast rather than drop them.
+    if getattr(sig, "args", None):
+        raise ValueError(
+            f"callback signature {task!r} has positional args; PG self-chaining "
+            "supports kwargs-only callbacks"
         )
     return ContinuationSpec(
-        task_name=sig.task,
+        task_name=task,
         kwargs=dict(getattr(sig, "kwargs", None) or {}),
         queue=queue,
     )

--- a/workers/ide_callback/tasks.py
+++ b/workers/ide_callback/tasks.py
@@ -94,8 +94,20 @@ def _emit_event(
     )
 
 
-def _get_task_error(failed_task_id: str, default: str) -> str:
-    """Retrieve the error message from a failed Celery task's result backend."""
+def _get_task_error(
+    failed_task_id: str, default: str, explicit: str | None = None
+) -> str:
+    """Resolve the error text for a failed-task callback.
+
+    Prefers an ``explicit`` error when the caller already has it: the PG
+    self-chained path carries the real error via ``callback_kwargs['error']``
+    because the executor ran eagerly (``task.apply``) and never wrote a Celery
+    result backend under ``failed_task_id`` — so the ``AsyncResult`` lookup below
+    is empty there. The Celery ``link_error`` path passes no explicit error and
+    falls back to the result backend, then the ``default``.
+    """
+    if explicit:
+        return explicit
     try:
         from celery.result import AsyncResult
 
@@ -321,7 +333,9 @@ def ide_index_error(
     api = _get_api_client()
 
     try:
-        error_msg = _get_task_error(failed_task_id, default="Indexing failed")
+        error_msg = _get_task_error(
+            failed_task_id, default="Indexing failed", explicit=cb.get("error")
+        )
 
         # Clean up the indexing-in-progress flag
         if doc_id_key:
@@ -499,7 +513,9 @@ def ide_prompt_error(
     api = _get_api_client()
 
     try:
-        error_msg = _get_task_error(failed_task_id, default="Prompt execution failed")
+        error_msg = _get_task_error(
+            failed_task_id, default="Prompt execution failed", explicit=cb.get("error")
+        )
 
         _emit_event(
             api,
@@ -642,7 +658,11 @@ def extraction_error(
     # Context-manage clients to avoid per-task session leaks.
     with _get_extraction_client() as api, _get_api_client() as ps_api:
         try:
-            error_msg = _get_task_error(failed_task_id, default="Text extraction failed")
+            error_msg = _get_task_error(
+                failed_task_id,
+                default="Text extraction failed",
+                explicit=cb.get("error"),
+            )
 
             api.mark_extraction_error(
                 source=source,

--- a/workers/ide_callback/tasks.py
+++ b/workers/ide_callback/tasks.py
@@ -106,7 +106,7 @@ def _get_task_error(
     is empty there. The Celery ``link_error`` path passes no explicit error and
     falls back to the result backend, then the ``default``.
     """
-    if explicit:
+    if explicit is not None:
         return explicit
     try:
         from celery.result import AsyncResult

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -20,6 +20,7 @@ resolve in ``current_app.tasks``.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import signal
@@ -28,6 +29,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeVar
 
 from celery import current_app
+
+from unstract.core.data_models import ContinuationSpec, TaskPayload
 
 from ..fairness import FAIRNESS_HEADER_NAME
 from .client import PgQueueClient
@@ -65,6 +68,19 @@ _DEFAULT_MAX_ATTEMPTS = 5
 # raise WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS above
 # max(batch_size x worst_case_task_seconds, backoff_max).
 _DEFAULT_HEALTH_STALE_SECONDS = 60.0
+
+
+def _json_safe(value: object) -> object:
+    """Round-trip through JSON with ``default=str`` so non-JSON-native values
+    (UUID / datetime) survive a self-chained enqueue.
+
+    ``PgQueueClient.send`` serialises with a plain ``json.dumps`` (no
+    ``default=``), so a self-chained continuation whose prepended argument is an
+    executor result dict containing a UUID/datetime would raise ``TypeError`` —
+    swallowed by ``_chain_continuation`` and the callback (plus its user-facing
+    event) lost. Coercing here mirrors the backend producer's ``_json_safe``.
+    """
+    return json.loads(json.dumps(value, default=str))
 
 
 class PgQueueConsumer:
@@ -182,7 +198,7 @@ class PgQueueConsumer:
                 message.msg_id,
                 payload,
             )
-            self._fail_reply(reply_key, "malformed message: missing task_name")
+            self._fail_dispatch(payload, error="malformed message: missing task_name")
             self._client.delete(message.msg_id)
             return
 
@@ -199,8 +215,9 @@ class PgQueueConsumer:
                 message.read_ct,
                 payload,
             )
-            self._fail_reply(
-                reply_key, f"task {task_name} exceeded max_attempts={self.max_attempts}"
+            self._fail_dispatch(
+                payload,
+                error=f"task {task_name} exceeded max_attempts={self.max_attempts}",
             )
             self._client.delete(message.msg_id)
             return
@@ -213,7 +230,7 @@ class PgQueueConsumer:
                 task_name,
                 message.msg_id,
             )
-            self._fail_reply(reply_key, f"unknown task {task_name}")
+            self._fail_dispatch(payload, error=f"unknown task {task_name}")
             self._client.delete(message.msg_id)
             return
 
@@ -229,36 +246,21 @@ class PgQueueConsumer:
                 throw=True,
             )
         except Exception as exc:
-            if reply_key:
-                # Record the failure so the waiting caller gets a definitive
-                # result instead of blocking to its timeout, then ACK. We do NOT
+            if reply_key or on_error:
+                # Request-reply / async-callback dispatch: surface the failure on
+                # its return channel (store the error reply, or self-chain on_error
+                # carrying the real error text), then ACK regardless. We do NOT
                 # vt-redeliver: a redelivery would race a result the caller may
                 # already have consumed, and re-running the executor is costly
                 # (LLM spend). The executor task's own autoretry covers transient
-                # errors within this attempt; the caller re-dispatches with a
-                # fresh reply_key to retry the whole RPC.
-                self._fail_reply(reply_key, f"{type(exc).__name__}: {exc}")
+                # errors within this attempt; the caller re-dispatches with a fresh
+                # handle to retry the whole RPC. _fail_dispatch is best-effort, so
+                # the ack never wedges.
+                self._fail_dispatch(payload, error=f"{type(exc).__name__}: {exc}")
                 self._client.delete(message.msg_id)  # ack
                 logger.exception(
-                    "PG-queue consumer: request-reply task %r (msg_id=%s) failed "
-                    "— stored error + acked (reply_key=%s)",
-                    task_name,
-                    message.msg_id,
-                    reply_key,
-                )
-                return
-            if on_error:
-                # Async/callback: self-chain the on_error continuation, then ACK
-                # regardless — same anti-double-spend reasoning as reply_key (a
-                # vt-redelivery would re-run the executor / re-spend LLM tokens).
-                # _chain_continuation is best-effort, so the ack never wedges.
-                self._chain_continuation(
-                    on_error, prepend=payload.get("task_id") or "", payload=payload
-                )
-                self._client.delete(message.msg_id)  # ack
-                logger.exception(
-                    "PG-queue consumer: callback task %r (msg_id=%s) failed — "
-                    "self-chained on_error + acked",
+                    "PG-queue consumer: dispatch %r (msg_id=%s) failed — surfaced "
+                    "via reply/on_error + acked",
                     task_name,
                     message.msg_id,
                 )
@@ -296,6 +298,13 @@ class PgQueueConsumer:
             # queue before the ack — the §5 hand-off (PG analogue of Celery's link).
             # Best-effort (never raises): a chain failure logs + still acks, so the
             # executor is not re-run (LLM double-spend); the callback is lost.
+            #
+            # "success" == the task did not RAISE (parity with Celery `link`, which
+            # also fires on any non-exception return). A task that *returns* a failed
+            # ExecutionResult (success=False, no raise) deliberately follows this
+            # path — the on_success callback receives the failed result and renders
+            # it — exactly as on Celery. This is NOT the missing-on_error drop bug
+            # the early-drop branches handle.
             self._chain_continuation(on_success, prepend=eager.result, payload=payload)
 
         if not self._client.delete(message.msg_id):  # ack
@@ -319,7 +328,14 @@ class PgQueueConsumer:
             self._result_backend = PgResultBackend()
         self._result_backend.store_result(reply_key, result=result, error=error)
 
-    def _chain_continuation(self, spec: dict, *, prepend: object, payload: dict) -> None:
+    def _chain_continuation(
+        self,
+        spec: ContinuationSpec,
+        *,
+        prepend: object,
+        payload: TaskPayload,
+        error: str | None = None,
+    ) -> None:
         """Enqueue a self-chained callback continuation (best-effort, never raises).
 
         The PG analogue of Celery firing a ``link`` / ``link_error``: after the
@@ -327,7 +343,15 @@ class PgQueueConsumer:
         ``queue``) onto its queue with ``prepend`` as the first positional arg —
         the executor result dict on success, the dispatch ``task_id`` on error —
         exactly the first parameter the callback signature expects (mirroring
-        Celery prepending the parent task's return value).
+        Celery prepending the parent task's return value). The prepended value is
+        JSON-coerced so a UUID/datetime in an executor result can't make the
+        enqueue's ``json.dumps`` raise and silently drop the callback.
+
+        ``error`` (failure path only): the real error text. On PG there is no
+        Celery ``AsyncResult`` for the on_error callback (e.g. ``ide_prompt_error``)
+        to recover the message from — the executor ran eagerly — so we hand it
+        through ``callback_kwargs['error']``, which those callbacks prefer over the
+        empty ``AsyncResult`` lookup. Absent on the success path.
 
         Never raises: a failure here must not wedge the executor message's ack
         (which is taken regardless, to avoid an expensive re-run). It just means
@@ -335,12 +359,17 @@ class PgQueueConsumer:
         """
         try:
             queue = spec["queue"]
+            kwargs = dict(spec.get("kwargs") or {})
+            if error is not None:
+                cb = dict(kwargs.get("callback_kwargs") or {})
+                cb.setdefault("error", error)
+                kwargs["callback_kwargs"] = cb
             self._client.send(
                 queue,
                 to_payload(
                     spec["task_name"],
-                    args=[prepend],
-                    kwargs=spec.get("kwargs") or {},
+                    args=[_json_safe(prepend)],
+                    kwargs=kwargs,
                     queue=queue,
                 ),
                 org_id=self._continuation_org(payload),
@@ -353,20 +382,43 @@ class PgQueueConsumer:
             )
 
     @staticmethod
-    def _continuation_org(payload: dict) -> str:
+    def _continuation_org(payload: TaskPayload) -> str:
         """Best-effort org id for a chained callback (fairness/debug on its queue).
 
         The executor request carries it in the context dict (``args[0]``);
-        callbacks are not fairness-critical, so any extraction failure degrades to
-        ``""`` (no org).
+        callbacks are not fairness-critical, so a missing/odd shape degrades to
+        ``""`` (no org). The guards below cover every non-dict shape, so no
+        try/except is needed.
         """
-        try:
-            args = payload.get("args") or []
-            if args and isinstance(args[0], dict):
-                return str(args[0].get("organization_id") or "")
-        except Exception:
-            pass
+        args = payload.get("args") or []
+        if args and isinstance(args[0], dict):
+            return str(args[0].get("organization_id") or "")
         return ""
+
+    def _fail_dispatch(self, payload: TaskPayload, *, error: str) -> None:
+        """Surface a terminal dispatch failure on whichever return channel applies.
+
+        Request-reply (``reply_key``) → store the error for the blocking caller.
+        Async/callback (``on_error``) → self-chain the on_error continuation,
+        carrying the real ``error`` text. Best-effort + never raises — the caller
+        acks regardless. Used by BOTH the run-raised path and the early-drop
+        branches (malformed / poison / unknown task), so a ``dispatch_with_callback``
+        failure ALWAYS reaches its on_error callback, not only when the task body
+        raised (the realistic poison-executor case is exactly when the user most
+        needs the error surfaced).
+        """
+        reply_key = payload.get("reply_key")
+        if reply_key:
+            self._fail_reply(reply_key, error)
+            return
+        on_error = payload.get("on_error")
+        if on_error:
+            self._chain_continuation(
+                on_error,
+                prepend=payload.get("task_id") or "",
+                payload=payload,
+                error=error,
+            )
 
     def _fail_reply(self, reply_key: str | None, error: str) -> None:
         """Best-effort failure reply for a request-reply message that can't run

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -33,6 +33,7 @@ from ..fairness import FAIRNESS_HEADER_NAME
 from .client import PgQueueClient
 from .liveness import LivenessServer as _BaseLivenessServer
 from .result_backend import PgResultBackend
+from .task_payload import to_payload
 
 if TYPE_CHECKING:
     from celery import Celery
@@ -164,6 +165,13 @@ class PgQueueConsumer:
         # its full timeout). Present → store the outcome + ack after one attempt;
         # absent → fire-and-forget (the existing leaf/pipeline path).
         reply_key = payload.get("reply_key")
+        # Async/callback (dispatch_with_callback) self-chaining (③c): a callback
+        # to enqueue after the task runs (on_success after success, on_error after
+        # failure) — the PG analogue of Celery firing a link/link_error. Mutually
+        # exclusive with reply_key. ``task_id`` is the dispatch id prepended to the
+        # on_error callback as the failed id (Celery link_error parity).
+        on_success = payload.get("on_success")
+        on_error = payload.get("on_error")
 
         # Malformed / foreign payload: no task name → can't run; drop with a
         # log that points at the payload, not at task registration.
@@ -239,6 +247,22 @@ class PgQueueConsumer:
                     reply_key,
                 )
                 return
+            if on_error:
+                # Async/callback: self-chain the on_error continuation, then ACK
+                # regardless — same anti-double-spend reasoning as reply_key (a
+                # vt-redelivery would re-run the executor / re-spend LLM tokens).
+                # _chain_continuation is best-effort, so the ack never wedges.
+                self._chain_continuation(
+                    on_error, prepend=payload.get("task_id") or "", payload=payload
+                )
+                self._client.delete(message.msg_id)  # ack
+                logger.exception(
+                    "PG-queue consumer: callback task %r (msg_id=%s) failed — "
+                    "self-chained on_error + acked",
+                    task_name,
+                    message.msg_id,
+                )
+                return
             # Fire-and-forget: leave the row — its vt expires and it is
             # redelivered (bounded by max_attempts above).
             logger.exception(
@@ -267,6 +291,12 @@ class PgQueueConsumer:
                     message.msg_id,
                     reply_key,
                 )
+        elif on_success:
+            # Async/callback: self-chain the success continuation onto the callback
+            # queue before the ack — the §5 hand-off (PG analogue of Celery's link).
+            # Best-effort (never raises): a chain failure logs + still acks, so the
+            # executor is not re-run (LLM double-spend); the callback is lost.
+            self._chain_continuation(on_success, prepend=eager.result, payload=payload)
 
         if not self._client.delete(message.msg_id):  # ack
             logger.warning(
@@ -288,6 +318,55 @@ class PgQueueConsumer:
         if self._result_backend is None:
             self._result_backend = PgResultBackend()
         self._result_backend.store_result(reply_key, result=result, error=error)
+
+    def _chain_continuation(self, spec: dict, *, prepend: object, payload: dict) -> None:
+        """Enqueue a self-chained callback continuation (best-effort, never raises).
+
+        The PG analogue of Celery firing a ``link`` / ``link_error``: after the
+        executor task runs, enqueue ``spec`` (``task_name`` + ``kwargs`` +
+        ``queue``) onto its queue with ``prepend`` as the first positional arg —
+        the executor result dict on success, the dispatch ``task_id`` on error —
+        exactly the first parameter the callback signature expects (mirroring
+        Celery prepending the parent task's return value).
+
+        Never raises: a failure here must not wedge the executor message's ack
+        (which is taken regardless, to avoid an expensive re-run). It just means
+        the callback — and its user-facing WebSocket event — is lost, logged loud.
+        """
+        try:
+            queue = spec["queue"]
+            self._client.send(
+                queue,
+                to_payload(
+                    spec["task_name"],
+                    args=[prepend],
+                    kwargs=spec.get("kwargs") or {},
+                    queue=queue,
+                ),
+                org_id=self._continuation_org(payload),
+            )
+        except Exception:
+            logger.exception(
+                "PG-queue consumer: FAILED to self-chain continuation %r — the "
+                "callback (and its user-facing event) is lost",
+                spec.get("task_name") if isinstance(spec, dict) else spec,
+            )
+
+    @staticmethod
+    def _continuation_org(payload: dict) -> str:
+        """Best-effort org id for a chained callback (fairness/debug on its queue).
+
+        The executor request carries it in the context dict (``args[0]``);
+        callbacks are not fairness-critical, so any extraction failure degrades to
+        ``""`` (no org).
+        """
+        try:
+            args = payload.get("args") or []
+            if args and isinstance(args[0], dict):
+                return str(args[0].get("organization_id") or "")
+        except Exception:
+            pass
+        return ""
 
     def _fail_reply(self, reply_key: str | None, error: str) -> None:
         """Best-effort failure reply for a request-reply message that can't run

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -246,7 +246,7 @@ class PgQueueConsumer:
                 throw=True,
             )
         except Exception as exc:
-            if reply_key or on_error:
+            if reply_key or on_success or on_error:
                 # Request-reply / async-callback dispatch: surface the failure on
                 # its return channel (store the error reply, or self-chain on_error
                 # carrying the real error text), then ACK regardless. We do NOT
@@ -254,8 +254,11 @@ class PgQueueConsumer:
                 # already have consumed, and re-running the executor is costly
                 # (LLM spend). The executor task's own autoretry covers transient
                 # errors within this attempt; the caller re-dispatches with a fresh
-                # handle to retry the whole RPC. _fail_dispatch is best-effort, so
-                # the ack never wedges.
+                # handle to retry the whole RPC. ``on_success`` is in the guard too:
+                # an on_success-only callback dispatch (on_error omitted) that raises
+                # must still ACK — falling through to vt-redelivery would re-run the
+                # executor (the LLM double-spend this path exists to avoid).
+                # _fail_dispatch is best-effort, so the ack never wedges.
                 self._fail_dispatch(payload, error=f"{type(exc).__name__}: {exc}")
                 self._client.delete(message.msg_id)  # ack
                 logger.exception(
@@ -296,8 +299,6 @@ class PgQueueConsumer:
         elif on_success:
             # Async/callback: self-chain the success continuation onto the callback
             # queue before the ack — the §5 hand-off (PG analogue of Celery's link).
-            # Best-effort (never raises): a chain failure logs + still acks, so the
-            # executor is not re-run (LLM double-spend); the callback is lost.
             #
             # "success" == the task did not RAISE (parity with Celery `link`, which
             # also fires on any non-exception return). A task that *returns* a failed
@@ -305,7 +306,17 @@ class PgQueueConsumer:
             # path — the on_success callback receives the failed result and renders
             # it — exactly as on Celery. This is NOT the missing-on_error drop bug
             # the early-drop branches handle.
-            self._chain_continuation(on_success, prepend=eager.result, payload=payload)
+            #
+            # If the success hand-off can't be enqueued (transport/DB error, bad
+            # queue), fall back to on_error so the HTTP-202 caller still gets a
+            # terminal event instead of hanging after the LLM spend already
+            # happened. Both are best-effort + still ack (no executor re-run).
+            if not self._chain_continuation(
+                on_success, prepend=eager.result, payload=payload
+            ):
+                self._fail_dispatch(
+                    payload, error="result delivery failed; see worker logs"
+                )
 
         if not self._client.delete(message.msg_id):  # ack
             logger.warning(
@@ -335,7 +346,7 @@ class PgQueueConsumer:
         prepend: object,
         payload: TaskPayload,
         error: str | None = None,
-    ) -> None:
+    ) -> bool:
         """Enqueue a self-chained callback continuation (best-effort, never raises).
 
         The PG analogue of Celery firing a ``link`` / ``link_error``: after the
@@ -353,9 +364,13 @@ class PgQueueConsumer:
         through ``callback_kwargs['error']``, which those callbacks prefer over the
         empty ``AsyncResult`` lookup. Absent on the success path.
 
+        Returns ``True`` if the continuation was enqueued, ``False`` if it failed.
         Never raises: a failure here must not wedge the executor message's ack
-        (which is taken regardless, to avoid an expensive re-run). It just means
-        the callback — and its user-facing WebSocket event — is lost, logged loud.
+        (which is taken regardless, to avoid an expensive re-run). The success path
+        uses the return value to fall back to on_error so the caller still gets a
+        terminal event; the failure path can't recover further (the callback — and
+        its user-facing WebSocket event — is lost, logged loud with the run/task/org
+        so the stranded session is correlatable).
         """
         try:
             queue = spec["queue"]
@@ -374,12 +389,20 @@ class PgQueueConsumer:
                 ),
                 org_id=self._continuation_org(payload),
             )
+            return True
         except Exception:
+            ctx = payload.get("args") or [{}]
+            ctx0 = ctx[0] if ctx and isinstance(ctx[0], dict) else {}
             logger.exception(
                 "PG-queue consumer: FAILED to self-chain continuation %r — the "
-                "callback (and its user-facing event) is lost",
+                "callback (and its user-facing event) is lost "
+                "(run_id=%s task_id=%s org=%s)",
                 spec.get("task_name") if isinstance(spec, dict) else spec,
+                ctx0.get("run_id"),
+                payload.get("task_id"),
+                self._continuation_org(payload),
             )
+            return False
 
     @staticmethod
     def _continuation_org(payload: TaskPayload) -> str:

--- a/workers/queue_backend/pg_queue/executor_rpc.py
+++ b/workers/queue_backend/pg_queue/executor_rpc.py
@@ -44,7 +44,7 @@ import os
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from unstract.core.data_models import PgTaskStatus
+from unstract.core.data_models import ContinuationSpec, PgTaskStatus
 from unstract.flags.feature_flag import check_feature_flag_status
 from unstract.sdk1.execution.dispatcher import ExecutionDispatcher
 from unstract.sdk1.execution.result import ExecutionResult
@@ -74,6 +74,46 @@ _QUEUE_PREFIX = "celery_executor_"
 # env, else 3600s) so a PG-routed caller waits exactly as long as a Celery one.
 _DEFAULT_TIMEOUT_ENV = "EXECUTOR_RESULT_TIMEOUT"
 _DEFAULT_TIMEOUT = 3600
+
+
+class _DispatchHandle:
+    """Minimal duck-type of Celery ``AsyncResult`` for the PG callback path.
+
+    ``dispatch_with_callback`` callers read only ``.id`` (to return the task id
+    in the HTTP 202 response); they must NOT call ``.get()`` — the result arrives
+    via the self-chained callback (WebSocket), not by polling here. Exposing just
+    ``.id`` lets a PG dispatch return the same shape the call sites already use.
+    """
+
+    __slots__ = ("id",)
+
+    def __init__(self, task_id: str) -> None:
+        self.id = task_id
+
+
+def _signature_to_spec(sig: Any | None) -> ContinuationSpec | None:
+    """Translate a Celery ``Signature`` to a serialisable continuation spec.
+
+    Reads only the three attributes PG self-chaining needs — task name, kwargs,
+    target queue — so the prompt-studio call sites keep passing
+    ``signature(name, kwargs=..., queue=...)`` unchanged; only the PG branch
+    translates. ``None`` (no callback for that outcome) passes through. A
+    signature without a queue is a configuration error: PG routes by the row's
+    queue and must not silently default it, so we fail fast.
+    """
+    if sig is None:
+        return None
+    queue = (getattr(sig, "options", None) or {}).get("queue")
+    if not queue:
+        raise ValueError(
+            f"callback signature {getattr(sig, 'task', sig)!r} has no queue; "
+            "PG self-chaining routes by the row's queue and cannot default it"
+        )
+    return ContinuationSpec(
+        task_name=sig.task,
+        kwargs=dict(getattr(sig, "kwargs", None) or {}),
+        queue=queue,
+    )
 
 
 def resolve_executor_transport(context: ExecutionContext) -> bool:
@@ -152,7 +192,7 @@ class PgExecutionDispatcher:
         queue = f"{_QUEUE_PREFIX}{context.executor_name}"
         org = str(getattr(context, "organization_id", "") or "")
         try:
-            self._enqueue(queue, context, reply_key, org)
+            self._enqueue(queue, context, org, reply_key=reply_key)
         except Exception as exc:
             logger.exception(
                 "PG executor dispatch: enqueue failed (executor=%s run_id=%s)",
@@ -231,22 +271,103 @@ class PgExecutionDispatcher:
         )
         return ExecutionResult.failure(error=row.get("error") or "executor task failed")
 
+    def dispatch_async(
+        self, context: ExecutionContext, headers: dict[str, Any] | None = None
+    ) -> str:
+        """Fire-and-forget enqueue of ``execute_extraction``; returns the task id.
+
+        The PG analogue of the SDK ``dispatch_async``: no ``reply_key``, no
+        callback, no blocking. There is no PG ``AsyncResult`` backend, so a caller
+        that needs the outcome uses :meth:`dispatch_with_callback` (a self-chained
+        continuation), not polling on this id. ``headers`` is accepted and ignored
+        for substitutability (PG carries routing in the payload, not Celery
+        headers). Enqueue failures propagate — parity with the SDK, which lets a
+        broker error out of ``dispatch_async``.
+        """
+        task_id = str(uuid.uuid4())
+        queue = f"{_QUEUE_PREFIX}{context.executor_name}"
+        org = str(getattr(context, "organization_id", "") or "")
+        self._enqueue(queue, context, org, task_id=task_id)
+        logger.info(
+            "PG executor dispatch_async: enqueued task_id=%s queue=%s run_id=%s",
+            task_id,
+            queue,
+            context.run_id,
+        )
+        return task_id
+
+    def dispatch_with_callback(
+        self,
+        context: ExecutionContext,
+        on_success: Any | None = None,
+        on_error: Any | None = None,
+        task_id: str | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> _DispatchHandle:
+        """Fire-and-forget enqueue with self-chained callbacks (§5 model).
+
+        The PG analogue of the SDK ``dispatch_with_callback``: instead of Celery
+        ``link`` / ``link_error`` (which the broker fires), the on-success /
+        on-error Celery ``Signature``s are translated to serialisable
+        :class:`ContinuationSpec`s and carried in the payload. After the executor
+        consumer runs ``execute_extraction`` it self-chains the matching
+        continuation onto the callback queue. Returns a :class:`_DispatchHandle`
+        exposing ``.id`` (== ``task_id``) so call sites read the task id exactly
+        as on the Celery path. ``headers`` is accepted and ignored (see
+        :meth:`dispatch_async`).
+        """
+        task_id = task_id or str(uuid.uuid4())
+        queue = f"{_QUEUE_PREFIX}{context.executor_name}"
+        org = str(getattr(context, "organization_id", "") or "")
+        success_spec = _signature_to_spec(on_success)
+        error_spec = _signature_to_spec(on_error)
+        self._enqueue(
+            queue,
+            context,
+            org,
+            on_success=success_spec,
+            on_error=error_spec,
+            task_id=task_id,
+        )
+        logger.info(
+            "PG executor dispatch_with_callback: enqueued task_id=%s queue=%s "
+            "run_id=%s on_success=%s on_error=%s",
+            task_id,
+            queue,
+            context.run_id,
+            success_spec["task_name"] if success_spec else None,
+            error_spec["task_name"] if error_spec else None,
+        )
+        return _DispatchHandle(task_id)
+
     @staticmethod
     def _enqueue(
-        queue: str, context: ExecutionContext, reply_key: str, org_id: str
+        queue: str,
+        context: ExecutionContext,
+        org_id: str,
+        *,
+        reply_key: str | None = None,
+        on_success: ContinuationSpec | None = None,
+        on_error: ContinuationSpec | None = None,
+        task_id: str | None = None,
     ) -> None:
-        """Enqueue the ``execute_extraction`` request-reply message.
+        """Enqueue an ``execute_extraction`` message (request-reply or callback).
 
         A short-lived client owns its connection for just the insert (which
         commits internally) so the message is durably visible to the
         ``worker-pg-executor`` consumer before we begin polling — and no
-        connection is pinned for the whole (possibly long) RPC.
+        connection is pinned for the whole (possibly long) RPC. The optional keys
+        select the dispatch shape: ``reply_key`` → request-reply; ``on_success`` /
+        ``on_error`` / ``task_id`` → async/callback (self-chained).
         """
         payload = to_payload(
             _EXECUTE_TASK,
             args=[context.to_dict()],
             queue=queue,
             reply_key=reply_key,
+            on_success=on_success,
+            on_error=on_error,
+            task_id=task_id,
         )
         with PgQueueClient() as client:
             client.send(queue, payload, org_id=org_id)
@@ -272,10 +393,10 @@ class PgExecutionDispatcher:
 class RoutingExecutionDispatcher:
     """Gate-routed executor dispatcher returned by :func:`get_executor_dispatcher`.
 
-    ``dispatch()`` chooses PG vs Celery per call (instant rollout/rollback);
-    ``dispatch_async`` / ``dispatch_with_callback`` always delegate to Celery —
-    the async/callback path stays on Celery until a later continuation slice.
-    Duck-typed against the SDK ``ExecutionDispatcher`` so call sites are unchanged.
+    Every mode chooses PG vs Celery per call (instant rollout/rollback):
+    ``dispatch()`` (request-reply), ``dispatch_async`` (fire-and-forget) and
+    ``dispatch_with_callback`` (self-chained callbacks). Duck-typed against the SDK
+    ``ExecutionDispatcher`` so call sites are unchanged.
     """
 
     def __init__(self, celery_app: object | None = None) -> None:
@@ -303,10 +424,32 @@ class RoutingExecutionDispatcher:
     def dispatch_async(
         self, context: ExecutionContext, headers: dict[str, Any] | None = None
     ) -> str:
+        if resolve_executor_transport(context):
+            return self._pg.dispatch_async(context)
         return self._celery.dispatch_async(context, headers=headers)
 
-    def dispatch_with_callback(self, context: ExecutionContext, **kwargs: Any) -> Any:
-        return self._celery.dispatch_with_callback(context, **kwargs)
+    def dispatch_with_callback(
+        self,
+        context: ExecutionContext,
+        on_success: Any | None = None,
+        on_error: Any | None = None,
+        task_id: str | None = None,
+        headers: dict[str, Any] | None = None,
+    ) -> Any:
+        if resolve_executor_transport(context):
+            return self._pg.dispatch_with_callback(
+                context,
+                on_success=on_success,
+                on_error=on_error,
+                task_id=task_id,
+            )
+        return self._celery.dispatch_with_callback(
+            context,
+            on_success=on_success,
+            on_error=on_error,
+            task_id=task_id,
+            headers=headers,
+        )
 
 
 def get_executor_dispatcher(

--- a/workers/queue_backend/pg_queue/executor_rpc.py
+++ b/workers/queue_backend/pg_queue/executor_rpc.py
@@ -45,6 +45,7 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from unstract.core.data_models import ContinuationSpec, PgTaskStatus
+from unstract.core.execution_dispatch import DispatchHandle, signature_to_continuation
 from unstract.flags.feature_flag import check_feature_flag_status
 from unstract.sdk1.execution.dispatcher import ExecutionDispatcher
 from unstract.sdk1.execution.result import ExecutionResult
@@ -74,46 +75,6 @@ _QUEUE_PREFIX = "celery_executor_"
 # env, else 3600s) so a PG-routed caller waits exactly as long as a Celery one.
 _DEFAULT_TIMEOUT_ENV = "EXECUTOR_RESULT_TIMEOUT"
 _DEFAULT_TIMEOUT = 3600
-
-
-class _DispatchHandle:
-    """Minimal duck-type of Celery ``AsyncResult`` for the PG callback path.
-
-    ``dispatch_with_callback`` callers read only ``.id`` (to return the task id
-    in the HTTP 202 response); they must NOT call ``.get()`` — the result arrives
-    via the self-chained callback (WebSocket), not by polling here. Exposing just
-    ``.id`` lets a PG dispatch return the same shape the call sites already use.
-    """
-
-    __slots__ = ("id",)
-
-    def __init__(self, task_id: str) -> None:
-        self.id = task_id
-
-
-def _signature_to_spec(sig: Any | None) -> ContinuationSpec | None:
-    """Translate a Celery ``Signature`` to a serialisable continuation spec.
-
-    Reads only the three attributes PG self-chaining needs — task name, kwargs,
-    target queue — so the prompt-studio call sites keep passing
-    ``signature(name, kwargs=..., queue=...)`` unchanged; only the PG branch
-    translates. ``None`` (no callback for that outcome) passes through. A
-    signature without a queue is a configuration error: PG routes by the row's
-    queue and must not silently default it, so we fail fast.
-    """
-    if sig is None:
-        return None
-    queue = (getattr(sig, "options", None) or {}).get("queue")
-    if not queue:
-        raise ValueError(
-            f"callback signature {getattr(sig, 'task', sig)!r} has no queue; "
-            "PG self-chaining routes by the row's queue and cannot default it"
-        )
-    return ContinuationSpec(
-        task_name=sig.task,
-        kwargs=dict(getattr(sig, "kwargs", None) or {}),
-        queue=queue,
-    )
 
 
 def resolve_executor_transport(context: ExecutionContext) -> bool:
@@ -303,7 +264,7 @@ class PgExecutionDispatcher:
         on_error: Any | None = None,
         task_id: str | None = None,
         headers: dict[str, Any] | None = None,
-    ) -> _DispatchHandle:
+    ) -> DispatchHandle:
         """Fire-and-forget enqueue with self-chained callbacks (§5 model).
 
         The PG analogue of the SDK ``dispatch_with_callback``: instead of Celery
@@ -311,7 +272,7 @@ class PgExecutionDispatcher:
         on-error Celery ``Signature``s are translated to serialisable
         :class:`ContinuationSpec`s and carried in the payload. After the executor
         consumer runs ``execute_extraction`` it self-chains the matching
-        continuation onto the callback queue. Returns a :class:`_DispatchHandle`
+        continuation onto the callback queue. Returns a :class:`DispatchHandle`
         exposing ``.id`` (== ``task_id``) so call sites read the task id exactly
         as on the Celery path. ``headers`` is accepted and ignored (see
         :meth:`dispatch_async`).
@@ -319,8 +280,8 @@ class PgExecutionDispatcher:
         task_id = task_id or str(uuid.uuid4())
         queue = f"{_QUEUE_PREFIX}{context.executor_name}"
         org = str(getattr(context, "organization_id", "") or "")
-        success_spec = _signature_to_spec(on_success)
-        error_spec = _signature_to_spec(on_error)
+        success_spec = signature_to_continuation(on_success)
+        error_spec = signature_to_continuation(on_error)
         self._enqueue(
             queue,
             context,
@@ -338,7 +299,7 @@ class PgExecutionDispatcher:
             success_spec["task_name"] if success_spec else None,
             error_spec["task_name"] if error_spec else None,
         )
-        return _DispatchHandle(task_id)
+        return DispatchHandle(task_id)
 
     @staticmethod
     def _enqueue(

--- a/workers/queue_backend/pg_queue/task_payload.py
+++ b/workers/queue_backend/pg_queue/task_payload.py
@@ -48,8 +48,15 @@ def to_payload(
     continuation after the task runs (success → ``on_success``, failure →
     ``on_error``). ``task_id`` is the dispatch id the consumer prepends to
     ``on_error`` as the failed id (Celery ``link_error`` parity). These are
-    mutually exclusive with ``reply_key`` (blocking vs callback dispatch).
+    mutually exclusive with ``reply_key`` (blocking vs callback dispatch) — passing
+    both is rejected, since the consumer checks ``reply_key`` first and would
+    silently drop the callback.
     """
+    if reply_key is not None and (on_success is not None or on_error is not None):
+        raise ValueError(
+            "reply_key (request-reply) and on_success/on_error (callback) are "
+            "mutually exclusive"
+        )
     payload = TaskPayload(
         task_name=task_name,
         args=list(args) if args is not None else [],

--- a/workers/queue_backend/pg_queue/task_payload.py
+++ b/workers/queue_backend/pg_queue/task_payload.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 # re-exported here so existing ``from .task_payload import TaskPayload`` imports
 # keep working. The ``to_payload`` builder stays worker-side (it depends on the
 # worker-only ``FairnessKey``).
-from unstract.core.data_models import TaskPayload
+from unstract.core.data_models import ContinuationSpec, TaskPayload
 
 if TYPE_CHECKING:
     from ..fairness import FairnessKey
@@ -33,12 +33,22 @@ def to_payload(
     queue: str | None = None,
     fairness: FairnessKey | None = None,
     reply_key: str | None = None,
+    on_success: ContinuationSpec | None = None,
+    on_error: ContinuationSpec | None = None,
+    task_id: str | None = None,
 ) -> TaskPayload:
     """Build the JSON-serialisable task payload for the PG queue.
 
     ``reply_key`` marks a **request-reply** dispatch (the executor RPC on PG):
     the executor consumer writes the task's result/error to ``pg_task_result``
     under it for the blocking caller to poll. Omitted = fire-and-forget.
+
+    ``on_success`` / ``on_error`` mark an **async/callback** dispatch
+    (``dispatch_with_callback``): the executor consumer self-chains the matching
+    continuation after the task runs (success → ``on_success``, failure →
+    ``on_error``). ``task_id`` is the dispatch id the consumer prepends to
+    ``on_error`` as the failed id (Celery ``link_error`` parity). These are
+    mutually exclusive with ``reply_key`` (blocking vs callback dispatch).
     """
     payload = TaskPayload(
         task_name=task_name,
@@ -47,8 +57,14 @@ def to_payload(
         queue=queue,
         fairness=fairness.to_dict() if fairness is not None else None,
     )
-    # Only set for request-reply dispatches — keeps fire-and-forget rows
-    # byte-identical to before this field existed (mirrors the backend producer).
+    # Each optional key is set only when present — keeps fire-and-forget rows
+    # byte-identical to before these fields existed (mirrors the backend producer).
     if reply_key is not None:
         payload["reply_key"] = reply_key
+    if on_success is not None:
+        payload["on_success"] = on_success
+    if on_error is not None:
+        payload["on_error"] = on_error
+    if task_id is not None:
+        payload["task_id"] = task_id
     return payload

--- a/workers/tests/test_executor_rpc.py
+++ b/workers/tests/test_executor_rpc.py
@@ -11,9 +11,11 @@ row is a plain ``dict`` (``PgResultBackend``) instead of a Django model.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from queue_backend.pg_queue.executor_rpc import (
     PgExecutionDispatcher,
     RoutingExecutionDispatcher,
+    _signature_to_spec,
     resolve_executor_transport,
 )
 
@@ -298,11 +300,126 @@ class TestRoutingZeroRegression:
         assert "headers" not in pg.dispatch.call_args.kwargs
         celery.dispatch.assert_not_called()
 
-    def test_async_and_callback_always_celery(self):
-        """The callback/async path stays on Celery regardless of the gate (a later slice)."""
+    def test_async_and_callback_stay_celery_when_gate_off(self):
+        """Zero-regression: gate off → async/callback delegate to Celery unchanged."""
         dispatcher, celery, pg = self._build()
-        dispatcher.dispatch_async(_ctx())
-        dispatcher.dispatch_with_callback(_ctx(), on_success=None)
+        with patch(f"{_MOD}.resolve_executor_transport", return_value=False):
+            dispatcher.dispatch_async(_ctx(), headers={"h": 1})
+            dispatcher.dispatch_with_callback(_ctx(), on_success="s", on_error="e")
         celery.dispatch_async.assert_called_once()
         celery.dispatch_with_callback.assert_called_once()
-        pg.dispatch.assert_not_called()
+        pg.dispatch_async.assert_not_called()
+        pg.dispatch_with_callback.assert_not_called()
+
+    def test_async_and_callback_route_to_pg_when_gated(self):
+        """Gate on (③c) → async/callback take the PG self-chained path."""
+        dispatcher, celery, pg = self._build()
+        with patch(f"{_MOD}.resolve_executor_transport", return_value=True):
+            dispatcher.dispatch_async(_ctx())
+            dispatcher.dispatch_with_callback(
+                _ctx(), on_success="s", on_error="e", task_id="t"
+            )
+        pg.dispatch_async.assert_called_once()
+        pg.dispatch_with_callback.assert_called_once()
+        # PG carries callbacks in the payload, not Celery headers → no header leak.
+        assert "headers" not in pg.dispatch_with_callback.call_args.kwargs
+        celery.dispatch_async.assert_not_called()
+        celery.dispatch_with_callback.assert_not_called()
+
+
+class TestSignatureToSpec:
+    """Celery ``Signature`` → serialisable continuation spec (the §5 wire-form)."""
+
+    def test_none_passes_through(self):
+        assert _signature_to_spec(None) is None
+
+    def test_translates_task_kwargs_and_queue(self):
+        sig = MagicMock(
+            task="ide_prompt_complete",
+            kwargs={"callback_kwargs": {"room": "r1"}},
+            options={"queue": "ide_callback"},
+        )
+        assert _signature_to_spec(sig) == {
+            "task_name": "ide_prompt_complete",
+            "kwargs": {"callback_kwargs": {"room": "r1"}},
+            "queue": "ide_callback",
+        }
+
+    def test_missing_queue_fails_fast(self):
+        sig = MagicMock(task="ide_prompt_complete", kwargs={}, options={})
+        with pytest.raises(ValueError, match="no queue"):
+            _signature_to_spec(sig)
+
+
+class TestPgAsyncCallbackWiring:
+    """PG fire-and-forget + self-chained-callback enqueue shapes.
+
+    ``to_payload`` runs for real; only ``PgQueueClient`` is mocked. Pins that the
+    async path carries NO reply_key (it must not block a consumer) and the callback
+    path carries the translated continuations + the tracking task_id.
+    """
+
+    @staticmethod
+    def _ctx():
+        c = MagicMock()
+        c.executor_name = "legacy"
+        c.run_id = "r"
+        c.organization_id = "org9"
+        c.to_dict.return_value = {"run_id": "r", "organization_id": "org9"}
+        return c
+
+    @staticmethod
+    def _client():
+        client = MagicMock()
+        client.__enter__.return_value = client
+        return client
+
+    def test_dispatch_async_is_fire_and_forget(self):
+        client = self._client()
+        with patch(f"{_MOD}.PgQueueClient", return_value=client):
+            task_id = PgExecutionDispatcher().dispatch_async(self._ctx())
+        client.send.assert_called_once()
+        queue_arg, payload_arg = client.send.call_args.args[:2]
+        assert queue_arg == "celery_executor_legacy"
+        assert client.send.call_args.kwargs["org_id"] == "org9"
+        assert payload_arg["task_name"] == "execute_extraction"
+        assert payload_arg["task_id"] == task_id
+        # No reply_key (would make a consumer try to store a reply) and no callback.
+        assert "reply_key" not in payload_arg
+        assert "on_success" not in payload_arg
+        assert "on_error" not in payload_arg
+
+    def test_dispatch_with_callback_carries_continuations(self):
+        client = self._client()
+        on_s = MagicMock(
+            task="ide_prompt_complete",
+            kwargs={"callback_kwargs": {"room": "r1"}},
+            options={"queue": "ide_callback"},
+        )
+        on_e = MagicMock(
+            task="ide_prompt_error",
+            kwargs={"callback_kwargs": {"room": "r1"}},
+            options={"queue": "ide_callback"},
+        )
+        with patch(f"{_MOD}.PgQueueClient", return_value=client):
+            handle = PgExecutionDispatcher().dispatch_with_callback(
+                self._ctx(), on_success=on_s, on_error=on_e, task_id="tid-7"
+            )
+        assert handle.id == "tid-7"  # call sites read .id off the handle
+        payload_arg = client.send.call_args.args[1]
+        assert payload_arg["on_success"] == {
+            "task_name": "ide_prompt_complete",
+            "kwargs": {"callback_kwargs": {"room": "r1"}},
+            "queue": "ide_callback",
+        }
+        assert payload_arg["on_error"]["task_name"] == "ide_prompt_error"
+        assert payload_arg["task_id"] == "tid-7"
+        assert "reply_key" not in payload_arg  # callback, not request-reply
+
+    def test_dispatch_with_callback_defaults_task_id(self):
+        client = self._client()
+        with patch(f"{_MOD}.PgQueueClient", return_value=client):
+            handle = PgExecutionDispatcher().dispatch_with_callback(self._ctx())
+        # No task_id passed → a uuid is generated and echoed on the handle + payload.
+        assert handle.id
+        assert client.send.call_args.args[1]["task_id"] == handle.id

--- a/workers/tests/test_executor_rpc.py
+++ b/workers/tests/test_executor_rpc.py
@@ -15,9 +15,9 @@ import pytest
 from queue_backend.pg_queue.executor_rpc import (
     PgExecutionDispatcher,
     RoutingExecutionDispatcher,
-    _signature_to_spec,
     resolve_executor_transport,
 )
+from unstract.core.execution_dispatch import DispatchHandle, signature_to_continuation
 
 _MOD = "queue_backend.pg_queue.executor_rpc"
 
@@ -327,30 +327,6 @@ class TestRoutingZeroRegression:
         celery.dispatch_with_callback.assert_not_called()
 
 
-class TestSignatureToSpec:
-    """Celery ``Signature`` → serialisable continuation spec (the §5 wire-form)."""
-
-    def test_none_passes_through(self):
-        assert _signature_to_spec(None) is None
-
-    def test_translates_task_kwargs_and_queue(self):
-        sig = MagicMock(
-            task="ide_prompt_complete",
-            kwargs={"callback_kwargs": {"room": "r1"}},
-            options={"queue": "ide_callback"},
-        )
-        assert _signature_to_spec(sig) == {
-            "task_name": "ide_prompt_complete",
-            "kwargs": {"callback_kwargs": {"room": "r1"}},
-            "queue": "ide_callback",
-        }
-
-    def test_missing_queue_fails_fast(self):
-        sig = MagicMock(task="ide_prompt_complete", kwargs={}, options={})
-        with pytest.raises(ValueError, match="no queue"):
-            _signature_to_spec(sig)
-
-
 class TestPgAsyncCallbackWiring:
     """PG fire-and-forget + self-chained-callback enqueue shapes.
 
@@ -423,3 +399,36 @@ class TestPgAsyncCallbackWiring:
         # No task_id passed → a uuid is generated and echoed on the handle + payload.
         assert handle.id
         assert client.send.call_args.args[1]["task_id"] == handle.id
+
+
+class TestSharedDispatchHelpers:
+    """The transport-agnostic helpers lifted to ``unstract.core`` (shared by the
+    backend + workers executor-RPC mirrors). Tested once here, not per-mirror.
+    """
+
+    def test_signature_none_passes_through(self):
+        assert signature_to_continuation(None) is None
+
+    def test_signature_translates_task_kwargs_and_queue(self):
+        sig = MagicMock(
+            task="ide_prompt_complete",
+            kwargs={"callback_kwargs": {"room": "r1"}},
+            options={"queue": "ide_callback"},
+        )
+        assert signature_to_continuation(sig) == {
+            "task_name": "ide_prompt_complete",
+            "kwargs": {"callback_kwargs": {"room": "r1"}},
+            "queue": "ide_callback",
+        }
+
+    def test_signature_missing_queue_fails_fast(self):
+        sig = MagicMock(task="ide_prompt_complete", kwargs={}, options={})
+        with pytest.raises(ValueError, match="no queue"):
+            signature_to_continuation(sig)
+
+    def test_dispatch_handle_exposes_only_id(self):
+        handle = DispatchHandle("tid-1")
+        assert handle.id == "tid-1"
+        # __slots__ → no stray attributes (callers must not poke at .get()/.result).
+        with pytest.raises(AttributeError):
+            handle.result = 1  # type: ignore[attr-defined]

--- a/workers/tests/test_executor_rpc.py
+++ b/workers/tests/test_executor_rpc.py
@@ -369,11 +369,13 @@ class TestPgAsyncCallbackWiring:
         client = self._client()
         on_s = MagicMock(
             task="ide_prompt_complete",
+            args=(),
             kwargs={"callback_kwargs": {"room": "r1"}},
             options={"queue": "ide_callback"},
         )
         on_e = MagicMock(
             task="ide_prompt_error",
+            args=(),
             kwargs={"callback_kwargs": {"room": "r1"}},
             options={"queue": "ide_callback"},
         )
@@ -412,6 +414,7 @@ class TestSharedDispatchHelpers:
     def test_signature_translates_task_kwargs_and_queue(self):
         sig = MagicMock(
             task="ide_prompt_complete",
+            args=(),  # a real kwargs-only Celery Signature has empty .args
             kwargs={"callback_kwargs": {"room": "r1"}},
             options={"queue": "ide_callback"},
         )
@@ -422,8 +425,23 @@ class TestSharedDispatchHelpers:
         }
 
     def test_signature_missing_queue_fails_fast(self):
-        sig = MagicMock(task="ide_prompt_complete", kwargs={}, options={})
+        sig = MagicMock(task="ide_prompt_complete", kwargs={}, options={"queue": ""})
         with pytest.raises(ValueError, match="no queue"):
+            signature_to_continuation(sig)
+
+    def test_signature_missing_task_fails_fast(self):
+        sig = MagicMock(task=None, kwargs={}, options={"queue": "ide_callback"})
+        with pytest.raises(ValueError, match="no task name"):
+            signature_to_continuation(sig)
+
+    def test_signature_with_positional_args_fails_fast(self):
+        sig = MagicMock(
+            task="ide_prompt_complete",
+            args=("pos",),
+            kwargs={},
+            options={"queue": "ide_callback"},
+        )
+        with pytest.raises(ValueError, match="positional args"):
             signature_to_continuation(sig)
 
     def test_dispatch_handle_exposes_only_id(self):

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -34,6 +34,15 @@ def _boom_task():
     raise RuntimeError("boom")
 
 
+@shared_task(name="test_pg_consumer.dt")
+def _dt_task():
+    # Returns a non-JSON-native value (datetime) — the self-chain must coerce it
+    # before enqueue, else client.send's plain json.dumps would raise.
+    from datetime import datetime
+
+    return {"when": datetime(2020, 1, 1)}  # noqa: DTZ001 — fixed value for the test
+
+
 @pytest.fixture(autouse=True)
 def _clear_calls():
     _calls.clear()
@@ -564,6 +573,46 @@ class TestSelfChain:
         payload_arg = client.send.call_args.args[1]
         assert payload_arg["task_name"] == "cb.err"
         assert payload_arg["args"] == ["tid-9"]  # dispatch task_id as the failed id
+        # The real error text rides callback_kwargs['error'] (no Celery AsyncResult
+        # to recover it from on PG) so on_error callbacks surface it, not a default.
+        assert "RuntimeError: boom" in payload_arg["kwargs"]["callback_kwargs"]["error"]
+
+    def test_early_drop_branches_still_chain_on_error(self):
+        # Critical: a dispatch_with_callback that hits malformed/unknown/poison must
+        # still fire on_error — else the HTTP-202 caller hangs with no terminal event.
+        err = self._spec("cb.err")
+        cases = [
+            # (msg_id, payload, read_ct)  — malformed / unknown / poison
+            (10, {"on_error": err, "task_id": "t"}, 1),
+            (11, {"task_name": "nope.nope", "on_error": err, "task_id": "t"}, 1),
+            (12, {"task_name": "test_pg_consumer.boom", "on_error": err, "task_id": "t"}, 99),
+        ]
+        for msg_id, payload, read_ct in cases:
+            client = MagicMock()
+            client.read.return_value = [_msg(msg_id, payload, read_ct=read_ct)]
+            PgQueueConsumer(["q"], client=client).poll_once()
+            client.delete.assert_called_once_with(msg_id)  # dropped/acked
+            client.send.assert_called_once()  # on_error STILL chained
+            payload_arg = client.send.call_args.args[1]
+            assert payload_arg["task_name"] == "cb.err"
+            assert payload_arg["args"] == ["t"]
+            assert payload_arg["kwargs"]["callback_kwargs"]["error"]  # the drop reason
+
+    def test_non_json_safe_result_is_coerced_before_chaining(self):
+        client = MagicMock()
+        payload = {
+            "task_name": "test_pg_consumer.dt",
+            "on_success": self._spec(),
+            "task_id": "tid",
+        }
+        client.read.return_value = [_msg(6, payload)]
+        PgQueueConsumer(["q"], client=client).poll_once()
+        client.send.assert_called_once()  # not swallowed by a json.dumps TypeError
+        chained = client.send.call_args.args[1]["args"][0]
+        assert isinstance(chained["when"], str)  # datetime → str (default=str)
+        import json as _json
+
+        _json.dumps(chained)  # the coerced payload is plain-json serialisable
 
     def test_no_continuation_is_plain_fire_and_forget(self):
         client = MagicMock()
@@ -589,6 +638,18 @@ class TestSelfChain:
         assert org_of({"args": [{"organization_id": "orgZ"}]}) == "orgZ"
         assert org_of({"args": [42]}) == ""
         assert org_of({}) == ""
+
+    def test_reply_key_and_callback_are_mutually_exclusive(self):
+        # The consumer checks reply_key first and would silently drop a callback —
+        # so to_payload rejects the ambiguous combination at the build boundary.
+        spec = self._spec()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            to_payload("execute_extraction", reply_key="rk", on_success=spec)
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            to_payload("execute_extraction", reply_key="rk", on_error=spec)
+        # Either alone is fine.
+        assert to_payload("execute_extraction", reply_key="rk")["reply_key"] == "rk"
+        assert to_payload("execute_extraction", on_success=spec)["on_success"] == spec
 
 
 if __name__ == "__main__":

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -521,5 +521,75 @@ class TestRequestReply:
         assert "FAILED to store request-reply result" in caplog.text
 
 
+class TestSelfChain:
+    """Async/callback self-chaining (③c): with no reply_key, the consumer enqueues
+    the on_success / on_error continuation onto its queue after the task runs, then
+    acks regardless (a vt-redelivery would re-run the executor = LLM double-spend).
+    Best-effort: a chain-enqueue failure still acks. ``client.send`` is the
+    self-chain enqueue (the mock client is also read/delete).
+    """
+
+    @staticmethod
+    def _spec(task="cb.done", queue="ide_callback"):
+        return {
+            "task_name": task,
+            "kwargs": {"callback_kwargs": {"room": "r1"}},
+            "queue": queue,
+        }
+
+    def test_success_chains_on_success_with_result_and_acks(self):
+        client = MagicMock()
+        payload = {**_ok_payload(3, 4), "on_success": self._spec(), "task_id": "tid"}
+        client.read.return_value = [_msg(1, payload)]
+        PgQueueConsumer(["q"], client=client).poll_once()
+        client.delete.assert_called_once_with(1)  # executor msg acked
+        client.send.assert_called_once()  # continuation enqueued
+        queue_arg, payload_arg = client.send.call_args.args[:2]
+        assert queue_arg == "ide_callback"
+        assert payload_arg["task_name"] == "cb.done"
+        assert payload_arg["args"] == [7]  # x + y prepended (Celery link parity)
+        assert payload_arg["kwargs"] == {"callback_kwargs": {"room": "r1"}}
+
+    def test_failure_chains_on_error_with_task_id_and_acks(self):
+        client = MagicMock()
+        payload = {
+            "task_name": "test_pg_consumer.boom",
+            "on_error": self._spec("cb.err"),
+            "task_id": "tid-9",
+        }
+        client.read.return_value = [_msg(2, payload)]
+        PgQueueConsumer(["q"], client=client).poll_once()
+        client.delete.assert_called_once_with(2)  # acked, NOT left for redelivery
+        client.send.assert_called_once()
+        payload_arg = client.send.call_args.args[1]
+        assert payload_arg["task_name"] == "cb.err"
+        assert payload_arg["args"] == ["tid-9"]  # dispatch task_id as the failed id
+
+    def test_no_continuation_is_plain_fire_and_forget(self):
+        client = MagicMock()
+        client.read.return_value = [_msg(3, _ok_payload(1, 1))]
+        PgQueueConsumer(["q"], client=client).poll_once()
+        client.send.assert_not_called()  # nothing self-chained
+        client.delete.assert_called_once_with(3)  # acked
+
+    def test_chain_failure_on_success_still_acks(self, caplog):
+        client = MagicMock()
+        client.send.side_effect = RuntimeError("queue down")
+        payload = {**_ok_payload(2, 2), "on_success": self._spec()}
+        client.read.return_value = [_msg(4, payload)]
+        with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
+            PgQueueConsumer(["q"], client=client).poll_once()
+        client.delete.assert_called_once_with(4)  # acked despite the chain failure
+        assert "FAILED to self-chain" in caplog.text
+
+    def test_continuation_org_extracted_from_context(self):
+        # The chained callback inherits the executor request's org (context dict);
+        # non-dict / absent args degrade to "" (callbacks aren't fairness-critical).
+        org_of = PgQueueConsumer._continuation_org
+        assert org_of({"args": [{"organization_id": "orgZ"}]}) == "orgZ"
+        assert org_of({"args": [42]}) == ""
+        assert org_of({}) == ""
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -614,6 +614,40 @@ class TestSelfChain:
 
         _json.dumps(chained)  # the coerced payload is plain-json serialisable
 
+    def test_on_success_only_failure_acks_not_redelivered(self):
+        # An on_success-only callback dispatch (on_error omitted) whose executor
+        # RAISES must ACK — not fall through to vt-redelivery and re-run the
+        # executor (LLM double-spend). No on_error → nothing chained, but acked.
+        client = MagicMock()
+        payload = {
+            "task_name": "test_pg_consumer.boom",
+            "on_success": self._spec(),
+            "task_id": "tid",
+        }
+        client.read.return_value = [_msg(7, payload)]
+        PgQueueConsumer(["q"], client=client).poll_once()
+        client.delete.assert_called_once_with(7)  # acked, NOT left for redelivery
+        client.send.assert_not_called()  # success callback not fired on a raise
+
+    def test_on_success_enqueue_failure_falls_back_to_on_error(self):
+        # If the success hand-off can't be enqueued, surface on_error so the caller
+        # still gets a terminal event instead of hanging after the LLM spend.
+        client = MagicMock()
+        client.send.side_effect = [RuntimeError("queue down"), 999]  # 1st fails, 2nd ok
+        payload = {
+            **_ok_payload(2, 2),
+            "on_success": self._spec("cb.ok"),
+            "on_error": self._spec("cb.err"),
+            "task_id": "tid",
+        }
+        client.read.return_value = [_msg(8, payload)]
+        PgQueueConsumer(["q"], client=client).poll_once()
+        assert client.send.call_count == 2  # on_success attempt, then on_error fallback
+        fallback = client.send.call_args_list[1].args[1]
+        assert fallback["task_name"] == "cb.err"
+        assert "delivery failed" in fallback["kwargs"]["callback_kwargs"]["error"]
+        client.delete.assert_called_once_with(8)  # acked
+
     def test_no_continuation_is_plain_fire_and_forget(self):
         client = MagicMock()
         client.read.return_value = [_msg(3, _ok_payload(1, 1))]


### PR DESCRIPTION
## What

Migrates the executor RPC's **async/callback** path off Celery onto the PG queue, completing the executor-transport migration (the blocking path landed in 9h-c). Targets the `feat/UN-3445-pg-queue-integration` branch (not `main`).

Today `dispatch_with_callback` (Prompt Studio run/index/extract, lookups) always rides Celery `link`/`link_error`. This routes it through Postgres instead, via **§5 fire-and-forget self-chaining**: the executor consumer, after running `execute_extraction`, enqueues the continuation itself.

## How

- **Routing** — `dispatch_async` / `dispatch_with_callback` now pick PG-vs-Celery per call via the single `pg_queue_enabled` flag (same gate as the rest of the feature), in both backend and workers `executor_rpc.py`.
- **Self-chaining** — the `on_success`/`on_error` Celery `Signature`s are translated to a serialisable `ContinuationSpec` (`task_name`/`kwargs`/`queue`) carried in the task payload. After the executor runs, the consumer self-chains the matching continuation onto the callback queue: the result dict prepended on success, the dispatch `task_id` on error (Celery `link_error` parity). It acks regardless of chain outcome — a vt-redelivery would re-run the executor (LLM double-spend); a chain failure is logged loud and best-effort.
- **Consumer** — new gated `worker-pg-ide-callback` service drains the `ide_callback` queue (compose profile `pg-queue`).
- **Wire contract** — `ContinuationSpec` + `on_success`/`on_error`/`task_id` added to the shared `TaskPayload` in `unstract.core` (all optional, set only when present).

## Zero-regression

Every new path is gated and **fails closed to Celery**. Gate OFF is byte-identical to the prior behaviour: `dispatch_with_callback` delegates to the unchanged SDK `ExecutionDispatcher` (`send_task(..., link=, link_error=)`), no continuation payload, no self-chain. **Call sites are unchanged** — they keep passing Celery `Signature`s; the dispatcher translates them only on the PG branch.

## Tests

- payload set/unset (optional keys), `signature → spec` translation (incl. missing-queue fail-fast)
- consumer self-chain success/error branches + chain-enqueue-failure-still-acks guard
- routing gate ON/OFF for all three dispatch modes (backend + workers)

## Dev-tested end-to-end (flag ON)

`backend dispatch_with_callback → PG → worker-pg-executor execute_extraction → self-chain → worker-pg-ide-callback ide_prompt_complete → emit-websocket 200, output persisted` — zero RabbitMQ. Non-regression confirmed with a flag ON/OFF A/B (identical behaviour).

After this slice the executor transport is fully on PG; RabbitMQ can be decommissioned next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)