### PR TITLE
UN-3660 [FIX] PG barrier decrement — phase-split reconnect-retry on stale connection

### DIFF
--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -94,6 +94,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# psycopg2 errors that mean the connection itself is dead (dropped socket /
+# PgBouncer recycle / server termination), as opposed to a logical/data error on
+# a live connection. Shared by ``_cursor`` / ``_recover_after_error`` (discard the
+# stale thread-local handle), the idempotent pre-dispatch write retry, and the
+# decrement phase-split retry, so the "was this a connection death?" test can't
+# drift across them. Mirrors ``PgQueueClient._CONN_DEAD_ERRORS`` (UN-3654) and
+# ``PgResultBackend._CONN_DEAD_ERRORS`` (UN-3659), the siblings this models on.
+_CONN_DEAD_ERRORS: Final[tuple[type[Exception], ...]] = (
+    psycopg2.OperationalError,
+    psycopg2.InterfaceError,
+)
+
+
 # Thread-local owned connection (prefork → one per child; thread-local keeps it
 # correct under -P threads too, since a libpq connection is not concurrency-safe
 # across threads). Self-recovers a dropped socket / PgBouncer recycle — same
@@ -109,6 +122,27 @@ def _get_conn() -> PgConnection:
     return conn
 
 
+def _recover_after_error(conn: PgConnection, exc: BaseException) -> bool:
+    """Roll back ``conn``; if it is dead, discard the thread-local handle so the
+    next :func:`_get_conn` reconnects. Returns whether the connection was judged
+    dead (a failed rollback proves it dead regardless of the original error).
+
+    Factored out so ``_cursor`` and the decrement phase-split (which can't use
+    ``_cursor`` because it must distinguish execute-phase from commit-phase
+    failures) share one definition of "recover a connection after an error".
+    """
+    conn_dead = isinstance(exc, _CONN_DEAD_ERRORS)
+    try:
+        conn.rollback()
+    except Exception:
+        conn_dead = True
+    if conn_dead or conn.closed:
+        with contextlib.suppress(Exception):
+            conn.close()
+        _local.conn = None
+    return conn_dead
+
+
 @contextlib.contextmanager
 def _cursor() -> Iterator[Any]:
     """Yield a cursor; commit on success, roll back + recover on error."""
@@ -118,15 +152,7 @@ def _cursor() -> Iterator[Any]:
             yield cur
         conn.commit()
     except Exception as exc:
-        conn_dead = isinstance(exc, (psycopg2.OperationalError, psycopg2.InterfaceError))
-        try:
-            conn.rollback()
-        except Exception:
-            conn_dead = True
-        if conn_dead or conn.closed:
-            with contextlib.suppress(Exception):
-                conn.close()
-            _local.conn = None
+        _recover_after_error(conn, exc)
         raise
 
 
@@ -145,6 +171,11 @@ _BARRIER_WRITE_ATTEMPTS: Final = 2  # total attempts: 1 initial + 1 retry
 # avoids immediately re-hammering a struggling server on the rarer server-side
 # errors the broad psycopg2.OperationalError catch also covers.
 _BARRIER_RETRY_BACKOFF_SECONDS: Final = 0.5
