### PR TITLE
[HOTFIX] Raise URLValidator max_length to 8192 for long S3 presigned URLs

### DIFF
--- a/backend/backend/settings/base.py
+++ b/backend/backend/settings/base.py
@@ -15,9 +15,16 @@ from pathlib import Path
 from urllib.parse import quote
 
 import httpx
+from django.core.validators import URLValidator
 from dotenv import find_dotenv, load_dotenv
 from utils.common_utils import CommonUtils
 from utils.cors_origin import normalize_web_app_origin
+
+# Django 5.0+ caps URLValidator at 2048 chars. S3 pre-signed URLs signed with
+# temporary/STS credentials (carrying X-Amz-Security-Token) routinely exceed this,
+# causing "Enter a valid URL." on the API deployment `presigned_urls` field.
+# Raise the cap globally. No-op on Django 4.2.x (no such attribute is checked).
+URLValidator.max_length = 8192
 
 missing_settings = []
 


### PR DESCRIPTION
## Hotfix (Scenario 2: OSS-only) — target OSS \`v0.176.4\` → release \`v0.176.5\`

### Problem
API deployment requests with S3 pre-signed URLs fail validation with:
\`\`\`json
{"code":"invalid","detail":"Enter a valid URL.","attr":"presigned_urls.0"}
\`\`\`
Django 5.0+ caps \`URLValidator\` at **2048 characters**. Pre-signed URLs signed with **temporary/STS credentials** carry a large \`X-Amz-Security-Token\` (~1.5 KB), pushing the URL past 2048 chars, so DRF's \`URLField\` rejects them before they're ever parsed. Confirmed live against prod: the same URL trimmed under 2048 passes validation; at 2094 chars it fails.

### Fix
Raise the global \`URLValidator.max_length\` to 8192 in settings. Scheme/host validation is unchanged; only the arbitrary length ceiling is lifted. No-op on Django 4.2.x (attribute not checked there). No DB/migration impact — the URL is downloaded transiently and never persisted.

### Files
- \`backend/backend/settings/base.py\` (applies to all envs via \`from base import *\`)

### Follow-up (per Hotfix Deployment Guide)
- [ ] Merge this PR into \`v0.176.4-hotfix\`
- [ ] Cut OSS GitHub release \`v0.176.5\` targeting \`v0.176.4-hotfix\` (do **not** mark latest unless it's current prod)
- [ ] Enterprise \`v0.170.1-hotfix\` branch → RC build pinning Specific OSS version \`v0.176.5\`
- [ ] Back-merge \`v0.176.4-hotfix\` → \`main\` after prod deploy