### PR TITLE
UN-3185 [FIX] Deterministic CSS cascade (single bundle) + asset gzip + Edit LLM Profile modal layout

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -29,8 +29,7 @@ http {
 
     gzip  on;
     # nginx gzips only text/html by default; add asset types (~5-6x smaller).
-    gzip_types text/css application/javascript application/json image/svg+xml
-               application/font-woff font/woff2;
+    gzip_types text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
     gzip_vary on;
     # GKE LB adds a Via header; default gzip_proxied off would skip every request.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,14 +28,12 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
-    # nginx only gzips text/html by default; list the static asset types so JS,
-    # CSS and fonts are compressed too (~5-6x smaller on the wire).
+    # nginx gzips only text/html by default; add asset types (~5-6x smaller).
     gzip_types text/css application/javascript application/json image/svg+xml
                application/font-woff font/woff2;
     gzip_min_length 1024;
     gzip_vary on;
-    # Behind the GKE load balancer every request carries a Via header;
-    # default gzip_proxied off would skip compression for all of them.
+    # GKE LB adds a Via header; default gzip_proxied off would skip every request.
     gzip_proxied any;
 
     # Non-root user will not have access to default

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,6 +28,12 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
+    # nginx only gzips text/html by default; list the static asset types so JS,
+    # CSS and fonts are compressed too (~5-6x smaller on the wire).
+    gzip_types text/css application/javascript application/json image/svg+xml
+               application/font-woff font/woff2;
+    gzip_min_length 1024;
+    gzip_vary on;
 
     # Non-root user will not have access to default
     # /var/cache/nginx/ prefix.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -34,6 +34,9 @@ http {
                application/font-woff font/woff2;
     gzip_min_length 1024;
     gzip_vary on;
+    # Behind the GKE load balancer every request carries a Via header;
+    # default gzip_proxied off would skip compression for all of them.
+    gzip_proxied any;
 
     # Non-root user will not have access to default
     # /var/cache/nginx/ prefix.

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
@@ -1,16 +1,13 @@
 /* Styles for AddLlmProfile */
 
-/* .conn-modal-form-pad-left (SettingsModal) wraps every settings panel, so
-   scope the padding override to this form alone. */
+/* Scope padding override to this form; .conn-modal-form-pad-left is shared. */
 .conn-modal-form-pad-left:has(> .add-llm-profile-body) {
   padding: 8px 16px;
 }
 
-/* The settings row is hard-fixed to 800px, which forces this form's column
-   (.conn-modal-col) to scroll. Let the row size to the form so the modal
-   grows instead of showing an inner scrollbar. Scoped via :has so the other
-   settings panels and the connector dialog (shared .conn-modal-row/-col) are
-   untouched. !important overrides the inline height on the row. */
+/* Drop the inner scrollbar: size the fixed-800px row to the form so the modal
+   grows instead. :has scopes it so sibling panels / connector dialog (shared
+   .conn-modal-row/-col) are untouched; !important beats the inline height. */
 .conn-modal-row:has(.add-llm-profile-body) {
   height: auto !important;
 }
@@ -18,10 +15,7 @@
   overflow-y: visible;
 }
 
