### PR TITLE
UN-3616 [FEAT] PG Queue — route API-triggered pipeline trigger through the transport flag

### DIFF
--- a/backend/pipeline_v2/piepline_api_execution_views.py
+++ b/backend/pipeline_v2/piepline_api_execution_views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from backend.celery_service import app as celery_app
 from pipeline_v2.deployment_helper import DeploymentHelper
 from pipeline_v2.models import Pipeline
+from pipeline_v2.pipeline_dispatch import dispatch_pipeline_trigger
 
 logger = logging.getLogger(__name__)
 
@@ -29,17 +30,14 @@ class PipelineApiExecution(views.APIView):
     def post(
         self, request: Request, org_name: str, pipeline_id: str, pipeline: Pipeline
     ) -> Response:
-        celery_app.send_task(
-            "scheduler.tasks.execute_pipeline_task",
-            args=[
-                "",  # workflow_id
-                org_name,  # org_schema
-                "",  # execution_action
-                "",  # execution_id
-                pipeline_id,  # pipepline_id
-                True,  # with_logs
-                pipeline.pipeline_name,  # name
-            ],
+        # Route through the transport flag (PG when enabled for this pipeline/org,
+        # else Celery — fail-closed). Matches the scheduled-pipeline path, which
+        # already enqueues this task onto the PG queue.
+        dispatch_pipeline_trigger(
+            celery_app=celery_app,
+            org_id=org_name,
+            pipeline_id=pipeline_id,
+            pipeline_name=pipeline.pipeline_name,
         )
         logger.info(f"Triggered {pipeline} by API")
         return Response({"message": f"Triggered {pipeline}"}, status=status.HTTP_200_OK)

--- a/backend/pipeline_v2/piepline_api_execution_views.py
+++ b/backend/pipeline_v2/piepline_api_execution_views.py
@@ -30,9 +30,8 @@ class PipelineApiExecution(views.APIView):
     def post(
         self, request: Request, org_name: str, pipeline_id: str, pipeline: Pipeline
     ) -> Response:
-        # Route through the transport flag (PG when enabled for this pipeline/org,
-        # else Celery — fail-closed). Matches the scheduled-pipeline path, which
-        # already enqueues this task onto the PG queue.
+        # Route through the transport flag instead of hardcoding Celery
+        # (see dispatch_pipeline_trigger).
         dispatch_pipeline_trigger(
             celery_app=celery_app,
             org_id=org_name,

--- a/backend/pipeline_v2/pipeline_dispatch.py
+++ b/backend/pipeline_v2/pipeline_dispatch.py
@@ -23,7 +23,7 @@ from uuid import UUID
 from pg_queue.producer import enqueue_task
 from workflow_manager.workflow_v2.transport import resolve_transport
 
-from unstract.core.data_models import WorkflowTransport
+from unstract.core.data_models import is_pg_transport
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +56,9 @@ def dispatch_pipeline_trigger(
         organization_id=org_id,
         pipeline_id=pipeline_id,
     )
-    # Compare the enum member (not a bare string) so a literal typo can't silently
-    # fall through to the Celery branch; WorkflowTransport is a str-enum.
-    if transport == WorkflowTransport.PG_QUEUE:
+    # Use the shared is_pg_transport() — the single source for "what counts as PG
+    # transport" — rather than opening a second comparison site.
+    if is_pg_transport(transport):
         msg_id = enqueue_task(
             task_name=PIPELINE_TRIGGER_TASK,
             queue=SCHEDULER_QUEUE,

--- a/backend/pipeline_v2/pipeline_dispatch.py
+++ b/backend/pipeline_v2/pipeline_dispatch.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import UUID
 
 from pg_queue.producer import enqueue_task
 from workflow_manager.workflow_v2.transport import resolve_transport
@@ -36,16 +37,16 @@ SCHEDULER_QUEUE = "scheduler"
 def dispatch_pipeline_trigger(
     *,
     celery_app: Any,
-    org_id: str,
-    pipeline_id: str,
+    org_id: str | UUID,
+    pipeline_id: str | UUID,
     pipeline_name: str,
-) -> str:
+) -> None:
     """Dispatch the pipeline-trigger task on the resolved transport.
 
-    Returns the transport actually used (``"pg_queue"`` / ``"celery"``). The
-    positional args match ``execute_pipeline_task``'s signature on **both** paths:
-    ``(workflow_id, org_schema, execution_action, execution_id, pipeline_id,
-    with_logs, name)``.
+    The positional args match ``execute_pipeline_task``'s signature on **both**
+    paths: ``(workflow_id, org_schema, execution_action, execution_id,
+    pipeline_id, with_logs, name)``. ``org_id`` / ``pipeline_id`` accept ``UUID``
+    (what ``resolve_transport`` takes) and are str-coerced into the task args.
     """
     args = ["", str(org_id), "", "", str(pipeline_id), True, pipeline_name]
     # No execution exists yet (it's created inside the task), so the trigger
@@ -69,7 +70,6 @@ def dispatch_pipeline_trigger(
             pipeline_id,
             msg_id,
         )
-        return transport
-    celery_app.send_task(PIPELINE_TRIGGER_TASK, args=args)
-    logger.info("Pipeline %s trigger dispatched on Celery", pipeline_id)
-    return transport
+    else:
+        celery_app.send_task(PIPELINE_TRIGGER_TASK, args=args)
+        logger.info("Pipeline %s trigger dispatched on Celery", pipeline_id)

--- a/backend/pipeline_v2/pipeline_dispatch.py
+++ b/backend/pipeline_v2/pipeline_dispatch.py
@@ -1,17 +1,17 @@
 """Transport-routed dispatch for the API-triggered pipeline execution trigger.
 
-The **scheduled** pipeline path already enqueues
-``scheduler.tasks.execute_pipeline_task`` onto the PG queue
-(``pg_scheduler.dispatch_due_schedules`` → the ``scheduler`` queue, run by
-``worker-pg-scheduler``). The **API-trigger** view historically sent it only to
-Celery — so when the flag was on, the trigger stayed on Celery while the
-execution it spawns rode PG, breaking uniform flag control. This routes the
-trigger through the same :func:`resolve_transport` flag as everything else.
+Routes ``scheduler.tasks.execute_pipeline_task`` through the same
+:func:`resolve_transport` flag as the rest of the execution path: the PG queue
+when enabled for this pipeline/org, else Celery. **Fail-closed** — with the
+master gate off (the production default) it resolves to Celery, behaving exactly
+like the prior unconditional ``send_task`` (zero regression). The
+scheduled-pipeline path already enqueues this task onto the PG ``scheduler``
+queue (``pg_scheduler.dispatch_due_schedules``, run by ``worker-pg-scheduler``);
+this brings the API-trigger view to parity.
 
-**Fail-closed / zero regression:** with the master gate off (production default)
-``resolve_transport`` returns Celery → identical to the prior ``send_task``. The
-task args are byte-identical on both paths, so the consumer behaves the same
-regardless of transport.
+The same ``args`` are sent on both paths; on PG they're JSON-normalized by
+``enqueue_task`` (UUIDs/datetimes → str), a no-op for these string/bool values,
+so the consumer sees the same payload.
 """
 
 from __future__ import annotations
@@ -47,7 +47,7 @@ def dispatch_pipeline_trigger(
     ``(workflow_id, org_schema, execution_action, execution_id, pipeline_id,
     with_logs, name)``.
     """
-    args = ["", org_id, "", "", str(pipeline_id), True, pipeline_name]
+    args = ["", str(org_id), "", "", str(pipeline_id), True, pipeline_name]
     # No execution exists yet (it's created inside the task), so the trigger
     # buckets the flag by pipeline_id as the sticky entity.
     transport = resolve_transport(
@@ -55,7 +55,9 @@ def dispatch_pipeline_trigger(
         organization_id=org_id,
         pipeline_id=pipeline_id,
     )
-    if transport == WorkflowTransport.PG_QUEUE.value:
+    # Compare the enum member (not a bare string) so a literal typo can't silently
+    # fall through to the Celery branch; WorkflowTransport is a str-enum.
+    if transport == WorkflowTransport.PG_QUEUE:
         msg_id = enqueue_task(
             task_name=PIPELINE_TRIGGER_TASK,
             queue=SCHEDULER_QUEUE,

--- a/backend/pipeline_v2/pipeline_dispatch.py
+++ b/backend/pipeline_v2/pipeline_dispatch.py
@@ -1,0 +1,73 @@
+"""Transport-routed dispatch for the API-triggered pipeline execution trigger.
+
+The **scheduled** pipeline path already enqueues
+``scheduler.tasks.execute_pipeline_task`` onto the PG queue
+(``pg_scheduler.dispatch_due_schedules`` → the ``scheduler`` queue, run by
+``worker-pg-scheduler``). The **API-trigger** view historically sent it only to
+Celery — so when the flag was on, the trigger stayed on Celery while the
+execution it spawns rode PG, breaking uniform flag control. This routes the
+trigger through the same :func:`resolve_transport` flag as everything else.
+
+**Fail-closed / zero regression:** with the master gate off (production default)
+``resolve_transport`` returns Celery → identical to the prior ``send_task``. The
+task args are byte-identical on both paths, so the consumer behaves the same
+regardless of transport.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pg_queue.producer import enqueue_task
+from workflow_manager.workflow_v2.transport import resolve_transport
+
+from unstract.core.data_models import WorkflowTransport
+
+logger = logging.getLogger(__name__)
+
+# The fired task + the PG queue a ``scheduler`` consumer polls. Mirrors
+# ``pg_scheduler.PIPELINE_TRIGGER_TASK`` / ``SCHEDULER_QUEUE_NAME`` — kept as local
+# constants so the backend doesn't import the workers package.
+PIPELINE_TRIGGER_TASK = "scheduler.tasks.execute_pipeline_task"
+SCHEDULER_QUEUE = "scheduler"
+
+
+def dispatch_pipeline_trigger(
+    *,
+    celery_app: Any,
+    org_id: str,
+    pipeline_id: str,
+    pipeline_name: str,
+) -> str:
+    """Dispatch the pipeline-trigger task on the resolved transport.
+
+    Returns the transport actually used (``"pg_queue"`` / ``"celery"``). The
+    positional args match ``execute_pipeline_task``'s signature on **both** paths:
+    ``(workflow_id, org_schema, execution_action, execution_id, pipeline_id,
+    with_logs, name)``.
+    """
+    args = ["", org_id, "", "", str(pipeline_id), True, pipeline_name]
+    # No execution exists yet (it's created inside the task), so the trigger
+    # buckets the flag by pipeline_id as the sticky entity.
+    transport = resolve_transport(
+        execution_id=pipeline_id,
+        organization_id=org_id,
+        pipeline_id=pipeline_id,
+    )
+    if transport == WorkflowTransport.PG_QUEUE.value:
+        msg_id = enqueue_task(
+            task_name=PIPELINE_TRIGGER_TASK,
+            queue=SCHEDULER_QUEUE,
+            args=args,
+            org_id=str(org_id or ""),
+        )
+        logger.info(
+            "Pipeline %s trigger enqueued on PG scheduler queue (msg_id=%s)",
+            pipeline_id,
+            msg_id,
+        )
+        return transport
+    celery_app.send_task(PIPELINE_TRIGGER_TASK, args=args)
+    logger.info("Pipeline %s trigger dispatched on Celery", pipeline_id)
+    return transport

--- a/backend/pipeline_v2/tests/test_pipeline_dispatch.py
+++ b/backend/pipeline_v2/tests/test_pipeline_dispatch.py
@@ -33,8 +33,7 @@ class TestDispatchPipelineTrigger:
             patch.object(pd, "resolve_transport", return_value="pg_queue"),
             patch.object(pd, "enqueue_task", return_value=42) as enqueue,
         ):
-            transport = _dispatch(celery)
-        assert transport == "pg_queue"
+            _dispatch(celery)
         enqueue.assert_called_once()
         kwargs = enqueue.call_args.kwargs
         assert kwargs["task_name"] == "scheduler.tasks.execute_pipeline_task"
@@ -76,8 +75,7 @@ class TestDispatchPipelineTrigger:
             patch.object(pd, "resolve_transport", return_value="celery"),
             patch.object(pd, "enqueue_task") as enqueue,
         ):
-            transport = _dispatch(celery)
-        assert transport == "celery"
+            _dispatch(celery)
         celery.send_task.assert_called_once_with(
             "scheduler.tasks.execute_pipeline_task", args=_EXPECTED_ARGS
         )

--- a/backend/pipeline_v2/tests/test_pipeline_dispatch.py
+++ b/backend/pipeline_v2/tests/test_pipeline_dispatch.py
@@ -7,7 +7,10 @@ otherwise (fail-closed), with byte-identical args on both paths.
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 import pipeline_v2.pipeline_dispatch as pd
 
@@ -39,6 +42,33 @@ class TestDispatchPipelineTrigger:
         assert kwargs["args"] == _EXPECTED_ARGS
         assert kwargs["org_id"] == "org_x"
         celery.send_task.assert_not_called()
+
+    def test_pg_enqueue_failure_propagates_with_no_celery_fallback(self):
+        # The dispatcher has no try/except → a PG enqueue failure must surface
+        # (no silent Celery fallback, which would risk a double-dispatch).
+        celery = MagicMock()
+        with (
+            patch.object(pd, "resolve_transport", return_value="pg_queue"),
+            patch.object(pd, "enqueue_task", side_effect=RuntimeError("pg down")),
+        ):
+            with pytest.raises(RuntimeError, match="pg down"):
+                _dispatch(celery)
+        celery.send_task.assert_not_called()
+
+    def test_uuid_pipeline_id_is_coerced_to_str_in_args(self):
+        # resolve_transport accepts a UUID, but the task args must carry strings.
+        pid = uuid.UUID("b1f16024-45f2-4e39-8756-d40e24148e30")
+        celery = MagicMock()
+        with (
+            patch.object(pd, "resolve_transport", return_value="pg_queue") as resolve,
+            patch.object(pd, "enqueue_task", return_value=1) as enqueue,
+        ):
+            pd.dispatch_pipeline_trigger(
+                celery_app=celery, org_id="org_x", pipeline_id=pid, pipeline_name="P"
+            )
+        assert enqueue.call_args.kwargs["args"][4] == str(pid)
+        # The raw UUID is passed to resolve_transport as the sticky entity.
+        assert resolve.call_args.kwargs["execution_id"] == pid
 
     def test_routes_to_celery_when_flag_resolves_celery(self):
         celery = MagicMock()

--- a/backend/pipeline_v2/tests/test_pipeline_dispatch.py
+++ b/backend/pipeline_v2/tests/test_pipeline_dispatch.py
@@ -1,0 +1,81 @@
+"""Unit tests for the API-triggered pipeline-trigger transport routing (UN-3616).
+
+`resolve_transport` + `enqueue_task` are patched on the module, so no Flipt / DB
+is needed — these pin the routing contract: PG when the flag resolves PG, Celery
+otherwise (fail-closed), with byte-identical args on both paths.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pipeline_v2.pipeline_dispatch as pd
+
+_EXPECTED_ARGS = ["", "org_x", "", "", "pid-1", True, "My Pipeline"]
+
+
+def _dispatch(celery_app):
+    return pd.dispatch_pipeline_trigger(
+        celery_app=celery_app,
+        org_id="org_x",
+        pipeline_id="pid-1",
+        pipeline_name="My Pipeline",
+    )
+
+
+class TestDispatchPipelineTrigger:
+    def test_routes_to_pg_when_flag_resolves_pg(self):
+        celery = MagicMock()
+        with (
+            patch.object(pd, "resolve_transport", return_value="pg_queue"),
+            patch.object(pd, "enqueue_task", return_value=42) as enqueue,
+        ):
+            transport = _dispatch(celery)
+        assert transport == "pg_queue"
+        enqueue.assert_called_once()
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["task_name"] == "scheduler.tasks.execute_pipeline_task"
+        assert kwargs["queue"] == "scheduler"
+        assert kwargs["args"] == _EXPECTED_ARGS
+        assert kwargs["org_id"] == "org_x"
+        celery.send_task.assert_not_called()
+
+    def test_routes_to_celery_when_flag_resolves_celery(self):
+        celery = MagicMock()
+        with (
+            patch.object(pd, "resolve_transport", return_value="celery"),
+            patch.object(pd, "enqueue_task") as enqueue,
+        ):
+            transport = _dispatch(celery)
+        assert transport == "celery"
+        celery.send_task.assert_called_once_with(
+            "scheduler.tasks.execute_pipeline_task", args=_EXPECTED_ARGS
+        )
+        enqueue.assert_not_called()
+
+    def test_resolve_transport_called_with_pipeline_as_entity(self):
+        celery = MagicMock()
+        with (
+            patch.object(pd, "resolve_transport", return_value="celery") as resolve,
+            patch.object(pd, "enqueue_task"),
+        ):
+            _dispatch(celery)
+        kwargs = resolve.call_args.kwargs
+        assert kwargs["execution_id"] == "pid-1"  # buckets by pipeline_id
+        assert kwargs["organization_id"] == "org_x"
+        assert kwargs["pipeline_id"] == "pid-1"
+
+    def test_args_identical_on_both_paths(self):
+        # The consumer must behave the same regardless of transport — assert the
+        # PG-path args equal the Celery-path args.
+        celery = MagicMock()
+        with patch.object(pd, "resolve_transport", return_value="celery"):
+            _dispatch(celery)
+        celery_args = celery.send_task.call_args.kwargs["args"]
+        celery2 = MagicMock()
+        with (
+            patch.object(pd, "resolve_transport", return_value="pg_queue"),
+            patch.object(pd, "enqueue_task", return_value=1) as enqueue,
+        ):
+            _dispatch(celery2)
+        assert enqueue.call_args.kwargs["args"] == celery_args


### PR DESCRIPTION
## What

The API-triggered pipeline view (`PipelineApiExecution.post`) dispatched `scheduler.tasks.execute_pipeline_task` on **Celery unconditionally** — so when the flag was on, the trigger stayed on Celery while the execution it spawns rode PG, breaking uniform flag control (one of the migration's correctness bars: flag ON → all PG, flag OFF → all Celery, zero regression).

The **scheduled** pipeline path already routes this task to PG (`pg_scheduler.dispatch_due_schedules` → `scheduler` queue, run by `worker-pg-scheduler`). Only the API-trigger view bypassed it.

## How

A new `dispatch_pipeline_trigger` helper routes the trigger through `resolve_transport` (the same flag as everything else):
- **PG** → enqueue `execute_pipeline_task` to the `scheduler` queue via `pg_queue.producer.enqueue_task`, with the **exact arg shape** `pg_scheduler` already sends.
- **Celery** → `send_task` (unchanged).
- **Fail-closed** — master gate off (production default) → Celery → byte-identical to before, **zero regression**.

Routing logic lives in the helper, not the view (tiny-jobs).

## Tests

- 4 unit tests: PG/Celery routing, pipeline-id entity bucketing, identical args on both paths.
- Dev-tested against the live flag: gate ON → PG `scheduler` queue (correct args), gate OFF → Celery `send_task`.

## Scope notes

- This closes 1 of the dispatch-coverage gaps found in the completeness audit. The audit's other OSS candidate (`submit_file_batch_for_processing`) is **dead code** — defined + URL-registered, never called — handled separately.
- The 2 remaining gaps are cloud-side (`manual_review` execution-time tasks), tracked separately.

Lands on the `feat/UN-3445-pg-queue-integration` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)