### PR TITLE
UN-3657 [FIX] Execution serializer — terminal-failure run reports unaccounted files as failed, not in-progress

### DIFF
--- a/backend/workflow_manager/execution/serializer/execution.py
+++ b/backend/workflow_manager/execution/serializer/execution.py
@@ -1,7 +1,11 @@
+import logging
+
 from rest_framework import serializers
 
 from workflow_manager.workflow_v2.enums import ExecutionStatus
 from workflow_manager.workflow_v2.models import WorkflowExecution
+
+logger = logging.getLogger(__name__)
 
 
 # TODO: Optimize with select_related / prefetch_related to reduce DB queries
@@ -25,30 +29,59 @@ class ExecutionSerializer(serializers.ModelSerializer):
         """Fetch the pipeline or API deployment name"""
         return obj.pipeline_name
 
+    def _status_count(self, obj: WorkflowExecution, status_value: str) -> int:
+        """COUNT of this execution's file rows in ``status_value``, memoised per
+        (execution, status) so the successful/failed fields don't issue
+        duplicate COUNTs for the same status within one serialization pass.
+        """
+        cache = self.__dict__.setdefault("_status_count_cache", {})
+        key = (str(obj.id), status_value)
+        if key not in cache:
+            cache[key] = obj.file_executions.filter(status=status_value).count()
+        return cache[key]
+
     def get_successful_files(self, obj: WorkflowExecution) -> int:
         """Return the count of successfully executed files"""
-        return obj.file_executions.filter(status=ExecutionStatus.COMPLETED.value).count()
+        return self._status_count(obj, ExecutionStatus.COMPLETED.value)
 
     def get_failed_files(self, obj: WorkflowExecution) -> int:
-        """Return the count of failed executed files.
+        """Return the count of failed files.
 
-        For a terminal *failure* run (ERROR/STOPPED), every file that did not
-        succeed is a failure — including files that never got a file-execution
-        row because orchestration aborted before creating them, or were left
-        PENDING/EXECUTING by the abort. The UI derives "in progress" as
-        ``total - successful - failed``, so without this a finished failure run
-        shows phantom in-progress files (e.g. an early barrier-dispatch failure
-        with 0 rows reads as "N in progress" instead of "N failed").
+        For a terminal *failure* run (ERROR/STOPPED), files that never reached a
+        terminal row — orchestration aborted before creating them, or they were
+        left PENDING/EXECUTING — are failures, not "in progress". The UI derives
+        in-progress as ``total - successful - failed`` (frontend
+        ``DetailedLogs.jsx``), so without this a finished failure run shows
+        phantom in-progress files. A no-op whenever every file already has a
+        terminal COMPLETED/ERROR row.
 
