### PR TITLE
UN-3610 [FEAT] PG Queue — reaper retention sweep (pg_task_result + pg_batch_dedup orphans)

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -837,6 +837,12 @@ services:
       - APPLICATION_NAME=unstract-worker-pg-reaper
       - WORKER_PG_REAPER_INTERVAL_SECONDS=${WORKER_PG_REAPER_INTERVAL_SECONDS:-5}
       - WORKER_PG_REAPER_HEALTH_PORT=8086
+      # Retention sweep (cadence-gated inside the leader's tick): drop expired
+      # pg_task_result rows + orphaned pg_batch_dedup markers so neither grows
+      # unbounded as the gate ramps. Dedup retention must exceed the longest
+      # execution (default 24h) so an in-flight marker is never swept.
+      - WORKER_PG_REAPER_SWEEP_SECONDS=${WORKER_PG_REAPER_SWEEP_SECONDS:-300}
+      - WORKER_PG_DEDUP_RETENTION_SECONDS=${WORKER_PG_DEDUP_RETENTION_SECONDS:-86400}
     labels:
       - traefik.enable=false
     volumes:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -839,8 +839,9 @@ services:
       - WORKER_PG_REAPER_HEALTH_PORT=8086
       # Retention sweep (cadence-gated inside the leader's tick): drop expired
       # pg_task_result rows + orphaned pg_batch_dedup markers so neither grows
-      # unbounded as the gate ramps. Dedup retention must exceed the longest
-      # execution (default 24h) so an in-flight marker is never swept.
+      # unbounded as the gate ramps. The dedup retention below (default 24h) should
+      # be kept above the longest possible execution, so an in-flight marker is
+      # never swept.
       - WORKER_PG_REAPER_SWEEP_SECONDS=${WORKER_PG_REAPER_SWEEP_SECONDS:-300}
       - WORKER_PG_DEDUP_RETENTION_SECONDS=${WORKER_PG_DEDUP_RETENTION_SECONDS:-86400}
     labels:

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -51,7 +51,8 @@ import os
 import signal
 import threading
 import time
-from typing import TYPE_CHECKING, NamedTuple, Protocol
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, TypeVar
 
 from unstract.core.data_models import ExecutionStatus
 
@@ -69,6 +70,15 @@ logger = logging.getLogger(__name__)
 # Cadence: how often the leader renews + runs recovery. Enforced shorter than
 # the lease window in PgReaper.__init__.
 _DEFAULT_REAPER_INTERVAL_SECONDS = 5.0
+# Retention sweep cadence — far rarer than the tick (cleanup, not recovery), so
+# the per-cycle DELETE doesn't run every few seconds.
+_DEFAULT_SWEEP_INTERVAL_SECONDS = 300.0
+# How long an orphaned ``pg_batch_dedup`` marker lives before the sweep drops it.
+# MUST exceed the longest possible execution so an in-flight marker is never swept
+# out from under a running fan-out. 24h is comfortably above any single execution.
+_DEFAULT_DEDUP_RETENTION_SECONDS = 86400
+
+_N = TypeVar("_N", int, float)
 
 
 class LeaderLeaseLike(Protocol):
@@ -125,6 +135,91 @@ def reaper_interval_from_env() -> float:
             f"Unset it to default to {_DEFAULT_REAPER_INTERVAL_SECONDS}s."
         )
     return value
