### PR TITLE
[FIX] Unblock OSS first-time setup — sample envs, host-gateway, ollama hint

### DIFF
--- a/backend/sample.env
+++ b/backend/sample.env
@@ -202,7 +202,7 @@ API_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_ur
 #Remote storage related envs
 PERMANENT_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 TEMPORARY_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
-REMOTE_PROMPT_STUDIO_FILE_PATH="unstract/prompt-studio-data"
+REMOTE_PROMPT_STUDIO_FILE_PATH=unstract/prompt-studio-data
 
 # Storage Provider for Tool registry
 TOOL_REGISTRY_STORAGE_CREDENTIALS='{"provider":"local"}'

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -64,7 +64,9 @@ SESSION_EXPIRATION_TIME_IN_SECOND=7200
 WEB_APP_ORIGIN_URL="http://frontend.unstract.localhost"
 
 # API keys for trusted services
-INTERNAL_SERVICE_API_KEY=
+# Workers send this as X-API-Key on internal calls to backend.
+# Must match workers/sample.env INTERNAL_SERVICE_API_KEY; rotate in both for prod.
+INTERNAL_SERVICE_API_KEY=dev-internal-key-123
 
 # Unstract Core envs
 BUILTIN_FUNCTIONS_API_KEY=
@@ -199,6 +201,7 @@ API_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_ur
 
 #Remote storage related envs
 PERMANENT_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
+TEMPORARY_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 REMOTE_PROMPT_STUDIO_FILE_PATH="unstract/prompt-studio-data"
 
 # Storage Provider for Tool registry

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,9 +2,16 @@ name: ${COMPOSE_PROJECT_NAME:-docker}
 include:
   - docker-compose-dev-essentials.yaml
 
+# Reusable host-gateway mapping so containers can reach services on the host
+# (e.g. host-installed Ollama at http://host.docker.internal:11434).
+x-host-gateway: &host_gateway
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+
 services:
   # Backend service
   backend:
+    <<: *host_gateway
     image: unstract/backend:${VERSION}
     container_name: unstract-backend
     restart: unless-stopped
@@ -34,12 +41,10 @@ services:
       - traefik.enable=true
       - traefik.http.routers.backend.rule=Host(`frontend.unstract.localhost`) && (PathPrefix(`/api/v1`) || PathPrefix(`/deployment`) || PathPrefix(`/public`))
       - traefik.http.services.backend.loadbalancer.server.port=8000
-    extra_hosts:
-      # "host-gateway" is a special string that translates to host docker0 i/f IP.
-      - "host.docker.internal:host-gateway"
 
   # Celery worker for dashboard metrics processing
   worker-metrics:
+    <<: *host_gateway
     image: unstract/backend:${VERSION}
     container_name: unstract-worker-metrics
     restart: unless-stopped
@@ -61,6 +66,7 @@ services:
   # Processes post-execution callbacks via InternalAPIClient (no Django).
   # Handles: ide_index_complete/error, ide_prompt_complete/error.
   worker-ide-callback:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-ide-callback
     restart: unless-stopped
@@ -82,6 +88,7 @@ services:
 
   # Celery Flower
   celery-flower:
+    <<: *host_gateway
     image: unstract/backend:${VERSION}
     container_name: unstract-celery-flower
     restart: unless-stopped
@@ -105,6 +112,7 @@ services:
 
   # Celery Beat
   celery-beat:
+    <<: *host_gateway
     image: unstract/backend:${VERSION}
     container_name: unstract-celery-beat
     restart: unless-stopped
@@ -152,6 +160,7 @@ services:
       - traefik.enable=false
 
   prompt-service:
+    <<: *host_gateway
     image: unstract/prompt-service:${VERSION}
     container_name: unstract-prompt-service
     restart: unless-stopped
@@ -166,9 +175,6 @@ services:
       - ../prompt-service/.env
     labels:
       - traefik.enable=false
