### PR TITLE
UN-3659 [FIX] PG result backend — reconnect-retry on stale store_result connection

### DIFF
--- a/workers/queue_backend/pg_queue/result_backend.py
+++ b/workers/queue_backend/pg_queue/result_backend.py
@@ -37,7 +37,7 @@ import contextlib
 import json
 import logging
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any, Final, Self
 
 import psycopg2
@@ -52,6 +52,17 @@ if TYPE_CHECKING:
     from psycopg2.extensions import connection as PgConnection
 
 logger = logging.getLogger(__name__)
+
+# psycopg2 errors that mean the connection itself is dead (dropped socket /
+# PgBouncer recycle / server termination). Shared by ``_cursor`` (decides whether
+# to discard the cached handle) and ``_store_with_reconnect`` (decides whether the
+# one-shot retry is eligible) so the two can't drift — narrowing one without the
+# other would silently break the retry's "was this a connection death?" test.
+# Mirrors ``PgQueueClient._CONN_DEAD_ERRORS`` (UN-3654), the sibling this models on.
+_CONN_DEAD_ERRORS: Final[tuple[type[Exception], ...]] = (
+    psycopg2.OperationalError,
+    psycopg2.InterfaceError,
+)
 
 # How long a stored result lives before the reaper's retention sweep may delete
 # it. Defaults to the executor caller-timeout default so a result always
@@ -119,9 +130,7 @@ class PgResultBackend:
                 yield cur
             conn.commit()
         except Exception as exc:
-            conn_dead = isinstance(
-                exc, (psycopg2.OperationalError, psycopg2.InterfaceError)
-            )
+            conn_dead = isinstance(exc, _CONN_DEAD_ERRORS)
             try:
                 conn.rollback()
             except Exception:
@@ -139,7 +148,7 @@ class PgResultBackend:
                 self._conn = None
             raise
 
-    def _store_with_reconnect(self, operation: Any) -> None:
+    def _store_with_reconnect(self, operation: Callable[[Any], None]) -> None:
         """Run an idempotent store ``operation(cur)`` in a committed cursor,
         retrying ONCE if the cached connection was reaped while idle.
 
@@ -150,7 +159,14 @@ class PgResultBackend:
         heals the *next* call, so without a retry the *current* ``store_result``
         fails, the result is silently dropped, and the blocking caller is
         stranded forever (the exec-b11ba2f3 hang). On a dead-connection error
-        ``_cursor`` has already dropped the handle, so the retry reconnects.
+        ``_cursor`` (when it OWNS the connection) has already dropped the handle,
+        so the retry reconnects.
+
+        Only **owned** connections are retried: ``_cursor`` clears a dead handle
+        only when ``_owns_conn`` (an injected connection is the caller's), so for
+        an injected connection the retry would re-acquire the same dead handle and
+        buy nothing — re-raise immediately. Production is always owned (the
+        executor consumer constructs ``PgResultBackend()``).
 
         Safe to retry unconditionally (no reused-vs-fresh guard needed, unlike
         the non-idempotent ``PgQueueClient.send``): the write is
@@ -162,15 +178,17 @@ class PgResultBackend:
                 with self._cursor() as cur:
                     operation(cur)
                 return
-            except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
-                if attempt >= _STORE_RETRY_ATTEMPTS:
+            except _CONN_DEAD_ERRORS:
+                # Last attempt, or an injected (non-owned) conn _cursor won't
+                # have dropped — retrying can't reconnect, so re-raise.
+                if attempt >= _STORE_RETRY_ATTEMPTS or not self._owns_conn:
                     raise
+                # Describe what was observed, not an inferred cause: this catch
+                # also covers deadlock / statement-timeout / admin-shutdown, not
+                # only a stale idle reap. exc_info carries the type + message.
                 logger.warning(
                     "PgResultBackend: result write failed with a connection-level "
-                    "error (%s: %s); dropping the cached connection and retrying "
-                    "once (stale idle reap or DB unavailable)",
-                    type(exc).__name__,
-                    exc,
+                    "error; dropping the cached connection and retrying once",
                     exc_info=True,
                 )
                 time.sleep(_STORE_RETRY_BACKOFF_SECONDS)
@@ -208,11 +226,14 @@ class PgResultBackend:
         ``result`` is the decoded JSONB dict (psycopg2 parses ``jsonb`` to a
         Python ``dict``); ``None`` means the task has not finished yet.
 
-        No reconnect-retry here (unlike :meth:`store_result`): the only caller,
-        ``executor_rpc.wait_for_result``, makes a FRESH ``PgResultBackend`` per
-        wait and then polls every ~0.2–2s, so this connection is new and kept
-        warm — it has no idle window to be reaped. A failure on a fresh
-        connection is a genuine error, not a stale-reap.
+        No reconnect-retry here (unlike :meth:`store_result`). The invariant it
+        relies on: the sole entry point into a wait (``executor_rpc.wait_for_result``
+        → this class's :meth:`wait_for_result` → ``get_result``) constructs a
+        FRESH ``PgResultBackend`` per wait and polls it every ~0.2–2s, so this
+        connection is new and kept warm — no idle window to be reaped, and a
+        failure on a fresh connection is a genuine error, not a stale reap. If a
+        long-lived backend ever gains a one-shot ``get_result`` lookup, revisit
+        this.
         """
         with self._cursor() as cur:
             cur.execute(_get_sql(), (str(task_id),))