+
+# One retry for the NON-idempotent barrier DECREMENT — but only on an
+# execute-phase failure on a reused connection (see :func:`_apply_decrement`),
+# never on commit (ambiguous). Same one-shot bound as the idempotent write.
+_BARRIER_DECREMENT_ATTEMPTS: Final = 2  # total attempts: 1 initial + 1 retry
 
 
 def _run_idempotent_pre_dispatch_write(
@@ -174,7 +205,7 @@ def _run_idempotent_pre_dispatch_write(
             with _cursor() as cur:
                 operation(cur)
             return
-        except (psycopg2.OperationalError, psycopg2.InterfaceError) as exc:
+        except _CONN_DEAD_ERRORS as exc:
             # _cursor already dropped the dead thread-local conn → the next
             # _get_conn() reconnects. Retry once; re-raise if it still fails
             # (a genuinely-down DB surfaces as ERROR, as before). Name the real
@@ -597,6 +628,99 @@ def _fire_barrier_callback(
     return str(callback_signature.apply_async().id)
 
 
+def _apply_decrement(execution_id: str, result_json: str) -> tuple[int, Any] | None:
+    """Apply the barrier decrement ``UPDATE`` and return its ``(remaining,
+    results)`` RETURNING row (``None`` if the barrier row is already gone).
+
+    The decrement is NON-idempotent — re-applying it double-counts (premature
+    callback fire with incomplete results, or a strand past 0) — so it is split
+    into its two phases and retried in ONLY the one phase where a re-apply is
+    provably safe:
+
+    - **EXECUTE phase** (``UPDATE … RETURNING`` + ``fetchone``) — the statement
+      runs but is NOT yet committed. A connection-level failure here on a
+      **reused** (cached) connection is the PgBouncer idle-reap: the statement
+      never reached the server, no commit was issued, and the open transaction is
+      rolled back on disconnect. So the decrement provably never landed →
+      reconnect and re-apply it exactly once. (Only a *cached* connection can be a
+      stale idle-reaped handle; a freshly-created one failing is a genuine DB
+      error, not a reap, so it is not retried.) **This safety relies on the
+      connection being non-autocommit** (``create_pg_connection`` opens it that
+      way): even if the server actually ran the ``UPDATE`` before the socket
+      dropped, it sits in an uncommitted transaction that is rolled back on
+      disconnect — durability happens ONLY at the commit below — so re-applying
+      can never double-count.
+    - **COMMIT phase** — ``conn.commit()``. A failure here is AMBIGUOUS: the
+      server may have applied the commit before the socket dropped. Re-applying
+      could double-count, so it is NEVER retried — it propagates, and the caller
+      (:func:`run_batch_with_barrier`) tears the barrier down so the execution
+      fails fast rather than risk a corrupted counter.
+
+    Any non-connection error (e.g. the NUL-byte ``psycopg2.DataError`` from the
+    jsonb cast) also propagates unchanged — only the idle-reap self-heals. This is
+    the decrement's counterpart to ``PgQueueClient.send``'s reused-guard
+    (UN-3654) and the idempotent pre-dispatch write's retry, but phase-split
+    because the decrement, unlike those, must never replay a committed write.
+    """
+    sql = (
+        f"UPDATE {qualified('pg_barrier_state')} "
+        "   SET remaining = remaining - 1, "
+        "       results = results || jsonb_build_array(%s::jsonb) "
+        " WHERE execution_id = %s "
+        "RETURNING remaining, results"
+    )
+    for attempt in range(1, _BARRIER_DECREMENT_ATTEMPTS + 1):
+        # Only a connection cached BEFORE this attempt can be a stale idle-reaped
+        # handle; a freshly-reconnected one failing is a genuine error, not a reap.
+        reused = getattr(_local, "conn", None) is not None and not _local.conn.closed
+        conn = _get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, (result_json, execution_id))
+                row = cur.fetchone()
+        except Exception as exc:
+            conn_dead = _recover_after_error(conn, exc)
+            # Retry ONLY a reused-conn death on the execute phase: it never
+            # committed (re-applying lands exactly once) and reconnecting can
+            # actually help. A fresh-conn death (DB genuinely down), a DataError,
+            # or the last attempt all propagate unchanged.
+            if conn_dead and reused and attempt < _BARRIER_DECREMENT_ATTEMPTS:
+                logger.warning(
+                    "[exec:%s] PgBarrier decrement: execute failed on a cached "
+                    "connection (%s) — reconnecting and re-applying once "
+                    "(attempt %d/%d); the decrement never committed, so it lands "
+                    "exactly once.",
+                    execution_id,
+                    type(exc).__name__,
+                    attempt,
+                    _BARRIER_DECREMENT_ATTEMPTS,
+                    exc_info=True,
+                )
+                time.sleep(_BARRIER_RETRY_BACKOFF_SECONDS)
+                continue
+            raise
+        try:
+            conn.commit()
+        except Exception as exc:
+            _recover_after_error(conn, exc)
+            # AMBIGUOUS — the server may have committed. Re-applying could
+            # double-count, so do NOT retry: propagate so the caller tears the
+            # barrier down (fail-fast) rather than corrupt the counter.
+            logger.warning(
+                "[exec:%s] PgBarrier decrement: commit failed (%s) — NOT retrying "
+                "(the server may already have applied it; a re-apply would "
+                "double-count). Propagating so the barrier is torn down.",
+                execution_id,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            raise
+        return row
+    # Unreachable: the loop either returns the row or raises. The bare raise keeps
+    # the type checker honest about the no-fallthrough invariant.
+    raise AssertionError("unreachable: _apply_decrement loop exited without return")
+
+
 def _barrier_pg_decrement(
     result: Any,
     *,
@@ -616,12 +740,19 @@ def _barrier_pg_decrement(
       the header task's body — a PG-consumed task fires no ``.link``, so the
       decrement must run in-body.
 
-    Callers MUST run each decrement in its own committed transaction (the
-    decrement ``UPDATE`` runs in its own ``_cursor()`` txn) and MUST NOT retry
-    it: a replay re-runs the decrement and corrupts the count. This is enforced
-    loudly, not just in prose — entry raises if the shared connection is already
-    mid-transaction (see the guard below). The Celery wrapper additionally pins
-    ``max_retries=0``; an orphaned barrier is bounded by ``expires_at`` instead.
+    Callers MUST run each decrement in its own committed transaction and MUST NOT
+    replay a *committed* decrement: re-applying one that already landed corrupts
+    the count (fires the callback early with incomplete results, or skips past 0
+    and strands the barrier). This is enforced loudly, not just in prose — entry
+    raises if the shared connection is already mid-transaction (see the guard
+    below), and the Celery wrapper pins ``max_retries=0`` so a task-level replay
+    can't re-drive it; an orphaned barrier is bounded by ``expires_at`` instead.
+
+    The decrement DOES self-heal one narrow, provably-safe case via
+    :func:`_apply_decrement`: an execute-phase failure on a cached connection that
+    PgBouncer idle-reaped (the statement never reached the server, so nothing
+    committed) is reconnected and re-applied exactly once. A commit-phase failure
+    is ambiguous and is NEVER retried — see :func:`_apply_decrement`.
     """
     # Enforce the "own committed transaction" contract loudly. A caller that
     # invokes this inside an already-open transaction on the shared thread-local
@@ -656,16 +787,7 @@ def _barrier_pg_decrement(
     # jsonb_build_array(...) appends exactly one element regardless of the
     # result's shape (``||`` would concatenate if the result were itself a list).
     try:
-        with _cursor() as cur:
-            cur.execute(
-                f"UPDATE {qualified('pg_barrier_state')} "
-                "   SET remaining = remaining - 1, "
-                "       results = results || jsonb_build_array(%s::jsonb) "
-                " WHERE execution_id = %s "
-                "RETURNING remaining, results",
-                (result_json, execution_id),
-            )
-            row = cur.fetchone()
+        row = _apply_decrement(execution_id, result_json)
     except psycopg2.DataError:
         # json.dumps accepts a few bytes jsonb rejects — notably a NUL (0x00)
         # in a string. The cast above then raises, the decrement never lands, and

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -63,7 +63,7 @@ import threading
 import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 import psycopg2
 import psycopg2.extensions
@@ -83,6 +83,7 @@ from .fairness import (
     WorkloadType,
 )
 from .handle import BarrierHandle
+from .pg_queue.connection import CONN_DEAD_ERRORS as _CONN_DEAD_ERRORS
 from .pg_queue.connection import create_pg_connection
 from .pg_queue.schema import qualified
 
@@ -94,17 +95,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# psycopg2 errors that mean the connection itself is dead (dropped socket /
-# PgBouncer recycle / server termination), as opposed to a logical/data error on
-# a live connection. Shared by ``_cursor`` / ``_recover_after_error`` (discard the
-# stale thread-local handle), the idempotent pre-dispatch write retry, and the
-# decrement phase-split retry, so the "was this a connection death?" test can't
-# drift across them. Mirrors ``PgQueueClient._CONN_DEAD_ERRORS`` (UN-3654) and
-# ``PgResultBackend._CONN_DEAD_ERRORS`` (UN-3659), the siblings this models on.
-_CONN_DEAD_ERRORS: Final[tuple[type[Exception], ...]] = (
-    psycopg2.OperationalError,
-    psycopg2.InterfaceError,
-)
+# ``_CONN_DEAD_ERRORS`` (the "is this a connection death?" test, used by
+# ``_recover_after_error``/``_cursor`` to discard a stale handle and by the
+# enqueue/decrement retries to decide eligibility) is imported from
+# ``pg_queue.connection`` so the dispatch/result/barrier sites can't drift.
 
 
 # Thread-local owned connection (prefork → one per child; thread-local keeps it
@@ -135,6 +129,17 @@ def _recover_after_error(conn: PgConnection, exc: BaseException) -> bool:
     try:
         conn.rollback()
     except Exception:
+        # A failed rollback proves the connection is unusable regardless of the
+        # original error's subclass — treat it as dead. Surface why (instead of
+        # swallowing it): this also reclassifies a non-conn error (e.g. DataError)
+        # whose rollback fails into the dead/retry path, so the trail must show it
+        # was the rollback, not the original error, that condemned the connection.
+        logger.warning(
+            "PgBarrier: rollback during error recovery failed (original error %s) "
+            "— treating the connection as dead and discarding it.",
+            type(exc).__name__,
+            exc_info=True,
+        )
         conn_dead = True
     if conn_dead or conn.closed:
         with contextlib.suppress(Exception):
@@ -628,9 +633,21 @@ def _fire_barrier_callback(
     return str(callback_signature.apply_async().id)
 
 
-def _apply_decrement(execution_id: str, result_json: str) -> tuple[int, Any] | None:
+class _DecrementRow(NamedTuple):
+    """The decrement ``UPDATE … RETURNING`` row, named so the caller reads
+    ``row.remaining`` / ``row.results`` instead of positional ``row[0]`` / ``row[1]``
+    and the ``results`` list-shape is documented in the type.
+    """
+
+    remaining: int
+    results: list[Any]
+
+
+def _apply_decrement(
+    execution_id: str, result_json: str, *, reused: bool
+) -> _DecrementRow | None:
     """Apply the barrier decrement ``UPDATE`` and return its ``(remaining,
-    results)`` RETURNING row (``None`` if the barrier row is already gone).
+    results)`` row (``None`` if the barrier row is already gone).
 
     The decrement is NON-idempotent — re-applying it double-counts (premature
     callback fire with incomplete results, or a strand past 0) — so it is split
@@ -638,27 +655,32 @@ def _apply_decrement(execution_id: str, result_json: str) -> tuple[int, Any] | N
     provably safe:
 
     - **EXECUTE phase** (``UPDATE … RETURNING`` + ``fetchone``) — the statement
-      runs but is NOT yet committed. A connection-level failure here on a
-      **reused** (cached) connection is the PgBouncer idle-reap: the statement
+      runs but is NOT yet committed. A connection-level failure here when the
+      connection was *cached* (``reused`` — sampled by the caller BEFORE the entry
+      guard materialises a connection) is the PgBouncer idle-reap: the statement
       never reached the server, no commit was issued, and the open transaction is
       rolled back on disconnect. So the decrement provably never landed →
-      reconnect and re-apply it exactly once. (Only a *cached* connection can be a
-      stale idle-reaped handle; a freshly-created one failing is a genuine DB
-      error, not a reap, so it is not retried.) **This safety relies on the
-      connection being non-autocommit** (``create_pg_connection`` opens it that
-      way): even if the server actually ran the ``UPDATE`` before the socket
-      dropped, it sits in an uncommitted transaction that is rolled back on
-      disconnect — durability happens ONLY at the commit below — so re-applying
-      can never double-count.
+      reconnect and re-apply it exactly once. A *freshly-created* connection
+      failing (``reused`` False) is a genuine DB error, not a reap, so it is NOT
+      retried — a reconnect would buy nothing. **This safety relies on the
+      connection being non-autocommit** (psycopg2's default; ``create_pg_connection``
+      does not override it): even if the server actually ran the ``UPDATE`` before
+      the socket dropped, it sits in an uncommitted transaction that is rolled back
+      on disconnect — durability happens ONLY at the commit below — so re-applying
+      can never double-count. (``test_create_pg_connection_is_non_autocommit`` pins
+      that default at its source.)
     - **COMMIT phase** — ``conn.commit()``. A failure here is AMBIGUOUS: the
       server may have applied the commit before the socket dropped. Re-applying
-      could double-count, so it is NEVER retried — it propagates, and the caller
-      (:func:`run_batch_with_barrier`) tears the barrier down so the execution
-      fails fast rather than risk a corrupted counter.
+      could double-count, so it is NEVER retried — it propagates. On the in-body
+      PG path (:func:`run_batch_with_barrier`) the caller then tears the barrier
+      down so the execution fails fast; on the Celery ``.link`` path
+      (:func:`barrier_pg_decr_and_check`, ``max_retries=0``) it is not retried and
+      the barrier is reclaimed at ``expires_at`` by the reaper. Either way the
+      counter is never corrupted.
 
     Any non-connection error (e.g. the NUL-byte ``psycopg2.DataError`` from the
     jsonb cast) also propagates unchanged — only the idle-reap self-heals. This is
-    the decrement's counterpart to ``PgQueueClient.send``'s reused-guard
+    the decrement's counterpart to ``pg_queue.client.send``'s reused-guard
     (UN-3654) and the idempotent pre-dispatch write's retry, but phase-split
     because the decrement, unlike those, must never replay a committed write.
     """
@@ -670,20 +692,18 @@ def _apply_decrement(execution_id: str, result_json: str) -> tuple[int, Any] | N
         "RETURNING remaining, results"
     )
     for attempt in range(1, _BARRIER_DECREMENT_ATTEMPTS + 1):
-        # Only a connection cached BEFORE this attempt can be a stale idle-reaped
-        # handle; a freshly-reconnected one failing is a genuine error, not a reap.
-        reused = getattr(_local, "conn", None) is not None and not _local.conn.closed
         conn = _get_conn()
         try:
             with conn.cursor() as cur:
                 cur.execute(sql, (result_json, execution_id))
-                row = cur.fetchone()
+                fetched = cur.fetchone()
         except Exception as exc:
             conn_dead = _recover_after_error(conn, exc)
             # Retry ONLY a reused-conn death on the execute phase: it never
             # committed (re-applying lands exactly once) and reconnecting can
-            # actually help. A fresh-conn death (DB genuinely down), a DataError,
-            # or the last attempt all propagate unchanged.
+            # actually help. ``reused`` reflects the connection state at entry, so
+            # it is True only on the first attempt's cached handle; a reconnect
+            # makes the next attempt fresh, and the attempt bound stops the loop.
             if conn_dead and reused and attempt < _BARRIER_DECREMENT_ATTEMPTS:
                 logger.warning(
                     "[exec:%s] PgBarrier decrement: execute failed on a cached "
@@ -698,26 +718,45 @@ def _apply_decrement(execution_id: str, result_json: str) -> tuple[int, Any] | N
                 )
                 time.sleep(_BARRIER_RETRY_BACKOFF_SECONDS)
                 continue
+            # Not retried. A non-connection error (e.g. DataError) is logged by the
+            # caller's own teardown; but a conn-dead give-up (fresh-conn death, or
+            # the retry budget spent) would otherwise be silent — log it so the
+            # terminal "didn't self-heal" decision leaves the same breadcrumb the
+            # retryable path does, then propagate.
+            if conn_dead:
+                logger.warning(
+                    "[exec:%s] PgBarrier decrement: execute failed with a "
+                    "connection error (%s) that is NOT being retried (reused=%s, "
+                    "attempt %d/%d) — propagating; the barrier is not self-healed "
+                    "here.",
+                    execution_id,
+                    type(exc).__name__,
+                    reused,
+                    attempt,
+                    _BARRIER_DECREMENT_ATTEMPTS,
+                    exc_info=True,
+                )
             raise
         try:
             conn.commit()
         except Exception as exc:
             _recover_after_error(conn, exc)
             # AMBIGUOUS — the server may have committed. Re-applying could
-            # double-count, so do NOT retry: propagate so the caller tears the
-            # barrier down (fail-fast) rather than corrupt the counter.
+            # double-count, so do NOT retry: propagate (the caller fails the
+            # barrier fast, or it is reclaimed at expiry) rather than corrupt it.
             logger.warning(
                 "[exec:%s] PgBarrier decrement: commit failed (%s) — NOT retrying "
                 "(the server may already have applied it; a re-apply would "
-                "double-count). Propagating so the barrier is torn down.",
+                "double-count). Propagating.",
                 execution_id,
                 type(exc).__name__,
                 exc_info=True,
             )
             raise
-        return row
-    # Unreachable: the loop either returns the row or raises. The bare raise keeps
-    # the type checker honest about the no-fallthrough invariant.
+        return None if fetched is None else _DecrementRow(int(fetched[0]), fetched[1])
+    # Defensive: the loop always returns or raises before here. The annotation
+    # permits None, so a type checker would NOT catch a stray fall-through — this
+    # guards a future edit that breaks the always-return/raise invariant.
     raise AssertionError("unreachable: _apply_decrement loop exited without return")
 
 
@@ -754,6 +793,15 @@ def _barrier_pg_decrement(
     committed) is reconnected and re-applied exactly once. A commit-phase failure
     is ambiguous and is NEVER retried — see :func:`_apply_decrement`.
     """
+    # Sample whether the decrement will run on a *cached* connection BEFORE the
+    # entry-guard's _get_conn() below materialises one. _apply_decrement's
+    # reused-guard needs the pre-guard state: a freshly-created connection must NOT
+    # be classified 'reused' (only a cached handle can be a stale idle-reap), but
+    # the guard's _get_conn() would otherwise always leave _local.conn populated,
+    # making 'reused' permanently True. Mirrors pg_queue.client.send, which samples
+    # before any _get_conn().
+    conn_was_cached = getattr(_local, "conn", None) is not None and not _local.conn.closed
+
     # Enforce the "own committed transaction" contract loudly. A caller that
     # invokes this inside an already-open transaction on the shared thread-local
     # connection would hold the row lock across the call and let the outer txn's
@@ -787,7 +835,7 @@ def _barrier_pg_decrement(
     # jsonb_build_array(...) appends exactly one element regardless of the
     # result's shape (``||`` would concatenate if the result were itself a list).
     try:
-        row = _apply_decrement(execution_id, result_json)
+        row = _apply_decrement(execution_id, result_json, reused=conn_was_cached)
     except psycopg2.DataError:
         # json.dumps accepts a few bytes jsonb rejects — notably a NUL (0x00)
         # in a string. The cast above then raises, the decrement never lands, and
@@ -811,7 +859,7 @@ def _barrier_pg_decrement(
         )
         return {"status": "abandoned", "remaining": None}
 
-    remaining, all_results = int(row[0]), row[1]
+    remaining, all_results = row.remaining, row.results
     logger.info(f"[exec:{execution_id}] PgBarrier decrement → remaining={remaining}")
 
     if remaining > 0:

--- a/workers/queue_backend/pg_queue/client.py
+++ b/workers/queue_backend/pg_queue/client.py
@@ -34,9 +34,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final, Self
 
-import psycopg2
-
 from ..fairness import DEFAULT_PRIORITY, MAX_PRIORITY, MIN_PRIORITY
+from .connection import CONN_DEAD_ERRORS as _CONN_DEAD_ERRORS
 from .connection import create_pg_connection
 from .schema import qualified
 
@@ -46,16 +45,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# psycopg2 errors that mean the connection itself is dead (dropped socket /
-# PgBouncer recycle / server termination) rather than a statement-level fault.
-# Shared by ``_cursor`` (decides whether to discard the cached handle) and
-# ``send`` (decides whether the one-shot reconnect-retry is eligible) so the two
-# sites can't drift — narrowing one without the other would silently break the
-# retry's "was this a connection death?" test.
-_CONN_DEAD_ERRORS: Final[tuple[type[Exception], ...]] = (
-    psycopg2.OperationalError,
-    psycopg2.InterfaceError,
-)
+# ``_CONN_DEAD_ERRORS`` (the "is this a connection death?" test, shared by
+# ``_cursor`` discarding the cached handle and ``send`` deciding retry eligibility)
+# is imported from ``.connection`` so the dispatch/result/barrier sites can't drift.
 
 
 # Atomic claim. Takes up to %(qty)s ready messages no other transaction

--- a/workers/queue_backend/pg_queue/connection.py
+++ b/workers/queue_backend/pg_queue/connection.py
@@ -27,6 +27,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# psycopg2 errors that mean the connection itself is dead (dropped socket /
+# PgBouncer recycle / server termination), as opposed to a logical/data error on
+# a live connection. Single source of truth for every PG-queue site that decides
+# "was this a connection death?" — the dispatch ``send`` reused-guard
+# (``pg_queue.client``, UN-3654), the ``store_result`` retry
+# (``pg_queue.result_backend``, UN-3659) and the barrier enqueue/decrement
+# (``pg_barrier``, UN-3651/UN-3660). Hoisted here (the module all of them already
+# import) so the three call sites can't drift apart.
+CONN_DEAD_ERRORS: tuple[type[Exception], ...] = (
+    psycopg2.OperationalError,
+    psycopg2.InterfaceError,
+)
+
 # Bounded retry for *transient* connect failures (DB restart, PgBouncer pool
 # wait, brief network partition, "too many clients" spikes) — the common cloud
 # blips. Opening a connection is side-effect-free, so retrying it is safe and

--- a/workers/queue_backend/pg_queue/result_backend.py
+++ b/workers/queue_backend/pg_queue/result_backend.py
@@ -40,11 +40,10 @@ import time
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any, Final, Self
 
-import psycopg2
-
 from unstract.core.data_models import PgTaskStatus
 from unstract.core.polling import poll_for_row
 
+from .connection import CONN_DEAD_ERRORS as _CONN_DEAD_ERRORS
 from .connection import create_pg_connection
 from .schema import qualified
 
@@ -53,16 +52,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# psycopg2 errors that mean the connection itself is dead (dropped socket /
-# PgBouncer recycle / server termination). Shared by ``_cursor`` (decides whether
-# to discard the cached handle) and ``_store_with_reconnect`` (decides whether the
-# one-shot retry is eligible) so the two can't drift — narrowing one without the
-# other would silently break the retry's "was this a connection death?" test.
-# Mirrors ``PgQueueClient._CONN_DEAD_ERRORS`` (UN-3654), the sibling this models on.
-_CONN_DEAD_ERRORS: Final[tuple[type[Exception], ...]] = (
-    psycopg2.OperationalError,
-    psycopg2.InterfaceError,
-)
+# ``_CONN_DEAD_ERRORS`` (the "is this a connection death?" test, shared by
+# ``_cursor`` discarding the cached handle and ``_store_with_reconnect`` deciding
+# retry eligibility) is imported from ``.connection`` so the dispatch/result/barrier
+# sites can't drift.
 
 # How long a stored result lives before the reaper's retention sweep may delete
 # it. Defaults to the executor caller-timeout default so a result always

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -271,9 +271,15 @@ class TestDecrementPhaseSplitRetry:
     The count is therefore never double-applied. (UN-3660)
     """
 
-    @pytest.fixture(autouse=True)
-    def _no_sleep(self, monkeypatch):
-        monkeypatch.setattr(pg_barrier.time, "sleep", lambda *_a, **_k: None)
+    @pytest.fixture
+    def sleeps(self, monkeypatch):
+        # Record (and skip) the retry backoff so a test can assert it fired exactly
+        # when — and only when — a retry happens. Deleting the time.sleep in
+        # _apply_decrement, or a refactor that starts hammering a struggling DB,
+        # changes this list.
+        calls: list[float] = []
+        monkeypatch.setattr(pg_barrier.time, "sleep", calls.append)
+        return calls
 
     @pytest.mark.parametrize(
         "exc",
@@ -284,7 +290,7 @@ class TestDecrementPhaseSplitRetry:
         ids=["OperationalError", "InterfaceError"],
     )
     def test_execute_phase_reaped_cached_conn_retries_once(
-        self, _clean_local, monkeypatch, caplog, exc
+        self, _clean_local, monkeypatch, caplog, sleeps, exc
     ):
         # The idle-reap: a cached conn fails mid-execute (never committed), so the
         # decrement reconnects and re-applies exactly once on a healthy conn.
@@ -294,17 +300,20 @@ class TestDecrementPhaseSplitRetry:
         monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
 
         with caplog.at_level("WARNING"):
-            pg_barrier._apply_decrement("exec-1", '{"ok": true}')
+            pg_barrier._apply_decrement("exec-1", '{"ok": true}', reused=True)
 
         assert dead.executes == 1 and healthy.executes == 1  # exactly one extra try
         assert dead.commits == 0  # the reaped attempt never committed
         assert dead.closed is True  # stale conn discarded
         assert healthy.commits == 1  # committed exactly once, on the retry
         assert pg_barrier._local.conn is healthy
+        assert sleeps == [pg_barrier._BARRIER_RETRY_BACKOFF_SECONDS]  # backoff fired once
         assert "execute failed on a cached connection" in caplog.text
         assert type(exc).__name__ in caplog.text
 
-    def test_commit_phase_failure_is_not_retried(self, _clean_local, monkeypatch):
+    def test_commit_phase_failure_is_not_retried(
+        self, _clean_local, monkeypatch, sleeps
+    ):
         # A commit failure is AMBIGUOUS (the server may have applied it) → must
         # NOT retry, or the decrement could land twice. It propagates; the dead
         # conn is discarded; no reconnect is attempted.
@@ -319,34 +328,40 @@ class TestDecrementPhaseSplitRetry:
         )
 
         with pytest.raises(psycopg2.OperationalError, match="during commit"):
-            pg_barrier._apply_decrement("exec-2", '{"ok": true}')
+            pg_barrier._apply_decrement("exec-2", '{"ok": true}', reused=True)
 
         assert conn.executes == 1  # the UPDATE ran exactly once
         assert conn.commits == 1  # commit was attempted exactly once
         assert reconnects == []  # NEVER reconnected/retried after a commit failure
         assert conn.closed is True  # the dead conn was discarded
+        assert sleeps == []  # no backoff — a commit failure is not retried
 
     def test_fresh_conn_execute_failure_is_not_retried(
-        self, _clean_local, monkeypatch
+        self, _clean_local, monkeypatch, sleeps
     ):
-        # No cached conn → the first conn is freshly created. A failure on a fresh
-        # conn is a genuine DB error, not an idle-reap, so the reused-guard skips
-        # the retry and it surfaces immediately.
+        # reused=False (the production wrapper passes this when no conn was cached
+        # before the entry guard). A failure on a fresh conn is a genuine DB error,
+        # not an idle-reap, so the reused-guard skips the retry — even though it is
+        # a connection-dead error — and it surfaces immediately.
         err = psycopg2.OperationalError("db down")
-        made = []
+        conn = _FakeConn(execute_error=err)
+        pg_barrier._local.conn = conn
+        reconnects = []
         monkeypatch.setattr(
             pg_barrier,
             "create_pg_connection",
-            lambda **_k: made.append(c := _FakeConn(execute_error=err)) or c,
+            lambda **_k: reconnects.append(1) or _FakeConn(),
         )
-        pg_barrier._local.conn = None  # nothing cached → fresh
 
         with pytest.raises(psycopg2.OperationalError, match="db down"):
-            pg_barrier._apply_decrement("exec-3", '{"ok": true}')
+            pg_barrier._apply_decrement("exec-3", '{"ok": true}', reused=False)
 
-        assert len(made) == 1  # created once, never retried
+        assert reconnects == []  # fresh-conn death is not retried
+        assert sleeps == []  # …so no backoff either
 
-    def test_non_connection_error_is_not_retried(self, _clean_local, monkeypatch):
+    def test_non_connection_error_is_not_retried(
+        self, _clean_local, monkeypatch, sleeps
+    ):
         # A DataError (e.g. a NUL byte rejected by the jsonb cast) is not a
         # connection death → propagate immediately so the caller tears the barrier
         # down. A live conn after a logical error is NOT discarded.
@@ -360,24 +375,77 @@ class TestDecrementPhaseSplitRetry:
         )
 
         with pytest.raises(psycopg2.DataError):
-            pg_barrier._apply_decrement("exec-4", '{"ok": true}')
+            pg_barrier._apply_decrement("exec-4", '{"ok": true}', reused=True)
 
         assert reconnects == []  # no retry on a logical/data error
         assert conn.closed is False  # a live conn after a data error is kept
+        assert sleeps == []  # not retried → no backoff
 
-    def test_reraises_after_second_execute_failure(self, _clean_local, monkeypatch):
-        # The one-shot bound: if the reconnect target also dies on execute,
-        # re-raise rather than loop (and the second conn is "fresh" anyway).
+    def test_reraises_after_one_retry(self, _clean_local, monkeypatch, sleeps):
+        # The one-shot bound: a reused-conn idle-reap retries ONCE; if the
+        # reconnect target also dies on execute, re-raise rather than loop. On
+        # attempt 2 the attempt bound (attempt < _BARRIER_DECREMENT_ATTEMPTS) is
+        # what refuses the next retry — note reused is still True (the caller's
+        # entry-time value), so bumping the attempt constant would NOT add
+        # self-heals unless the reconnect logic also re-evaluated freshness.
         err = psycopg2.OperationalError("still down")
         pg_barrier._local.conn = _FakeConn(execute_error=err)
+        reconnects = []
         monkeypatch.setattr(
             pg_barrier,
             "create_pg_connection",
-            lambda **_k: _FakeConn(execute_error=err),
+            lambda **_k: reconnects.append(1) or _FakeConn(execute_error=err),
         )
 
         with pytest.raises(psycopg2.OperationalError, match="still down"):
-            pg_barrier._apply_decrement("exec-5", '{"ok": true}')
+            pg_barrier._apply_decrement("exec-5", '{"ok": true}', reused=True)
+
+        assert len(reconnects) == 1  # exactly one reconnect, then gave up
+        assert sleeps == [pg_barrier._BARRIER_RETRY_BACKOFF_SECONDS]  # one backoff
+
+    def test_wrapper_fresh_conn_not_retried_end_to_end(
+        self, _clean_local, monkeypatch, sleeps
+    ):
+        # Through the PRODUCTION entry (_barrier_pg_decrement), not _apply_decrement
+        # directly: with no cached conn, the entry-guard's _get_conn() creates a
+        # fresh one — but _barrier_pg_decrement samples `reused` BEFORE the guard,
+        # so it threads reused=False and a genuine fresh-conn DB error is NOT
+        # retried. Pins the sample-before-the-guard wiring the direct-call tests
+        # can't see (the guard would otherwise leave _local.conn always populated).
+        err = psycopg2.OperationalError("db down")
+        creates = []
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: creates.append(c := _FakeConn(execute_error=err)) or c,
+        )
+        pg_barrier._local.conn = None  # nothing cached → wrapper samples reused=False
+
+        with pytest.raises(psycopg2.OperationalError, match="db down"):
+            _barrier_pg_decrement(
+                {"f": 1}, execution_id="exec-FRESH", callback_descriptor=_CALLBACK
+            )
+
+        assert len(creates) == 1  # the guard created one; NO retry reconnect
+        assert sleeps == []  # a fresh-conn death is not retried → no backoff
+
+
+def test_create_pg_connection_is_non_autocommit():
+    """The decrement phase-split's exactly-once safety rests on the connection
+    being non-autocommit (an uncommitted UPDATE rolls back on disconnect, so an
+    execute-phase failure is never durable). Pin that at its SOURCE — a future
+    ``conn.autocommit = True`` in ``create_pg_connection`` would silently
+    reintroduce the double-count the split exists to prevent, and no other test
+    would catch it (the barrier_db fixture sets autocommit itself)."""
+    os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
+    try:
+        conn = create_pg_connection(env_prefix="TEST_DB_")
+    except psycopg2.OperationalError as exc:
+        pytest.skip(f"Postgres not reachable: {exc}")
+    try:
+        assert conn.autocommit is False
+    finally:
+        conn.close()
 
 
 # --- Layer 2: enqueue + link/abort with a real injected connection ---

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -16,6 +16,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import psycopg2
+import psycopg2.extensions
 import pytest
 from queue_backend import barrier as barrier_mod
 from queue_backend import pg_barrier
@@ -135,11 +136,14 @@ class _FakeCursorCtx:
 class _FakeConn:
     """Minimal psycopg2-connection stub. ``execute_error`` (if set) is raised by
     every cursor.execute on this connection — simulating a stale/dead socket.
+    ``commit_error`` (if set) is raised by ``commit()`` after the execute lands —
+    the ambiguous "reaped during commit" case the decrement must NOT retry.
     """
 
-    def __init__(self, *, execute_error=None):
+    def __init__(self, *, execute_error=None, commit_error=None):
         self.closed = False
         self._execute_error = execute_error
+        self._commit_error = commit_error
         self.commits = 0
         self.rollbacks = 0
         self.executes = 0
@@ -154,12 +158,19 @@ class _FakeConn:
 
     def commit(self):
         self.commits += 1
+        if self._commit_error is not None:
+            raise self._commit_error
 
     def rollback(self):
         self.rollbacks += 1
 
     def close(self):
         self.closed = True
+
+    def get_transaction_status(self):
+        # The decrement entry-guard checks this; a stub conn is always idle (each
+        # _cursor use commits), so it never trips the open-transaction guard.
+        return psycopg2.extensions.TRANSACTION_STATUS_IDLE
 
 
 @pytest.fixture
@@ -248,6 +259,125 @@ class TestIdempotentWriteRetry:
             pg_barrier._run_idempotent_pre_dispatch_write(
                 lambda cur: cur.execute("X"), what="test"
             )
+
+
+class TestDecrementPhaseSplitRetry:
+    """`_apply_decrement` is the NON-idempotent barrier decrement, so unlike the
+    idempotent pre-dispatch write it CANNOT retry freely. It self-heals exactly
+    one provably-safe case — an execute-phase failure on a *cached* connection
+    (the PgBouncer idle-reap: the statement never reached the server, so nothing
+    committed) — and refuses every other: a commit-phase failure is ambiguous
+    (the server may have applied it) and a fresh-conn failure is a real DB error.
+    The count is therefore never double-applied. (UN-3660)
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self, monkeypatch):
+        monkeypatch.setattr(pg_barrier.time, "sleep", lambda *_a, **_k: None)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            psycopg2.OperationalError("server closed the connection unexpectedly"),
+            psycopg2.InterfaceError("connection already closed"),
+        ],
+        ids=["OperationalError", "InterfaceError"],
+    )
+    def test_execute_phase_reaped_cached_conn_retries_once(
+        self, _clean_local, monkeypatch, caplog, exc
+    ):
+        # The idle-reap: a cached conn fails mid-execute (never committed), so the
+        # decrement reconnects and re-applies exactly once on a healthy conn.
+        dead = _FakeConn(execute_error=exc)
+        healthy = _FakeConn()
+        pg_barrier._local.conn = dead  # cached → "reused"
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
+
+        with caplog.at_level("WARNING"):
+            pg_barrier._apply_decrement("exec-1", '{"ok": true}')
+
+        assert dead.executes == 1 and healthy.executes == 1  # exactly one extra try
+        assert dead.commits == 0  # the reaped attempt never committed
+        assert dead.closed is True  # stale conn discarded
+        assert healthy.commits == 1  # committed exactly once, on the retry
+        assert pg_barrier._local.conn is healthy
+        assert "execute failed on a cached connection" in caplog.text
+        assert type(exc).__name__ in caplog.text
+
+    def test_commit_phase_failure_is_not_retried(self, _clean_local, monkeypatch):
+        # A commit failure is AMBIGUOUS (the server may have applied it) → must
+        # NOT retry, or the decrement could land twice. It propagates; the dead
+        # conn is discarded; no reconnect is attempted.
+        commit_err = psycopg2.OperationalError("server closed during commit")
+        conn = _FakeConn(commit_error=commit_err)
+        pg_barrier._local.conn = conn
+        reconnects = []
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: reconnects.append(1) or _FakeConn(),
+        )
+
+        with pytest.raises(psycopg2.OperationalError, match="during commit"):
+            pg_barrier._apply_decrement("exec-2", '{"ok": true}')
+
+        assert conn.executes == 1  # the UPDATE ran exactly once
+        assert conn.commits == 1  # commit was attempted exactly once
+        assert reconnects == []  # NEVER reconnected/retried after a commit failure
+        assert conn.closed is True  # the dead conn was discarded
+
+    def test_fresh_conn_execute_failure_is_not_retried(
+        self, _clean_local, monkeypatch
+    ):
+        # No cached conn → the first conn is freshly created. A failure on a fresh
+        # conn is a genuine DB error, not an idle-reap, so the reused-guard skips
+        # the retry and it surfaces immediately.
+        err = psycopg2.OperationalError("db down")
+        made = []
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: made.append(c := _FakeConn(execute_error=err)) or c,
+        )
+        pg_barrier._local.conn = None  # nothing cached → fresh
+
+        with pytest.raises(psycopg2.OperationalError, match="db down"):
+            pg_barrier._apply_decrement("exec-3", '{"ok": true}')
+
+        assert len(made) == 1  # created once, never retried
+
+    def test_non_connection_error_is_not_retried(self, _clean_local, monkeypatch):
+        # A DataError (e.g. a NUL byte rejected by the jsonb cast) is not a
+        # connection death → propagate immediately so the caller tears the barrier
+        # down. A live conn after a logical error is NOT discarded.
+        conn = _FakeConn(execute_error=psycopg2.DataError("invalid byte 0x00"))
+        pg_barrier._local.conn = conn
+        reconnects = []
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: reconnects.append(1) or _FakeConn(),
+        )
+
+        with pytest.raises(psycopg2.DataError):
+            pg_barrier._apply_decrement("exec-4", '{"ok": true}')
+
+        assert reconnects == []  # no retry on a logical/data error
+        assert conn.closed is False  # a live conn after a data error is kept
+
+    def test_reraises_after_second_execute_failure(self, _clean_local, monkeypatch):
+        # The one-shot bound: if the reconnect target also dies on execute,
+        # re-raise rather than loop (and the second conn is "fresh" anyway).
+        err = psycopg2.OperationalError("still down")
+        pg_barrier._local.conn = _FakeConn(execute_error=err)
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: _FakeConn(execute_error=err),
+        )
+
+        with pytest.raises(psycopg2.OperationalError, match="still down"):
+            pg_barrier._apply_decrement("exec-5", '{"ok": true}')
 
 
 # --- Layer 2: enqueue + link/abort with a real injected connection ---