-    extra_hosts:
-      # "host-gateway" is a special string that translates to host docker0 i/f IP.
-      - "host.docker.internal:host-gateway"
 
   x2text-service:
     image: unstract/x2text-service:${VERSION}
@@ -184,6 +190,7 @@ services:
       - traefik.enable=false
 
   runner:
+    <<: *host_gateway
     image: unstract/runner:${VERSION}
     container_name: unstract-runner
     restart: unless-stopped
@@ -206,6 +213,7 @@ services:
   # ====================================================================
 
   worker-api-deployment-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-api-deployment-v2
     restart: unless-stopped
@@ -238,6 +246,7 @@ services:
       - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
 
   worker-callback-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-callback-v2
     restart: unless-stopped
@@ -264,6 +273,7 @@ services:
       - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
 
   worker-file-processing-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-file-processing-v2
     restart: unless-stopped
@@ -316,6 +326,7 @@ services:
       - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
 
   worker-general-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-general-v2
     restart: unless-stopped
@@ -343,6 +354,7 @@ services:
       - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
 
   worker-notification-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-notification-v2
     restart: unless-stopped
@@ -391,6 +403,7 @@ services:
       - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
 
   worker-log-consumer-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-log-consumer-v2
     restart: unless-stopped
@@ -440,6 +453,7 @@ services:
       - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
 
   worker-log-history-scheduler-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-log-history-scheduler-v2
     restart: unless-stopped
@@ -463,6 +477,7 @@ services:
       - traefik.enable=false
 
   worker-scheduler-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-scheduler-v2
     restart: unless-stopped
@@ -507,6 +522,7 @@ services:
       - ${TOOL_REGISTRY_CONFIG_SRC_PATH}:/data/tool_registry_config
 
   worker-executor-v2:
+    <<: *host_gateway
     image: unstract/worker-unified:${VERSION}
     container_name: unstract-worker-executor-v2
     restart: unless-stopped

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,6 +4,11 @@ include:
 
 # Reusable host-gateway mapping so containers can reach services on the host
 # (e.g. host-installed Ollama at http://host.docker.internal:11434).
+# NOTE: YAML merge (<<:) merges mappings shallowly and does NOT concatenate
+# lists. If a service ever needs additional extra_hosts entries alongside
+# this one, inline ALL entries under that service (including
+# host.docker.internal:host-gateway) instead of using the anchor — a sibling
+# extra_hosts key would silently shadow the anchor's list.
 x-host-gateway: &host_gateway
   extra_hosts:
     - "host.docker.internal:host-gateway"

--- a/run-platform.sh
+++ b/run-platform.sh
@@ -35,10 +35,24 @@ check_dependencies() {
   fi
   if ! docker info >/dev/null 2>&1; then
     echo "$red_text""Cannot connect to the Docker daemon.""$default_text"
-    echo "  - Check group membership:    getent group docker"
-    echo "  - Add your user to it:       sudo usermod -aG docker \$USER"
-    echo "  - Activate in current shell: newgrp docker"
-    echo "  - For new shells, a full desktop logout (not just terminal close) is required."
+    case "$(uname -s)" in
+      Linux*)
+        echo "  On Linux (daemon access via the 'docker' group):"
+        echo "    - Check group membership:    getent group docker"
+        echo "    - Add your user to it:       sudo usermod -aG docker \$USER"
+        echo "    - Activate in current shell: newgrp docker"
+        echo "    - For new shells, a full desktop logout (not just terminal close) is required."
+        ;;
+      Darwin*)
+        echo "  On macOS: ensure Docker Desktop is running (whale icon in the menu bar)."
+        ;;
+      MINGW*|MSYS*|CYGWIN*)
+        echo "  On Windows: ensure Docker Desktop is running and WSL integration is enabled if applicable."
+        ;;
+      *)
+        echo "  Ensure the Docker daemon is running and your user can reach its socket."
+        ;;
+    esac
     exit 1
   fi
   # For 'docker compose' vs 'docker-compose', see https://stackoverflow.com/a/66526176.

