### PR TITLE
UN-3651 [FIX] PG barrier enqueue — reconnect-retry on stale cached connection

### DIFF
--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -128,6 +128,53 @@ def _cursor() -> Iterator[Any]:
         raise
 
 
+# One retry for an IDEMPOTENT barrier write. The thread-local connection is
+# cached across barrier ops, so it can be reaped server-side (PgBouncer
+# server_idle_timeout / DB failover) while sitting idle BETWEEN ops — and
+# ``_get_conn`` can't tell, since ``conn.closed`` is a client-side flag only.
+# The first statement after the idle gap then fails; ``_cursor`` discards the
+# dead conn, so a single retry runs against a freshly reconnected one. This
+# turns a transient blip (which previously aborted the whole execution at
+# barrier enqueue) into a self-heal.
+_BARRIER_WRITE_ATTEMPTS = 2
+
+
+def _run_idempotent_write(operation: Callable[[Any], None], *, what: str) -> None:
+    """Run ``operation(cur)`` in a committed cursor, retrying ONCE if the cached
+    connection was dead.
+
+    Restricted to **idempotent** statements run BEFORE any task dispatch — the
+    barrier UPSERT (``ON CONFLICT … DO UPDATE`` → same row, same state) + the
+    per-execution dedup reset (``DELETE WHERE execution_id``). Re-running them
+    after an ambiguous commit is a no-op, so a retry can neither duplicate a row
+    nor double-dispatch work (no header has been enqueued yet).
+
+    Deliberately NOT used for the barrier **decrement** (``remaining =
+    remaining - 1``): that is not idempotent — a re-applied decrement could drive
+    ``remaining`` to 0 early and fire the callback twice — so it stays on the
+    plain :func:`_cursor` (recover-but-don't-retry). Same for ``claim_batch``,
+    whose ``RETURNING`` answer flips on a retry.
+    """
+    for attempt in range(1, _BARRIER_WRITE_ATTEMPTS + 1):
+        try:
+            with _cursor() as cur:
+                operation(cur)
+            return
+        except (psycopg2.OperationalError, psycopg2.InterfaceError):
+            # _cursor already dropped the dead thread-local conn → the next
+            # _get_conn() reconnects. Retry once; re-raise if it still fails
+            # (a genuinely-down DB surfaces as ERROR, as before).
+            if attempt >= _BARRIER_WRITE_ATTEMPTS:
+                raise
+            logger.warning(
+                "PgBarrier: %s lost its DB connection (attempt %d/%d); "
+                "reconnecting and retrying",
+                what,
+                attempt,
+                _BARRIER_WRITE_ATTEMPTS,
+            )
+
+
 def _delete_barrier(execution_id: str) -> None:
     with _cursor() as cur:
         cur.execute(
@@ -311,7 +358,7 @@ class PgBarrier:
                     f"could not be reaper-recovered. This is a bug in the caller."
                 )
 
-            with _cursor() as cur:
+            def _reset_barrier(cur: Any) -> None:
                 # UPSERT clears any leftover state from a prior run with this id.
                 # No inline expiry sweep here — an unbounded global DELETE on the
                 # enqueue hot path risks lock contention / deadlocks between
@@ -338,6 +385,11 @@ class PgBarrier:
                     f"DELETE FROM {qualified('pg_batch_dedup')} WHERE execution_id = %s",
                     (execution_id,),
                 )
