### PR TITLE
UN-3584 [FEAT] Restrict LLM adapter creation to org admins (controlled mode)

### DIFF
--- a/backend/account_v2/migrations/0006_organization_restrict_llm_adapter_creation.py
+++ b/backend/account_v2/migrations/0006_organization_restrict_llm_adapter_creation.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("account_v2", "0005_alter_platformkey_organization"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="organization",
+            name="restrict_llm_adapter_creation",
+            field=models.BooleanField(
+                db_comment=(
+                    "Controlled mode: when True, only organization admins may "
+                    "create LLM adapters in this org. Default False preserves "
+                    "open creation."
+                ),
+                default=False,
+            ),
+        ),
+    ]

--- a/backend/account_v2/models.py
+++ b/backend/account_v2/models.py
@@ -39,6 +39,13 @@ class Organization(models.Model):
         default=-1,
         db_comment="token limit set in case of frition less onbaoarded org",
     )
+    restrict_llm_adapter_creation = models.BooleanField(
+        default=False,
+        db_comment=(
+            "Controlled mode: when True, only organization admins may create "
+            "LLM adapters in this org. Default False preserves open creation."
+        ),
+    )
 
     class Meta:
         verbose_name = "Organization"

--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -175,6 +175,28 @@ class AdapterInstanceViewSet(ResourceShareManagementMixin, ModelViewSet):
             return AdapterListSerializer
         return AdapterInstanceSerializer
 
+    @staticmethod
+    def _enforce_llm_creation_restriction(request: Any, adapter_type: str) -> None:
+        """Controlled mode (UN-3584): only org admins may create LLM adapters
+        when the org has enabled the restriction. Service accounts (platform
+        API-key sessions) and non-LLM adapter types bypass; the default
+        (flag off) keeps creation open for everyone.
+        """
+        if adapter_type != AdapterKeys.LLM:
+            return
+        if getattr(request.user, "is_service_account", False):
+            return
+        organization = UserContext.get_organization()
+        if (
+            organization
+            and organization.restrict_llm_adapter_creation
+            and not OrganizationMemberService.is_user_organization_admin(request.user)
+        ):
+            raise PermissionDenied(
+                "LLM adapter creation is restricted to organization admins. "
+                "Please contact your organization admin."
+            )
+
     def create(self, request: Any) -> Response:
         serializer = self.get_serializer(data=request.data)
 
@@ -187,22 +209,7 @@ class AdapterInstanceViewSet(ResourceShareManagementMixin, ModelViewSet):
 
         serializer.is_valid(raise_exception=True)
         adapter_type = serializer.validated_data.get(AdapterKeys.ADAPTER_TYPE)
-
-        # Controlled mode (UN-3584): when the org has restricted LLM adapter
-        # creation, only organization admins may create LLM adapters. Other
-        # adapter types are unaffected, and the default (flag off) keeps
-        # creation open for everyone.
-        if adapter_type == AdapterKeys.LLM:
-            organization = UserContext.get_organization()
-            if (
-                organization
-                and organization.restrict_llm_adapter_creation
-                and not OrganizationMemberService.is_user_organization_admin(request.user)
-            ):
-                raise PermissionDenied(
-                    "LLM adapter creation is restricted to organization admins. "
-                    "Please contact your organization admin."
-                )
+        self._enforce_llm_creation_restriction(request, adapter_type)
 
         try:
             if adapter_type == AdapterKeys.X2TEXT and use_platform_unstract_key:

--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -224,7 +224,12 @@ class AdapterInstanceViewSet(ResourceShareManagementMixin, ModelViewSet):
                     adapter_metadata_b
                 )
 
-            instance = serializer.save()
+            # Bind the adapter to the request-scoped organization, overriding any
+            # client-supplied `organization` in the payload (the serializer
+            # exposes it via fields="__all__"). This keeps the row's org
+            # consistent with the org the controlled-mode check above evaluated,
+            # so the per-org restriction can't be sidestepped via the payload.
+            instance = serializer.save(organization=UserContext.get_organization())
             organization_member = OrganizationMemberService.get_user_by_id(
                 request.user.id
             )

--- a/backend/adapter_processor_v2/views.py
+++ b/backend/adapter_processor_v2/views.py
@@ -16,6 +16,7 @@ from permissions.resource_share_views import ResourceShareManagementMixin
 from plugins import get_plugin
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer
@@ -24,6 +25,7 @@ from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from tenant_account_v2.organization_member_service import OrganizationMemberService
 from tool_instance_v2.models import ToolInstance
 from utils.filtering import FilterHelper