--- a/run-platform.sh
+++ b/run-platform.sh
@@ -33,6 +33,14 @@ check_dependencies() {
     echo "$red_text""docker not found. Exiting.""$default_text"
     exit 1
   fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "$red_text""Cannot connect to the Docker daemon.""$default_text"
+    echo "  - Check group membership:    getent group docker"
+    echo "  - Add your user to it:       sudo usermod -aG docker \$USER"
+    echo "  - Activate in current shell: newgrp docker"
+    echo "  - For new shells, a full desktop logout (not just terminal close) is required."
+    exit 1
+  fi
   # For 'docker compose' vs 'docker-compose', see https://stackoverflow.com/a/66526176.
   docker compose >/dev/null 2>&1
   if [ $? -eq 0 ]; then

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/ollama.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/static/ollama.json
@@ -23,7 +23,7 @@
       "type": "string",
       "title": "Base URL",
       "default": "",
-      "description": "Provide the base URL where Ollama server is running. Example: `http://docker.host.internal:11434` or `http://localhost:11434`"
+      "description": "Provide the base URL where Ollama server is running. Example: `http://host.docker.internal:11434` or `http://localhost:11434`"
     },
     "max_retries": {
       "type": "number",

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/ollama.json
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/static/ollama.json
@@ -23,7 +23,7 @@
       "type": "string",
       "title": "Base URL",
       "default": "",
-      "description": "Provide the base URL where Ollama server is running. Example: http://docker.host.internal:11434 or http://localhost:11434"
+      "description": "Provide the base URL where Ollama server is running. Example: http://host.docker.internal:11434 or http://localhost:11434"
     },
     "max_tokens": {
       "type": "number",

--- a/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
+++ b/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
@@ -59,6 +59,11 @@ class EnvHelper:
                 f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
             ) from e
         credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, {})
+        if not isinstance(credentials, dict):
+            raise FileStorageError(
+                f"Env var '{env_name}' field '{CredentialKeyword.CREDENTIALS}' must be a JSON object. "
+                f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
+            )
         if storage_type == StorageType.PERMANENT:
             return PermanentFileStorage(provider=provider, **credentials)
         elif storage_type == StorageType.SHARED_TEMPORARY:

--- a/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
+++ b/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
@@ -61,8 +61,8 @@ class EnvHelper:
         credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, {})
         if not isinstance(credentials, dict):
             raise FileStorageError(
-                f"Env var '{env_name}' field '{CredentialKeyword.CREDENTIALS}' must be a JSON object. "
-                f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
+                f"Env var '{env_name}' field '{CredentialKeyword.CREDENTIALS}' "
+                f"must be a JSON object. Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
             )
         if storage_type == StorageType.PERMANENT:
             return PermanentFileStorage(provider=provider, **credentials)

--- a/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
+++ b/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
@@ -44,6 +44,11 @@ class EnvHelper:
                 f"Env var '{env_name}' is not valid JSON: {e}. "
                 f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
             ) from e
+        if not isinstance(file_storage_creds, dict):
+            raise FileStorageError(
+                f"Env var '{env_name}' must be a JSON object. "
+                f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
+            )
         try:
             provider = FileStorageProvider(file_storage_creds[CredentialKeyword.PROVIDER])
             credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, {})
@@ -56,9 +61,12 @@ class EnvHelper:
             else:
                 raise NotImplementedError()
             return file_storage
-        except KeyError as e:
-            logger.error(f"Required credentials are missing in the env: {str(e)}")
+        except (KeyError, TypeError, ValueError) as e:
+            logger.error(f"Invalid storage configuration in env: {str(e)}")
             logger.error(f"The configuration format is {EnvHelper.ENV_CONFIG_FORMAT}")
-            raise e
+            raise FileStorageError(
+                f"Invalid storage configuration in env var '{env_name}': {e}. "
+                f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
+            ) from e
         except FileStorageError as e:
             raise e

--- a/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
+++ b/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
@@ -51,22 +51,17 @@ class EnvHelper:
             )
         try:
             provider = FileStorageProvider(file_storage_creds[CredentialKeyword.PROVIDER])