+
+
+def _positive_duration_from_env(name: str, default: _N, cast: Callable[[str], _N]) -> _N:
+    """Read a positive duration env var (default on unset; raise on invalid/<=0).
+
+    Same loud-on-misconfig posture as :func:`reaper_interval_from_env`, shared by
+    the sweep-cadence and dedup-retention knobs.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = cast(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{name}={raw!r} is not a number. Unset it to default to {default}."
+        ) from exc
+    if value <= 0:
+        raise ValueError(
+            f"{name}={value} must be positive. Unset it to default to {default}."
+        )
+    return value
+
+
+def reaper_sweep_interval_from_env() -> float:
+    """Retention-sweep cadence from ``WORKER_PG_REAPER_SWEEP_SECONDS`` (default 300s)."""
+    return _positive_duration_from_env(
+        "WORKER_PG_REAPER_SWEEP_SECONDS", _DEFAULT_SWEEP_INTERVAL_SECONDS, float
+    )
+
+
+def dedup_retention_from_env() -> int:
+    """Dedup-orphan age from ``WORKER_PG_DEDUP_RETENTION_SECONDS`` (default 24h)."""
+    return _positive_duration_from_env(
+        "WORKER_PG_DEDUP_RETENTION_SECONDS", _DEFAULT_DEDUP_RETENTION_SECONDS, int
+    )
+
+
+def sweep_expired_results(conn: PgConnection) -> int:
+    """Delete expired executor-RPC result rows; return the number deleted.
+
+    ``pg_task_result`` rows carry ``expires_at = now() + retention`` (written by
+    the consumer's ``store_result``). Once past it no caller can still be waiting
+    (the result outlived the caller-timeout), so the row is safe to drop. The
+    table has no other reader once expired, so this is the only thing keeping it
+    from growing unbounded with each RPC. Idempotent (``DELETE … WHERE``) and uses
+    the ``pg_task_result_expires_idx`` index. Rolls back on error so the manual-
+    commit connection isn't left in an aborted-txn state.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM pg_task_result WHERE expires_at <= now()")
+            deleted = cur.rowcount
+        conn.commit()
+        return deleted
+    except Exception:
+        with contextlib.suppress(Exception):
+            conn.rollback()
+        raise
+
+
+def sweep_orphan_dedup(conn: PgConnection, retention_seconds: int) -> int:
+    """Delete orphaned per-batch dedup markers older than *retention_seconds*.
+
+    ``pg_batch_dedup`` markers are normally cleared on barrier teardown / reaper
+    barrier-recovery, but a partial-failure execution can leave them behind. A
+    marker only matters while its execution is in flight, so anything older than
+    the longest possible execution (*retention_seconds*) is a safe-to-drop orphan.
+    Time-based on ``created_at`` (the table has no per-row expiry column).
+    Idempotent; rolls back on error.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM pg_batch_dedup "
+                "WHERE created_at <= now() - make_interval(secs => %s)",
+                (retention_seconds,),
+            )
+            deleted = cur.rowcount
+        conn.commit()
+        return deleted
+    except Exception:
+        with contextlib.suppress(Exception):
+            conn.rollback()
+        raise
 
 
 def _execution_status(
@@ -380,6 +475,8 @@ class PgReaper:
         lease: LeaderLeaseLike,
         *,
         interval_seconds: float | None = None,
+        sweep_interval_seconds: float | None = None,
+        dedup_retention_seconds: int | None = None,
         sweep_conn: PgConnection | None = None,
         api_client: InternalAPIClient | None = None,
     ) -> None:
@@ -401,6 +498,25 @@ class PgReaper:
                 f"lease window {lease.lease_seconds}s, or the leader loses the "
                 f"lease between renews"
             )
+        # Retention-sweep cadence + dedup-orphan horizon (validated like interval:
+        # an injected non-positive value reaches here unvalidated by the env parser).
+        self._sweep_interval = (
+            sweep_interval_seconds
+            if sweep_interval_seconds is not None
+            else reaper_sweep_interval_from_env()
+        )
+        if self._sweep_interval <= 0:
+            raise ValueError("sweep_interval_seconds must be positive")
+        self._dedup_retention = (
+            dedup_retention_seconds
+            if dedup_retention_seconds is not None
+            else dedup_retention_from_env()
+        )
+        if self._dedup_retention <= 0:
+            raise ValueError("dedup_retention_seconds must be positive")
+        # 0 → "never swept", so the first leader tick sweeps immediately; advanced
+        # to monotonic() each sweep so the cadence holds thereafter.
+        self._last_sweep_monotonic = 0.0
         self._sweep_conn = sweep_conn
         self._owns_sweep_conn = sweep_conn is None
         # Lazily built so the reaper can be constructed without env/HTTP set up
@@ -499,7 +615,38 @@ class PgReaper:
         except Exception:
             self._discard_owned_sweep_conn()
             raise
+        # Orchestrator's third job: retention cleanup (cadence-gated, so it does
+        # NOT run every tick). Last so a sweep error can't skip recovery/schedules.
+        self._maybe_sweep()
         return TickOutcome(was_leader=True, reclaimed=reclaimed)
+
+    def _maybe_sweep(self) -> None:
+        """Run the retention sweep at most once per ``_sweep_interval``.
+
+        Leader-only (called from :meth:`tick` after recovery + schedules). Deletes
+        expired ``pg_task_result`` rows and orphaned ``pg_batch_dedup`` markers so
+        neither table grows unbounded as the gate ramps. The cadence is advanced
+        BEFORE sweeping so a failure waits one interval before retry rather than
+        hammering the DB every tick; the owned sweep conn is discarded on error
+        (parity with recovery/schedules).
+        """
+        now = time.monotonic()
+        if now - self._last_sweep_monotonic < self._sweep_interval:
+            return
+        self._last_sweep_monotonic = now
+        try:
+            results = sweep_expired_results(self._get_sweep_conn())
+            dedup = sweep_orphan_dedup(self._get_sweep_conn(), self._dedup_retention)
+        except Exception:
+            self._discard_owned_sweep_conn()
+            raise
+        if results or dedup:
+            logger.info(
+                "Reaper: retention sweep deleted %s pg_task_result + "
+                "%s pg_batch_dedup row(s)",
+                results,
+                dedup,
+            )
 
     def run(self, *, install_signals: bool = True) -> None:
         """Lease-maintenance + recovery loop until stopped; releases on exit."""

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -151,8 +151,10 @@ def _positive_duration_from_env(name: str, default: _N, cast: Callable[[str], _N
     try:
         value = cast(raw)
     except ValueError as exc:
+        # Include the cause: an int knob given "1.5" IS a number, just not an int —
+        # "is not a number" would mislead. The cause spells out the real reason.
         raise ValueError(
-            f"{name}={raw!r} is not a number. Unset it to default to {default}."
+            f"{name}={raw!r} cannot be parsed: {exc}. Unset it to default to {default}."
         ) from exc
     if value <= 0:
         raise ValueError(
@@ -696,7 +698,7 @@ class PgReaper:
             self._sweep_fail_streak[table] = streak
             logger.exception(
                 "Reaper: retention sweep of %s failed (%s consecutive) — will retry "
-                "next cycle",
+                "after the next sweep interval",
                 table,
                 streak,
             )

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -73,9 +73,11 @@ _DEFAULT_REAPER_INTERVAL_SECONDS = 5.0
 # Retention sweep cadence — far rarer than the tick (cleanup, not recovery), so
 # the per-cycle DELETE doesn't run every few seconds.
 _DEFAULT_SWEEP_INTERVAL_SECONDS = 300.0
-# How long an orphaned ``pg_batch_dedup`` marker lives before the sweep drops it.
-# MUST exceed the longest possible execution so an in-flight marker is never swept
-# out from under a running fan-out. 24h is comfortably above any single execution.
+# Default age before an orphaned ``pg_batch_dedup`` marker is swept. Should be set
+# (here / via WORKER_PG_DEDUP_RETENTION_SECONDS) above the longest possible
+# execution, else a still-in-flight marker could be swept out from under a running
+# fan-out — this is operator-enforced, not coupled in code to the actual bound. 24h
+# is comfortably above any single execution.
 _DEFAULT_DEDUP_RETENTION_SECONDS = 86400
 
 _N = TypeVar("_N", int, float)
@@ -173,16 +175,38 @@ def dedup_retention_from_env() -> int:
     )
 
 
+def _rollback_after_sweep_failure(conn: PgConnection, table: str) -> None:
+    """Roll back after a failed sweep DELETE; surface a rollback that itself fails.
+
+    The caller re-raises the original error regardless — but a rollback that also
+    raises (broken socket / admin-terminated backend) signals a dead connection, so
+    log it rather than swallow it silently (which would hide why the next cycle's
+    reconnect is needed).
+    """
+    try:
+        conn.rollback()
+    except Exception:
+        logger.warning(
+            "Reaper: rollback after a failed %s sweep also failed "
+            "(connection likely dead)",
+            table,
+            exc_info=True,
+        )
+
+
 def sweep_expired_results(conn: PgConnection) -> int:
     """Delete expired executor-RPC result rows; return the number deleted.
 
     ``pg_task_result`` rows carry ``expires_at = now() + retention`` (written by
-    the consumer's ``store_result``). Once past it no caller can still be waiting
-    (the result outlived the caller-timeout), so the row is safe to drop. The
-    table has no other reader once expired, so this is the only thing keeping it
-    from growing unbounded with each RPC. Idempotent (``DELETE … WHERE``) and uses
-    the ``pg_task_result_expires_idx`` index. Rolls back on error so the manual-
-    commit connection isn't left in an aborted-txn state.
+    the consumer's ``store_result``, ``DEFAULT_RETENTION_SECONDS``). Once past it no
+    caller is still waiting **by default** — that retention matches the caller-
+    timeout default (``EXECUTOR_RESULT_TIMEOUT``), so the result has outlived any
+    wait. (An operator who raises the caller timeout ABOVE the store retention could
+    in principle have a result swept mid-wait; size the retention >= the longest
+    caller timeout.) The table has no other reader once expired, so this is the only
+    thing keeping it from growing unbounded with each RPC. Idempotent
+    (``DELETE … WHERE``) and uses the ``pg_task_result_expires_idx`` index. Rolls
+    back on error so the manual-commit connection isn't left in an aborted-txn state.
     """
     try:
         with conn.cursor() as cur:
@@ -191,8 +215,7 @@ def sweep_expired_results(conn: PgConnection) -> int:
         conn.commit()
         return deleted
     except Exception:
-        with contextlib.suppress(Exception):
-            conn.rollback()
+        _rollback_after_sweep_failure(conn, "pg_task_result")
         raise
 
 
@@ -203,7 +226,9 @@ def sweep_orphan_dedup(conn: PgConnection, retention_seconds: int) -> int:
     barrier-recovery, but a partial-failure execution can leave them behind. A
     marker only matters while its execution is in flight, so anything older than
     the longest possible execution (*retention_seconds*) is a safe-to-drop orphan.
-    Time-based on ``created_at`` (the table has no per-row expiry column).
+    Filters on ``created_at``, which is deliberately **unindexed** (see
+    ``backend/pg_queue/models.py``), so each sweep seq-scans — fine at the 5-min
+    cadence on a normally-near-empty table; add an index if the dedup table grows.
     Idempotent; rolls back on error.
     """
     try:
@@ -217,8 +242,7 @@ def sweep_orphan_dedup(conn: PgConnection, retention_seconds: int) -> int:
         conn.commit()
         return deleted
     except Exception:
-        with contextlib.suppress(Exception):
-            conn.rollback()
+        _rollback_after_sweep_failure(conn, "pg_batch_dedup")
         raise
 
 
@@ -514,9 +538,13 @@ class PgReaper:
         )
         if self._dedup_retention <= 0:
             raise ValueError("dedup_retention_seconds must be positive")
-        # 0 → "never swept", so the first leader tick sweeps immediately; advanced
-        # to monotonic() each sweep so the cadence holds thereafter.
-        self._last_sweep_monotonic = 0.0
+        # None → "never swept", so the first leader tick sweeps immediately; set to
+        # monotonic() each sweep so the cadence holds thereafter. (A None sentinel,
+        # not 0.0, so the gate doesn't lean on monotonic() never returning ~0.)
+        self._last_sweep_monotonic: float | None = None
+        # Per-table consecutive-failure streak — surfaced in the failure log so a
+        # persistently-failing sweep (and which table) is traceable in prod.
+        self._sweep_fail_streak: dict[str, int] = {}
         self._sweep_conn = sweep_conn
         self._owns_sweep_conn = sweep_conn is None
         # Lazily built so the reaper can be constructed without env/HTTP set up
@@ -625,21 +653,24 @@ class PgReaper:
 
         Leader-only (called from :meth:`tick` after recovery + schedules). Deletes
         expired ``pg_task_result`` rows and orphaned ``pg_batch_dedup`` markers so
-        neither table grows unbounded as the gate ramps. The cadence is advanced
-        BEFORE sweeping so a failure waits one interval before retry rather than
-        hammering the DB every tick; the owned sweep conn is discarded on error
-        (parity with recovery/schedules).
+        neither table grows unbounded as the gate ramps. The two sweeps run
+        **independently** (via :meth:`_run_sweep`): they cover different tables, so
+        a persistent fault in one must not skip — and then cadence-gate out — the
+        other. The cadence is advanced BEFORE sweeping so a failure waits one
+        interval before retry rather than hammering the DB every tick.
         """
         now = time.monotonic()
-        if now - self._last_sweep_monotonic < self._sweep_interval:
+        if (
+            self._last_sweep_monotonic is not None
+            and now - self._last_sweep_monotonic < self._sweep_interval
+        ):
             return
         self._last_sweep_monotonic = now
-        try:
-            results = sweep_expired_results(self._get_sweep_conn())
-            dedup = sweep_orphan_dedup(self._get_sweep_conn(), self._dedup_retention)
-        except Exception:
-            self._discard_owned_sweep_conn()
-            raise
+        results = self._run_sweep("pg_task_result", sweep_expired_results)
+        dedup = self._run_sweep(
+            "pg_batch_dedup",
+            lambda conn: sweep_orphan_dedup(conn, self._dedup_retention),
+        )
         if results or dedup:
             logger.info(
                 "Reaper: retention sweep deleted %s pg_task_result + "
@@ -647,6 +678,32 @@ class PgReaper:
                 results,
                 dedup,
             )
+
+    def _run_sweep(self, table: str, fn: Callable[[PgConnection], int]) -> int:
+        """Run one retention sweep best-effort; return its row count (0 on failure).
+
+        A cleanup failure is NOT propagated (it must not fail the tick) and must not
+        starve the sibling sweep — it is logged at this boundary with the table name
+        and a consecutive-failure streak (so a bloated ``pg_task_result`` /
+        ``pg_batch_dedup`` in prod is traceable, distinct from the generic
+        tick-failure log), and the owned conn is discarded so the next cycle
+        reconnects. A clean run resets the streak.
+        """
+        try:
+            count = fn(self._get_sweep_conn())
+        except Exception:
+            streak = self._sweep_fail_streak.get(table, 0) + 1
+            self._sweep_fail_streak[table] = streak
+            logger.exception(
+                "Reaper: retention sweep of %s failed (%s consecutive) — will retry "
+                "next cycle",
+                table,
+                streak,
+            )
+            self._discard_owned_sweep_conn()
+            return 0
+        self._sweep_fail_streak[table] = 0
+        return count
 
     def run(self, *, install_signals: bool = True) -> None:
         """Lease-maintenance + recovery loop until stopped; releases on exit."""

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -15,6 +15,7 @@ Layers:
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
@@ -103,6 +104,14 @@ class TestSweepEnv:
         with pytest.raises(ValueError):
             dedup_retention_from_env()
 
+    def test_cast_distinction_float_vs_int(self, monkeypatch):
+        # sweep parses as float, dedup as int — the cast is load-bearing.
+        monkeypatch.setenv("WORKER_PG_REAPER_SWEEP_SECONDS", "1.5")
+        assert reaper_sweep_interval_from_env() == pytest.approx(1.5)
+        monkeypatch.setenv("WORKER_PG_DEDUP_RETENTION_SECONDS", "1.5")
+        with pytest.raises(ValueError):  # int("1.5") rejects the fractional value
+            dedup_retention_from_env()
+
 
 class _FakeLease:
     """Duck-typed LeaderLease. ``acquires``/``renews`` accept a bool (constant)
@@ -147,6 +156,21 @@ class TestConstruction:
 
     def test_valid_interval_accepted(self):
         PgReaper(_FakeLease(lease_seconds=10), interval_seconds=3, sweep_conn=object())
+
+    def test_non_positive_sweep_interval_rejected(self):
+        # An injected knob bypasses the env parser's guard → re-validated in __init__.
+        with pytest.raises(ValueError, match="sweep_interval"):
+            PgReaper(
+                _FakeLease(), interval_seconds=1, sweep_interval_seconds=0,
+                sweep_conn=object(),
+            )
+
+    def test_non_positive_dedup_retention_rejected(self):
+        with pytest.raises(ValueError, match="dedup_retention"):
+            PgReaper(
+                _FakeLease(), interval_seconds=1, dedup_retention_seconds=0,
+                sweep_conn=object(),
+            )
 
 
 # --- Layer 2: leadership gating (fake lease + patched sweep, no DB) ---
@@ -321,15 +345,37 @@ class TestRetentionSweepSql:
         assert args[1] == (999,)  # the retention param is bound, not interpolated
         conn.commit.assert_called_once()
 
-    def test_sweep_rolls_back_on_error(self):
+    @pytest.mark.parametrize(
+        "sweep",
+        [
+            lambda conn: sweep_expired_results(conn),
+            lambda conn: sweep_orphan_dedup(conn, 60),
+        ],
+        ids=["expired_results", "orphan_dedup"],
+    )
+    def test_sweep_rolls_back_on_error(self, sweep):
+        # Both helpers have their own try/except/rollback — exercise each.
         cur = MagicMock()
         cur.execute.side_effect = psycopg2.OperationalError("dead")
         conn = MagicMock()
         conn.cursor.return_value.__enter__.return_value = cur
         with pytest.raises(psycopg2.OperationalError):
-            sweep_expired_results(conn)
+            sweep(conn)
         conn.rollback.assert_called_once()
         conn.commit.assert_not_called()
+
+    def test_rollback_failure_is_logged_and_original_error_raised(self, caplog):
+        # If rollback itself raises, surface it (don't swallow) but still propagate
+        # the ORIGINAL DELETE error, not the rollback's.
+        cur = MagicMock()
+        cur.execute.side_effect = psycopg2.OperationalError("dead")
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        conn.rollback.side_effect = psycopg2.InterfaceError("conn dead")
+        with caplog.at_level(logging.WARNING, logger="queue_backend.pg_queue.reaper"):
+            with pytest.raises(psycopg2.OperationalError):
+                sweep_expired_results(conn)
+        assert "rollback after a failed pg_task_result sweep also failed" in caplog.text
 
 
 class TestRetentionSweepTick:
@@ -344,10 +390,11 @@ class TestRetentionSweepTick:
 
     def test_leader_sweeps(self, stub_retention_sweep):
         reaper = self._reaper(_FakeLease(acquires=True, renews=True))
+        conn = reaper._sweep_conn  # capture once (don't re-fetch in the assertion)
         with patch.object(reaper_mod, "recover_expired_barriers", return_value=[]):
             reaper.tick()
-        stub_retention_sweep.results.assert_called_once()
-        stub_retention_sweep.dedup.assert_called_once_with(reaper._get_sweep_conn(), 86400)
+        stub_retention_sweep.results.assert_called_once_with(conn)
+        stub_retention_sweep.dedup.assert_called_once_with(conn, 86400)
 
     def test_standby_does_not_sweep(self, stub_retention_sweep):
         reaper = self._reaper(_FakeLease(acquires=False))
@@ -380,21 +427,64 @@ class TestRetentionSweepTick:
             reaper.tick()
         assert order == ["recover", "schedule", "sweep"]
 
-    def test_sweep_error_discards_owned_conn(self, stub_retention_sweep):
+    def test_one_sweep_failing_does_not_starve_the_other(
+        self, stub_retention_sweep, caplog
+    ):
+        # [High] independence: a failing pg_task_result sweep must NOT skip the
+        # pg_batch_dedup sweep, must NOT propagate (cleanup mustn't fail the tick),
+        # and must discard the owned conn so the sibling reconnects.
         reaper = PgReaper(
             _FakeLease(acquires=True, renews=True),
             interval_seconds=0.01,
             sweep_interval_seconds=300,
             api_client=object(),
         )
-        owned = MagicMock()
-        owned.closed = False
+        owned = MagicMock(closed=False)
         reaper._sweep_conn = owned
         stub_retention_sweep.results.side_effect = psycopg2.OperationalError("db gone")
+        with (
+            patch.object(
+                reaper_mod, "create_pg_connection", return_value=MagicMock(closed=False)
+            ) as reconnect,
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.reaper"),
+        ):
+            reaper.tick()  # must NOT raise
+        stub_retention_sweep.results.assert_called_once()  # attempted + failed
+        stub_retention_sweep.dedup.assert_called_once()  # sibling still ran
+        reconnect.assert_called_once()  # reconnected after the discard
+        assert "retention sweep of pg_task_result failed (1 consecutive)" in caplog.text
+
+    def test_failing_sweep_still_advances_cadence(self, stub_retention_sweep):
+        # The stamp is advanced before the sweep, so a failure waits one interval
+        # before retry (no DB hammering) — a second immediate tick is gated out.
+        reaper = self._reaper(_FakeLease(acquires=True, renews=True))
+        stub_retention_sweep.results.side_effect = RuntimeError("boom")
         with patch.object(reaper_mod, "recover_expired_barriers", return_value=[]):
-            with pytest.raises(psycopg2.OperationalError):
-                reaper.tick()
-        assert reaper._sweep_conn is None  # discarded
+            reaper.tick()
+            reaper.tick()
+        assert stub_retention_sweep.results.call_count == 1  # not retried immediately
+
+    def test_logs_counts_only_when_rows_deleted(self, stub_retention_sweep, caplog):
+        reaper = self._reaper(_FakeLease(acquires=True, renews=True))
+        stub_retention_sweep.results.return_value = 0
+        stub_retention_sweep.dedup.return_value = 4  # one non-zero → still logs
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            caplog.at_level(logging.INFO, logger="queue_backend.pg_queue.reaper"),
+        ):
+            reaper.tick()
+        assert "deleted 0 pg_task_result + 4 pg_batch_dedup row(s)" in caplog.text
+
+    def test_no_log_when_nothing_deleted(self, stub_retention_sweep, caplog):
+        reaper = self._reaper(_FakeLease(acquires=True, renews=True))
+        # both stubs default to return_value=0
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            caplog.at_level(logging.INFO, logger="queue_backend.pg_queue.reaper"),
+        ):
+            reaper.tick()
+        assert "retention sweep deleted" not in caplog.text
 
 
 # --- Layer 3: connection handling (mocked, no DB) ---

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -27,9 +27,14 @@ from queue_backend.pg_queue import reaper as reaper_mod
 from queue_backend.pg_queue.connection import create_pg_connection
 from queue_backend.pg_queue.reaper import (
     PgReaper,
+    dedup_retention_from_env,
     reaper_interval_from_env,
+    reaper_sweep_interval_from_env,
     recover_expired_barriers,
+    sweep_expired_results,
+    sweep_orphan_dedup,
 )