--- a/workers/queue_backend/pg_queue/result_backend.py
+++ b/workers/queue_backend/pg_queue/result_backend.py
@@ -24,7 +24,11 @@ Two deliberate properties:
 Connection discipline mirrors :class:`~queue_backend.pg_queue.client.PgQueueClient`:
 an injected connection is the caller's (tests); otherwise one is created lazily
 from the backend ``DB_*`` env and owned here (rolled back on error, discarded +
-reconnected when it goes bad).
+reconnected when it goes bad). The executor consumer caches one backend for its
+lifetime, so the write connection sits idle between tasks and PgBouncer can reap
+it; :meth:`store_result` therefore retries once on a dead connection so the
+result is still written (and the blocking caller unblocked) rather than dropped
+— see :meth:`_store_with_reconnect`.
 """
 
 from __future__ import annotations
@@ -32,8 +36,9 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import time
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Final, Self
 
 import psycopg2
 
@@ -85,6 +90,11 @@ _POLL_MAX_SECONDS = 2.0
 STATUS_COMPLETED = PgTaskStatus.COMPLETED.value
 STATUS_FAILED = PgTaskStatus.FAILED.value
 
+# One reconnect-retry for the IDEMPOTENT result write (see _store_with_reconnect).
+# Literals (not env-driven) so the one-shot bound can't be widened operationally.
+_STORE_RETRY_ATTEMPTS: Final = 2  # total attempts: 1 initial + 1 retry
+_STORE_RETRY_BACKOFF_SECONDS: Final = 0.5
+
 
 class PgResultBackend:
     """``store_result`` / ``get_result`` / ``wait_for_result`` over ``pg_task_result``."""
@@ -129,6 +139,42 @@ class PgResultBackend:
                 self._conn = None
             raise
 
+    def _store_with_reconnect(self, operation: Any) -> None:
+        """Run an idempotent store ``operation(cur)`` in a committed cursor,
+        retrying ONCE if the cached connection was reaped while idle.
+
+        The executor consumer caches one ``PgResultBackend`` for its lifetime
+        (``consumer.py``), so this connection sits idle BETWEEN tasks and can be
+        dropped server-side (PgBouncer ``server_idle_timeout`` / failover) — and
+        ``conn.closed`` is a client-side flag only. ``_cursor``'s discard only
+        heals the *next* call, so without a retry the *current* ``store_result``
+        fails, the result is silently dropped, and the blocking caller is
+        stranded forever (the exec-b11ba2f3 hang). On a dead-connection error
+        ``_cursor`` has already dropped the handle, so the retry reconnects.
+
+        Safe to retry unconditionally (no reused-vs-fresh guard needed, unlike
+        the non-idempotent ``PgQueueClient.send``): the write is
+        ``INSERT … ON CONFLICT (task_id) DO NOTHING``, so re-running after an
+        ambiguous failure can neither duplicate nor clobber a recorded result.
+        """
+        for attempt in range(1, _STORE_RETRY_ATTEMPTS + 1):
+            try:
+                with self._cursor() as cur:
+                    operation(cur)
+                return
+            except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
+                if attempt >= _STORE_RETRY_ATTEMPTS:
+                    raise
+                logger.warning(
+                    "PgResultBackend: result write failed with a connection-level "
+                    "error (%s: %s); dropping the cached connection and retrying "
+                    "once (stale idle reap or DB unavailable)",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
+                time.sleep(_STORE_RETRY_BACKOFF_SECONDS)
+
     def store_result(
         self,
         task_id: str,
@@ -141,23 +187,32 @@ class PgResultBackend:
 
         ``result`` (a dict, e.g. ``ExecutionResult.to_dict()``) → ``completed``.
         Otherwise → ``failed`` with ``error`` text. Idempotent: a second write
-        for the same key (at-least-once redelivery) is a no-op.
+        for the same key (at-least-once redelivery) is a no-op. Survives a stale
+        cached connection via a one-shot reconnect-retry (see
+        :meth:`_store_with_reconnect`).
         """
         if result is not None:
             status, result_json, error_text = STATUS_COMPLETED, json.dumps(result), ""
         else:
             status, result_json, error_text = STATUS_FAILED, None, error or ""
