### PR TITLE
UN-2966 [HOTFIX] Fix Execution Logs table header overlapping summary cards

### DIFF
--- a/frontend/src/components/logging/detailed-logs/DetailedLogs.css
+++ b/frontend/src/components/logging/detailed-logs/DetailedLogs.css
@@ -71,8 +71,11 @@
   width: 250px;
   margin: 0;
   padding: 0;
-  height: 60px;
   margin-right: 20px;
+}
+
+.logs-details-card .ant-card-body {
+  padding: 8px 16px;
 }
 
 .logging-card-icons {


### PR DESCRIPTION
## What

Fixes the **Execution Logs** detail page where the file table's header row overlapped and clipped the summary cards (**Started** / **Ran for** / **Processed files**), making the card content unreadable.

## Why

Regression from #1687 (UN-2966 "Auto-refresh and controls for execution logs"), which moved the page to a `flex` column with `overflow:hidden` and a sticky table header, and gave the summary cards a rigid `height:60px`. antd's default ~24px card-body padding leaves only ~12px for the two lines of card content, so it overflowed the 60px box and got clipped under the sticky header.

Reported on cloud staging (table header overlapping summary cards on Execution Logs page).

## How

- Drop the fixed `height:60px` on `.logs-details-card` so the content drives the card height.
- Compact `.logs-details-card .ant-card-body` padding to `8px 16px` so the two-line content fits cleanly and the cards stay visually compact.

Single-file, CSS-only change (`DetailedLogs.css`).

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why.

No. The change is scoped to `.logs-details-card` (the three summary cards on the Execution Logs detail page) — no React component logic and no shared components are touched. Per the triage discussion, a full UI regression run is not required as long as the change is isolated to this section, which it is.

## Notes on Testing

- `vite build` passes cleanly.
- Verified the buggy `height:60px` exists on this hotfix base (`v0.176.3-hotfix`) and the fix applies there.

## Related Issues or PRs

- Regression introduced by #1687.
- Jira: UN-2966.
- Hotfix on the `v0.176.3` OSS line (pinned by cloud prod `v0.170.0`); will be back-merged into `main`.