+
 
 # The reaper's leader tick also runs the PG scheduler tick (②b). Its behaviour
 # is covered in test_pg_scheduler.py; stub it here by default so the leadership /
@@ -41,6 +46,20 @@ def stub_scheduler_tick(monkeypatch):
     mock = MagicMock(return_value=0)
     monkeypatch.setattr(reaper_mod, "dispatch_due_schedules", mock)
     return mock
+
+
+# The leader tick also runs the retention sweep (UN-3610). Stub the two sweep
+# helpers by default so the leadership / connection tests don't hit a real DELETE
+# on their dummy connections; the SQL-contract tests import the real helpers
+# directly (unaffected by this module-attribute patch), and the sweep-wiring tests
+# opt in via the returned mocks.
+@pytest.fixture(autouse=True)
+def stub_retention_sweep(monkeypatch):
+    results = MagicMock(return_value=0)
+    dedup = MagicMock(return_value=0)
+    monkeypatch.setattr(reaper_mod, "sweep_expired_results", results)
+    monkeypatch.setattr(reaper_mod, "sweep_orphan_dedup", dedup)
+    return SimpleNamespace(results=results, dedup=dedup)
 
 
 # --- Layer 1: env + construction (no DB) ---
@@ -60,6 +79,29 @@ class TestIntervalEnv:
         monkeypatch.setenv("WORKER_PG_REAPER_INTERVAL_SECONDS", bad)
         with pytest.raises(ValueError):
             reaper_interval_from_env()