-        with self._cursor() as cur:
-            cur.execute(
+        self._store_with_reconnect(
+            lambda cur: cur.execute(
                 _store_sql(),
                 (str(task_id), status, result_json, error_text, retention_seconds),
             )
+        )
 
     def get_result(self, task_id: str) -> dict[str, Any] | None:
         """Return ``{status, result, error}`` if the row exists, else ``None``.
 
         ``result`` is the decoded JSONB dict (psycopg2 parses ``jsonb`` to a
         Python ``dict``); ``None`` means the task has not finished yet.
+
+        No reconnect-retry here (unlike :meth:`store_result`): the only caller,
+        ``executor_rpc.wait_for_result``, makes a FRESH ``PgResultBackend`` per
+        wait and then polls every ~0.2–2s, so this connection is new and kept
+        warm — it has no idle window to be reaped. A failure on a fresh
+        connection is a genuine error, not a stale-reap.
         """
         with self._cursor() as cur:
             cur.execute(_get_sql(), (str(task_id),))

--- a/workers/tests/test_pg_result_backend.py
+++ b/workers/tests/test_pg_result_backend.py
@@ -11,11 +11,14 @@ import os
 import threading
 import time
 import uuid
+from unittest.mock import MagicMock
 
+import psycopg2
 import pytest
 
 from queue_backend.pg_queue.connection import create_pg_connection
 from queue_backend.pg_queue.result_backend import (
+    _STORE_RETRY_BACKOFF_SECONDS,
     STATUS_COMPLETED,
     STATUS_FAILED,
     PgResultBackend,
@@ -83,7 +86,8 @@ class TestWait:
 
     def test_wait_picks_up_late_write_from_other_conn(self, result_backend):
         """The real request-reply path: the waiter polls on its connection while
-        the result is committed from a separate connection mid-wait."""
+        the result is committed from a separate connection mid-wait.
+        """
         k = _key()
         os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
         writer = PgResultBackend(conn=create_pg_connection(env_prefix="TEST_DB_"))
@@ -101,3 +105,126 @@ class TestWait:
             writer.close()
         assert row is not None
         assert row["result"] == {"late": True}
+
+
+# --- Unit: store_result reconnect-retry on a stale cached connection (UN-3659) ---
+
+
+class _CursorCtx:
+    """Mimic a psycopg2 cursor used as a context manager."""
+
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self._cursor
+
+    def __exit__(self, *_):
+        return False
+
+
+class TestStoreResultReconnectRetry:
+    """store_result self-heals a connection PgBouncer reaped while the executor
+    sat idle — the exec-b11ba2f3 hang. Idempotent (ON CONFLICT), so the retry is
+    unconditional (no reused-vs-fresh guard, unlike PgQueueClient.send).
+    """
+
+    @staticmethod
+    def _conn(*, execute_side_effect=None):
+        cur = MagicMock()
+        if execute_side_effect is not None:
+            cur.execute.side_effect = execute_side_effect
+        conn = MagicMock()
+        conn.closed = 0
+        conn.cursor.return_value = _CursorCtx(cur)
+        return conn, cur
+
+    @staticmethod
+    def _no_sleep(monkeypatch):
+        sleep = MagicMock()
+        monkeypatch.setattr("queue_backend.pg_queue.result_backend.time.sleep", sleep)
+        return sleep
+
+    def test_stale_conn_retries_and_writes_result(self, monkeypatch):
+        # Cached owned conn reaped while idle fails its first INSERT; the one-shot
+        # retry reconnects (factory) and the result is written + committed.
+        dead, _ = self._conn(execute_side_effect=psycopg2.OperationalError("idle reap"))
+        fresh, fresh_cur = self._conn()
+        factory = MagicMock(return_value=fresh)
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection", factory
+        )
+        self._no_sleep(monkeypatch)
+        rb = PgResultBackend()  # owns its connection
+        rb._conn = dead  # simulate a cached (reused) connection
+
+        rb.store_result("k", result={"ok": True})
+
+        dead.close.assert_called_once()  # stale conn discarded
+        factory.assert_called_once()  # reconnected exactly once
+        fresh_cur.execute.assert_called_once()  # the retry INSERT ran
+        fresh.commit.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "exc_type", [psycopg2.OperationalError, psycopg2.InterfaceError]
+    )
+    def test_retries_both_connection_dead_error_types(self, monkeypatch, exc_type):
+        # InterfaceError ("connection already closed") is the other stale symptom;
+        # narrowing the except to OperationalError alone would re-break the fix.
+        dead, _ = self._conn(execute_side_effect=exc_type("dead"))
+        fresh, _ = self._conn()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection",
+            MagicMock(return_value=fresh),
+        )
+        self._no_sleep(monkeypatch)
+        rb = PgResultBackend()
+        rb._conn = dead
+
+        rb.store_result("k", result={"ok": True})  # must not raise
+        fresh.commit.assert_called_once()
+
+    def test_backoff_fires_once_on_retry(self, monkeypatch):
+        dead, _ = self._conn(execute_side_effect=psycopg2.OperationalError("reap"))
+        fresh, _ = self._conn()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection",
+            MagicMock(return_value=fresh),
+        )
+        sleep = self._no_sleep(monkeypatch)
+        rb = PgResultBackend()
+        rb._conn = dead
+
+        rb.store_result("k", result={"ok": True})
+        sleep.assert_called_once_with(_STORE_RETRY_BACKOFF_SECONDS)
+
+    def test_retry_also_fails_reraises_after_one_reconnect(self, monkeypatch):
+        dead1, _ = self._conn(execute_side_effect=psycopg2.OperationalError("reap"))
+        dead2, _ = self._conn(execute_side_effect=psycopg2.OperationalError("still"))
+        factory = MagicMock(return_value=dead2)
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection", factory
+        )
+        self._no_sleep(monkeypatch)
+        rb = PgResultBackend()
+        rb._conn = dead1
+
+        with pytest.raises(psycopg2.OperationalError):
+            rb.store_result("k", result={"ok": True})
+        factory.assert_called_once()  # exactly one reconnect, no loop
+
+    def test_non_connection_error_not_retried(self, monkeypatch):
+        # A logical error (not Operational/Interface) is not a stale-conn symptom.
+        bad, _ = self._conn(execute_side_effect=RuntimeError("logic"))
+        factory = MagicMock()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection", factory
+        )
+        sleep = self._no_sleep(monkeypatch)
+        rb = PgResultBackend()
+        rb._conn = bad
+
+        with pytest.raises(RuntimeError):
+            rb.store_result("k", result={"ok": True})
+        factory.assert_not_called()
+        sleep.assert_not_called()

--- a/workers/tests/test_pg_result_backend.py
+++ b/workers/tests/test_pg_result_backend.py
@@ -15,7 +15,6 @@ from unittest.mock import MagicMock
 
 import psycopg2
 import pytest
-
 from queue_backend.pg_queue.connection import create_pg_connection
 from queue_backend.pg_queue.result_backend import (
     _STORE_RETRY_BACKOFF_SECONDS,
@@ -145,7 +144,14 @@ class TestStoreResultReconnectRetry:
         monkeypatch.setattr("queue_backend.pg_queue.result_backend.time.sleep", sleep)
         return sleep
 
-    def test_stale_conn_retries_and_writes_result(self, monkeypatch):
+    # Both outcomes go through the same write path — the PR's whole point is that
+    # a *failed* task's result (error=) is delivered too, not silently dropped.
+    @pytest.mark.parametrize(
+        "outcome",
+        [{"result": {"ok": True}}, {"error": "boom"}],
+        ids=["completed", "failed"],
+    )
+    def test_stale_conn_retries_and_writes_result(self, monkeypatch, outcome):
         # Cached owned conn reaped while idle fails its first INSERT; the one-shot
         # retry reconnects (factory) and the result is written + committed.
         dead, _ = self._conn(execute_side_effect=psycopg2.OperationalError("idle reap"))
@@ -158,12 +164,49 @@ class TestStoreResultReconnectRetry:
         rb = PgResultBackend()  # owns its connection
         rb._conn = dead  # simulate a cached (reused) connection
 
-        rb.store_result("k", result={"ok": True})
+        rb.store_result("k", **outcome)
 
         dead.close.assert_called_once()  # stale conn discarded
         factory.assert_called_once()  # reconnected exactly once
         fresh_cur.execute.assert_called_once()  # the retry INSERT ran
         fresh.commit.assert_called_once()
+
+    def test_commit_time_reap_retries(self, monkeypatch):
+        # An idle reap usually surfaces when the buffered INSERT flushes at
+        # conn.commit() (after the cursor yield), not at execute() — that path
+        # must retry too.
+        dead, _ = self._conn()
+        dead.commit.side_effect = psycopg2.OperationalError("reaped at commit")
+        fresh, _ = self._conn()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection",
+            MagicMock(return_value=fresh),
+        )
+        self._no_sleep(monkeypatch)
+        rb = PgResultBackend()
+        rb._conn = dead
+
+        rb.store_result("k", result={"ok": True})  # must self-heal
+        dead.close.assert_called_once()
+        fresh.commit.assert_called_once()
+
+    def test_injected_connection_not_retried(self, monkeypatch):
+        # An injected (caller-owned) conn is never discarded by _cursor, so a
+        # retry would re-acquire the same dead handle — short-circuit to re-raise
+        # without the spurious backoff sleep.
+        conn, _ = self._conn(execute_side_effect=psycopg2.OperationalError("dead"))
+        factory = MagicMock()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection", factory
+        )
+        sleep = self._no_sleep(monkeypatch)
+        rb = PgResultBackend(conn=conn)  # injected -> not owned
+
+        with pytest.raises(psycopg2.OperationalError):
+            rb.store_result("k", result={"ok": True})
+        factory.assert_not_called()
+        sleep.assert_not_called()
+        conn.close.assert_not_called()  # caller's connection untouched
 
     @pytest.mark.parametrize(
         "exc_type", [psycopg2.OperationalError, psycopg2.InterfaceError]
@@ -228,3 +271,42 @@ class TestStoreResultReconnectRetry:
             rb.store_result("k", result={"ok": True})
         factory.assert_not_called()
         sleep.assert_not_called()
+
+
+class TestStoreResultRealReconnect:
+    """DB-gated: store_result REALLY reconnects against live PG (not just mock
+    orchestration). Skips when Postgres is unreachable (pg_conn fixture). This is
+    the test that fails if _cursor stopped nulling _conn or the reconnect handle
+    were unusable — the mock tests can't see that.
+    """
+
+    def test_real_reconnect_heals_closed_connection(self, pg_conn, monkeypatch):
+        # The owned backend reconnects via result_backend.create_pg_connection;
+        # point that at the integration DB (TEST_DB_*), the same one pg_conn uses
+        # (the bare DB_* env is the suite's unit-isolation placeholder).
+        os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.result_backend.create_pg_connection",
+            lambda *a, **k: create_pg_connection(env_prefix="TEST_DB_"),
+        )
+
+        key = _key()
+        rb = PgResultBackend()  # owned, real connection to the test DB
+        try:
+            _ = rb.conn  # materialise the connection
+            rb._conn.close()  # client-side close -> InterfaceError on next use
+            rb.store_result(key, result={"healed": True})  # must self-heal
+        finally:
+            rb.close()
+
+        # The row really landed — read it back on the fixture's own connection.
+        pg_conn.rollback()  # clear any aborted txn before reading
+        with pg_conn.cursor() as cur:
+            cur.execute(
+                "SELECT result->>'healed' FROM pg_task_result WHERE task_id = %s",
+                (key,),
+            )
+            row = cur.fetchone()
+            cur.execute("DELETE FROM pg_task_result WHERE task_id = %s", (key,))
+        pg_conn.commit()
+        assert row is not None and row[0] == "true"


### PR DESCRIPTION
## What
`PgResultBackend.store_result()` now survives a connection that PgBouncer reaped while the executor sat idle — a one-shot reconnect-retry. Sibling of UN-3654.

## Why
A PG execution **hung permanently** (exec `b11ba2f3`, ali dev) after the worker was idle ~56 min (flag off → enabled + run, past PgBouncer `server_idle_timeout`). The logs showed every file **extracted text and answered 4/4 prompts successfully**, then:

```
PgResultBackend: rollback failed; treating connection as dead
psycopg2.OperationalError: server closed the connection unexpectedly
FAILED to store request-reply result (...) — acking anyway; caller will time out
```

The executor consumer caches **one** `PgResultBackend` for its lifetime, so its write connection is long-lived and idle-reapable. `_cursor` discards a dead connection so the *next* call reconnects, but `store_result()`'s *current* call failed with no retry → the result was dropped → the blocking file-processing callers waited forever, got SIGKILLed, and the execution was orphaned in `EXECUTING`. UN-3654 added the retry to dispatch `send()` and the consumer's claim connection but **not** to this result-write path.

## How
`store_result()` retries once on `OperationalError`/`InterfaceError`. **Unconditional** (no reused-vs-fresh guard, unlike `send()`) because the write is `INSERT … ON CONFLICT (task_id) DO NOTHING` — re-running can't duplicate or clobber a recorded result. `_cursor` already drops the dead conn, so the retry reconnects and writes the result, unblocking the caller.

## Scope (audited the other PG paths)
- `store_result` — **fixed** (long-lived cached conn).
- `get_result`/`wait_for_result` — **safe**, left as-is: its only caller (`executor_rpc.wait_for_result`) makes a *fresh* `PgResultBackend` per wait and polls every ~0.2–2s, so no idle window. (Documented inline.)
- Consumer `read`/`delete` + periodic leader/reaper/scheduler loops — self-heal next cycle.
- **Related follow-up (separate ticket):** the `PgBarrier` decrement / `claim_batch` (cached thread-local conn) has the same idle-reap risk and was deliberately left non-retried by UN-3651 (non-idempotent); UN-3654's reused-guard would resolve it. Not the trigger here.

## Tests
- **Dev-test:** real `pg_terminate_backend` A/B — bare INSERT fails on the reaped conn with the exact `server closed the connection` that stranded `b11ba2f3`; `store_result()` self-heals and the row is verified in the DB.
- **6 unit tests:** retry+succeed, both `Operational`/`Interface` error types, backoff fires once, retry-also-fails raises after exactly one reconnect, non-connection error not retried. Full file: 13 passed.

## Op note
`b11ba2f3` won't self-recover (no execution-level reaper for stuck `EXECUTING`) — mark it FAILED on the primary or re-run.