-/* Pin the submit button to the bottom of the scrollable panel so it stays
-   visible as the form grows (e.g. Advanced Settings expanded) instead of
-   flowing past the modal. Background is set inline from the antd theme token
-   so scrolling fields don't show through. */
+/* Sticky footer keeps the submit button visible as the form grows. */
 .add-llm-profile-footer {
   position: sticky;
   bottom: 0;

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
@@ -1,12 +1,9 @@
 /* Styles for AddLlmProfile */
 
-/* The settings modal's content column (.conn-modal-col) is the real scroll
-   container. .settings-body-pad-top declares its own overflow-y: auto with no
-   bounded height, which does nothing except register a nested scroll context
-   that would stop the sticky footer below from pinning to .conn-modal-col.
-   Drop it back to visible for this form. */
-.settings-body-pad-top.add-llm-profile-scroll-root {
-  overflow: visible;
+/* .conn-modal-form-pad-left (SettingsModal) wraps every settings panel, so
+   scope the padding override to this form alone. */
+.conn-modal-form-pad-left:has(> .add-llm-profile-body) {
+  padding: 8px 16px;
 }
 
 /* Pin the submit button to the bottom of the scrollable panel so it stays

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
@@ -1,13 +1,9 @@
 /* Styles for AddLlmProfile */
 
-/* Scope padding override to this form; .conn-modal-form-pad-left is shared. */
 .conn-modal-form-pad-left:has(> .add-llm-profile-body) {
   padding: 8px 16px;
 }
 
-/* Drop the inner scrollbar: size the fixed-800px row to the form so the modal
-   grows instead. :has scopes it so sibling panels / connector dialog (shared
-   .conn-modal-row/-col) are untouched; !important beats the inline height. */
 .conn-modal-row:has(.add-llm-profile-body) {
   height: auto !important;
 }
@@ -15,7 +11,6 @@
   overflow-y: visible;
 }
 
-/* Sticky footer keeps the submit button visible as the form grows. */
 .add-llm-profile-footer {
   position: sticky;
   bottom: 0;

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.css
@@ -6,6 +6,18 @@
   padding: 8px 16px;
 }
 
+/* The settings row is hard-fixed to 800px, which forces this form's column
+   (.conn-modal-col) to scroll. Let the row size to the form so the modal
+   grows instead of showing an inner scrollbar. Scoped via :has so the other
+   settings panels and the connector dialog (shared .conn-modal-row/-col) are
+   untouched. !important overrides the inline height on the row. */
+.conn-modal-row:has(.add-llm-profile-body) {
+  height: auto !important;
+}
+.conn-modal-col:has(.add-llm-profile-body) {
+  overflow-y: visible;
+}
+
 /* Pin the submit button to the bottom of the scrollable panel so it stays
    visible as the form grows (e.g. Advanced Settings expanded) instead of
    flowing past the modal. Background is set inline from the antd theme token

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
@@ -453,7 +453,7 @@ function AddLlmProfile({
   };
 
   return (
-    <div className="settings-body-pad-top add-llm-profile-scroll-root">
+    <div className="add-llm-profile-body">
       <Form
         form={form}
         layout="vertical"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -143,6 +143,10 @@ export default defineConfig(({ mode }) => {
       target: "esnext",
       outDir: "build",
       sourcemap: true,
+      // Keep all CSS in one stylesheet. Per-chunk CSS (the default) loads in
+      // navigation order, so equal-specificity rules across components resolve
+      // unpredictably. JS code-splitting is unaffected.
+      cssCodeSplit: false,
       // Chunk size warning limit
       chunkSizeWarningLimit: 1000,
       rollupOptions: {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -143,9 +143,9 @@ export default defineConfig(({ mode }) => {
       target: "esnext",
       outDir: "build",
       sourcemap: true,
-      // Keep all CSS in one stylesheet. Per-chunk CSS (the default) loads in
-      // navigation order, so equal-specificity rules across components resolve
-      // unpredictably. JS code-splitting is unaffected.
+      // Single stylesheet: per-chunk CSS loads in navigation order, making
+      // equal-specificity cross-component rules resolve unpredictably. JS
+      // splitting is unaffected.
       cssCodeSplit: false,
       // Chunk size warning limit
       chunkSizeWarningLimit: 1000,


### PR DESCRIPTION
## What

Frontend fixes under UN-3185 (lazy-loading follow-ups), all in `frontend/`:

- **Deterministic CSS cascade** — render all CSS into a single bundle (`cssCodeSplit: false`) instead of per-route chunks.
- **Compress static assets** — `gzip_types` + `gzip_proxied any` in `nginx.conf` so JS/CSS/fonts gzip on the wire.
- **Edit LLM Profile modal layout** — drop the `#2119` scroll-context workaround, scope the content padding, and remove the inner scrollbar.

## Why

- After #2114 split route pages into `React.lazy` chunks, each route's CSS loads as a separate file at navigation time. Equal-specificity rules across components then resolve in **load order**, which is non-deterministic — breaking the **Edit LLM Profile** form and overlapping the **Execution Logs** table header onto the summary cards. Merging CSS into one bundle restores the deterministic order that existed before the split (JS code-splitting — the actual perf win — is unaffected).
- `nginx` had `gzip on` but no `gzip_types`, so only `text/html` compressed; and `gzip_proxied` defaults to `off`, so even with types listed nothing compressed behind the GKE load balancer (every request carries a `Via` header). Assets shipped uncompressed (~341 KB CSS). This offsets the single-bundle's upfront cost and speeds every asset.
- The Edit LLM Profile modal showed an unnecessary inner scrollbar: the settings row is hard-fixed at `800px`, forcing the form's column (`.conn-modal-col`) to scroll once Advanced Settings expands.

## How

- `vite.config.js`: `build.cssCodeSplit: false`.
- `nginx.conf`: add `gzip_types` (css/js/json/svg/fonts), `gzip_min_length`, `gzip_vary on`, `gzip_proxied any`.
- `AddLlmProfile.jsx/.css`: replace the form root's shared `settings-body-pad-top`/`add-llm-profile-scroll-root` classes with a single `add-llm-profile-body` marker; drop the dead `overflow: visible` override; scope the content padding via `:has()`; and let the settings row size to the form (`:has(.add-llm-profile-body) { height: auto !important }`) so the modal grows instead of nesting a scrollbar.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No.
- The modal changes are scoped via `:has(.add-llm-profile-body)`, which matches only the Edit LLM Profile form. The shared `.conn-modal-row` / `.conn-modal-col` / `.conn-modal-form-pad-left` classes are still used by the other Prompt Studio settings panels and by `ConfigureConnectorModal` (the connector dialog) — none of those carry the marker, so they are untouched. No shared CSS rule was deleted (the classes are still in use, i.e. not unused).
- `cssCodeSplit: false` and the `nginx` gzip settings are build/serving config; no application behaviour changes.

## Notes on Testing

- Built and deployed to the `chandru-unstract-dev` namespace (staging). Verified on `chandru.globe.unstract.com`: a single `/assets/*.css` bundle; assets served `content-encoding: gzip` (CSS 341 KB → 78 KB on the wire); the scoped `:has` rules present in the served bundle.

## Related Issues or PRs

- UN-3185. Follow-up to #2114 / #2118 / #2119.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