+
+
+class TestSweepEnv:
+    def test_sweep_interval_default_and_override(self, monkeypatch):
+        monkeypatch.delenv("WORKER_PG_REAPER_SWEEP_SECONDS", raising=False)
+        assert reaper_sweep_interval_from_env() == pytest.approx(300.0)
+        monkeypatch.setenv("WORKER_PG_REAPER_SWEEP_SECONDS", "30")
+        assert reaper_sweep_interval_from_env() == pytest.approx(30.0)
+
+    def test_dedup_retention_default_and_override(self, monkeypatch):
+        monkeypatch.delenv("WORKER_PG_DEDUP_RETENTION_SECONDS", raising=False)
+        assert dedup_retention_from_env() == 86400
+        monkeypatch.setenv("WORKER_PG_DEDUP_RETENTION_SECONDS", "3600")
+        assert dedup_retention_from_env() == 3600
+
+    @pytest.mark.parametrize("bad", ["0", "-5", "abc"])
+    def test_invalid_raises(self, monkeypatch, bad):
+        monkeypatch.setenv("WORKER_PG_REAPER_SWEEP_SECONDS", bad)
+        monkeypatch.setenv("WORKER_PG_DEDUP_RETENTION_SECONDS", bad)
+        with pytest.raises(ValueError):
+            reaper_sweep_interval_from_env()
+        with pytest.raises(ValueError):
+            dedup_retention_from_env()
 
 
 class _FakeLease:
@@ -243,6 +285,112 @@ class TestSchedulerTick:
         owned.closed = False  # so _get_sweep_conn returns it, doesn't reconnect
         reaper._sweep_conn = owned
         stub_scheduler_tick.side_effect = psycopg2.OperationalError("db gone")
+        with patch.object(reaper_mod, "recover_expired_barriers", return_value=[]):
+            with pytest.raises(psycopg2.OperationalError):
+                reaper.tick()
+        assert reaper._sweep_conn is None  # discarded
+
+
+class TestRetentionSweepSql:
+    """The sweep helpers' SQL contract (mock cursor, no DB). These call the real
+    helpers (imported at module load), unaffected by the autouse stub which patches
+    the module attribute the reaper looks up at call time.
+    """
+
+    @staticmethod
+    def _conn_cur(rowcount):
+        cur = MagicMock()
+        cur.rowcount = rowcount
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        return conn, cur
+
+    def test_sweep_expired_results_sql(self):
+        conn, cur = self._conn_cur(3)
+        assert sweep_expired_results(conn) == 3
+        sql = cur.execute.call_args[0][0]
+        assert "DELETE FROM pg_task_result" in sql and "expires_at <= now()" in sql
+        conn.commit.assert_called_once()
+
+    def test_sweep_orphan_dedup_sql(self):
+        conn, cur = self._conn_cur(2)
+        assert sweep_orphan_dedup(conn, 999) == 2
+        args = cur.execute.call_args[0]
+        assert "DELETE FROM pg_batch_dedup" in args[0]
+        assert "created_at <= now() - make_interval" in args[0]
+        assert args[1] == (999,)  # the retention param is bound, not interpolated
+        conn.commit.assert_called_once()
+
+    def test_sweep_rolls_back_on_error(self):
+        cur = MagicMock()
+        cur.execute.side_effect = psycopg2.OperationalError("dead")
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        with pytest.raises(psycopg2.OperationalError):
+            sweep_expired_results(conn)
+        conn.rollback.assert_called_once()
+        conn.commit.assert_not_called()
+
+
+class TestRetentionSweepTick:
+    """The sweep runs leader-only, after recovery + schedule, cadence-gated."""
+
+    def _reaper(self, lease, **kw):
+        kw.setdefault("sweep_interval_seconds", 300)
+        kw.setdefault("dedup_retention_seconds", 86400)
+        return PgReaper(
+            lease, interval_seconds=0.01, sweep_conn=object(), api_client=object(), **kw
+        )
+
+    def test_leader_sweeps(self, stub_retention_sweep):
+        reaper = self._reaper(_FakeLease(acquires=True, renews=True))
+        with patch.object(reaper_mod, "recover_expired_barriers", return_value=[]):
+            reaper.tick()
+        stub_retention_sweep.results.assert_called_once()
+        stub_retention_sweep.dedup.assert_called_once_with(reaper._get_sweep_conn(), 86400)
+
+    def test_standby_does_not_sweep(self, stub_retention_sweep):
+        reaper = self._reaper(_FakeLease(acquires=False))
+        with patch.object(reaper_mod, "recover_expired_barriers"):
+            reaper.tick()
+        stub_retention_sweep.results.assert_not_called()
+        stub_retention_sweep.dedup.assert_not_called()
+
+    def test_cadence_gates_repeat_within_interval(self, stub_retention_sweep):
+        # Two leader ticks well within the 300s interval → swept once, not twice.
+        reaper = self._reaper(_FakeLease(acquires=True, renews=True))
+        with patch.object(reaper_mod, "recover_expired_barriers", return_value=[]):
+            reaper.tick()
+            reaper.tick()
+        assert stub_retention_sweep.results.call_count == 1
+        assert stub_retention_sweep.dedup.call_count == 1
+
+    def test_runs_after_recovery_and_schedule(
+        self, stub_scheduler_tick, stub_retention_sweep
+    ):
+        order = []
+        reaper = self._reaper(_FakeLease(acquires=True, renews=True))
+        stub_scheduler_tick.side_effect = lambda *_: order.append("schedule")
+        stub_retention_sweep.results.side_effect = lambda *_: order.append("sweep") or 0
+        with patch.object(
+            reaper_mod,
+            "recover_expired_barriers",
+            side_effect=lambda *_: order.append("recover") or [],
+        ):
+            reaper.tick()
+        assert order == ["recover", "schedule", "sweep"]
+
+    def test_sweep_error_discards_owned_conn(self, stub_retention_sweep):
+        reaper = PgReaper(
+            _FakeLease(acquires=True, renews=True),
+            interval_seconds=0.01,
+            sweep_interval_seconds=300,
+            api_client=object(),
+        )
+        owned = MagicMock()
+        owned.closed = False
+        reaper._sweep_conn = owned
+        stub_retention_sweep.results.side_effect = psycopg2.OperationalError("db gone")
         with patch.object(reaper_mod, "recover_expired_barriers", return_value=[]):
             with pytest.raises(psycopg2.OperationalError):
                 reaper.tick()

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -109,7 +109,9 @@ class TestSweepEnv:
         monkeypatch.setenv("WORKER_PG_REAPER_SWEEP_SECONDS", "1.5")
         assert reaper_sweep_interval_from_env() == pytest.approx(1.5)
         monkeypatch.setenv("WORKER_PG_DEDUP_RETENTION_SECONDS", "1.5")
