### PR TITLE
UN-3185: Fix squished route-loading spinner in the content area

### DIFF
--- a/frontend/src/components/error/LazyOutlet/LazyOutlet.css
+++ b/frontend/src/components/error/LazyOutlet/LazyOutlet.css
@@ -1,0 +1,17 @@
+/* Center the route-loading fallback in the content area. */
+.lazyOutletFallback {
+  display: flex;
+  width: 100%;
+  min-height: 60vh;
+  align-items: center;
+  justify-content: center;
+}
+
+/* GenericLoader's .center uses `width/height: inherit`, which collapses to a
+   narrow column inside the flex content area (the loader text ends up wrapping
+   one word per line next to the sidebar). Pin it to the full fallback width so
+   it renders centered at its natural size instead. */
+.lazyOutletFallback > .center {
+  width: 100%;
+  height: auto;
+}

--- a/frontend/src/components/error/LazyOutlet/LazyOutlet.jsx
+++ b/frontend/src/components/error/LazyOutlet/LazyOutlet.jsx
@@ -4,6 +4,7 @@ import { Outlet, useLocation } from "react-router-dom";
 
 import { GenericLoader } from "../../generic-loader/GenericLoader.jsx";
 import { ErrorBoundary } from "../../widgets/error-boundary/ErrorBoundary.jsx";
+import "./LazyOutlet.css";
 
 // A failed dynamic import — almost always a stale hashed chunk after a
 // redeploy (the client's index.html references a filename the CDN no longer
@@ -74,7 +75,15 @@ export function LazyOutlet() {
       onError={handleRouteError}
       fallbackComponent={<RouteLoadError />}
     >
-      <Suspense fallback={<GenericLoader />}>
+      {/* Wrap the loader so it fills the content area and stays centered — see
+          LazyOutlet.css for why GenericLoader needs this here. */}
+      <Suspense
+        fallback={
+          <div className="lazyOutletFallback">
+            <GenericLoader />
+          </div>
+        }
+      >
         <Outlet />
       </Suspense>
     </ErrorBoundary>


### PR DESCRIPTION
## What

- Fix the route-loading spinner being squished into a narrow column (text wrapping one word per line) next to the sidebar — a follow-up to #2114.

## Why

- #2114 added `LazyOutlet` (a content-scoped `<Suspense>` inside `PageLayout`/`FullPageLayout`). Its fallback is `GenericLoader`, whose root `.center` uses `width/height: inherit` (`index.css`). At the app-level Suspense that inherits the full viewport, but inside the flex content area it collapses to a narrow column, so the loader renders cramped and left-aligned instead of centered.

## How

- Wrap the content-area fallback in a full-width, flex-centered `.lazyOutletFallback` box and pin the loader (`> .center`) to `width: 100%`, so it renders centered at its natural size regardless of how `inherit` resolves in the parent context. The app-level loader in `Router.jsx` is untouched (it doesn't use this wrapper).

## Can this PR break any existing features?

- No. CSS-only change scoped to a new `.lazyOutletFallback` class used solely by `LazyOutlet`'s Suspense fallback. No behavior, routing, or other component is affected.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- None.

## Related Issues or PRs

- UN-3185. Follow-up to #2114 (merged).

## Dependencies Versions

- None.

## Notes on Testing

- `npm run build` green. Verified in-browser against the loaded stylesheet that `.lazyOutletFallback > .center` resolves to the full fallback width (e.g. a 500px fallback yields a 500px `.center`) instead of tracking the `inherit` chain, and the loader is flex-centered.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