+
+            # Both statements are idempotent and run BEFORE any header dispatch,
+            # so a one-shot retry on a stale cached connection can't duplicate
+            # state or double-dispatch — see _run_idempotent_write.
+            _run_idempotent_write(_reset_barrier, what=f"enqueue exec={execution_id}")
 
             self._dispatch_headers(
                 header_tasks,

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -60,9 +60,10 @@ import contextlib
 import json
 import logging
 import threading
+import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import psycopg2
 import psycopg2.extensions
@@ -88,6 +89,7 @@ from .pg_queue.schema import qualified
 if TYPE_CHECKING:
     from celery.canvas import Signature
     from psycopg2.extensions import connection as PgConnection
+    from psycopg2.extensions import cursor as PgCursor
 
 logger = logging.getLogger(__name__)
 
@@ -128,51 +130,70 @@ def _cursor() -> Iterator[Any]:
         raise
 
 
-# One retry for an IDEMPOTENT barrier write. The thread-local connection is
-# cached across barrier ops, so it can be reaped server-side (PgBouncer
-# server_idle_timeout / DB failover) while sitting idle BETWEEN ops — and
-# ``_get_conn`` can't tell, since ``conn.closed`` is a client-side flag only.
+# One retry for an IDEMPOTENT, pre-dispatch barrier write. The thread-local
+# connection is cached across barrier ops, so it can be reaped server-side
+# (PgBouncer server_idle_timeout / DB failover) while sitting idle BETWEEN ops —
+# and ``_get_conn`` can't tell, since ``conn.closed`` is a client-side flag only.
 # The first statement after the idle gap then fails; ``_cursor`` discards the
-# dead conn, so a single retry runs against a freshly reconnected one. This
-# turns a transient blip (which previously aborted the whole execution at
-# barrier enqueue) into a self-heal.
-_BARRIER_WRITE_ATTEMPTS = 2
+# dead conn, so a single retry runs against a freshly reconnected one. This turns
+# a transient blip (which previously aborted the whole execution at barrier
+# enqueue) into a self-heal. Kept a literal (not env-driven) so the idempotency
+# bound can't be weakened operationally.
+_BARRIER_WRITE_ATTEMPTS: Final = 2  # total attempts: 1 initial + 1 retry
+# Small fixed pause before the retry. The idle-reap case reconnects instantly
+# regardless; this only widens the self-heal window for a brief DB failover, and
+# avoids immediately re-hammering a struggling server on the rarer server-side
+# errors the broad psycopg2.OperationalError catch also covers.
+_BARRIER_RETRY_BACKOFF_SECONDS: Final = 0.5
 
 
-def _run_idempotent_write(operation: Callable[[Any], None], *, what: str) -> None:
+def _run_idempotent_pre_dispatch_write(
+    operation: Callable[[PgCursor], None], *, what: str
+) -> None:
     """Run ``operation(cur)`` in a committed cursor, retrying ONCE if the cached
     connection was dead.
 
-    Restricted to **idempotent** statements run BEFORE any task dispatch — the
-    barrier UPSERT (``ON CONFLICT … DO UPDATE`` → same row, same state) + the
+    The name spells out the contract because it can't be type-enforced: only call
+    with an **idempotent** statement run **before** any task dispatch — the
+    barrier UPSERT (``ON CONFLICT … DO UPDATE`` → same row, ``remaining``/
+    ``results`` reset identically; timestamps refresh, harmlessly) + the
     per-execution dedup reset (``DELETE WHERE execution_id``). Re-running them
     after an ambiguous commit is a no-op, so a retry can neither duplicate a row
-    nor double-dispatch work (no header has been enqueued yet).
+    nor double-dispatch work (no header has been enqueued yet). The ``-> None``
+    op signature also blocks passing a ``RETURNING``-reading op by construction.
 
     Deliberately NOT used for the barrier **decrement** (``remaining =
-    remaining - 1``): that is not idempotent — a re-applied decrement could drive
-    ``remaining`` to 0 early and fire the callback twice — so it stays on the
-    plain :func:`_cursor` (recover-but-don't-retry). Same for ``claim_batch``,
-    whose ``RETURNING`` answer flips on a retry.
+    remaining - 1``): it is not idempotent — a re-applied decrement can fire the
+    callback **prematurely with incomplete results**, or skip past 0 and
+    **strand the barrier** to expiry — so it stays on the plain :func:`_cursor`
+    (recover-but-don't-retry). Same for ``claim_batch``, whose ``RETURNING``
+    answer flips on a retry.
     """
     for attempt in range(1, _BARRIER_WRITE_ATTEMPTS + 1):
         try:
             with _cursor() as cur:
                 operation(cur)
             return
-        except (psycopg2.OperationalError, psycopg2.InterfaceError):
+        except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
             # _cursor already dropped the dead thread-local conn → the next
             # _get_conn() reconnects. Retry once; re-raise if it still fails
-            # (a genuinely-down DB surfaces as ERROR, as before).
+            # (a genuinely-down DB surfaces as ERROR, as before). Name the real
+            # error + keep the traceback: the broad catch also covers server-side
+            # conditions (statement timeout, deadlock, admin shutdown), so the
+            # message must not assert a connection drop it can't be sure of.
             if attempt >= _BARRIER_WRITE_ATTEMPTS:
                 raise
             logger.warning(
-                "PgBarrier: %s lost its DB connection (attempt %d/%d); "
-                "reconnecting and retrying",
+                "PgBarrier: %s — DB write failed (%s: %s); cached connection "
+                "likely stale, reconnecting and retrying (attempt %d/%d)",
                 what,
+                type(exc).__name__,
+                exc,
                 attempt,
                 _BARRIER_WRITE_ATTEMPTS,
+                exc_info=True,
             )
+            time.sleep(_BARRIER_RETRY_BACKOFF_SECONDS)
 
 
 def _delete_barrier(execution_id: str) -> None:
@@ -358,7 +379,7 @@ class PgBarrier:
                     f"could not be reaper-recovered. This is a bug in the caller."
                 )
 