-        with pytest.raises(ValueError):  # int("1.5") rejects the fractional value
+        # int("1.5") rejects the fractional value; the message names the real cause
+        # ("cannot be parsed: …") rather than the misleading "is not a number".
+        with pytest.raises(ValueError, match="cannot be parsed"):
             dedup_retention_from_env()
 
 


### PR DESCRIPTION
## What

Wires the deferred retention sweep into the PG reaper, before the gate ramps toward 100%. Targets `feat/UN-3445-pg-queue-integration` (not `main`).

Two queue-infra tables grow unbounded today:
- **`pg_task_result`** — the executor-RPC result store. Every row already carries `expires_at = now()+3600s` (written by the consumer's `store_result`) and the `pg_task_result_expires_idx` index exists, but nothing deletes expired rows (the model docstring flags the sweep as "not wired yet").
- **`pg_batch_dedup`** — per-`(execution_id, batch_index)` idempotency markers. Cleared on barrier teardown / reaper barrier-recovery, but a partial-failure execution can leave orphans.

## How

- **`sweep_expired_results(conn)`** — `DELETE FROM pg_task_result WHERE expires_at <= now()`. Once past `expires_at` no caller can still be waiting (the result outlived the caller-timeout).
- **`sweep_orphan_dedup(conn, retention)`** — `DELETE FROM pg_batch_dedup WHERE created_at <= now() - interval`. Time-based backstop; retention (default **24h**) must exceed the longest execution so an in-flight marker is never swept.
- Both run in `PgReaper.tick()` **under leadership**, after recovery + schedules, **cadence-gated** by `WORKER_PG_REAPER_SWEEP_SECONDS` (default 300s) so the ~5s loop doesn't `DELETE` every cycle. Own try/except discards the owned sweep conn on error (parity with the existing steps).
- Env knobs (`WORKER_PG_REAPER_SWEEP_SECONDS`, `WORKER_PG_DEDUP_RETENTION_SECONDS`) surfaced on the compose `worker-pg-reaper` service.

## Non-regression

Workers-only: **no migration, no writer change, no flag**. Idempotent (`DELETE WHERE`), dark until rows exist; cadence + leader-gated. The reaper already runs — this adds a third, rarer job to its tick.

## Tests

Env parsers (default/override/invalid), SQL contract (mock cursor — asserts the DELETE shape + bound retention param + rollback-on-error), and tick wiring: leader-only / standby-skips / cadence-gated (one sweep across two quick ticks) / runs-after-recovery-and-schedule / error-discards-owned-conn. **27 green.**

## Dev-tested live

Recreated `worker-pg-reaper` on the rebuilt image; on its first leader tick:
```
Reaper: acquired leadership
Reaper: retention sweep deleted 9 pg_task_result + 1 pg_batch_dedup row(s)
```
The 9 `pg_task_result` rows were real orphans from earlier executor-RPC dev-tests (all >1h past `expires_at`); the `pg_batch_dedup` row was a 25h-old marker seeded for the test. Both tables clean afterward, counts logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)