+from utils.user_context import UserContext
 
 from adapter_processor_v2.adapter_processor import AdapterProcessor
 from adapter_processor_v2.constants import AdapterKeys
@@ -184,9 +186,25 @@ class AdapterInstanceViewSet(ResourceShareManagementMixin, ModelViewSet):
             use_platform_unstract_key = True
 
         serializer.is_valid(raise_exception=True)
-        try:
-            adapter_type = serializer.validated_data.get(AdapterKeys.ADAPTER_TYPE)
+        adapter_type = serializer.validated_data.get(AdapterKeys.ADAPTER_TYPE)
 
+        # Controlled mode (UN-3584): when the org has restricted LLM adapter
+        # creation, only organization admins may create LLM adapters. Other
+        # adapter types are unaffected, and the default (flag off) keeps
+        # creation open for everyone.
+        if adapter_type == AdapterKeys.LLM:
+            organization = UserContext.get_organization()
+            if (
+                organization
+                and organization.restrict_llm_adapter_creation
+                and not OrganizationMemberService.is_user_organization_admin(request.user)
+            ):
+                raise PermissionDenied(
+                    "LLM adapter creation is restricted to organization admins. "
+                    "Please contact your organization admin."
+                )
+
+        try:
             if adapter_type == AdapterKeys.X2TEXT and use_platform_unstract_key:
                 adapter_metadata_b = serializer.validated_data.get(
                     AdapterKeys.ADAPTER_METADATA_B

--- a/backend/tenant_account_v2/urls.py
+++ b/backend/tenant_account_v2/urls.py
@@ -1,13 +1,23 @@
 from django.urls import include, path
 
 from tenant_account_v2 import groups_urls, invitation_urls, users_urls
-from tenant_account_v2.views import get_organization, get_roles, reset_password
+from tenant_account_v2.views import (
+    get_organization,
+    get_roles,
+    organization_settings,
+    reset_password,
+)
 
 urlpatterns = [
     path("roles", get_roles, name="roles"),
     path("users/", include(users_urls)),
     path("invitation/", include(invitation_urls)),
     path("organization", get_organization, name="get_organization"),
+    path(
+        "organization/settings",
+        organization_settings,
+        name="organization_settings",
+    ),
     path("reset_password", reset_password, name="reset_password"),
     path("", include(groups_urls)),
 ]

--- a/backend/tenant_account_v2/views.py
+++ b/backend/tenant_account_v2/views.py
@@ -4,10 +4,13 @@ from typing import Any
 from account_v2.authentication_controller import AuthenticationController
 from account_v2.dto import UserRoleData
 from account_v2.models import Organization
+from platform_api.permissions import IsOrganizationAdmin
 from rest_framework import status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from utils.user_context import UserContext
 from utils.user_session import UserSessionUtils
 
 from tenant_account_v2.dto import OrganizationLoginResponse, ResetUserPasswordDto
@@ -50,6 +53,39 @@ def reset_password(request: Request) -> Response:
             status=status.HTTP_400_BAD_REQUEST,
             data={"status": "failed", "message": data.message},
         )
+
+
+@api_view(["GET", "PATCH"])
+@permission_classes([IsAuthenticated, IsOrganizationAdmin])
+def organization_settings(request: Request) -> Response:
+    """Read or update org-level settings. Admin-only.
+
+    Currently exposes the ``restrict_llm_adapter_creation`` controlled-mode
+    flag. GET returns the current value; PATCH updates it.
+    """
+    organization = UserContext.get_organization()
+    if not organization:
+        return Response(
+            status=status.HTTP_404_NOT_FOUND,
+            data={"message": "Org Not Found"},
+        )
+
+    if request.method == "PATCH":
+        value = request.data.get("restrict_llm_adapter_creation")
+        if not isinstance(value, bool):
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": "restrict_llm_adapter_creation must be a boolean"},
+            )
+        organization.restrict_llm_adapter_creation = value
+        organization.save(update_fields=["restrict_llm_adapter_creation", "modified_at"])
+
+    return Response(
+        status=status.HTTP_200_OK,
+        data={
+            "restrict_llm_adapter_creation": (organization.restrict_llm_adapter_creation)
+        },
+    )
 
 
 @api_view(["GET"])

--- a/backend/tenant_account_v2/views.py
+++ b/backend/tenant_account_v2/views.py
@@ -78,7 +78,14 @@ def organization_settings(request: Request) -> Response:
                 data={"message": "restrict_llm_adapter_creation must be a boolean"},
             )
         organization.restrict_llm_adapter_creation = value