-            def _reset_barrier(cur: Any) -> None:
+            def _reset_barrier(cur: PgCursor) -> None:
                 # UPSERT clears any leftover state from a prior run with this id.
                 # No inline expiry sweep here — an unbounded global DELETE on the
                 # enqueue hot path risks lock contention / deadlocks between
@@ -386,10 +407,11 @@ class PgBarrier:
                     (execution_id,),
                 )
 
-            # Both statements are idempotent and run BEFORE any header dispatch,
-            # so a one-shot retry on a stale cached connection can't duplicate
-            # state or double-dispatch — see _run_idempotent_write.
-            _run_idempotent_write(_reset_barrier, what=f"enqueue exec={execution_id}")
+            # Idempotent + pre-dispatch → safe to retry; see
+            # _run_idempotent_pre_dispatch_write.
+            _run_idempotent_pre_dispatch_write(
+                _reset_barrier, what=f"enqueue exec={execution_id}"
+            )
 
             self._dispatch_headers(
                 header_tasks,

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -43,6 +43,7 @@ def _pg_header(task_name="process_file_batch", args=None, queue="file_processing
     sig.options = {"queue": queue}
     return sig
 
+
 _CALLBACK = {
     "task_name": "process_batch_callback_api",
     "kwargs": {"execution_id": "exec-1", "pipeline_id": "pipe-1"},
@@ -113,6 +114,121 @@ class TestEnqueueShortCircuits:
                 callback_queue="general",
                 app_instance=None,
             )
+
+
+# --- Idempotent-write reconnect-retry (no DB) ---
+
+
+class _FakeCursorCtx:
+    def __init__(self, on_execute):
+        self._on_execute = on_execute
+
+    def __enter__(self):
+        cur = MagicMock(name="cursor")
+        cur.execute.side_effect = self._on_execute
+        return cur
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    """Minimal psycopg2-connection stub. ``execute_error`` (if set) is raised by
+    every cursor.execute on this connection — simulating a stale/dead socket.
+    """
+
+    def __init__(self, *, execute_error=None):
+        self.closed = False
+        self._execute_error = execute_error
+        self.commits = 0
+        self.rollbacks = 0
+        self.executes = 0
+
+    def cursor(self):
+        def _on_execute(*_a, **_k):
+            self.executes += 1
+            if self._execute_error is not None:
+                raise self._execute_error
+
+        return _FakeCursorCtx(_on_execute)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def _clean_local():
+    """Ensure the module thread-local connection is reset around each test."""
+    pg_barrier._local.conn = None
+    yield
+    pg_barrier._local.conn = None
+
+
+class TestIdempotentWriteRetry:
+    """`_run_idempotent_write` self-heals a stale cached connection with ONE
+    retry — the fix for the `server closed the connection unexpectedly` abort at
+    barrier enqueue. It must retry ONLY on connection errors, stay bounded, and
+    never silently swallow a real (non-connection) failure.
+    """
+
+    def test_retries_once_on_dead_connection_then_succeeds(
+        self, _clean_local, monkeypatch
+    ):
+        dead = _FakeConn(
+            execute_error=psycopg2.OperationalError(
+                "server closed the connection unexpectedly"
+            )
+        )
+        healthy = _FakeConn()
+        pg_barrier._local.conn = dead
+        # On reconnect (_cursor discarded the dead conn), hand back the healthy one.
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
+
+        attempts = []
+
+        def op(cur):
+            attempts.append(1)
+            cur.execute("UPSERT ...", ("x",))
+
+        pg_barrier._run_idempotent_write(op, what="test")
+
+        assert len(attempts) == 2  # first failed mid-execute, retry succeeded
+        assert dead.closed is True  # stale conn discarded
+        assert healthy.commits == 1  # committed exactly once, on the retry
+        assert pg_barrier._local.conn is healthy
+
+    def test_does_not_retry_non_connection_error(self, _clean_local, monkeypatch):
+        healthy = _FakeConn()
+        pg_barrier._local.conn = healthy
+        reconnects = []
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: reconnects.append(1) or _FakeConn(),
+        )
+
+        def op(cur):
+            raise ValueError("not a connection problem")
+
+        with pytest.raises(ValueError, match="not a connection problem"):
+            pg_barrier._run_idempotent_write(op, what="test")
+        assert reconnects == []  # a real error must surface immediately, no retry
+
+    def test_reraises_after_exhausting_attempts(self, _clean_local, monkeypatch):
+        err = psycopg2.OperationalError("still down")
+        # Every connection (initial + reconnect) is dead → both attempts fail.
+        monkeypatch.setattr(
+            pg_barrier, "create_pg_connection", lambda **_k: _FakeConn(execute_error=err)
+        )
+
+        with pytest.raises(psycopg2.OperationalError, match="still down"):
+            pg_barrier._run_idempotent_write(lambda cur: cur.execute("X"), what="test")
 
 
 # --- Layer 2: enqueue + link/abort with a real injected connection ---
@@ -484,7 +600,6 @@ class TestAbort:
     def test_registered_under_canonical_name(self):
         assert barrier_pg_abort.name == "barrier_pg_abort"
 
-
     def test_max_retries_zero(self):
         # A Celery retry would replay the decrement and corrupt the count.
         assert barrier_pg_decr_and_check.max_retries == 0
@@ -795,9 +910,7 @@ class TestPgFireAndForgetMode:
             raise RuntimeError("broker down")
 
         dispatch_side_effect.claimed = False
-        with patch(
-            "queue_backend.dispatch.dispatch", side_effect=dispatch_side_effect
-        ):
+        with patch("queue_backend.dispatch.dispatch", side_effect=dispatch_side_effect):
             with pytest.raises(RuntimeError, match="broker down"):
                 PgBarrier().enqueue(
                     [_pg_header(), _pg_header()],

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -171,20 +171,31 @@ def _clean_local():
 
 
 class TestIdempotentWriteRetry:
-    """`_run_idempotent_write` self-heals a stale cached connection with ONE
-    retry — the fix for the `server closed the connection unexpectedly` abort at
-    barrier enqueue. It must retry ONLY on connection errors, stay bounded, and
-    never silently swallow a real (non-connection) failure.
+    """`_run_idempotent_pre_dispatch_write` self-heals a stale cached connection
+    with ONE retry — the fix for the `server closed the connection unexpectedly`
+    abort at barrier enqueue. It must retry ONLY on connection errors, stay
+    bounded, and never silently swallow a real (non-connection) failure.
     """
 
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self, monkeypatch):
+        # The retry backoff is real (0.5s); skip the wall-clock wait in tests.
+        monkeypatch.setattr(pg_barrier.time, "sleep", lambda *_a, **_k: None)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            psycopg2.OperationalError("server closed the connection unexpectedly"),
+            psycopg2.InterfaceError("connection already closed"),
+        ],
+        ids=["OperationalError", "InterfaceError"],
+    )
     def test_retries_once_on_dead_connection_then_succeeds(
-        self, _clean_local, monkeypatch
+        self, _clean_local, monkeypatch, caplog, exc
     ):
-        dead = _FakeConn(
-            execute_error=psycopg2.OperationalError(
-                "server closed the connection unexpectedly"
-            )
-        )
+        # InterfaceError is the more common stale-socket symptom, so both arms of
+        # the (OperationalError, InterfaceError) catch must self-heal.
+        dead = _FakeConn(execute_error=exc)
         healthy = _FakeConn()
         pg_barrier._local.conn = dead
         # On reconnect (_cursor discarded the dead conn), hand back the healthy one.
@@ -196,12 +207,18 @@ class TestIdempotentWriteRetry:
             attempts.append(1)
             cur.execute("UPSERT ...", ("x",))
 
-        pg_barrier._run_idempotent_write(op, what="test")
+        with caplog.at_level("WARNING"):
+            pg_barrier._run_idempotent_pre_dispatch_write(op, what="test")
 
         assert len(attempts) == 2  # first failed mid-execute, retry succeeded
+        assert dead.executes == 1 and healthy.executes == 1  # exactly one extra try
+        assert dead.commits == 0  # no partial commit on the failed attempt
         assert dead.closed is True  # stale conn discarded
         assert healthy.commits == 1  # committed exactly once, on the retry
         assert pg_barrier._local.conn is healthy
+        # logs on retry (not on success) and names the real error, not a guess.
+        assert "reconnecting and retrying" in caplog.text
+        assert type(exc).__name__ in caplog.text
 
     def test_does_not_retry_non_connection_error(self, _clean_local, monkeypatch):
         healthy = _FakeConn()
@@ -217,7 +234,7 @@ class TestIdempotentWriteRetry:
             raise ValueError("not a connection problem")
 
         with pytest.raises(ValueError, match="not a connection problem"):
-            pg_barrier._run_idempotent_write(op, what="test")
+            pg_barrier._run_idempotent_pre_dispatch_write(op, what="test")
         assert reconnects == []  # a real error must surface immediately, no retry
 
     def test_reraises_after_exhausting_attempts(self, _clean_local, monkeypatch):
@@ -228,7 +245,9 @@ class TestIdempotentWriteRetry:
         )
 
         with pytest.raises(psycopg2.OperationalError, match="still down"):
-            pg_barrier._run_idempotent_write(lambda cur: cur.execute("X"), what="test")
+            pg_barrier._run_idempotent_pre_dispatch_write(
+                lambda cur: cur.execute("X"), what="test"
+            )
 
 
 # --- Layer 2: enqueue + link/abort with a real injected connection ---
@@ -296,6 +315,38 @@ class TestPgBarrierEnqueue:
         for _, cloned in tasks:
             cloned.link.assert_called_once()
             cloned.link_error.assert_called_once()
+            cloned.apply_async.assert_called_once()
+
+    def test_enqueue_self_heals_on_stale_connection(self, barrier_db, monkeypatch):
+        # End-to-end through enqueue(): the first barrier write hits a dead cached
+        # conn; the fix must reconnect to the REAL db, land the row exactly once,
+        # and still dispatch every header exactly once (no double-dispatch). This
+        # pins the wiring — reverting enqueue() to the inline `with _cursor()`
+        # would make this fail (the no-DB retry tests alone would not catch that).
+        monkeypatch.setattr(pg_barrier.time, "sleep", lambda *_a, **_k: None)
+        dead = _FakeConn(
+            execute_error=psycopg2.OperationalError(
+                "server closed the connection unexpectedly"
+            )
+        )
+        pg_barrier._local.conn = (
+            dead  # the barrier_db fixture's real conn is the reconnect target
+        )
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: barrier_db)
+
+        tasks = [_mock_header_task() for _ in range(3)]
+        handle = PgBarrier().enqueue(
+            [t for t, _ in tasks],
+            callback_task_name="cb",
+            callback_kwargs={"execution_id": "exec-HEAL"},
+            callback_queue="general",
+            app_instance=None,
+        )
+
+        assert handle.id == "exec-HEAL"
+        assert dead.closed is True  # stale conn discarded by _cursor
+        assert _row(barrier_db, "exec-HEAL") == (3, [])  # row landed once, remaining=N
+        for _, cloned in tasks:  # every header dispatched exactly once
             cloned.apply_async.assert_called_once()
 
     def test_fairness_header_stamped(self, barrier_db):


### PR DESCRIPTION
## What
A transient `psycopg2.OperationalError: server closed the connection unexpectedly` during the **PgBarrier enqueue** (the barrier UPSERT) aborted the whole ETL execution → status `ERROR` with 0 files created.

## Root cause
PgBarrier keeps a **thread-local cached** Postgres connection reused across barrier ops. While idle *between* ops it can be reaped server-side (PgBouncer `server_idle_timeout` / DB failover / TCP teardown), and `_get_conn` can't tell — `conn.closed` is a client-side flag only — so the first statement after the idle gap fails. The existing `_cursor` *recovers* the dead conn (so the next call reconnects) but does **not retry** the failed op → the execution aborts.

## Fix
A one-shot reconnect-retry (`_run_idempotent_write`, attempts=2) scoped to the **idempotent, pre-dispatch** barrier write only — the UPSERT (`ON CONFLICT … DO UPDATE` → same row/state) + the per-execution dedup reset. Re-running them after an ambiguous commit is a no-op, and no header has been dispatched yet, so a retry can **neither duplicate a row nor double-dispatch work**.

**Idempotency boundary preserved:** the non-idempotent **decrement** (`remaining - 1`) and `claim_batch` stay on the plain `_cursor` (recover-but-don't-retry) — a re-applied decrement could fire the callback early, so it must never auto-retry.

## Scope / non-regression
Workers only (`pg_barrier.py`), under the `pg_queue_enabled` flag — PgBarrier runs **only** on the PG transport. Flag OFF → `CeleryChordBarrier`, this code never runs → zero Celery-path regression. The change is additive on the PG happy path (first attempt succeeds, identical to before); the only behavior change is that a previously-fatal transient drop now self-heals.

## Verification
- **Unit:** +3 tests (retry-then-succeed, no-retry-on-non-connection-error, reraise-after-exhaust). Full PgBarrier suite **54 passed**; ruff clean.
- **Live A/B against real Postgres** (rebuilt worker image), reproducing the exact incident error via `pg_terminate_backend`:
  - **WITHOUT fix** (old `with _cursor()` path): raises → barrier row not written (0) → execution aborts.
  - **WITH fix**: logs `reconnecting and retrying` → barrier row written (1) → execution proceeds.
  - **Control:** plain `_cursor` (decrement path) raises with **no** retry → boundary intact.

Ref: UN-3651