### PR TITLE
[FIX] Surface non_field_errors and name resources in 404s in the central DRF error path

### DIFF
--- a/backend/middleware/exception.py
+++ b/backend/middleware/exception.py
@@ -73,7 +73,8 @@ def _enrich_not_found_detail(response: Response | None, context: Any) -> None:
         return
     label = str(model._meta.verbose_name).capitalize()
     for err in data.get("errors", []):
-        if err.get("code") == "not_found":
+        # Guard: a raise here would mask the original error with a 500.
+        if isinstance(err, dict) and err.get("code") == "not_found":
             err["detail"] = f"{label} not found."
 
 

--- a/backend/middleware/exception.py
+++ b/backend/middleware/exception.py
@@ -47,10 +47,34 @@ def drf_logging_exc_handler(exc: Exception, context: Any) -> Response | None:
         return response
 
     response: Response | None = exception_handler(exc=exc, context=context)
+    _enrich_not_found_detail(response=response, context=context)
     ExceptionLoggingMiddleware.format_exc_and_log(
         request=request, response=response, exception=exc
     )
     return response
+
+
+def _enrich_not_found_detail(response: Response | None, context: Any) -> None:
+    """Replace DRF's generic "Not found." with the resource's name.
+
+    Derives a human label from the view's `queryset` model so every 404
+    reads "<Resource> not found." app-wide, no per-view work. Uses the
+    static `queryset` attr (not `get_queryset()`) to avoid running view
+    logic during error handling; views without it keep the generic message.
+    Override `Meta.verbose_name` to tune a model's label.
+    """
+    if response is None or getattr(response, "status_code", None) != 404:
+        return
+    data = getattr(response, "data", None)
+    if not isinstance(data, dict):
+        return
+    model = getattr(getattr(context.get("view"), "queryset", None), "model", None)
+    if model is None:
+        return
+    label = str(model._meta.verbose_name).capitalize()
+    for err in data.get("errors", []):
+        if err.get("code") == "not_found":
+            err["detail"] = f"{label} not found."
 
 
 class ExceptionLoggingMiddleware:

--- a/backend/middleware/test_exception.py
+++ b/backend/middleware/test_exception.py
@@ -57,3 +57,11 @@ def test_non_404_untouched():
 
 def test_none_response_is_safe():
     _enrich_not_found_detail(None, {})
+
+
+def test_non_dict_error_item_does_not_raise():
+    resp = _Resp(
+        404, {"errors": ["unexpected", {"code": "not_found", "detail": "Not found."}]}
+    )
+    _enrich_not_found_detail(resp, {"view": _View()})
+    assert resp.data["errors"][1]["detail"] == "Lookup definition not found."

--- a/backend/middleware/test_exception.py
+++ b/backend/middleware/test_exception.py
@@ -1,0 +1,59 @@
+"""Unit checks for the 404 detail enrichment in the DRF exception handler.
+
+Pure-logic; uses fakes so no DB or real models are needed. Importing the
+handler pulls DRF, which reads settings at import — configure a minimal
+settings object when the suite hasn't already, so this runs standalone too.
+"""
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(DEBUG=True, INSTALLED_APPS=[], DATABASES={})
+    django.setup()
+
+from middleware.exception import _enrich_not_found_detail  # noqa: E402
+
+
+class _Meta:
+    verbose_name = "lookup definition"
+
+
+class _Model:
+    _meta = _Meta
+
+
+class _QuerySet:
+    model = _Model
+
+
+class _View:
+    queryset = _QuerySet
+
+
+class _Resp:
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self.data = data
+
+
+def test_404_with_model_uses_verbose_name():
+    resp = _Resp(404, {"errors": [{"code": "not_found", "detail": "Not found."}]})
+    _enrich_not_found_detail(resp, {"view": _View()})
+    assert resp.data["errors"][0]["detail"] == "Lookup definition not found."
+
+
+def test_404_without_queryset_keeps_generic():
+    resp = _Resp(404, {"errors": [{"code": "not_found", "detail": "Not found."}]})
+    _enrich_not_found_detail(resp, {"view": object()})
+    assert resp.data["errors"][0]["detail"] == "Not found."
+
+
+def test_non_404_untouched():
+    resp = _Resp(400, {"errors": [{"code": "not_found", "detail": "Not found."}]})
+    _enrich_not_found_detail(resp, {"view": _View()})
+    assert resp.data["errors"][0]["detail"] == "Not found."
+
+
+def test_none_response_is_safe():
+    _enrich_not_found_detail(None, {})

--- a/backend/middleware/test_exception.py
+++ b/backend/middleware/test_exception.py
@@ -9,7 +9,7 @@ import django
 from django.conf import settings
 
 if not settings.configured:
-    settings.configure(DEBUG=True, INSTALLED_APPS=[], DATABASES={})
+    settings.configure(INSTALLED_APPS=[], DATABASES={})
     django.setup()
 
 from middleware.exception import _enrich_not_found_detail  # noqa: E402