-        Scoped to ``is_failure`` (ERROR/STOPPED) so COMPLETED runs and live
-        runs (PENDING/EXECUTING) keep the exact row-count behaviour — a no-op
-        whenever the rows already account for every file, so the success path
-        and real-time progress are untouched on every transport.
+        Never under-reports below the real ERROR-row count: if the terminal rows
+        already exceed ``total_files`` (counter drift / an impossible count) the
+        derived value would be too low, so fall back to the ERROR rows and log
+        the drift instead of silently clamping it away.
         """
-        if ExecutionStatus.is_failure(obj.status):
-            total = obj.total_files or 0
-            return max(0, total - self.get_successful_files(obj))
-        return obj.file_executions.filter(status=ExecutionStatus.ERROR.value).count()
+        error_rows = self._status_count(obj, ExecutionStatus.ERROR.value)
+        # is_failure swallows ValueError -> False for an unrecognised status, so a
+        # malformed/legacy status safely takes the plain row-count path (no raise,
+        # so it can't 500 the executions list — but also no reconcile for it).
+        if not ExecutionStatus.is_failure(obj.status):
+            return error_rows
+        successful = self._status_count(obj, ExecutionStatus.COMPLETED.value)
+        total = obj.total_files or 0
+        if successful + error_rows > total:
+            logger.warning(
+                "Execution %s terminal file counts exceed total_files "
+                "(status=%s total=%s successful=%s error_rows=%s); reporting "
+                "failed=%s",
+                obj.id,
+                obj.status,
+                total,
+                successful,
+                error_rows,
+                error_rows,
+            )
+            return error_rows
+        return total - successful
 
     def get_aggregated_total_pages_processed(self, obj: WorkflowExecution) -> int | None:
         """Return the total pages processed across all file executions."""

--- a/backend/workflow_manager/execution/serializer/execution.py
+++ b/backend/workflow_manager/execution/serializer/execution.py
@@ -30,7 +30,24 @@ class ExecutionSerializer(serializers.ModelSerializer):
         return obj.file_executions.filter(status=ExecutionStatus.COMPLETED.value).count()
 
     def get_failed_files(self, obj: WorkflowExecution) -> int:
-        """Return the count of failed executed files"""
+        """Return the count of failed executed files.
+
+        For a terminal *failure* run (ERROR/STOPPED), every file that did not
+        succeed is a failure — including files that never got a file-execution
+        row because orchestration aborted before creating them, or were left
+        PENDING/EXECUTING by the abort. The UI derives "in progress" as
+        ``total - successful - failed``, so without this a finished failure run
+        shows phantom in-progress files (e.g. an early barrier-dispatch failure
+        with 0 rows reads as "N in progress" instead of "N failed").
+
+        Scoped to ``is_failure`` (ERROR/STOPPED) so COMPLETED runs and live
+        runs (PENDING/EXECUTING) keep the exact row-count behaviour — a no-op
+        whenever the rows already account for every file, so the success path
+        and real-time progress are untouched on every transport.
+        """
+        if ExecutionStatus.is_failure(obj.status):
+            total = obj.total_files or 0
+            return max(0, total - self.get_successful_files(obj))
         return obj.file_executions.filter(status=ExecutionStatus.ERROR.value).count()
 
     def get_aggregated_total_pages_processed(self, obj: WorkflowExecution) -> int | None:

--- a/backend/workflow_manager/execution/tests/test_execution_serializer.py
+++ b/backend/workflow_manager/execution/tests/test_execution_serializer.py
@@ -1,0 +1,88 @@
+"""ExecutionSerializer file-count reconciliation (UN-3657).
+
+A terminal *failure* run (ERROR/STOPPED) must not report files as still
+"in progress": the UI derives in-progress as ``total - successful - failed``,
+so every non-successful file in a finished failure run has to land in
+``failed`` — including files that never got a ``file_execution`` row because
+orchestration aborted before creating them. COMPLETED and live
+(PENDING/EXECUTING) runs must keep the exact row-count behaviour.
+
+ORM is mocked, so no test database is required.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import django
+from django.apps import apps
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings.test")
+if not apps.ready:
+    django.setup()
+
+from workflow_manager.execution.serializer.execution import (  # noqa: E402
+    ExecutionSerializer,
+)
+from workflow_manager.workflow_v2.enums import ExecutionStatus  # noqa: E402
+
+
+def _execution(status, total_files, *, completed=0, errored=0):
+    """A WorkflowExecution stand-in whose ``file_executions`` row counts are
+    fixed per status.
+    """
+    obj = MagicMock()
+    obj.status = status
+    obj.total_files = total_files
+
+    def _filter(status=None, **_kwargs):
+        result = MagicMock()
+        result.count.return_value = {
+            ExecutionStatus.COMPLETED.value: completed,
+            ExecutionStatus.ERROR.value: errored,
+        }.get(status, 0)
+        return result
+
+    obj.file_executions.filter.side_effect = _filter
+    return obj
+
+
+class TestFailedFileReconciliation:
+    serializer = ExecutionSerializer()
+
+    def test_error_run_with_no_rows_counts_all_as_failed(self):
+        # The exec 4b180f05 case: ERROR before any file_execution row exists.
+        obj = _execution(ExecutionStatus.ERROR.value, 2)
+        assert self.serializer.get_successful_files(obj) == 0
+        assert (
+            self.serializer.get_failed_files(obj) == 2
+        )  # was 0 -> phantom "2 in progress"
+
+    def test_error_run_partial_rows_reconciles_unaccounted(self):
+        # total 3: 1 completed, 1 errored row, 1 never created -> 2 failed.
+        obj = _execution(ExecutionStatus.ERROR.value, 3, completed=1, errored=1)
+        assert self.serializer.get_failed_files(obj) == 2
+
+    def test_stopped_run_reconciles(self):
+        # STOPPED is a failure terminal state: 3 of 5 done -> 2 failed, 0 in-progress.
+        obj = _execution(ExecutionStatus.STOPPED.value, 5, completed=3)
+        assert self.serializer.get_failed_files(obj) == 2
+
+    def test_completed_run_uses_row_count_unchanged(self):
+        # Success path is untouched: failed == ERROR-row count, not reconciled.
+        clean = _execution(ExecutionStatus.COMPLETED.value, 2, completed=2)
+        assert self.serializer.get_failed_files(clean) == 0
+        partial = _execution(ExecutionStatus.COMPLETED.value, 2, completed=1, errored=1)
+        assert self.serializer.get_failed_files(partial) == 1
+
+    def test_live_run_uses_row_count_unchanged(self):
+        # An in-flight run keeps real-time row counts (no reconcile), so
+        # genuinely-pending files are NOT prematurely marked failed.
+        obj = _execution(ExecutionStatus.EXECUTING.value, 2)
+        assert self.serializer.get_failed_files(obj) == 0
+
+    def test_successful_over_total_is_clamped_not_negative(self):
+        # Defensive: a bad/stale count can't produce a negative failed count.
+        obj = _execution(ExecutionStatus.ERROR.value, 1, completed=2)
+        assert self.serializer.get_failed_files(obj) == 0