@@ -459,6 +589,78 @@ class TestDecrAndCheck:
         remaining, results = _row(barrier_db, "exec-P")
         assert remaining == 2
         assert results == [{"f": 1}]
+
+    def test_idle_reaped_conn_self_heals_and_decrements_exactly_once(
+        self, barrier_db, monkeypatch
+    ):
+        # End-to-end through the production entry (_barrier_pg_decrement): the
+        # decrement's cached conn was idle-reaped and fails the first execute; the
+        # phase-split retry reconnects to the REAL db and lands the decrement
+        # EXACTLY once (2 → 1, not 2 → 0, and one result appended). Reverting
+        # _apply_decrement to a plain `with _cursor()` makes this fail.
+        monkeypatch.setattr(pg_barrier.time, "sleep", lambda *_a, **_k: None)
+        _seed(barrier_db, "exec-HEALD", 2)
+        dead = _FakeConn(
+            execute_error=psycopg2.OperationalError(
+                "server closed the connection unexpectedly"
+            )
+        )
+        pg_barrier._local.conn = dead  # the barrier_db fixture conn is the target
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: barrier_db)
+
+        out = _barrier_pg_decrement(
+            {"f": "x"}, execution_id="exec-HEALD", callback_descriptor=_CALLBACK
+        )
+
+        assert out["status"] == "pending" and out["remaining"] == 1
+        assert dead.closed is True  # stale conn discarded
+        assert _row(barrier_db, "exec-HEALD") == (1, [{"f": "x"}])  # decremented once
+
+    def test_pg_terminate_backend_mid_decrement_fires_callback_once(
+        self, barrier_db, monkeypatch
+    ):
+        # The strongest pin: a REAL server-side connection kill (the
+        # pg_terminate_backend analog of a PgBouncer idle-reap) mid-decrement. The
+        # victim is a genuine non-autocommit connection (production posture); we
+        # terminate its backend for real, then drive the decrement that takes the
+        # barrier to 0. The phase-split retry must reconnect to live PG, land the
+        # decrement EXACTLY once, and fire the callback EXACTLY once. A
+        # double-count would drive remaining to -1 → "abandoned" → no callback, so
+        # asserting "complete" + one signature call + row deleted proves
+        # exactly-once against a real terminated socket.
+        monkeypatch.setattr(pg_barrier.time, "sleep", lambda *_a, **_k: None)
+        _seed(barrier_db, "exec-PTB", 1)  # last batch: decrement → 0 fires callback
+
+        victim = create_pg_connection(env_prefix="TEST_DB_")  # non-autocommit
+        with victim.cursor() as cur:
+            cur.execute("SELECT pg_backend_pid()")
+            victim_pid = cur.fetchone()[0]
+        victim.rollback()  # return to IDLE so the decrement entry-guard passes
+        pg_barrier._local.conn = victim  # the decrement uses this cached conn
+
+        # Kill the victim's backend from the admin (fixture) connection — the
+        # client still thinks it's open (conn.closed == 0), exactly like an idle
+        # reap; the failure surfaces on the next statement (the decrement UPDATE).
+        with barrier_db.cursor() as cur:
+            cur.execute("SELECT pg_terminate_backend(%s)", (victim_pid,))
+        # The retry reconnects via create_pg_connection; in tests that must target
+        # the reachable TEST_DB_ (the bare DB_* host is the in-container name).
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: create_pg_connection(env_prefix="TEST_DB_"),
+        )
+
+        with patch("celery.current_app.signature") as sig:
+            sig.return_value.apply_async.return_value = MagicMock(id="cb-ptb")
+            out = barrier_pg_decr_and_check(
+                {"f": "x"}, execution_id="exec-PTB", callback_descriptor=_CALLBACK
+            )
+
+        assert out["status"] == "complete"  # reached 0 exactly once (not -1)
+        sig.assert_called_once()  # callback fired exactly once
+        assert _row(barrier_db, "exec-PTB") is None  # barrier torn down after fire
+        assert victim.closed  # the terminated conn was discarded by the retry
 
     def test_complete_fires_callback_with_aggregated_results(self, barrier_db):
         _seed(barrier_db, "exec-C", 1, results='[{"f": "a"}]')