--- a/frontend/src/hooks/useExceptionHandler.jsx
+++ b/frontend/src/hooks/useExceptionHandler.jsx
@@ -51,14 +51,14 @@ const useExceptionHandler = () => {
             // Field-bound errors render inline next to their input. Errors not
             // tied to a field (non_field_errors / attr-less) map to no input and
             // would otherwise vanish silently — surface them as a toast.
-            const nonFieldErrors = (errors || []).filter(
+            const nonFieldErrors = (Array.isArray(errors) ? errors : []).filter(
               (error) => !error?.attr || error.attr === "non_field_errors",
             );
             if (nonFieldErrors.length > 0) {
               return alert(
                 nonFieldErrors
                   .map((error) => error?.detail || errMessage)
-                  .join("\n"),
+                  .join(" • "),
               );
             }
             // No non-field errors: field-level errors are rendered inline.

--- a/frontend/src/hooks/useExceptionHandler.jsx
+++ b/frontend/src/hooks/useExceptionHandler.jsx
@@ -48,6 +48,20 @@ const useExceptionHandler = () => {
           // Handle validation errors
           if (setBackendErrors) {
             setBackendErrors(err?.response?.data);
+            // Field-bound errors render inline next to their input. Errors not
+            // tied to a field (non_field_errors / attr-less) map to no input and
+            // would otherwise vanish silently — surface them as a toast.
+            const nonFieldErrors = (errors || []).filter(
+              (error) => !error?.attr || error.attr === "non_field_errors",
+            );
+            if (nonFieldErrors.length > 0) {
+              return alert(
+                nonFieldErrors
+                  .map((error) => error?.detail || errMessage)
+                  .join("\n"),
+              );
+            }
+            // No non-field errors: field-level errors are rendered inline.
           } else {
             // Handle both single error and array of errors
             let errorMessage = "Validation error";

--- a/frontend/src/hooks/useExceptionHandler.jsx
+++ b/frontend/src/hooks/useExceptionHandler.jsx
@@ -48,9 +48,8 @@ const useExceptionHandler = () => {
           // Handle validation errors
           if (setBackendErrors) {
             setBackendErrors(err?.response?.data);
-            // Field-bound errors render inline next to their input. Errors not
-            // tied to a field (non_field_errors / attr-less) map to no input and
-            // would otherwise vanish silently — surface them as a toast.
+            // Non-field errors map to no input and would vanish silently;
+            // surface them as a toast. Field-bound errors render inline.
             const nonFieldErrors = (Array.isArray(errors) ? errors : []).filter(
               (error) => !error?.attr || error.attr === "non_field_errors",
             );
@@ -61,7 +60,6 @@ const useExceptionHandler = () => {
                   .join(" • "),
               );
             }
-            // No non-field errors: field-level errors are rendered inline.
           } else {
             // Handle both single error and array of errors
             let errorMessage = "Validation error";


### PR DESCRIPTION
## What
Two complementary fixes in the central DRF error path so API errors reach the user with usable text instead of silently vanishing or showing a context-free message.

### 1. Surface `non_field_errors` as a toast (frontend)
`useExceptionHandler` now surfaces validation errors that aren't bound to a form field (`non_field_errors`, or errors with no `attr`) as a toast, in addition to the existing inline field-error rendering.

When a form passes `setBackendErrors`, the handler routed `validation_error` responses to inline field rendering and returned no alert. Inline errors are matched to inputs by `attr` (via `getBackendErrorDetail`), but `non_field_errors` maps to **no** input — so those errors were rendered nowhere and **no toast** fired. The request looked like it silently succeeded. This became user-visible after the DRF 3.15 bump: duplicate-create errors arrive as nested `non_field_errors` (`"...must make a unique set"`) instead of a top-level `detail`. Reproduced on duplicate LLM profile name and table settings save (QA, rc.343).

### 2. Name the resource in 404s (backend)
DRF returns a bare `"Not found."` for **every** 404 across all apps, giving the user no context (the symptom behind the lookup-not-visible toast from unstract-cloud #1570). `drf_logging_exc_handler` now enriches the 404 detail using the view's `queryset` model `verbose_name`, so errors read **"<Resource> not found."** app-wide — no per-view or per-caller work, and future endpoints get it automatically.

- Uses the static `queryset` attr (not `get_queryset()`) to avoid running view logic during error handling.
- Uses `model._meta.verbose_name` (plain language) rather than the PascalCase class name; models can tune their label via `Meta.verbose_name`.
- Views without a static `queryset` keep the generic message — no regression.

## Scope / safety
- Both changes live in the single central error path → fix every consumer, not one form/view.
- No new deps. Biome + Prettier + ruff clean.
- FE change independent of DRF version (valuable on 3.14 today and 3.15 later).
- BE change covered by `backend/middleware/test_exception.py` (4 cases: enriched, no-queryset fallback, non-404 untouched, None-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)