### PR TITLE
[FIX] Revert djangorestframework 3.15.2 → 3.14.0 to avoid UniqueTogetherValidator errors

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "cron-descriptor==1.4.0", # For cron string description
     "cryptography>=48.0.1",
     "django==4.2.30",
-    "djangorestframework==3.15.2",
+    "djangorestframework==3.14.0",
     "django-cors-headers==4.3.1",
     # Pinning django-celery-beat to avoid build issues
     "django-celery-beat==2.5.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -874,14 +874,15 @@ wheels = [
 
 [[package]]
 name = "djangorestframework"
-version = "3.15.2"
+version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ce/31482eb688bdb4e271027076199e1aa8d02507e530b6d272ab8b4481557c/djangorestframework-3.15.2.tar.gz", hash = "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad", size = 1067420, upload-time = "2024-06-19T07:59:32.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/53/5b2a002c5ebafd60dff1e1945a7d63dee40155830997439a9ba324f0fd50/djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8", size = 1055343, upload-time = "2022-09-22T11:38:44.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/b6/fa99d8f05eff3a9310286ae84c4059b08c301ae4ab33ae32e46e8ef76491/djangorestframework-3.15.2-py3-none-any.whl", hash = "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20", size = 1071235, upload-time = "2024-06-19T07:59:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4b/3b46c0914ba4b7546a758c35fdfa8e7f017fcbe7f23c878239e93623337a/djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08", size = 1062761, upload-time = "2022-09-22T11:38:41.825Z" },
 ]
 
 [[package]]
@@ -3740,7 +3741,7 @@ requires-dist = [
     { name = "django-log-request-id", specifier = ">=2.1.0" },
     { name = "django-redis", specifier = "==5.4.0" },
     { name = "django-tenants", specifier = "==3.5.0" },
-    { name = "djangorestframework", specifier = "==3.15.2" },
+    { name = "djangorestframework", specifier = "==3.14.0" },
     { name = "drf-standardized-errors", specifier = ">=0.12.6" },
     { name = "drf-yasg", specifier = ">=1.21.8" },
     { name = "google-cloud-recaptcha-enterprise", specifier = ">=1.28.2" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ hook-check-django-migrations = [
     "celery>=5.3.4",
     "cron-descriptor==1.4.0",
     "django==4.2.30",
-    "djangorestframework==3.15.2",
+    "djangorestframework==3.14.0",
     # Pinning django-celery-beat to avoid build issues
     "django-celery-beat==2.5.0",
     "django-cors-headers>=4.3.1",

--- a/uv.lock
+++ b/uv.lock
@@ -834,14 +834,15 @@ wheels = [
 
 [[package]]
 name = "djangorestframework"
-version = "3.15.2"
+version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ce/31482eb688bdb4e271027076199e1aa8d02507e530b6d272ab8b4481557c/djangorestframework-3.15.2.tar.gz", hash = "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad", size = 1067420, upload-time = "2024-06-19T07:59:32.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/53/5b2a002c5ebafd60dff1e1945a7d63dee40155830997439a9ba324f0fd50/djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8", size = 1055343, upload-time = "2022-09-22T11:38:44.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/b6/fa99d8f05eff3a9310286ae84c4059b08c301ae4ab33ae32e46e8ef76491/djangorestframework-3.15.2-py3-none-any.whl", hash = "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20", size = 1071235, upload-time = "2024-06-19T07:59:26.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4b/3b46c0914ba4b7546a758c35fdfa8e7f017fcbe7f23c878239e93623337a/djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08", size = 1062761, upload-time = "2022-09-22T11:38:41.825Z" },
 ]
 
 [[package]]
@@ -3892,7 +3893,7 @@ hook-check-django-migrations = [
     { name = "django-cors-headers", specifier = ">=4.3.1" },
     { name = "django-redis", specifier = "==5.4.0" },
     { name = "django-tenants", specifier = "==3.5.0" },
-    { name = "djangorestframework", specifier = "==3.15.2" },
+    { name = "djangorestframework", specifier = "==3.14.0" },
     { name = "drf-yasg", specifier = "==1.21.7" },
     { name = "psycopg2-binary", specifier = "==2.9.9" },
     { name = "python-dotenv", specifier = "==1.2.2" },


### PR DESCRIPTION
## What

Pins `djangorestframework` back to **3.14.0** (from 3.15.2, bumped in #2087). Reverts only the DRF entry; other batched bumps from #2087 are untouched. Touches both `pyproject.toml` + both `uv.lock` (root + backend). `uv lock --check` passes.

## Why

DRF 3.15.2 regressed **rc.343**. DRF 3.15 auto-derives multi-field `UniqueTogetherValidator`s from model `UniqueConstraint`s (3.14 only did this for legacy `unique_together`). Every `ModelSerializer(fields="__all__")` over a model using `Meta.constraints=[UniqueConstraint(...)]` breaks two ways:

1. **Server-set constraint field** (e.g. `organization`) → `<field>: This field is required` on create. Partially patched by #2092 (5 org-attached models + mixin).
2. **Client-supplied constraint fields** (TableSettings, ProfileManager, agentic table settings, lookups) → `non_field_errors: "...must make a unique set"` raised at `is_valid()`, **short-circuiting** the views' intended `except IntegrityError: raise DuplicateData(<friendly>)` path. This replaced the friendly message *and* moved the error from a top-level `detail` string into nested `non_field_errors`, which the frontend doesn't surface → **silent failures**.

### QA-reported symptoms traced to this (rc.343)
- Prompt **table settings** not editable after first save (re-save → 400, `update_or_create` never runs).
- Duplicate **LLM profile** name → no error notification (silent fail); spec `test_profile_manager_dependency: Expected duplicate-profile error, got ""`.

## Trade-off

Loses the **CVE-2024-21520** XSS patch carried by 3.15.2 — **intentionally deprioritized** for now. The 3.15 upgrade will be reattempted as its own PR with a serializer-level fix (drop auto-derived uniqueness validators so duplicates flow to the DB `IntegrityError → DuplicateData` path).

## Note on recent fixes

The `organization editable=False` changes (#2092) remain correct under 3.14 — org is set server-side in `save()` from `UserContext`, never from request input, and the migrations are state-only (no DDL). No rollback needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)