### PR TITLE
UN-3654 [FIX] PG queue — reconnect-retry on stale dispatch connection (send())

### DIFF
--- a/workers/queue_backend/pg_queue/client.py
+++ b/workers/queue_backend/pg_queue/client.py
@@ -29,9 +29,10 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import time
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Final, Self
 
 import psycopg2
 
@@ -147,6 +148,13 @@ def insert_message_sql() -> str:
     )
 
 
+# Small fixed pause before send()'s single reconnect-retry (see send()). The
+# idle-reap case reconnects instantly regardless; this only widens the self-heal
+# window for a brief DB failover and avoids re-hammering a struggling server.
+# A literal, not env-driven, so the one-shot bound can't be weakened operationally.
+_SEND_RETRY_BACKOFF_SECONDS: Final = 0.5
+
+
 class PgQueueClient:
     """``send`` / ``read`` / ``delete`` over ``pg_queue_message``.
 
@@ -220,11 +228,53 @@ class PgQueueClient:
         MAX_PRIORITY]`` — out of range raises (it would silently jump/sink the
         row in the ``priority DESC`` claim order), mirroring ``read()``'s guards.
         The DB ``CheckConstraint`` is the backstop for any ORM/raw writer.
+
+        Reconnect-retry: the cached connection can be reaped server-side
+        (PgBouncer ``server_idle_timeout`` / DB failover) while idle BETWEEN
+        sends, and ``conn.closed`` is a client-side flag only — so the first
+        ``execute`` after the idle gap fails (this aborted whole executions at
+        the barrier's header dispatch). We retry ONCE, but only when the failing
+        connection was **reused** (cached, and owned by us): a reused conn that
+        dies on its first statement was reaped while idle, so the ``INSERT``
+        never reached the server — re-inserting can't duplicate. A **fresh**
+        connection failing is a genuine error (or an ambiguous mid-statement
+        death) → re-raise, never retry. Unlike the barrier's idempotent
+        pre-dispatch write, an ``INSERT`` is not idempotent, so this
+        reused-only guard is what keeps the retry from double-enqueuing; in the
+        rare reused-conn mid-statement-death case a duplicate batch enqueue is
+        absorbed by the ``claim_batch`` / ``pg_batch_dedup`` gate downstream.
         """
         if not MIN_PRIORITY <= priority <= MAX_PRIORITY:
             raise ValueError(
                 f"priority out of range [{MIN_PRIORITY}, {MAX_PRIORITY}]: {priority!r}"
             )