### PR DESCRIPTION
## What

Closes the **last** uncovered stale-connection-after-idle hang path in the PG-queue execution engine, after UN-3654 (dispatch `send`), UN-3651 (barrier enqueue) and UN-3659 (`store_result`).

The `PgBarrier` decrement —
```
UPDATE pg_barrier_state SET remaining = remaining - 1,
       results = results || jsonb_build_array(...) WHERE execution_id = ... RETURNING ...
```
runs on the worker's cached thread-local connection. After a worker sits idle > `server_idle_timeout` (PgBouncer) the connection is reaped server-side. The decrement's `try/except` caught only `psycopg2.DataError`, so an `OperationalError`/`InterfaceError` propagated, the batch's decrement was lost, `remaining` never reached 0, and the execution hung at the fan-in (all files `COMPLETED` but execution stuck `EXECUTING`) until the ~6h barrier expiry. Same class as the earlier hangs, one step later in the pipeline.

## Why not a plain retry (or `send`'s reused-guard)

The decrement is **non-idempotent**, and a double-apply is *harmful*: it can fire the callback early with incomplete results, or drive `remaining` past 0 and strand the barrier. Even `send()`'s reused-guard is not enough on its own here — a reused-connection failure at **commit** time is ambiguous (the server may have applied it).

## Fix — phase-split retry

