### PR TITLE
[MISC] Mark current-line hotfix releases as latest (semver supersession)

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -237,7 +237,20 @@ jobs:
           # (e.g. latest v0.176.3, hotfix -> v0.176.4) incorrectly marked latest=false.
           # Hotfixes on OLDER lines still stay latest=false because they do not
           # supersede the current latest.
-          CURRENT_LATEST=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name // empty' 2>/dev/null || true)
+          # Query the current "latest" release, distinguishing a genuine 404 (no latest
+          # release yet) from a transient API failure (rate limit / 5xx). On a transient
+          # failure we must NOT silently fall through to latest=true, or a back-version
+          # hotfix could wrongly steal "latest" — fail the job loudly instead. (Mirrors
+          # the existing guarded pattern in the "Fetch base release version" step above.)
+          if CURRENT_LATEST=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name // empty' 2>/tmp/gh_latest.err); then
+            :
+          elif grep -qiE 'HTTP 404|Not Found' /tmp/gh_latest.err; then
+            CURRENT_LATEST=""   # genuinely no latest release yet
+          else
+            echo "::error::Could not determine the current latest release (transient gh API failure); refusing to guess the 'latest' flag."
+            cat /tmp/gh_latest.err >&2
+            exit 1
+          fi
           if [[ -z "$CURRENT_LATEST" ]]; then
             echo "✅ No existing 'latest' release - marking $NEW_TAG as latest"
             RELEASE_ARGS+=(--latest=true)

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -229,12 +229,30 @@ jobs:
             --notes-start-tag "$LATEST_TAG"
           )
 
-          # Only mark as "latest" on main releases; hotfixes never override latest
-          # (matches the convention documented in the Hotfix Deployment Guide).
-          if [[ "$MODE" == "main" ]]; then
+          # Decide whether this release should become GitHub "latest".
+          #
+          # Rule: mark latest iff this version supersedes the current "latest" release
+          # (i.e. it is the newest stable release by semver). This replaces the old
+          # main-only heuristic, which left hotfixes on the CURRENT production line
+          # (e.g. latest v0.176.3, hotfix -> v0.176.4) incorrectly marked latest=false.
+          # Hotfixes on OLDER lines still stay latest=false because they do not
+          # supersede the current latest.
+          CURRENT_LATEST=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name // empty' 2>/dev/null || true)
+          if [[ -z "$CURRENT_LATEST" ]]; then
+            echo "✅ No existing 'latest' release - marking $NEW_TAG as latest"
             RELEASE_ARGS+=(--latest=true)
-          else
+          elif [[ "$NEW_TAG" == "$CURRENT_LATEST" ]]; then
+            echo "ℹ️ $NEW_TAG equals current latest $CURRENT_LATEST - leaving latest unchanged"
             RELEASE_ARGS+=(--latest=false)
+          else
+            NEWEST=$(printf '%s\n%s\n' "$NEW_TAG" "$CURRENT_LATEST" | sort -V | tail -n1)
+            if [[ "$NEWEST" == "$NEW_TAG" ]]; then
+              echo "✅ $NEW_TAG supersedes current latest $CURRENT_LATEST (mode: $MODE) - marking as latest"
+              RELEASE_ARGS+=(--latest=true)
+            else
+              echo "ℹ️ $NEW_TAG does not supersede current latest $CURRENT_LATEST (mode: $MODE) - NOT marking as latest"
+              RELEASE_ARGS+=(--latest=false)
+            fi
           fi
 
           if [[ "$PRERELEASE" == "true" ]]; then

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -237,34 +237,45 @@ jobs:
           # (e.g. latest v0.176.3, hotfix -> v0.176.4) incorrectly marked latest=false.
           # Hotfixes on OLDER lines still stay latest=false because they do not
           # supersede the current latest.
-          # Query the current "latest" release, distinguishing a genuine 404 (no latest
-          # release yet) from a transient API failure (rate limit / 5xx). On a transient
-          # failure we must NOT silently fall through to latest=true, or a back-version
-          # hotfix could wrongly steal "latest" — fail the job loudly instead. (Mirrors
-          # the existing guarded pattern in the "Fetch base release version" step above.)
-          if CURRENT_LATEST=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name // empty' 2>/tmp/gh_latest.err); then
-            :
-          elif grep -qiE 'HTTP 404|Not Found' /tmp/gh_latest.err; then
-            CURRENT_LATEST=""   # genuinely no latest release yet
-          else
-            echo "::error::Could not determine the current latest release (transient gh API failure); refusing to guess the 'latest' flag."
-            cat /tmp/gh_latest.err >&2
-            exit 1
-          fi
-          if [[ -z "$CURRENT_LATEST" ]]; then
-            echo "✅ No existing 'latest' release - marking $NEW_TAG as latest"
-            RELEASE_ARGS+=(--latest=true)
-          elif [[ "$NEW_TAG" == "$CURRENT_LATEST" ]]; then
-            echo "ℹ️ $NEW_TAG equals current latest $CURRENT_LATEST - leaving latest unchanged"
+          if [[ "$PRERELEASE" == "true" ]]; then
+            # A pre-release is never GitHub "latest" — skip the supersession check so we
+            # never emit --latest=true alongside --prerelease.
+            echo "ℹ️ Pre-release $NEW_TAG - not marking latest"
             RELEASE_ARGS+=(--latest=false)
           else