+        # Capture BEFORE the attempt: a fresh conn has self._conn is None here.
+        reused = self._conn is not None and self._owns_conn
+        try:
+            return self._insert_message(queue_name, message, org_id, priority)
+        except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
+            if not reused:
+                raise
+            logger.warning(
+                "PG-queue: send to queue=%r failed (%s: %s); cached connection "
+                "likely stale, reconnecting and retrying once",
+                queue_name,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            time.sleep(_SEND_RETRY_BACKOFF_SECONDS)
+            # _cursor already dropped the dead owned conn, so this reconnects.
+            return self._insert_message(queue_name, message, org_id, priority)
+
+    def _insert_message(
+        self,
+        queue_name: str,
+        message: dict[str, Any],
+        org_id: str | None,
+        priority: int,
+    ) -> int:
+        """One INSERT of a queue row, returning its ``msg_id`` (see :meth:`send`)."""
         with self._cursor() as cur:
             cur.execute(
                 insert_message_sql() + " RETURNING msg_id",

--- a/workers/queue_backend/pg_queue/client.py
+++ b/workers/queue_backend/pg_queue/client.py
@@ -46,6 +46,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# psycopg2 errors that mean the connection itself is dead (dropped socket /
+# PgBouncer recycle / server termination) rather than a statement-level fault.
+# Shared by ``_cursor`` (decides whether to discard the cached handle) and
+# ``send`` (decides whether the one-shot reconnect-retry is eligible) so the two
+# sites can't drift — narrowing one without the other would silently break the
+# retry's "was this a connection death?" test.
+_CONN_DEAD_ERRORS: Final[tuple[type[Exception], ...]] = (
+    psycopg2.OperationalError,
+    psycopg2.InterfaceError,
+)
+
+
 # Atomic claim. Takes up to %(qty)s ready messages no other transaction
 # holds, makes them invisible for %(vt)s seconds, returns them. SKIP LOCKED
 # => concurrent readers never claim the same visible row (no concurrent
@@ -148,10 +160,16 @@ def insert_message_sql() -> str:
     )
 
 
-# Small fixed pause before send()'s single reconnect-retry (see send()). The
-# idle-reap case reconnects instantly regardless; this only widens the self-heal
-# window for a brief DB failover and avoids re-hammering a struggling server.
-# A literal, not env-driven, so the one-shot bound can't be weakened operationally.
+# Pause duration before send()'s single reconnect-retry (see send()). This is
+# the length of the pause, NOT the retry count — the one-shot bound is enforced
+# structurally by send()'s single ``except`` + single retry call, not by this
+# value. A literal rather than env-driven so the pause can't be tuned into a
+# long blocking stall on the enqueue hot path. Note the sleep penalises the
+# common idle-reap path (which reconnects instantly) purely to buy a self-heal
+# window for the rarer brief DB failover, and to avoid re-hammering a struggling
+# server. Caveat: this is a blocking ``time.sleep``; if send() is ever pulled
+# into an async context it becomes an event-loop stall and must move to
+# ``asyncio.sleep``.
 _SEND_RETRY_BACKOFF_SECONDS: Final = 0.5
 
 
@@ -193,9 +211,13 @@ class PgQueueClient:
             # A failed rollback proves the connection is unusable, regardless
             # of which psycopg2 error subclass was raised (a server-side
             # termination mid-statement can surface as a bare DatabaseError).
-            conn_dead = isinstance(
-                exc, (psycopg2.OperationalError, psycopg2.InterfaceError)
-            )
+            # NOTE: ``send()``'s retry deliberately catches only
+            # ``_CONN_DEAD_ERRORS``; a server death that surfaces as a *bare*
+            # ``psycopg2.DatabaseError`` is still treated as dead here (via the
+            # failed-rollback branch below, which drops the handle) but is
+            # intentionally NOT retried by ``send()`` — it's left to the next
+            # call's reconnect.
+            conn_dead = isinstance(exc, _CONN_DEAD_ERRORS)
             try:
                 conn.rollback()
             except Exception:
@@ -233,16 +255,30 @@ class PgQueueClient:
         (PgBouncer ``server_idle_timeout`` / DB failover) while idle BETWEEN
         sends, and ``conn.closed`` is a client-side flag only — so the first
         ``execute`` after the idle gap fails (this aborted whole executions at
-        the barrier's header dispatch). We retry ONCE, but only when the failing
-        connection was **reused** (cached, and owned by us): a reused conn that
-        dies on its first statement was reaped while idle, so the ``INSERT``
-        never reached the server — re-inserting can't duplicate. A **fresh**
-        connection failing is a genuine error (or an ambiguous mid-statement
-        death) → re-raise, never retry. Unlike the barrier's idempotent
-        pre-dispatch write, an ``INSERT`` is not idempotent, so this
-        reused-only guard is what keeps the retry from double-enqueuing; in the
-        rare reused-conn mid-statement-death case a duplicate batch enqueue is
-        absorbed by the ``claim_batch`` / ``pg_batch_dedup`` gate downstream.
+        the barrier's header dispatch). We retry ONCE, but only on
+        ``_CONN_DEAD_ERRORS`` and only when the failing connection was
+        **reused**. The ``reused`` gate only distinguishes "cached BEFORE this
+        call" from "created DURING it" (captured before the attempt, which is
+        correct) — it makes the retry safe for the **idle-reap** case: a conn
+        reaped while idle dies on its first statement, so the ``INSERT`` never
+        ran and re-inserting can't duplicate. A **fresh** connection failing is
+        a genuine error → re-raise, never retry.
+
+        This is NOT exactly-once. A connection that dies AFTER the server has
+        committed the row but BEFORE psycopg2 read back ``RETURNING msg_id``
+        (the commit-loss / PgBouncer server-recycle case this very feature
+        targets) is indistinguishable here from an idle reap, so the retry would
+        re-insert an already-committed row. The enqueue is therefore
+        **at-least-once**: the ``reused`` gate removes the *common* duplicate
+        (idle reap) but cannot remove the *rare* one (post-commit death). That
+        residual duplicate leans on the module's at-least-once / idempotent-
+        consumer contract (see the module docstring header) as the GENERAL
+        backstop — every consumer here must already tolerate redelivery.
+        ``claim_batch`` / ``pg_batch_dedup`` is only the **batch-header-specific**
+        instance of that idempotency: it dedups duplicate batch *headers*, but
+        does NOT gate leaf tasks or the aggregating callback (which also reach
+        this ``send()`` via dispatch.py) — so it does not absorb every duplicate,
+        only batch-header ones.
         """
         if not MIN_PRIORITY <= priority <= MAX_PRIORITY:
             raise ValueError(
@@ -251,13 +287,19 @@ class PgQueueClient:
         # Capture BEFORE the attempt: a fresh conn has self._conn is None here.
         reused = self._conn is not None and self._owns_conn
         try:
-            return self._insert_message(queue_name, message, org_id, priority)
-        except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
+            return self._insert_message(
+                queue_name, message, org_id=org_id, priority=priority
+            )
+        except _CONN_DEAD_ERRORS as exc:
             if not reused:
                 raise
+            # Describe what we observed, not a verdict: a connection-level error
+            # on a reused conn is usually a stale idle reap, but a real DB
+            # outage looks the same here — don't assert "stale" as fact.
             logger.warning(
-                "PG-queue: send to queue=%r failed (%s: %s); cached connection "
-                "likely stale, reconnecting and retrying once",
+                "PG-queue: send to queue=%r failed with a connection-level error "
+                "on a reused cached connection (%s: %s); dropping it and retrying "
+                "once (stale reap or DB unavailable)",
                 queue_name,
                 type(exc).__name__,
                 exc,
@@ -265,12 +307,24 @@ class PgQueueClient:
             )
             time.sleep(_SEND_RETRY_BACKOFF_SECONDS)
             # _cursor already dropped the dead owned conn, so this reconnects.
-            return self._insert_message(queue_name, message, org_id, priority)
+            msg_id = self._insert_message(
+                queue_name, message, org_id=org_id, priority=priority
+            )
+            # Positive breadcrumb: the primary hazard is a silent duplicate
+            # enqueue (at-least-once, see docstring) — record the reconnect with
+            # the returned msg_id so a duplicate is correlatable after the fact.
+            logger.info(
+                "PG-queue: send to queue=%r succeeded on reconnect (msg_id=%s)",
+                queue_name,
+                msg_id,
+            )
+            return msg_id
 
     def _insert_message(
         self,
         queue_name: str,
         message: dict[str, Any],
+        *,
         org_id: str | None,
         priority: int,
     ) -> int:

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -197,6 +197,106 @@ class TestConnectionLifecycle:
         injected.close.assert_not_called()
 
 
+class TestSendReconnectRetry:
+    """``send()``'s one-shot reconnect-retry for a reused, idle-reaped connection.
+
+    A cached connection can be reaped server-side (PgBouncer
+    ``server_idle_timeout`` / failover) while idle between sends; the first
+    statement after the gap then fails. ``send()`` retries ONCE — but only when
+    the failing connection was **reused** (cached + owned), so the ``INSERT``
+    (which is not idempotent) can't be double-enqueued: a reused conn that dies
+    on its first statement was reaped while idle and never ran the write.
+    """
+
+    @staticmethod
+    def _conn(*, execute_side_effect=None, fetchone=(1,)):
+        cur = MagicMock()
+        if execute_side_effect is not None:
+            cur.execute.side_effect = execute_side_effect
+        cur.fetchone.return_value = fetchone
+        conn = MagicMock()
+        conn.closed = 0
+        conn.cursor.return_value = _CursorCtx(cur)
+        return conn, cur
+
+    @staticmethod
+    def _no_sleep(monkeypatch):
+        sleep = MagicMock()
+        monkeypatch.setattr("queue_backend.pg_queue.client.time.sleep", sleep)
+        return sleep
+
+    def test_reused_stale_conn_retries_and_succeeds(self, monkeypatch):
+        # Cached owned conn reaped while idle fails its first statement; the
+        # one-shot retry reconnects (factory) and the INSERT lands.
+        dead, _ = self._conn(execute_side_effect=psycopg2.OperationalError("idle reap"))
+        fresh, _ = self._conn(fetchone=(77,))
+        factory = MagicMock(return_value=fresh)
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        self._no_sleep(monkeypatch)
+        client = PgQueueClient()  # owns its connection
+        client._conn = dead  # simulate a cached (reused) connection
+
+        assert client.send("q", {"a": 1}) == 77  # the retry's INSERT
+        dead.close.assert_called_once()  # stale conn discarded
+        factory.assert_called_once()  # reconnected exactly once
+
+    def test_fresh_conn_failure_does_not_retry(self, monkeypatch):
+        # First-ever send (self._conn is None) is on a FRESH conn — a failure
+        # there is a genuine error / ambiguous; must NOT retry (could duplicate).
+        dead, _ = self._conn(execute_side_effect=psycopg2.OperationalError("down"))
+        factory = MagicMock(return_value=dead)
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        sleep = self._no_sleep(monkeypatch)
+        client = PgQueueClient()
+
+        with pytest.raises(psycopg2.OperationalError):
+            client.send("q", {"a": 1})
+        factory.assert_called_once()  # created once, NOT retried
+        sleep.assert_not_called()
+
+    def test_injected_conn_not_retried(self, monkeypatch):
+        # An injected (caller-owned) conn is never recycled, so retrying can't
+        # reconnect — and isn't ours to retry. Re-raise without retry.
+        conn, _ = self._conn(execute_side_effect=psycopg2.OperationalError("dead"))
+        sleep = self._no_sleep(monkeypatch)
+        client = PgQueueClient(conn=conn)
+
+        with pytest.raises(psycopg2.OperationalError):
+            client.send("q", {"a": 1})
+        sleep.assert_not_called()
+        conn.close.assert_not_called()  # caller's connection untouched
+
+    def test_retry_failure_reraises_once(self, monkeypatch):
+        # If the reconnected attempt also fails, raise — exactly one reconnect,
+        # no loop.
+        dead1, _ = self._conn(execute_side_effect=psycopg2.OperationalError("reap"))
+        dead2, _ = self._conn(execute_side_effect=psycopg2.OperationalError("still"))
+        factory = MagicMock(return_value=dead2)
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        self._no_sleep(monkeypatch)
+        client = PgQueueClient()
+        client._conn = dead1
+
+        with pytest.raises(psycopg2.OperationalError):
+            client.send("q", {"a": 1})
+        factory.assert_called_once()  # one reconnect only
+
+    def test_reused_conn_non_connection_error_not_retried(self, monkeypatch):
+        # A logical error (not Operational/Interface) on a reused conn is not a
+        # stale-connection symptom → re-raise, no reconnect.
+        bad, _ = self._conn(execute_side_effect=RuntimeError("logic"))
+        factory = MagicMock()
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        sleep = self._no_sleep(monkeypatch)
+        client = PgQueueClient()
+        client._conn = bad
+
+        with pytest.raises(RuntimeError):
+            client.send("q", {"a": 1})
+        factory.assert_not_called()
+        sleep.assert_not_called()
+
+
 class TestCreatePgConnection:
     """Unit coverage for the connection factory (no real DB)."""
 

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -13,6 +13,7 @@ Two layers:
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 import uuid
@@ -22,6 +23,7 @@ import psycopg2
 import pytest
 from queue_backend.fairness import DEFAULT_PRIORITY, MAX_PRIORITY, MIN_PRIORITY
 from queue_backend.pg_queue import PgQueueClient, QueueMessage
+from queue_backend.pg_queue.client import _SEND_RETRY_BACKOFF_SECONDS
 from queue_backend.pg_queue.connection import create_pg_connection
 from queue_backend.pg_queue.schema import qualified
 
@@ -225,20 +227,39 @@ class TestSendReconnectRetry:
         monkeypatch.setattr("queue_backend.pg_queue.client.time.sleep", sleep)
         return sleep
 
-    def test_reused_stale_conn_retries_and_succeeds(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "exc_type", [psycopg2.OperationalError, psycopg2.InterfaceError]
+    )
+    def test_reused_stale_conn_retries_and_succeeds(self, monkeypatch, caplog, exc_type):
         # Cached owned conn reaped while idle fails its first statement; the
-        # one-shot retry reconnects (factory) and the INSERT lands.
-        dead, _ = self._conn(execute_side_effect=psycopg2.OperationalError("idle reap"))
-        fresh, _ = self._conn(fetchone=(77,))
+        # one-shot retry reconnects (factory) and the INSERT lands. Exercise
+        # BOTH connection-dead error types — InterfaceError is the more likely
+        # stale symptom and is otherwise never covered, so narrowing the except
+        # to OperationalError alone would silently pass.
+        dead, _ = self._conn(execute_side_effect=exc_type("idle reap"))
+        fresh, fresh_cur = self._conn(fetchone=(77,))
         factory = MagicMock(return_value=fresh)
         monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
-        self._no_sleep(monkeypatch)
+        sleep = self._no_sleep(monkeypatch)
         client = PgQueueClient()  # owns its connection
         client._conn = dead  # simulate a cached (reused) connection
 
-        assert client.send("q", {"a": 1}) == 77  # the retry's INSERT
+        with caplog.at_level(logging.WARNING, logger="queue_backend.pg_queue.client"):
+            msg_id = client.send("q", {"a": 1}, org_id="org-7", priority=9)
+        assert msg_id == 77  # the retry's INSERT
         dead.close.assert_called_once()  # stale conn discarded
         factory.assert_called_once()  # reconnected exactly once
+        # The backoff actually fired (don't just discard the _no_sleep mock).
+        sleep.assert_called_once_with(_SEND_RETRY_BACKOFF_SECONDS)
+        # The retry's INSERT carries the passthrough params — a params-drop on
+        # the reconnect path would be caught here (assert on the FRESH cursor).
+        _, params = fresh_cur.execute.call_args.args
+        assert params[0] == "q"  # queue_name
+        assert params[2] == "org-7"  # org_id
+        assert params[3] == 9  # priority
+        # The connection-level failure surfaced as a WARNING on the retry.
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+        assert "retrying once" in caplog.text
 
     def test_fresh_conn_failure_does_not_retry(self, monkeypatch):
         # First-ever send (self._conn is None) is on a FRESH conn — a failure


### PR DESCRIPTION
## What

Adds a one-shot reconnect-retry to `PgQueueClient.send()` so a PG-routed dispatch survives a cached connection that was reaped server-side while idle. Follow-up to UN-3651.

## Why

A PG-transport ETL execution failed with `server closed the connection unexpectedly` at the barrier's header dispatch, ~30 min after the previous execution on the same worker thread — PgBouncer `server_idle_timeout` reaped the cached connection while it sat idle between executions.

UN-3651 added a reconnect-retry to the barrier's **idempotent** pre-dispatch write (`_reset_barrier`), and that retry fired and succeeded. But the very next call — the header dispatch via `dispatch._enqueue_pg` → `PgQueueClient.send()` → `INSERT` into `pg_queue_message` — uses a **separate** cached connection with no reconnect logic, so it failed and aborted the whole execution. UN-3651's guard did not cover this site.

Root cause (worker logs): the dispatch singleton's cached `psycopg2` connection was last used by the prior execution, then idle ~30 min; the server-side connection was dropped; the next `send()` INSERT hit a dead socket → `OperationalError` → execution `ERROR`.

## How

`send()`'s INSERT is **not idempotent** (auto `msg_id`), so a blind retry could double-enqueue. The retry therefore fires **only when the failing connection was reused** (cached + owned by the client):

- A **reused** connection that dies on its *first* statement was reaped while idle, so the INSERT never reached the server — re-inserting cannot duplicate.
- A **fresh** connection failing is a genuine error (or an ambiguous mid-statement death) → re-raise, never retry.
- In the rare reused-conn mid-statement-death case, a duplicate batch enqueue is absorbed by the existing `claim_batch` / `pg_batch_dedup` gate downstream.

Scope: **PG transport only** — the Celery dispatch path is untouched. Zero Celery regression.

## Tests

5 new unit tests in `test_pg_queue_client.py::TestSendReconnectRetry`:
- reused-stale conn → retry reconnects + succeeds
- fresh-conn failure → no retry (re-raises)
- injected conn → no retry (caller's connection untouched)
- retry-also-fails → raises after exactly one reconnect
- non-connection error on reused conn → no retry

Full file green (35 passed), pre-commit clean.

## Dev-test

Reproduced the exact condition against a running Postgres (terminated the cached backend with `pg_terminate_backend`, the same client-side symptom as the cloud idle reap):
- **Before-fix path** (un-wrapped INSERT) → `OperationalError: server closed the connection unexpectedly` (the failure that aborted the execution).
- **send()** → self-heals: reconnects, returns a `msg_id`, and the row is verified present in the DB.