--- a/backend/workflow_manager/execution/tests/test_execution_serializer.py
+++ b/backend/workflow_manager/execution/tests/test_execution_serializer.py
@@ -1,38 +1,52 @@
 """ExecutionSerializer file-count reconciliation (UN-3657).
 
-A terminal *failure* run (ERROR/STOPPED) must not report files as still
-"in progress": the UI derives in-progress as ``total - successful - failed``,
-so every non-successful file in a finished failure run has to land in
-``failed`` — including files that never got a ``file_execution`` row because
-orchestration aborted before creating them. COMPLETED and live
-(PENDING/EXECUTING) runs must keep the exact row-count behaviour.
+A terminal *failure* run (ERROR/STOPPED) must not report files as still "in
+progress": the UI derives in-progress as ``total - successful - failed``, so
+every non-successful file in a finished failure run has to land in ``failed`` —
+including files that never got a ``file_execution`` row. COMPLETED and live
+(PENDING/EXECUTING) runs keep the exact row-count behaviour.
 
-ORM is mocked, so no test database is required.
+DB-free and app-registry-free: the heavy ``WorkflowExecution`` model is stubbed
+in ``sys.modules`` before importing the serializer (mirrors
+``usage_v2/tests/test_helper.py`` / ``pg_queue/tests/test_producer.py``), so no
+``django.setup()`` / live DB is needed — the methods under test are pure. The
+real ``ExecutionStatus`` enum (no Django) is kept for its ``is_failure`` logic.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import sys
+import types
 from unittest.mock import MagicMock
 
-import django
-from django.apps import apps
+# Force (not setdefault): a dev shell that already exports DJANGO_SETTINGS_MODULE
+# (backend.settings.dev / .cloud) would otherwise redirect collection to a module
+# that may not exist here. DRF reads settings lazily; no django.setup() is run.
+os.environ["DJANGO_SETTINGS_MODULE"] = "backend.settings.test"
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings.test")
-if not apps.ready:
-    django.setup()
+# Stub the model module so importing the serializer needs no app registry / DB.
+_models_stub = types.ModuleType("workflow_manager.workflow_v2.models")
+_models_stub.WorkflowExecution = type("WorkflowExecution", (), {})
+sys.modules["workflow_manager.workflow_v2.models"] = _models_stub
 
 from workflow_manager.execution.serializer.execution import (  # noqa: E402
     ExecutionSerializer,
 )
 from workflow_manager.workflow_v2.enums import ExecutionStatus  # noqa: E402
 
+_LOGGER = "workflow_manager.execution.serializer.execution"
+_ids = iter(range(1, 100_000))
+
 
 def _execution(status, total_files, *, completed=0, errored=0):
-    """A WorkflowExecution stand-in whose ``file_executions`` row counts are
-    fixed per status.
+    """A WorkflowExecution stand-in with fixed per-status row counts and a unique
+    id (so the serializer's per-(id, status) count memo never collides across
+    cases).
     """
     obj = MagicMock()
