### PR TITLE
UN-3586 [FEAT] Allow platform API key rotation via API

### DIFF
--- a/backend/platform_api/permissions.py
+++ b/backend/platform_api/permissions.py
@@ -21,3 +21,34 @@ class IsOrganizationAdmin(BasePermission):
         except Exception:
             logger.exception("Error checking admin role for user %s", request.user.id)
             return False
+
+
+class CanRotatePlatformApiKey(BasePermission):
+    """Permission for the ``rotate`` action (UN-3586).
+
+    - **Session callers** must be organization admins (existing behavior —
+      an admin may rotate any key in their org).
+    - **Platform API key callers** (bearer/service-account sessions) may rotate
+      ONLY their own key, enabling self-service credential rotation via the API
+      without exposing other keys in the org. The org boundary is already
+      enforced upstream (auth middleware + org-scoped queryset); this adds the
+      intra-org "self only" restriction for key callers.
+
+    Note: the auth middleware already blocks ``read`` keys from POST, so only
+    ``read_write``/``full_access`` keys can reach rotate.
+    """
+
+    message = (
+        "You can only rotate your own API key. Rotating other keys requires an "
+        "organization admin."
+    )
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        platform_key = getattr(request, "platform_api_key", None)
+        if platform_key is not None:
+            # Platform API key caller: self-rotation only.
+            return str(view.kwargs.get("pk")) == str(platform_key.id)
+        # Session caller: must be an org admin (may rotate any key in the org).
+        return IsOrganizationAdmin().has_permission(request, view)

--- a/backend/platform_api/permissions.py
+++ b/backend/platform_api/permissions.py
@@ -34,6 +34,12 @@ class CanRotatePlatformApiKey(BasePermission):
       enforced upstream (auth middleware + org-scoped queryset); this adds the
       intra-org "self only" restriction for key callers.
 
+    The "self only" constraint for key callers is enforced object-level in
+    ``has_object_permission`` (the idiomatic DRF location); ``has_permission``
+    is the coarse session-vs-key gate. This permission is only used by the
+    detail-route ``rotate`` action, which fetches the row via ``get_object()``
+    and therefore always triggers the object-level check.
+
     Note: the auth middleware already blocks ``read`` keys from POST, so only
     ``read_write``/``full_access`` keys can reach rotate.
     """
@@ -46,9 +52,17 @@ class CanRotatePlatformApiKey(BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
-        platform_key = getattr(request, "platform_api_key", None)
-        if platform_key is not None:
-            # Platform API key caller: self-rotation only.
-            return str(view.kwargs.get("pk")) == str(platform_key.id)
+        if getattr(request, "platform_api_key", None) is not None:
+            # Platform API key caller: admitted here; the "own key only"
+            # constraint is enforced in has_object_permission below.
+            return True
         # Session caller: must be an org admin (may rotate any key in the org).
         return IsOrganizationAdmin().has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        platform_key = getattr(request, "platform_api_key", None)
+        if platform_key is not None:
+            # Platform API key may rotate only its own key.
+            return obj.id == platform_key.id
+        # Session admins were already gated in has_permission.
+        return True

--- a/backend/platform_api/permissions.py
+++ b/backend/platform_api/permissions.py
@@ -28,41 +28,28 @@ class CanRotatePlatformApiKey(BasePermission):
 
     - **Session callers** must be organization admins (existing behavior —
       an admin may rotate any key in their org).
-    - **Platform API key callers** (bearer/service-account sessions) may rotate
-      ONLY their own key, enabling self-service credential rotation via the API
-      without exposing other keys in the org. The org boundary is already
-      enforced upstream (auth middleware + org-scoped queryset); this adds the
-      intra-org "self only" restriction for key callers.
+    - **Platform API key callers** (bearer/service-account sessions) are also
+      allowed to rotate — this is the API/automation path that the admin-only
+      ``IsOrganizationAdmin`` gate otherwise blocks (it rejects service
+      accounts). Rotation stays confined to the caller's own organization via
+      the auth middleware (URL org must match the key's org) and the
+      org-scoped queryset, so a key can only rotate keys in its own org.
 
-    The "self only" constraint for key callers is enforced object-level in
-    ``has_object_permission`` (the idiomatic DRF location); ``has_permission``
-    is the coarse session-vs-key gate. This permission is only used by the
-    detail-route ``rotate`` action, which fetches the row via ``get_object()``
-    and therefore always triggers the object-level check.
-
-    Note: the auth middleware already blocks ``read`` keys from POST, so only
+    Note: the auth middleware blocks ``read`` keys from POST, so only
     ``read_write``/``full_access`` keys can reach rotate.
     """
 
     message = (
-        "You can only rotate your own API key. Rotating other keys requires an "
-        "organization admin."
+        "Rotating platform API keys requires an organization admin session "
+        "or a platform API key."
     )
 
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
+        # Platform API key (bearer) callers may rotate — the API/automation
+        # path that the admin-only IsOrganizationAdmin gate blocks.
         if getattr(request, "platform_api_key", None) is not None:
-            # Platform API key caller: admitted here; the "own key only"
-            # constraint is enforced in has_object_permission below.
             return True
         # Session caller: must be an org admin (may rotate any key in the org).
         return IsOrganizationAdmin().has_permission(request, view)
-
-    def has_object_permission(self, request, view, obj):
-        platform_key = getattr(request, "platform_api_key", None)
-        if platform_key is not None:
-            # Platform API key may rotate only its own key.
-            return obj.id == platform_key.id
-        # Session admins were already gated in has_permission.
-        return True

--- a/backend/platform_api/permissions.py
+++ b/backend/platform_api/permissions.py
@@ -3,6 +3,8 @@ import logging
 from account_v2.authentication_controller import AuthenticationController
 from rest_framework.permissions import BasePermission
 
+from platform_api.models import ApiKeyPermission
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,30 +28,38 @@ class IsOrganizationAdmin(BasePermission):
 class CanRotatePlatformApiKey(BasePermission):
     """Permission for the ``rotate`` action (UN-3586).
 
-    - **Session callers** must be organization admins (existing behavior —
-      an admin may rotate any key in their org).
-    - **Platform API key callers** (bearer/service-account sessions) are also
-      allowed to rotate — this is the API/automation path that the admin-only
-      ``IsOrganizationAdmin`` gate otherwise blocks (it rejects service
-      accounts). Rotation stays confined to the caller's own organization via
-      the auth middleware (URL org must match the key's org) and the
-      org-scoped queryset, so a key can only rotate keys in its own org.
+    - **Session callers** must be organization admins (an admin may rotate any
+      key in their org).
+    - **Platform API key callers** must present a ``full_access`` key — the
+      API/automation path that the admin-only ``IsOrganizationAdmin`` gate
+      otherwise blocks (it rejects service accounts). ``full_access`` is the
+      admin-equivalent tier (it already permits DELETE), so key management
+      belongs there.
 
-    Note: the auth middleware blocks ``read`` keys from POST, so only
-    ``read_write``/``full_access`` keys can reach rotate.
+    Why ``full_access`` only (not any bearer key): ``rotate`` returns the new
+    key value in its response, so allowing a lower-tier ``read_write`` key to
+    rotate a ``full_access`` key would let it read that key's new secret and
+    escalate its privileges. Requiring ``full_access`` closes that path — a
+    ``full_access`` caller rotating any key gains no privilege (it is already
+    the top tier), matching what a session admin can do.
+
+    Rotation stays confined to the caller's own organization via the auth
+    middleware (URL org must match the key's org) and the org-scoped queryset.
     """
 
     message = (
-        "Rotating platform API keys requires an organization admin session "
-        "or a platform API key."
+        "Rotating platform API keys requires an organization admin session or "
+        "a full_access platform API key."
     )
 
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
-        # Platform API key (bearer) callers may rotate — the API/automation
-        # path that the admin-only IsOrganizationAdmin gate blocks.
-        if getattr(request, "platform_api_key", None) is not None:
-            return True
+        platform_key = getattr(request, "platform_api_key", None)
+        if platform_key is not None:
+            # Key-based caller: only a full_access key may rotate. Prevents a
+            # read_write key from rotating a full_access key and reading its new
+            # secret from the response (privilege escalation) — see docstring.
+            return platform_key.permission == ApiKeyPermission.FULL_ACCESS
         # Session caller: must be an org admin (may rotate any key in the org).
         return IsOrganizationAdmin().has_permission(request, view)