-            NEWEST=$(printf '%s\n%s\n' "$NEW_TAG" "$CURRENT_LATEST" | sort -V | tail -n1)
-            if [[ "$NEWEST" == "$NEW_TAG" ]]; then
-              echo "✅ $NEW_TAG supersedes current latest $CURRENT_LATEST (mode: $MODE) - marking as latest"
-              RELEASE_ARGS+=(--latest=true)
+            # Query the current "latest" release, distinguishing a genuine 404 (no latest
+            # release yet) from a transient API failure (rate limit / 5xx). On a transient
+            # failure we must NOT silently fall through to latest=true, or a back-version
+            # hotfix could wrongly steal "latest" — fail the job loudly instead. (Mirrors
+            # the existing guarded pattern in the "Fetch base release version" step above.)
+            if CURRENT_LATEST=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name // empty' 2>/tmp/gh_latest.err); then
+              :
+            elif grep -qiE 'HTTP 404|Not Found' /tmp/gh_latest.err; then
+              CURRENT_LATEST=""   # genuinely no latest release yet
             else
-              echo "ℹ️ $NEW_TAG does not supersede current latest $CURRENT_LATEST (mode: $MODE) - NOT marking as latest"
+              echo "::error::Could not determine the current latest release (transient gh API failure); refusing to guess the 'latest' flag."
+              cat /tmp/gh_latest.err >&2
+              exit 1
+            fi
+            if [[ -z "$CURRENT_LATEST" ]]; then
+              echo "✅ No existing 'latest' release - marking $NEW_TAG as latest"
+              RELEASE_ARGS+=(--latest=true)
+            elif [[ "$NEW_TAG" == "$CURRENT_LATEST" ]]; then
+              # Defensive/unreachable: the "Check for tag collision" step rejects a NEW_TAG
+              # that already exists, and CURRENT_LATEST is an existing release, so the two
+              # cannot be equal here. Kept only as a guard against a tie if this block is
+              # ever reused without that upstream check.
+              echo "ℹ️ $NEW_TAG equals current latest $CURRENT_LATEST - leaving latest unchanged"
               RELEASE_ARGS+=(--latest=false)
+            else
+              NEWEST=$(printf '%s\n%s\n' "$NEW_TAG" "$CURRENT_LATEST" | sort -V | tail -n1)
+              if [[ "$NEWEST" == "$NEW_TAG" ]]; then
+                echo "✅ $NEW_TAG supersedes current latest $CURRENT_LATEST (mode: $MODE) - marking as latest"
+                RELEASE_ARGS+=(--latest=true)
+              else
+                echo "ℹ️ $NEW_TAG does not supersede current latest $CURRENT_LATEST (mode: $MODE) - NOT marking as latest"
+                RELEASE_ARGS+=(--latest=false)
+              fi
             fi
           fi
 


### PR DESCRIPTION
## What

- Fix `create-release.yaml` so a hotfix release on the **current production line** is marked GitHub `latest`.

## Why

- The workflow marked every non-`main` release `latest=false`, so a hotfix on the current production OSS line never became GitHub `latest` even when it superseded the existing latest.

## How

- Mark the release as `latest` iff its computed tag supersedes the current `releases/latest` by semver (was: only when `MODE == main`). Current-line hotfixes (e.g. latest `v0.176.3`, hotfix → `v0.176.4`) now become latest; hotfixes on older lines stay `latest=false`.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. Scoped to the single `--latest` flag decision in the "Create GitHub release" step. Main-line releases are always the newest by semver, so they remain `latest=true` exactly as before. Only new behavior: current-line hotfixes correctly become latest. Verified the decision logic with a mocked `gh` across current-line hotfix (→true), older-line hotfix (→false), main release (→true), and no-existing-latest (→true).

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- Hotfix Deployment Guide: https://zipstack.atlassian.net/wiki/spaces/PT/pages/491880450

## Related Issues or PRs

- Enterprise counterpart (same `latest` fix in `promote-rc-build-to-stable.yaml`, plus the `/devkit:hotfix` skill): Zipstack/unstract-cloud#1608

## Dependencies Versions

- None.

## Notes on Testing

- Extracted the edited bash decision block from the workflow and ran it under a mock `gh` (mirroring the Actions `bash -euo pipefail` shell); all cases produced the expected `--latest` flag. YAML validated.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
