### PR TITLE
UN-3185: Pin LLM profile form submit button as a sticky footer

### DIFF
--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
@@ -19,7 +19,7 @@
   z-index: 1;
   margin-bottom: 0;
   padding-top: 12px;
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--ant-color-border-secondary, #f0f0f0);
 }
 
 .add-llm-profile-row {

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
@@ -1,5 +1,27 @@
 /* Styles for AddLlmProfile */
 
+/* The settings modal's content column (.conn-modal-col) is the real scroll
+   container. .settings-body-pad-top declares its own overflow-y: auto with no
+   bounded height, which does nothing except register a nested scroll context
+   that would stop the sticky footer below from pinning to .conn-modal-col.
+   Drop it back to visible for this form. */
+.settings-body-pad-top.add-llm-profile-scroll-root {
+  overflow: visible;
+}
+
+/* Pin the submit button to the bottom of the scrollable panel so it stays
+   visible as the form grows (e.g. Advanced Settings expanded) instead of
+   flowing past the modal. Background is set inline from the antd theme token
+   so scrolling fields don't show through. */
+.add-llm-profile-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  margin-bottom: 0;
+  padding-top: 12px;
+  border-top: 1px solid #f0f0f0;
+}
+
 .add-llm-profile-row {
   width: 100%;
 }

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
@@ -453,7 +453,7 @@ function AddLlmProfile({
   };
 
   return (
-    <div className="settings-body-pad-top">
+    <div className="settings-body-pad-top add-llm-profile-scroll-root">
       <Form
         form={form}
         layout="vertical"
@@ -633,7 +633,10 @@ function AddLlmProfile({
             />
           </div>
         </SpaceWrapper>
-        <Form.Item className="display-flex-right">
+        <Form.Item
+          className="display-flex-right add-llm-profile-footer"
+          style={{ backgroundColor: token.colorBgContainer }}
+        >
           <Space>
             <CustomButton type="primary" htmlType="submit" loading={loading}>
               {editLlmProfileId ? "Update" : "Add"}


### PR DESCRIPTION
## What

- Fix the **Update / Add button overflowing** the prompt-studio Settings → LLM Profile add/edit form (most visible with *Advanced Settings* expanded — the button flowed past the modal's visible area instead of staying pinned).

## Why

- `SettingsModal` renders its body as a fixed `height: 800px` row with scrollable columns (`.conn-modal-col { overflow-y: auto }`). `AddLlmProfile` placed its submit button as the **last element in normal flow**, not a pinned footer, so a tall form (Advanced Settings expanded) pushed the button below the visible area.
- The form root (`.settings-body-pad-top`) also declared `overflow-y: auto` with **no bounded height** — a dead nested scroll context that prevented a sticky footer from pinning to the real scroller.

## How

- Make the submit `Form.Item` a **sticky footer** (`position: sticky; bottom: 0`) with a solid themed background (`token.colorBgContainer`) and a top border, so it stays pinned at the bottom of the scroll column while fields scroll beneath it.
- Override the dead nested `overflow-y: auto` back to `visible` for this form (scoped via a new `.add-llm-profile-scroll-root` class — does not affect other consumers of `.settings-body-pad-top`).

## Can this PR break any existing features?

- No. Changes are scoped to `AddLlmProfile` (one form component) via new classes; the override targets `.settings-body-pad-top.add-llm-profile-scroll-root` (both classes) so other settings panels are unaffected. No logic/behavior change — purely layout.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- None.

## Related Issues or PRs

- UN-3185. Separate from the perf PR (#2114, merged) and the loader-spinner fix (#2118). This is a pre-existing layout issue, not a regression from those.

## Dependencies Versions

- None.

## Notes on Testing

- `npm run build` green, biome clean.
- Verified the sticky pinning against the real CSS rules in-browser: with the nested `overflow-y: auto` + non-sticky button the footer sits ~321px below the visible scroll bottom (overflowed); with the override + sticky footer it pins to offset 0 (always visible) while scrolling.
- Note: the `ManageLlmProfiles` list view ("Add New LLM Profile" button) follows the same pattern and could get the same treatment if desired — left out to keep this focused on the reported edit form.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
