### PR TITLE
[MISC] Reject no-op OSS releases when there are no new commits

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -126,6 +126,30 @@ jobs:
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "Base release: $LATEST_TAG"
 
+      - name: Ensure there are new commits to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_TAG: ${{ steps.get-latest.outputs.latest_tag }}
+          BRANCH: ${{ github.ref_name }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          # Reject a no-op release: if the branch has no commits beyond the last release
+          # tag (e.g. main is already at v0.177.0), there is nothing to release. This
+          # prevents empty releases such as v0.177.1 pointing at the same commit as
+          # v0.177.0. The workflow has no local checkout, so use the compare API's
+          # `ahead_by` (commits on BRANCH not in LATEST_TAG).
+          AHEAD=$(gh api "repos/${{ github.repository }}/compare/${LATEST_TAG}...${BRANCH}" --jq '.ahead_by')
+          if [[ "$AHEAD" -eq 0 ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "::warning::No new commits on '$BRANCH' since $LATEST_TAG — a real run would be rejected (nothing to release)."
+            else
+              echo "::error::No new commits on '$BRANCH' since $LATEST_TAG — nothing to release. Aborting to avoid an empty release."
+              exit 1
+            fi
+          else
+            echo "✅ $AHEAD new commit(s) on '$BRANCH' since $LATEST_TAG"
+          fi
+
       - name: Compute next version
         id: compute-version
         env:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -137,9 +137,17 @@ jobs:
           # tag (e.g. main is already at v0.177.0), there is nothing to release. This
           # prevents empty releases such as v0.177.1 pointing at the same commit as
           # v0.177.0. The workflow has no local checkout, so use the compare API's
-          # `ahead_by` (commits on BRANCH not in LATEST_TAG).
-          AHEAD=$(gh api "repos/${{ github.repository }}/compare/${LATEST_TAG}...${BRANCH}" --jq '.ahead_by')
-          if [[ "$AHEAD" -eq 0 ]]; then
+          # `ahead_by` (commits on BRANCH not in LATEST_TAG). `// empty` stops a null/
+          # absent value from reaching the comparison as the literal "null"; we then
+          # require a non-negative integer and fail loudly on anything unexpected, so a
+          # transient API error is never mistaken for "no new commits".
+          AHEAD=$(gh api "repos/${{ github.repository }}/compare/${LATEST_TAG}...${BRANCH}" --jq '.ahead_by // empty') \
+            || { echo "::error::Could not query commits since $LATEST_TAG (compare API failed)."; exit 1; }
+          if ! [[ "$AHEAD" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unexpected ahead_by='${AHEAD:-<empty>}' from compare ${LATEST_TAG}...${BRANCH}; refusing to guess."
+            exit 1
+          fi
+          if [[ "$AHEAD" == "0" ]]; then
             if [[ "$DRY_RUN" == "true" ]]; then
               echo "::warning::No new commits on '$BRANCH' since $LATEST_TAG — a real run would be rejected (nothing to release)."
             else


### PR DESCRIPTION
## What

- Reject a release in `create-release.yaml` when the branch has **no new commits** since the last release.

## Why

- The workflow computed the next version and published a tag regardless of whether anything actually changed, producing **empty releases**. Concretely, `v0.177.1` points at the *same commit* as `v0.177.0` (`git rev-list v0.177.0..v0.177.1 --count` → `0`). See https://github.com/Zipstack/unstract/compare/v0.177.0...v0.177.1.

## How

- After *Fetch base release version*, a new step compares the branch against the latest release tag using the GitHub **compare API** (`ahead_by`) — the workflow has no local checkout, so this is the clean way to count new commits. If `ahead_by == 0`, abort with a clear error; `dry_run` only warns. Works for `main` and `vX.Y.Z-hotfix` branches.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. It only adds a pre-flight check that fails fast in the one case where the release would be a no-op (zero new commits). Legitimate releases (any branch with ≥1 new commit since the last release) are unaffected. Verified `ahead_by` against live data: `v0.177.0...main` → 0 (would reject), `v0.176.0...main` → 15, `v0.176.5...main` → 5 (allowed).

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- Hotfix Deployment Guide: https://zipstack.atlassian.net/wiki/spaces/PT/pages/491880450

## Related Issues or PRs

- Companion cloud PR (makes the RC build skip the OSS release instead of failing when there are no OSS changes): Zipstack/unstract-cloud#1610

## Dependencies Versions

- None.

## Notes on Testing

- YAML validated; mock-`gh` test of the new step: `ahead_by=0` + real run → `exit 1`; `ahead_by=0` + dry-run → warn only; `ahead_by>0` → proceed.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)