-        organization.save(update_fields=["restrict_llm_adapter_creation", "modified_at"])
+        organization.modified_by = request.user
+        organization.save(
+            update_fields=[
+                "restrict_llm_adapter_creation",
+                "modified_by",
+                "modified_at",
+            ]
+        )
 
     return Response(
         status=status.HTTP_200_OK,

--- a/frontend/src/components/settings/platform/PlatformSettings.jsx
+++ b/frontend/src/components/settings/platform/PlatformSettings.jsx
@@ -29,6 +29,19 @@ import { useExceptionHandler } from "../../../hooks/useExceptionHandler.jsx";
 import usePostHogEvents from "../../../hooks/usePostHogEvents.js";
 import { SettingsLayout } from "../settings-layout/SettingsLayout.jsx";
 
+// The "restrict LLM creation" control is enterprise/cloud-only: org admin
+// roles and user management don't exist in OSS, so this setting is meaningless
+// there. Detect the enterprise build by probing for an enterprise-only plugin
+// (absent in OSS) and hide the control entirely otherwise. Mirrors the
+// plugin-gating idiom used in SideNavBar.
+let isEnterpriseBuild = false;
+try {
+  await import("../../../plugins/store/unstract-subscription-plan-store");
+  isEnterpriseBuild = true;
+} catch {
+  // OSS build — enterprise plugins are not bundled.
+}
+
 const defaultKeys = [
   {
     id: null,
@@ -124,9 +137,14 @@ function PlatformSettings() {
   }, [sessionDetails?.orgId]);
 
   useEffect(() => {
-    // Admin-only org setting; skip the call entirely for non-admins (the
-    // endpoint is admin-gated and would 403) and before session hydration.
-    if (!sessionDetails?.orgId || !sessionDetails?.isAdmin) {
+    // Enterprise/cloud-only + admin-only setting; skip the call in OSS and for
+    // non-admins (the endpoint is admin-gated and would 403) and before
+    // session hydration.
+    if (
+      !isEnterpriseBuild ||
+      !sessionDetails?.orgId ||
+      !sessionDetails?.isAdmin
+    ) {
       return;
     }
     axiosPrivate({
@@ -538,7 +556,7 @@ function PlatformSettings() {
                   </Typography.Text>
                 </div>
               </div>
-              {sessionDetails?.isAdmin && (
+              {isEnterpriseBuild && sessionDetails?.isAdmin && (
                 <div className="plt-set-section">
                   <Typography.Title level={5}>
                     LLM Adapter Creation

--- a/frontend/src/components/settings/platform/PlatformSettings.jsx
+++ b/frontend/src/components/settings/platform/PlatformSettings.jsx
@@ -10,6 +10,7 @@ import {
   Input,
   InputNumber,
   Row,
+  Switch,
   Tag,
   Typography,
 } from "antd";
@@ -85,6 +86,9 @@ function PlatformSettings() {
   // UI shows minutes; wire format (and ConfigSpec.value) is seconds.
   const [batchIntervalMinutes, setBatchIntervalMinutes] = useState(null);
   const [isSavingInterval, setIsSavingInterval] = useState(false);
+  // Controlled-mode flag: only admins can create LLM adapters when true.
+  const [restrictLlmCreation, setRestrictLlmCreation] = useState(false);
+  const [isSavingRestriction, setIsSavingRestriction] = useState(false);
   const { sessionDetails } = useSessionStore();
   const { setAlertDetails } = useAlertStore();
   const axiosPrivate = useAxiosPrivate();
@@ -118,6 +122,57 @@ function PlatformSettings() {
         console.warn("Failed to load notification batch interval", err);
       });
   }, [sessionDetails?.orgId]);
+
+  useEffect(() => {
+    // Admin-only org setting; skip the call entirely for non-admins (the
+    // endpoint is admin-gated and would 403) and before session hydration.
+    if (!sessionDetails?.orgId || !sessionDetails?.isAdmin) {
+      return;
+    }
+    axiosPrivate({
+      method: "GET",
+      url: `/api/v1/unstract/${sessionDetails?.orgId}/organization/settings`,
+    })
+      .then((res) => {
+        setRestrictLlmCreation(
+          Boolean(res?.data?.restrict_llm_adapter_creation),
+        );
+      })
+      .catch((err) => {
+        console.warn("Failed to load LLM adapter creation setting", err);
+      });
+  }, [sessionDetails?.orgId, sessionDetails?.isAdmin]);
+
+  const handleToggleRestriction = (checked) => {
+    const previous = restrictLlmCreation;
+    setRestrictLlmCreation(checked); // optimistic
+    setIsSavingRestriction(true);
+    axiosPrivate({
+      method: "PATCH",
+      url: `/api/v1/unstract/${sessionDetails?.orgId}/organization/settings`,
+      headers: {
+        "X-CSRFToken": sessionDetails?.csrfToken,
+        "Content-Type": "application/json",
+      },
+      data: { restrict_llm_adapter_creation: checked },
+    })
+      .then((res) => {
+        setRestrictLlmCreation(
+          Boolean(res?.data?.restrict_llm_adapter_creation),
+        );
+        setAlertDetails({
+          type: "success",
+          content: "LLM adapter creation setting updated.",
+        });
+      })
+      .catch((err) => {
+        setRestrictLlmCreation(previous); // revert on failure
+        setAlertDetails(handleException(err, "Failed to update setting"));
+      })
+      .finally(() => {
+        setIsSavingRestriction(false);
+      });
+  };
 
   const handleSaveInterval = () => {
     if (
@@ -483,6 +538,32 @@ function PlatformSettings() {
                   </Typography.Text>
                 </div>
               </div>
+              {sessionDetails?.isAdmin && (
+                <div className="plt-set-section">
+                  <Typography.Title level={5}>
+                    LLM Adapter Creation
+                  </Typography.Title>
+                  <Typography.Text
+                    type="secondary"
+                    className="plt-set-section-subtitle"
+                  >
+                    Restrict creation of LLM connections to organization admins.
+                    When enabled, non-admin users cannot create LLM adapters.
+                  </Typography.Text>
+                  <div className="plt-set-inner-card">
+                    <div className="plt-set-notif-field-row">
+                      <Switch
+                        checked={restrictLlmCreation}
+                        loading={isSavingRestriction}
+                        onChange={handleToggleRestriction}
+                      />
+                      <Typography.Text>
+                        Only admins can create LLM adapters
+                      </Typography.Text>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           </IslandLayout>
         </div>


### PR DESCRIPTION
## What

Add a per-organization "controlled mode" setting that restricts creation of LLM adapters (connections) to organization admins.

## Why

UN-3584 (RLDatix on-prem onboarding blocker). Non-admin users must not be able to create unrestricted LLM connections, and this must be enforced in the product/API rather than by convention. Built as a general, opt-in product capability (any org can enable it), not a customer-specific hack.

## How

- **`account_v2`** — new `Organization.restrict_llm_adapter_creation` `BooleanField` (default `False`) + migration `0006_organization_restrict_llm_adapter_creation`.
- **`tenant_account_v2`** — new admin-only `GET`/`PATCH` `organization/settings` endpoint (reuses `IsOrganizationAdmin`) to read/toggle the flag.
- **`adapter_processor_v2`** — gate in `AdapterInstanceViewSet.create`: when the org flag is on and `adapter_type == LLM`, non-admins are rejected with `403 PermissionDenied` ("contact your organization admin"). Admins bypass; other adapter types and editing existing adapters are unaffected (the gate is on `create` only).
- **`frontend`** — admin-only toggle in Platform Settings, enterprise-gated (probes for an enterprise-only plugin) so it never renders in OSS, where org-admin / user-management doesn't exist.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No.
- The setting defaults **off**, so existing orgs keep open self-serve creation, unchanged.
- Enforcement only activates when an org admin explicitly enables it, and only blocks **non-admin** creation of **LLM** adapters — other adapter types, shared-adapter usage, and editing existing adapters are all unaffected.
- The UI toggle is gated to enterprise/cloud builds, so OSS is unaffected; the backend flag defaults off there too.

## Database Migrations

Yes — `backend/account_v2/migrations/0006_organization_restrict_llm_adapter_creation.py` adds `BooleanField(default=False)`. No data migration.

## Env Config

None.

## Relevant Docs

None.

## Related Issues or PRs

- Jira: https://zipstack.atlassian.net/browse/UN-3584

## Dependencies Versions

None.

## Notes on Testing

Deployed to a dev namespace (image `snapshot.74`) and verified live:
- Admin-only toggle renders in Platform Settings; `GET /organization/settings` returns 200 on load; `PATCH` persists the flag (200, value echoed); migration applied.
- With the setting **ON**: a non-admin creating an LLM adapter receives the 403 ("contact your organization admin"); an **admin can still create**; existing adapters remain editable for everyone.
- Cloud Logging for the rejected request shows a clean, single-line handled `PermissionDenied` (no traceback / unhandled error).

Out of scope (per ticket clarification): Bedrock inference-profile enforcement (the `model_id` / "Application Inference Profile ARN" field already exists in the Bedrock adapter) and an approved-model allowlist.

## Screenshots

_Platform Settings → "LLM Adapter Creation" toggle (admin-only, enterprise build); verified on dev._

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