--- a/backend/platform_api/views.py
+++ b/backend/platform_api/views.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from utils.user_context import UserContext
 
 from platform_api.models import PlatformApiKey
-from platform_api.permissions import IsOrganizationAdmin
+from platform_api.permissions import CanRotatePlatformApiKey, IsOrganizationAdmin
 from platform_api.serializers import (
     PlatformApiKeyCreateSerializer,
     PlatformApiKeyDetailSerializer,
@@ -19,6 +19,13 @@ from platform_api.services import create_api_user_for_key
 
 class PlatformApiKeyViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, IsOrganizationAdmin]
+
+    def get_permissions(self):
+        # Rotate allows self-service rotation by a platform API key (UN-3586);
+        # all other key-management actions stay admin/session-only.
+        if self.action == "rotate":
+            return [IsAuthenticated(), CanRotatePlatformApiKey()]
+        return super().get_permissions()
 
     def get_queryset(self):
         return PlatformApiKey.objects.filter(


### PR DESCRIPTION
## What

Allow a **platform API key (bearer token)** to call the `rotate` endpoint, so credentials can be rotated **via the API** for automation. Session org-admins keep rotate (unchanged).

## Why

UN-3586 (RLDatix on-prem blocker) asks for "rotate credentials **through the API**" for operational automation. **Confirmed empirically on staging (`globe.unstract.com`, main):**

```
GET  …/api/deployment/                     → 200   (valid key, bearer auth + reads work)
POST …/platform-api/keys/<id>/rotate/      → 403   "Only organization admins can manage platform API keys."
```

Rotation via a **logged-in admin session** already works (the UI's rotate button), but rotation with a **platform API key** was blocked — the `rotate` endpoint's `IsOrganizationAdmin` gate rejects service accounts, and a platform API key authenticates *as* a service account. So the token/automation path did not exist. This PR opens it.

## How

- New `CanRotatePlatformApiKey` permission on the `rotate` action:
  - **Session callers** → must be org admins (unchanged behavior).
  - **Platform API key callers** → must present a **`full_access`** key (the admin-equivalent tier, which already permits DELETE). `read`/`read_write` keys cannot rotate.
- **Why `full_access` (not any bearer key):** `rotate` returns the new key value, so letting a lower-tier `read_write` key rotate a `full_access` key would let it read that key's new secret and escalate `read_write → full_access`. Requiring `full_access` closes that path — a `full_access` caller rotating any key gains no privilege (it's already the top tier), matching what a session admin can do.
- **Org scoping unchanged and still enforced**: the auth middleware validates the URL `org_id` against the key's immutable org (403 on mismatch), and the viewset queryset is org-scoped — a key can only rotate keys **in its own organization**. Cross-org is impossible.
- `rotate` already returns the new key once via `PlatformApiKeyDetailSerializer` — no serializer change.

Note: an earlier revision restricted key callers to *self-only* rotation; that wasn't a ticket requirement and was dropped in favor of the `full_access`-tier gate above (a `full_access` key may rotate any key in its org, matching a session admin) — which also closes a privilege-escalation path flagged in review.

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No.
- Session-admin rotation is **unchanged** — the permission was only widened, additively, to also admit platform-API-key callers to an existing endpoint.
- **Cross-org isolation is unchanged** (auth middleware + org-scoped querysets; independently verified).
- No model, serializer, or migration change.

## Database Migrations

None.

## Env Config

None.

## Notes on Testing

- **Staging (`globe.unstract.com`, main) baseline:** bearer `rotate` → **403** (blocked); same key reads deployments → 200. Confirms the gap.
- **Dev (`deepak-unstract-dev`, `snapshot.1782909801`):** verified live against the new pod — a **`full_access`** key rotating a **different** key via bearer → **200** + new key; a **`read_write`** key attempting rotate → **403** (tested 3×, all denied — the privilege-escalation path is closed); session admin rotate → **200**. Cross-org remains blocked (auth middleware + org-scoped queryset).

## Related Issues or PRs

- Jira: https://zipstack.atlassian.net/browse/UN-3586
- Builds on UN-3405 (`full_access` tier).

## Checklist

I have read and understood the Contribution Guidelines.