-            credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, {})
-            if storage_type == StorageType.PERMANENT:
-                file_storage = PermanentFileStorage(provider=provider, **credentials)
-            elif storage_type == StorageType.SHARED_TEMPORARY:
-                file_storage = SharedTemporaryFileStorage(
-                    provider=provider, **credentials
-                )
-            else:
-                raise NotImplementedError()
-            return file_storage
-        except (KeyError, TypeError, ValueError) as e:
+        except (KeyError, ValueError) as e:
             logger.error(f"Invalid storage configuration in env: {str(e)}")
             logger.error(f"The configuration format is {EnvHelper.ENV_CONFIG_FORMAT}")
             raise FileStorageError(
                 f"Invalid storage configuration in env var '{env_name}': {e}. "
                 f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
             ) from e
-        except FileStorageError as e:
-            raise e
+        credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, {})
+        if storage_type == StorageType.PERMANENT:
+            return PermanentFileStorage(provider=provider, **credentials)
+        elif storage_type == StorageType.SHARED_TEMPORARY:
+            return SharedTemporaryFileStorage(provider=provider, **credentials)
+        else:
+            raise NotImplementedError()

--- a/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
+++ b/unstract/sdk1/src/unstract/sdk1/file_storage/env_helper.py
@@ -31,8 +31,20 @@ class EnvHelper:
             FileStorage: FIleStorage instance initialised using the provider
             and credentials configured in the env
         """
+        raw = os.environ.get(env_name)
+        if not raw:
+            raise FileStorageError(
+                f"Required env var '{env_name}' is unset or empty. "
+                f"Expected JSON config of the form: {EnvHelper.ENV_CONFIG_FORMAT}"
+            )
         try:
-            file_storage_creds = json.loads(os.environ.get(env_name, ""))
+            file_storage_creds = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise FileStorageError(
+                f"Env var '{env_name}' is not valid JSON: {e}. "
+                f"Expected: {EnvHelper.ENV_CONFIG_FORMAT}"
+            ) from e
+        try:
             provider = FileStorageProvider(file_storage_creds[CredentialKeyword.PROVIDER])
             credentials = file_storage_creds.get(CredentialKeyword.CREDENTIALS, {})
             if storage_type == StorageType.PERMANENT:

--- a/workers/sample.env
+++ b/workers/sample.env
@@ -317,7 +317,7 @@ WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials"
 API_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 
 # Remote storage for Prompt Studio / IDE flows. Must match backend/sample.env.
-# Required by executor and ide-callback workers; missing values crash json.loads in EnvHelper.
+# Required by executor and ide-callback workers; missing/empty values raise FileStorageError in EnvHelper.get_storage().
 PERMANENT_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 TEMPORARY_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 REMOTE_PROMPT_STUDIO_FILE_PATH=unstract/prompt-studio-data

--- a/workers/sample.env
+++ b/workers/sample.env
@@ -316,6 +316,12 @@ UNSTRACT_RUNNER_API_BACKOFF_FACTOR=3
 WORKFLOW_EXECUTION_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 API_FILE_STORAGE_CREDENTIALS='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
 
+# Remote storage for Prompt Studio / IDE flows. Must match backend/sample.env.
+# Required by executor and ide-callback workers; missing values crash json.loads in EnvHelper.
+PERMANENT_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
+TEMPORARY_REMOTE_STORAGE='{"provider": "minio", "credentials": {"endpoint_url": "http://unstract-minio:9000", "key": "minio", "secret": "minio123"}}'
+REMOTE_PROMPT_STUDIO_FILE_PATH=unstract/prompt-studio-data
+
 # File Execution Configuration
 WORKFLOW_EXECUTION_DIR_PREFIX=unstract/execution
 API_EXECUTION_DIR_PREFIX=unstract/api


### PR DESCRIPTION
## What

Fix six unrelated-but-co-incident bugs that make a first-time OSS install non-functional out of the box (specifically Prompt Studio indexing + host-installed adapters).

1. `backend/sample.env`: `INTERNAL_SERVICE_API_KEY` was blank → workers' `X-API-Key` calls into backend 500. Set to dev default that matches `workers/sample.env`.
2. `backend/sample.env`: add `TEMPORARY_REMOTE_STORAGE` (only `PERMANENT_*` was set).
3. `workers/sample.env`: add `PERMANENT_REMOTE_STORAGE`, `TEMPORARY_REMOTE_STORAGE`, `REMOTE_PROMPT_STUDIO_FILE_PATH`. Without these the executor/ide-callback workers crash at `json.loads("")` on first Prompt Studio index.
4. `unstract/sdk1/.../file_storage/env_helper.py`: raise `FileStorageError` with a clear remediation message when the storage env var is unset or invalid JSON, instead of `json.loads("")` exploding with a useless `JSONDecodeError`.
5. `adapters/llm1` + `adapters/embedding1` `ollama.json`: fix typo `docker.host.internal` → `host.docker.internal` in the Base URL hint.
6. `docker/docker-compose.yaml`: extract a YAML anchor `x-host-gateway` and apply it (`<<: *host_gateway`) to backend, prompt-service, runner, celery-*, and every worker-* (16 services). Before this only backend and prompt-service had `extra_hosts`, so adapter Test passed in prompt-service but real prompt execution from the worker pool failed with `EAI_NONAME` against `host.docker.internal`.
7. `run-platform.sh`: fail fast with actionable hint when `docker info` can't reach the daemon (missing docker group membership, etc.).

## Why

Reported by a new OSS user (2026-05-12): even after correctly setting up Ollama on the host and the bundled stack via `./run-platform.sh`, Prompt Studio indexing hangs forever and host-installed LLM/embedding adapters give confusing "Test passes, prompt fails" errors. Each fix here removes one step that blocks a fresh `git clone` from reaching a successful first prompt run.

## How

- Sample env edits + EnvHelper guard are additive; existing prod deployments that already set these vars are unaffected.
- Compose anchor: `<<: *host_gateway` merges into each service's mapping. Validated locally with `docker compose config` — anchor expands to 16 services.
- `docker info` check added immediately after the existing `command -v docker` check in `run-platform.sh`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. Changes are:
  - Sample envs (only affect fresh installs that copy from sample.env).
  - EnvHelper now raises a clearer error in cases that were already broken (empty / invalid JSON). Callers that pass a valid value see no change.
  - Compose anchor only adds an `extra_hosts` entry; no service config is changed otherwise.
  - `run-platform.sh` check fires before any container actions; only impacts the case where the daemon is unreachable, which already fails downstream.
  - Ollama JSON hint is a description string only.

## Database Migrations

- None

## Env Config

- New defaults in `backend/sample.env` and `workers/sample.env`. Existing `.env` files are not touched; users who already have working configs are unaffected. New installs that copy from `sample.env` get a functional Prompt Studio out of the box.

## Relevant Docs

- Should follow with a small docs update in `unstract-docs` for the "host-installed Ollama" / docker socket prerequisites notes (out of scope for this PR).

## Related Issues or PRs

- Originating report bundled with #2046 (Qdrant bump). This PR completes the rest of the first-time-setup blockers list.

## Dependencies Versions

- None changed.

## Notes on Testing

- Verified `docker compose -f docker/docker-compose.yaml config` resolves; YAML anchor expands `host.docker.internal:host-gateway` into all 16 expected services.
- EnvHelper: manual smoke — unsetting `PERMANENT_REMOTE_STORAGE` now raises `FileStorageError` with the expected message rather than `JSONDecodeError`.
- `run-platform.sh` docker-info check: simulated by stopping the daemon — script exits with the new hint instead of the original opaque error from `docker compose`.
- End-to-end Prompt Studio index against host-installed Ollama on Linux: works after the sample env + extra_hosts changes (per originating report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br691aZbhfcB4xdswrUjuw