+    obj.id = f"exec-{next(_ids)}"
     obj.status = status
     obj.total_files = total_files
 
@@ -48,41 +62,83 @@ def _execution(status, total_files, *, completed=0, errored=0):
     return obj
 
 
-class TestFailedFileReconciliation:
-    serializer = ExecutionSerializer()
+def _assert_no_phantom_in_progress(serializer, obj):
+    """The real contract: a finished run leaves zero files "in progress"."""
+    in_progress = (
+        obj.total_files
+        - serializer.get_successful_files(obj)
+        - serializer.get_failed_files(obj)
+    )
+    assert in_progress == 0
 
+
+class TestFailedFileReconciliation:
     def test_error_run_with_no_rows_counts_all_as_failed(self):
-        # The exec 4b180f05 case: ERROR before any file_execution row exists.
+        # ERROR before any file_execution row exists (the observed case).
+        s = ExecutionSerializer()
         obj = _execution(ExecutionStatus.ERROR.value, 2)
-        assert self.serializer.get_successful_files(obj) == 0
-        assert (
-            self.serializer.get_failed_files(obj) == 2
-        )  # was 0 -> phantom "2 in progress"
+        assert s.get_successful_files(obj) == 0
+        assert s.get_failed_files(obj) == 2  # was 0 -> phantom "2 in progress"
+        _assert_no_phantom_in_progress(s, obj)
 
     def test_error_run_partial_rows_reconciles_unaccounted(self):
         # total 3: 1 completed, 1 errored row, 1 never created -> 2 failed.
+        s = ExecutionSerializer()
         obj = _execution(ExecutionStatus.ERROR.value, 3, completed=1, errored=1)
-        assert self.serializer.get_failed_files(obj) == 2
+        assert s.get_failed_files(obj) == 2
+        _assert_no_phantom_in_progress(s, obj)
 
     def test_stopped_run_reconciles(self):
-        # STOPPED is a failure terminal state: 3 of 5 done -> 2 failed, 0 in-progress.
+        # STOPPED is a failure terminal state: 3 of 5 done -> 2 failed.
+        s = ExecutionSerializer()
         obj = _execution(ExecutionStatus.STOPPED.value, 5, completed=3)
-        assert self.serializer.get_failed_files(obj) == 2
+        assert s.get_failed_files(obj) == 2
+        _assert_no_phantom_in_progress(s, obj)
 
     def test_completed_run_uses_row_count_unchanged(self):
-        # Success path is untouched: failed == ERROR-row count, not reconciled.
+        s = ExecutionSerializer()
         clean = _execution(ExecutionStatus.COMPLETED.value, 2, completed=2)
-        assert self.serializer.get_failed_files(clean) == 0
+        assert s.get_failed_files(clean) == 0
         partial = _execution(ExecutionStatus.COMPLETED.value, 2, completed=1, errored=1)
-        assert self.serializer.get_failed_files(partial) == 1
+        assert s.get_failed_files(partial) == 1
+
+    def test_completed_run_not_reconciled_even_with_unaccounted(self):
+        # Deliberate asymmetry: a COMPLETED run is NOT reconciled — failed stays
+        # the ERROR-row count, not total - completed. Pins the decision so a
+        # future "reconcile everything" change fails here.
+        s = ExecutionSerializer()
+        obj = _execution(ExecutionStatus.COMPLETED.value, 3, completed=1, errored=1)
+        assert s.get_failed_files(obj) == 1  # ERROR rows, NOT total-completed (=2)
 
     def test_live_run_uses_row_count_unchanged(self):