Split the statement into its two phases and retry only the one where a re-apply is provably exactly-once:

- **EXECUTE** phase fails on a **reused** (cached) connection → idle-reap; the statement never committed → reconnect and re-apply **once**.
- **COMMIT** phase fails → ambiguous → **never** retry; propagate so the caller tears the barrier down (fail-fast — unchanged behaviour).
- Fresh-connection failure / `DataError` / non-connection error → propagate unchanged.

Safety rests on the connection being **non-autocommit** (verified in `create_pg_connection`): an execute-phase failure is never durable even if the server ran the `UPDATE`, because the open transaction is rolled back on disconnect. Durability happens only at `commit()`, the phase we never retry — so re-applying can never double-count.

Also adds the shared `_CONN_DEAD_ERRORS` constant (parity with `client.py` / `result_backend.py`, so the "is this a connection death?" test can't drift) and a `_recover_after_error` helper now reused by `_cursor`.

## Tests

- **6 unit** (`TestDecrementPhaseSplitRetry`): execute-retry-heals (both error types), **commit-fail-does-NOT-retry**, fresh-conn-no-retry, DataError-no-retry, one-shot bound.
- **Real-DB**: idle-reaped connection self-heals through the production entry and decrements **exactly once** (2→1, one result appended) — the no-double-decrement pin.
- **Real `pg_terminate_backend`**: a genuinely killed backend mid-decrement self-heals and fires the callback **exactly once**.
- Full `test_pg_barrier.py` (63) + sibling barrier suites (35) green; pre-commit clean.

Dev-tested end-to-end inside the live PG worker fleet against the real database (real backend termination mid-decrement → self-heal → callback once → barrier consumed).

After this, no stale-connection-after-idle path can hang an execution.