### PR TITLE
UN-3621 [HOTFIX] Structure tool no longer crashes when single-pass extraction returns a non-object output

### DIFF
--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -703,6 +703,19 @@ class LegacyExecutor(BaseExecutor):
         )
 
         output_map = structured_output.get(PSKeys.OUTPUT, {}) or {}
+        if not isinstance(output_map, dict):
+            # Single-pass can return a non-dict (e.g. a top-level JSON array) when the
+            # LLM emits a truncated/runaway response. Fail clearly instead of crashing
+            # on .values(), and keep the malformed shape from flowing downstream as a
+            # success.
+            return ExecutionResult.failure(
+                error=(
+                    f"Single-pass extraction returned a {type(output_map).__name__}, "
+                    "expected a field map; the LLM likely produced a truncated or "
+                    "runaway response (check output-token usage)."
+                ),
+                metadata={"usage_records": pipeline_records},
+            )
         answered = sum(1 for v in output_map.values() if v not in (None, "", [], {}))
         shim.stream_log(f"Pipeline completed: {answered}/{len(outputs)} prompts answered")
         out_metadata = {


### PR DESCRIPTION
## What
- Guard the structure pipeline against non-dict single-pass extraction output.
- Hotfix off `v0.176.3` (Scenario 2, OSS-only); base branch `v0.176.3-hotfix`, to be released as `v0.176.4`.

## Why
- Files were failing in production with `Structure tool failed: AttributeError: 'list' object has no attribute 'values'`.
- Root cause: single-pass extraction is expected to return a field→value object, but when the LLM returns a top-level JSON array (e.g. a runaway response that hit its 32000 output-token cap), `output` comes back as a `list`. `legacy_executor.py` called `.values()` on it to compute a cosmetic "X/Y answered" log stat, crashing the whole file (and the file wasn't even HITL-eligible).
- Live in prod: 2 orgs / 8 files in 24h; latent since #1960 (2026-05-13), intermittent because it only fires on the array-output condition.

## How
- Added an `isinstance(output_map, dict)` guard before the answered-count in `_handle_structure_pipeline`. On a non-dict payload it returns `ExecutionResult.failure(...)` with an actionable message and preserved usage records, instead of calling `.values()`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)
- No. The only behavior change is on a payload shape that already crashed (so it failed regardless) — now it fails cleanly with a clear message. Valid dict outputs are completely unaffected.

## Database Migrations
- None.

## Env Config
- None.

## Relevant Docs
- RCA posted in the on-call thread. Follows the Hotfix Deployment Guide (PT/491880450).

## Related Issues or PRs
- Root cause introduced in #1960. Follow-up (separate, cloud): harden the `single_pass_extraction` plugin to validate/normalize OUTPUT at the source, mirroring the existing guard in `answer_prompt.py:335`.

## Dependencies Versions
- None.

## Notes on Testing
- `pre-commit` passes (ruff, ruff-format, pycln, pyupgrade, secret scan); no new mypy issues from the diff.
- Repro: a single-pass run whose LLM output parses to a top-level list now fails with the clear message rather than `AttributeError`.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