-        # An in-flight run keeps real-time row counts (no reconcile), so
-        # genuinely-pending files are NOT prematurely marked failed.
+        # In-flight run keeps real-time row counts — genuinely-pending files are
+        # NOT prematurely marked failed.
+        s = ExecutionSerializer()
         obj = _execution(ExecutionStatus.EXECUTING.value, 2)
-        assert self.serializer.get_failed_files(obj) == 0
+        assert s.get_failed_files(obj) == 0
 
-    def test_successful_over_total_is_clamped_not_negative(self):
-        # Defensive: a bad/stale count can't produce a negative failed count.
+    def test_drift_does_not_under_report_below_error_rows(self, caplog):
+        # total_files stale/low vs real rows: 3 completed + 2 error, total=2.
+        # Must NOT report 0 (the naive total-successful); keep the 2 real ERROR
+        # rows and warn — the inverse of the phantom bug.
+        s = ExecutionSerializer()
+        obj = _execution(ExecutionStatus.ERROR.value, 2, completed=3, errored=2)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            assert s.get_failed_files(obj) == 2
+        assert any("exceed total_files" in r.message for r in caplog.records)
+
+    def test_successful_over_total_clamps_with_warning(self, caplog):
+        # Impossible count (more completed than total) — clamp to the safe value
+        # but log the anomaly rather than erasing it silently.
+        s = ExecutionSerializer()
         obj = _execution(ExecutionStatus.ERROR.value, 1, completed=2)
-        assert self.serializer.get_failed_files(obj) == 0
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            assert s.get_failed_files(obj) == 0
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_unknown_status_returns_error_rows_and_never_raises(self):
+        # is_failure swallows ValueError -> else (row-count) path. A malformed
+        # status must never raise (a raise would 500 the executions list).
+        s = ExecutionSerializer()
+        obj = _execution("GARBAGE", 5, completed=1, errored=1)
+        assert s.get_failed_files(obj) == 1  # ERROR-row count, no reconcile, no raise


### PR DESCRIPTION
## What

A terminal **ERROR/STOPPED** execution no longer shows files as still "in progress" in the UI.

## Why

Observed on PG exec `4b180f05` (ERROR, `total_files=2`) which displayed **"2 in progress"** for a finished run. `ExecutionSerializer` derives `successful_files`/`failed_files` as `SerializerMethodField`s that **count `workflow_file_execution` rows** (`status=COMPLETED`/`ERROR`). When orchestration fails **before** those rows are created (0 rows), both read 0, and the UI derives in-progress as `total - successful - failed = total` → phantom in-progress for a finished run. The persisted `workflow_execution.failed_files` column (set by UN-3652) is ignored by this serializer.

This affects **both transports** — a Celery orchestration that fails pre-row-creation shows the same artifact. It is not a PG regression; it's a latent display bug.

## How

`get_failed_files` now returns `total_files - successful_files` for a terminal **failure** run (`ExecutionStatus.is_failure` → ERROR/STOPPED): every file that didn't succeed in a finished failure run is a failure, including ones that never got a row or were left PENDING/EXECUTING by the abort.

Scoped to `is_failure`, so:
- **COMPLETED** runs → unchanged (row count) — success path untouched.
- **Live** runs (PENDING/EXECUTING) → unchanged — genuinely-pending files are not prematurely marked failed.
- No-op whenever the rows already account for every file.

`max(0, …)` guards a stale `successful > total` count. OSS read-path only; transport-agnostic.

> Note: Fix UN-3654 already **prevents** the specific failure that produced this display; this is defense-in-depth for *any* early-orchestration failure (bad source, permissions, validation).

## Tests

`test_execution_serializer.py` (6, ORM mocked — no test DB, mirroring the repo's existing mocked-ORM serializer tests): error/stopped reconcile (incl. the `4b180f05` 0-row case + partial rows), COMPLETED + EXECUTING unchanged, negative-clamp guard.

## Validation

Deterministic read-path logic, fully unit-covered across every branch. E2E validates on deploy: a failed execution will read "**N failed**, 0 in progress" instead of phantom in-progress.