### PR TITLE
UN-3661 [FIX] PG reaper — fast stuck-batch detection + file-execution cascade

### DIFF
--- a/backend/pg_queue/migrations/0011_pgbarrierstate_last_progress_at.py
+++ b/backend/pg_queue/migrations/0011_pgbarrierstate_last_progress_at.py
@@ -1,0 +1,23 @@
+# Generated for UN-3661 — PG barrier stuck-timeout (progress liveness).
+
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pg_queue", "0010_pgtaskresult"),
+    ]
+
+    operations = [
+        # Progress-liveness column for the reaper's fast stuck-detection. Default
+        # now() so any row created before this migration is treated as fresh.
+        # Deliberately UNINDEXED — written on every barrier decrement, so an index
+        # would break the decrement's heap-only-tuple (HOT) update; the reaper
+        # seq-scans this tiny (in-flight-only) table cheaply.
+        migrations.AddField(
+            model_name="pgbarrierstate",
+            name="last_progress_at",
+            field=models.DateTimeField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/backend/pg_queue/models.py
+++ b/backend/pg_queue/models.py
@@ -185,9 +185,10 @@ class PgBarrierState(models.Model):
     drives ``remaining`` to 0 dispatches the aggregating callback and deletes the
     row. A header-task failure aborts the barrier by deleting the row outright
     (``DELETE … RETURNING`` — atomic claim+teardown), so the callback can never
-    fire with partial results. ``expires_at`` bounds an orphaned barrier (header
-    tasks that never complete); a periodic sweep job (not yet implemented) is the
-    intended reclaim backstop.
+    fire with partial results. The ``pg-queue-reaper`` marks a stranded execution
+    ERROR when ``last_progress_at`` goes stale (no batch completed for
+    ``WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS``) or, as an absolute backstop, when
+    ``expires_at`` passes (see ``workers/queue_backend/pg_queue/reaper.py``).
 
     Managed=True / generated migration — no DB-side function, extension-free
     (UN-3533), same posture as ``PgQueueMessage``.
@@ -206,10 +207,22 @@ class PgBarrierState(models.Model):
     # Aggregated header-task results, appended in completion order (JSONB array).
     results = models.JSONField(default=list)
     created_at = models.DateTimeField(default=timezone.now)
-    # Orphan bound (Redis-TTL equivalent): a barrier whose header tasks never
-    # complete is reclaimable past this. Must exceed the longest execution
-    # wall-clock, same budgeting as WORKER_BARRIER_KEY_TTL_SECONDS.
+    # Absolute orphan cap (Redis-TTL equivalent, WORKER_BARRIER_KEY_TTL_SECONDS,
+    # default 6h): a last-resort backstop the reaper also sweeps. Fixed at enqueue
+    # — the *fast* stuck signal is last_progress_at below.
     expires_at = models.DateTimeField()
+    # Progress liveness (UN-3661): re-stamped to now() on enqueue AND on every
+    # decrement, so it tracks when a batch last completed. The reaper marks the
+    # execution ERROR once it is older than WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS
+    # (default 2.5h, = Celery's per-task FILE_PROCESSING_TASK_TIME_LIMIT) — a
+    # per-PROGRESS window that is invariant to MAX_PARALLEL_FILE_BATCHES (dynamic
+    # per-org), so it never false-fails a legitimately long multi-batch run.
+    # Deliberately UNINDEXED: it's written on every decrement, so indexing it would
+    # break the heap-only-tuple (HOT) update the decrement relies on — and the
+    # reaper's sweep of this tiny (in-flight-only) table is a cheap seq scan.
+    # Directly queryable ("when did this barrier last progress?") — the PG-queue
+    # "stuck-detection = plain SQL" property.
+    last_progress_at = models.DateTimeField(default=timezone.now)
 
     class Meta:
         db_table = "pg_barrier_state"

--- a/backend/pg_queue/models.py
+++ b/backend/pg_queue/models.py
@@ -214,8 +214,9 @@ class PgBarrierState(models.Model):
     # Progress liveness (UN-3661): re-stamped to now() on enqueue AND on every
     # decrement, so it tracks when a batch last completed. The reaper marks the
     # execution ERROR once it is older than WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS
-    # (default 2.5h, = Celery's per-task FILE_PROCESSING_TASK_TIME_LIMIT) — a
-    # per-PROGRESS window that is invariant to MAX_PARALLEL_FILE_BATCHES (dynamic
+    # (default 2.5h — in the same band as Celery's per-task
+    # FILE_PROCESSING_TASK_TIME_LIMIT, which ships 2h–3h) — a per-PROGRESS window
+    # that is invariant to MAX_PARALLEL_FILE_BATCHES (dynamic
     # per-org), so it never false-fails a legitimately long multi-batch run.
     # Deliberately UNINDEXED: it's written on every decrement, so indexing it would
     # break the heap-only-tuple (HOT) update the decrement relies on — and the

--- a/backend/workflow_manager/execution/tests/test_cascade_terminal_files.py
+++ b/backend/workflow_manager/execution/tests/test_cascade_terminal_files.py
@@ -1,0 +1,62 @@
+"""WorkflowExecutionInternalViewSet._cascade_terminal_files (UN-3661).
+
+When the reaper marks a stranded execution terminal with
+``cascade_terminal_files``, the execution's non-terminal (PENDING/EXECUTING) file
+executions must be marked to the same terminal status atomically — so a recovered
+strand never leaves execution=ERROR while its files stay EXECUTING (the b11ba2f3
+inconsistency). Terminal files (COMPLETED/ERROR/STOPPED) are left untouched.
+"""
+
+from django.test import TestCase
+
+from workflow_manager.file_execution.models import WorkflowFileExecution
+from workflow_manager.internal_views import WorkflowExecutionInternalViewSet
+from workflow_manager.workflow_v2.enums import ExecutionStatus
+from workflow_manager.workflow_v2.models.execution import WorkflowExecution
+from workflow_manager.workflow_v2.models.workflow import Workflow
+
+_cascade = WorkflowExecutionInternalViewSet._cascade_terminal_files
+
+
+class CascadeTerminalFilesTests(TestCase):
+    def setUp(self):
+        self.workflow = Workflow.objects.create(workflow_name="test-cascade-wf")
+        self.execution = WorkflowExecution.objects.create(
+            workflow=self.workflow, status=ExecutionStatus.EXECUTING
+        )
+
+    def _file(self, name, status):
+        return WorkflowFileExecution.objects.create(
+            workflow_execution=self.execution, file_name=name, status=status.value
+        )
+
+    def _reload(self, fe):
+        fe.refresh_from_db()
+        return fe
+
+    def test_cascades_only_non_terminal_files_to_the_terminal_status(self):
+        executing = self._file("a.pdf", ExecutionStatus.EXECUTING)
+        pending = self._file("b.pdf", ExecutionStatus.PENDING)
+        completed = self._file("c.pdf", ExecutionStatus.COMPLETED)
+
+        _cascade(self.execution, ExecutionStatus.ERROR, "boom")
+
+        assert self._reload(executing).status == ExecutionStatus.ERROR.value
+        assert self._reload(pending).status == ExecutionStatus.ERROR.value
+        # A file that already finished is left alone (no status overwrite).
+        assert self._reload(completed).status == ExecutionStatus.COMPLETED.value
+        assert self._reload(executing).execution_error == "boom"
+
+    def test_non_terminal_target_status_is_a_noop(self):
+        # The cascade only fires when the execution itself went terminal.
+        executing = self._file("a.pdf", ExecutionStatus.EXECUTING)
+        _cascade(self.execution, ExecutionStatus.EXECUTING, "x")
+        assert self._reload(executing).status == ExecutionStatus.EXECUTING.value
+
+    def test_idempotent_second_run_changes_nothing(self):
+        executing = self._file("a.pdf", ExecutionStatus.EXECUTING)
+        _cascade(self.execution, ExecutionStatus.ERROR, "first")
+        assert self._reload(executing).status == ExecutionStatus.ERROR.value
+        # Second run: the file is already terminal → excluded → error not clobbered.
+        _cascade(self.execution, ExecutionStatus.ERROR, "second")
+        assert self._reload(executing).execution_error == "first"

--- a/backend/workflow_manager/internal_serializers.py
+++ b/backend/workflow_manager/internal_serializers.py
@@ -175,6 +175,11 @@ class WorkflowExecutionStatusUpdateSerializer(serializers.Serializer):
 
     status = serializers.ChoiceField(choices=ExecutionStatus.choices)
     error_message = serializers.CharField(required=False, allow_blank=True)
+    # When true AND the new status is terminal, also mark this execution's
+    # non-terminal (PENDING/EXECUTING) file executions to the same terminal status,
+    # atomically. The reaper sets this so a stranded execution and its files reach a
+    # consistent terminal state (else execution=ERROR while its files stay EXECUTING).
+    cascade_terminal_files = serializers.BooleanField(required=False, default=False)
     total_files = serializers.IntegerField(
         required=False, min_value=0
     )  # Allow 0 but backend will only update if > 0

--- a/backend/workflow_manager/internal_serializers.py
+++ b/backend/workflow_manager/internal_serializers.py
@@ -189,12 +189,13 @@ class WorkflowExecutionStatusUpdateSerializer(serializers.Serializer):
     execution_time = serializers.FloatField(required=False, min_value=0)
 
     def validate(self, attrs):
-        """Reject impossible file-count aggregates + a meaningless cascade combo.
+        """Reject a meaningless cascade combo + impossible file-count aggregates."""
+        self._validate_cascade(attrs)
+        self._validate_file_aggregates(attrs)
+        return attrs
 
-        Per-field min_value=0 catches negatives, but successful + failed >
-        total or either component > total slips through and skews the
-        outcome-based notification filter downstream.
-        """
+    @staticmethod
+    def _validate_cascade(attrs) -> None:
         # cascade_terminal_files only makes sense when the new status is terminal
         # (it's a silent no-op otherwise) — reject the illegal combo at the boundary
         # rather than accepting-and-ignoring it.
@@ -210,6 +211,12 @@ class WorkflowExecutionStatusUpdateSerializer(serializers.Serializer):
                 }
             )
 
+    @staticmethod
+    def _validate_file_aggregates(attrs) -> None:
+        """Per-field min_value=0 catches negatives, but successful + failed > total
+        or either component > total slips through and skews the outcome-based
+        notification filter downstream.
+        """
         total = attrs.get("total_files")
         successful = attrs.get("successful_files")
         failed = attrs.get("failed_files")
@@ -221,23 +228,18 @@ class WorkflowExecutionStatusUpdateSerializer(serializers.Serializer):
                         "total_files": "total_files is required when file aggregates are provided."
                     }
                 )
-        else:
-            if successful is not None and successful > total:
-                raise serializers.ValidationError(
-                    {"successful_files": "successful_files cannot exceed total_files."}
-                )
-            if failed is not None and failed > total:
-                raise serializers.ValidationError(
-                    {"failed_files": "failed_files cannot exceed total_files."}
-                )
-            if (
-                successful is not None
-                and failed is not None
-                and successful + failed > total
-            ):
-                msg = "successful_files + failed_files cannot exceed total_files."
-                raise serializers.ValidationError({"non_field_errors": msg})
-        return attrs
+            return
+        if successful is not None and successful > total:
+            raise serializers.ValidationError(
+                {"successful_files": "successful_files cannot exceed total_files."}
+            )
+        if failed is not None and failed > total:
+            raise serializers.ValidationError(
+                {"failed_files": "failed_files cannot exceed total_files."}
+            )
+        if successful is not None and failed is not None and successful + failed > total:
+            msg = "successful_files + failed_files cannot exceed total_files."
+            raise serializers.ValidationError({"non_field_errors": msg})
 
 
 class OrganizationContextSerializer(serializers.Serializer):

--- a/backend/workflow_manager/internal_serializers.py
+++ b/backend/workflow_manager/internal_serializers.py
@@ -189,12 +189,27 @@ class WorkflowExecutionStatusUpdateSerializer(serializers.Serializer):
     execution_time = serializers.FloatField(required=False, min_value=0)
 
     def validate(self, attrs):
-        """Reject impossible file-count aggregates.
+        """Reject impossible file-count aggregates + a meaningless cascade combo.
 
         Per-field min_value=0 catches negatives, but successful + failed >
         total or either component > total slips through and skews the
         outcome-based notification filter downstream.
         """
+        # cascade_terminal_files only makes sense when the new status is terminal
+        # (it's a silent no-op otherwise) — reject the illegal combo at the boundary
+        # rather than accepting-and-ignoring it.
+        if attrs.get("cascade_terminal_files") and not ExecutionStatus.is_completed(
+            attrs["status"]
+        ):
+            raise serializers.ValidationError(
+                {
+                    "cascade_terminal_files": (
+                        "cascade_terminal_files=True requires a terminal status "
+                        "(COMPLETED/ERROR/STOPPED)."
+                    )
+                }
+            )
+
         total = attrs.get("total_files")
         successful = attrs.get("successful_files")
         failed = attrs.get("failed_files")

--- a/backend/workflow_manager/internal_views.py
+++ b/backend/workflow_manager/internal_views.py
@@ -550,13 +550,15 @@ class WorkflowExecutionInternalViewSet(viewsets.ReadOnlyModelViewSet):
         from workflow_manager.file_execution.models import WorkflowFileExecution
         from workflow_manager.workflow_v2.enums import ExecutionStatus
 
-        terminal = {
-            ExecutionStatus.COMPLETED.value,
-            ExecutionStatus.ERROR.value,
-            ExecutionStatus.STOPPED.value,
-        }
+        terminal = ExecutionStatus.terminal_values()  # canonical COMPLETED/ERROR/STOPPED
         if status_enum.value not in terminal:
             return
+        # Bulk .update() deliberately bypasses WorkflowFileExecution.update_status():
+        # this is a give-up recovery, so per-file execution_time is unknown (stays
+        # NULL) and the parent's failed/successful_files aggregates are NOT
+        # reconciled here — the execution's own terminal status (set above) is the
+        # source of truth (is_failure_run / notifications read it), and the
+        # serializer already derives failed counts for a terminal-failure run.
         cascaded = (
             WorkflowFileExecution.objects.filter(workflow_execution=execution)
             .exclude(status__in=terminal)

--- a/backend/workflow_manager/internal_views.py
+++ b/backend/workflow_manager/internal_views.py
@@ -512,6 +512,12 @@ class WorkflowExecutionInternalViewSet(viewsets.ReadOnlyModelViewSet):
                 # File aggregates are not handled by update_execution; persist separately.
                 self._update_file_aggregates(execution, validated_data)
 
+                # Reaper recovery: cascade the terminal status to any non-terminal
+                # file executions so the execution and its files agree (atomic with
+                # the status write above — they can't diverge).
+                if validated_data.get("cascade_terminal_files"):
+                    self._cascade_terminal_files(execution, status_enum, error_message)
+
             logger.info(
                 f"Updated workflow execution {id} status to {validated_data['status']}"
             )
@@ -529,6 +535,44 @@ class WorkflowExecutionInternalViewSet(viewsets.ReadOnlyModelViewSet):
             return Response(
                 {"error": "Failed to update workflow execution status", "detail": str(e)},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    @staticmethod
+    def _cascade_terminal_files(execution, status_enum, error_message) -> None:
+        """Mark this execution's non-terminal (PENDING/EXECUTING) file executions to
+        *status_enum*, so a reaper-recovered strand doesn't leave the execution
+        terminal while its files stay EXECUTING (the b11ba2f3 inconsistency).
+
+        No-op unless *status_enum* is terminal. Runs in the caller's transaction, so
+        the execution status and the file cascade commit together. Idempotent — a
+        re-run finds those files already terminal and updates nothing.
+        """
+        from workflow_manager.file_execution.models import WorkflowFileExecution
+        from workflow_manager.workflow_v2.enums import ExecutionStatus
+
+        terminal = {
+            ExecutionStatus.COMPLETED.value,
+            ExecutionStatus.ERROR.value,
+            ExecutionStatus.STOPPED.value,
+        }
+        if status_enum.value not in terminal:
+            return
+        cascaded = (
+            WorkflowFileExecution.objects.filter(workflow_execution=execution)
+            .exclude(status__in=terminal)
+            .update(
+                status=status_enum.value,
+                execution_error=(
+                    error_message
+                    or "[reaper-recovery] Execution stranded; file marked terminal "
+                    "to match the execution."
+                ),
+            )
+        )
+        if cascaded:
+            logger.info(
+                f"Cascaded terminal status {status_enum.value} to {cascaded} "
+                f"non-terminal file execution(s) of execution {execution.id}"
             )
 
     @staticmethod

--- a/unstract/core/src/unstract/core/data_models.py
+++ b/unstract/core/src/unstract/core/data_models.py
@@ -553,12 +553,22 @@ ExecutionStatus.choices = tuple(
 )
 
 
+# Canonical terminal-status values (COMPLETED/STOPPED/ERROR). One definition so
+# every terminal check — is_completed() below, and ORM ``status__in`` filters like
+# the reaper's file cascade — stays in sync when a status is added/removed.
+def _terminal_values(cls) -> frozenset[str]:
+    """The string values of the terminal execution statuses."""
+    return frozenset({cls.COMPLETED.value, cls.STOPPED.value, cls.ERROR.value})
+
+
+ExecutionStatus.terminal_values = classmethod(_terminal_values)
+
+
 # Add the is_completed method as a class method
 def _is_completed(cls, status: str) -> bool:
-    """Check if the execution status represents a completed state."""
+    """Check if the execution status represents a completed (terminal) state."""
     try:
-        status_enum = cls(status)
-        return status_enum in [cls.COMPLETED, cls.STOPPED, cls.ERROR]
+        return cls(status).value in cls.terminal_values()
     except ValueError:
         raise ValueError(f"Invalid status: {status}. Must be a valid ExecutionStatus.")
 

--- a/workers/queue_backend/barrier.py
+++ b/workers/queue_backend/barrier.py
@@ -81,6 +81,47 @@ def barrier_ttl_seconds() -> int:
     return value
 
 
+# PG barrier stuck-timeout — the "no progress" deadline for a PG-backed barrier.
+# Unlike the Redis backend's fixed key TTL, the PG barrier's ``expires_at`` SLIDES:
+# it's re-stamped to ``now() + this`` on enqueue AND on every decrement, so a
+# barrier only "expires" (→ the reaper marks it ERROR) after this long with NO
+# batch completing. Default 2.5h matches Celery's per-task ``FILE_PROCESSING_TASK_
+# TIME_LIMIT`` (9000s), giving crash / runaway parity: a batch whose worker died
+# (or that runs longer than Celery would allow) stalls progress and is reaped at
+# ~this bound, PROMPTLY (not at the old ~6h barrier expiry). A per-PROGRESS window
+# is invariant to how many batches run in parallel (``MAX_PARALLEL_FILE_BATCHES``
+# is dynamic per-org), so — unlike a per-execution age cap — it never false-fails a
+# legitimately long multi-batch run: any completion refreshes the deadline.
+_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS = 9000  # 2.5h, = Celery FILE_PROCESSING hard limit
+
+
+def barrier_stuck_timeout_seconds() -> int:
+    """PG barrier stuck-timeout from ``WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS`` (default 2.5h).
+
+    Read at call time (tests flip it). Invalid / non-positive values raise,
+    matching :func:`barrier_ttl_seconds`'s loud-on-misconfig posture — this bounds
+    how long a stalled execution stays non-terminal, so a garbled value must fail
+    fast rather than silently disable the recovery net.
+    """
+    raw = os.getenv("WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS")
+    if raw is None:
+        return _DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS={raw!r} is not an integer. Unset "
+            f"it to default to {_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS}s (2.5h)."
+        ) from exc
+    if value <= 0:
+        raise ValueError(
+            f"WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS={value} must be a positive "
+            f"integer. Unset it to default to "
+            f"{_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS}s (2.5h)."
+        )
+    return value
+
+
 class CallbackDescriptor(TypedDict):
     """Serialisable aggregating-callback spec baked into a barrier link signature.
 

--- a/workers/queue_backend/barrier.py
+++ b/workers/queue_backend/barrier.py
@@ -56,6 +56,29 @@ logger = logging.getLogger(__name__)
 _DEFAULT_BARRIER_TTL_SECONDS = 6 * 60 * 60  # 6h
 
 
+def _positive_int_env(var: str, default: int, human_default: str) -> int:
+    """Read positive-int env ``var``; return *default* when unset, raise (loud) on a
+    non-integer or non-positive value. *human_default* is how the default renders in
+    the error (e.g. ``"21600s (6h)"``). Shared by the two barrier duration knobs so
+    their parse/validate can't drift.
+    """
+    raw = os.getenv(var)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{var}={raw!r} is not an integer. Unset it to default to {human_default}."
+        ) from exc
+    if value <= 0:
+        raise ValueError(
+            f"{var}={value} must be a positive integer. Unset it to default to "
+            f"{human_default}."
+        )
+    return value
+
+
 def barrier_ttl_seconds() -> int:
     """Barrier TTL from ``WORKER_BARRIER_KEY_TTL_SECONDS`` (default 6h).
 
@@ -63,36 +86,26 @@ def barrier_ttl_seconds() -> int:
     matching ``get_barrier()``'s loud-on-misconfig posture — a TTL shorter than
     execution wall-clock would tear barriers down early (spurious behaviour).
     """
-    raw = os.getenv("WORKER_BARRIER_KEY_TTL_SECONDS")
-    if raw is None:
-        return _DEFAULT_BARRIER_TTL_SECONDS
-    try:
-        value = int(raw)
-    except ValueError as exc:
-        raise ValueError(
-            f"WORKER_BARRIER_KEY_TTL_SECONDS={raw!r} is not an integer. Unset it "
-            f"to default to {_DEFAULT_BARRIER_TTL_SECONDS}s (6h)."
-        ) from exc
-    if value <= 0:
-        raise ValueError(
-            f"WORKER_BARRIER_KEY_TTL_SECONDS={value} must be a positive integer. "
-            f"Unset it to default to {_DEFAULT_BARRIER_TTL_SECONDS}s (6h)."
-        )
-    return value
+    return _positive_int_env(
+        "WORKER_BARRIER_KEY_TTL_SECONDS",
+        _DEFAULT_BARRIER_TTL_SECONDS,
+        f"{_DEFAULT_BARRIER_TTL_SECONDS}s (6h)",
+    )
 
 
 # PG barrier stuck-timeout — the "no progress" deadline for a PG-backed barrier.
-# Unlike the Redis backend's fixed key TTL, the PG barrier's ``expires_at`` SLIDES:
-# it's re-stamped to ``now() + this`` on enqueue AND on every decrement, so a
-# barrier only "expires" (→ the reaper marks it ERROR) after this long with NO
-# batch completing. Default 2.5h matches Celery's per-task ``FILE_PROCESSING_TASK_
-# TIME_LIMIT`` (9000s), giving crash / runaway parity: a batch whose worker died
-# (or that runs longer than Celery would allow) stalls progress and is reaped at
-# ~this bound, PROMPTLY (not at the old ~6h barrier expiry). A per-PROGRESS window
-# is invariant to how many batches run in parallel (``MAX_PARALLEL_FILE_BATCHES``
-# is dynamic per-org), so — unlike a per-execution age cap — it never false-fails a
-# legitimately long multi-batch run: any completion refreshes the deadline.
-_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS = 9000  # 2.5h, = Celery FILE_PROCESSING hard limit
+# The barrier's ``last_progress_at`` column (NOT ``expires_at``) is re-stamped to
+# bare ``now()`` on enqueue AND on every decrement; the reaper applies THIS timeout
+# at query time (``last_progress_at < now() - stuck_timeout``, see
+# ``reaper._STRANDED_PREDICATE``), so a barrier is reaped only after this long with
+# NO batch completing. The 9000s (2.5h) default sits in the SAME BAND as Celery's
+# per-task ``FILE_PROCESSING_TASK_TIME_LIMIT`` — a tunable env shipping 7200 (2h) /
+# 10800 (3h) across the sample deployments — giving crash / runaway parity without
+# asserting an equality that rots when an operator tunes that var. A per-PROGRESS
+# window is invariant to how many batches run in parallel (``MAX_PARALLEL_FILE_
+# BATCHES`` is dynamic per-org), so — unlike a per-execution age cap — it never
+# false-fails a legitimately long multi-batch run: any completion refreshes it.
+_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS = 9000  # 2.5h — Celery file-proc band (2h–3h)
 
 
 def barrier_stuck_timeout_seconds() -> int:
@@ -103,23 +116,11 @@ def barrier_stuck_timeout_seconds() -> int:
     how long a stalled execution stays non-terminal, so a garbled value must fail
     fast rather than silently disable the recovery net.
     """
-    raw = os.getenv("WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS")
-    if raw is None:
-        return _DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS
-    try:
-        value = int(raw)
-    except ValueError as exc:
-        raise ValueError(
-            f"WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS={raw!r} is not an integer. Unset "
-            f"it to default to {_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS}s (2.5h)."
-        ) from exc
-    if value <= 0:
-        raise ValueError(
-            f"WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS={value} must be a positive "
-            f"integer. Unset it to default to "
-            f"{_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS}s (2.5h)."
-        )
-    return value
+    return _positive_int_env(
+        "WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS",
+        _DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS,
+        f"{_DEFAULT_BARRIER_STUCK_TIMEOUT_SECONDS}s (2.5h)",
+    )
 
 
 class CallbackDescriptor(TypedDict):

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -43,7 +43,8 @@ for the fan-in. The transport for the header tasks themselves is unchanged
    every decrement, tracking when a batch last completed. The
    :mod:`~queue_backend.pg_queue.reaper` marks the stranded execution ERROR once
    ``last_progress_at`` is older than ``WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS``
-   (default 2.5h, = Celery's per-task ``FILE_PROCESSING_TASK_TIME_LIMIT``) — a
+   (default 2.5h — in the same band as Celery's per-task
+   ``FILE_PROCESSING_TASK_TIME_LIMIT``, which ships 2h–3h) — a
    per-PROGRESS window, invariant to how many batches run in parallel
    (``MAX_PARALLEL_FILE_BATCHES`` is dynamic per-org), so it never false-fails a
    legitimately long multi-batch run. ``expires_at`` (fixed at enqueue,

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -17,7 +17,8 @@ for the fan-in. The transport for the header tasks themselves is unchanged
 **Wire model.**
 
 1. ``enqueue``: UPSERT one ``pg_barrier_state`` row (``remaining = N``,
-   ``results = []``, ``expires_at = now() + ttl``) — the UPSERT clears any stale
+   ``results = []``, ``expires_at = now() + ttl``, ``last_progress_at = now()``)
+   — the UPSERT clears any stale
    state from a prior run reusing the same ``execution_id``. Each header task is
    dispatched with
    ``.link(barrier_pg_decr_and_check)`` (success) and
@@ -38,10 +39,16 @@ for the fan-in. The transport for the header tasks themselves is unchanged
    (leaving the row for a sibling to retry) — there is no claimed-but-not-deleted
    window. Mirrors chord's default error semantic (callback not invoked on
    header failure).
-4. Orphan bound: like the Redis backend's key TTL, ``expires_at`` bounds a
-   barrier whose header tasks never complete. **No expiry reclaim ships in this
-   phase** — a periodic sweep job (keyed on ``pg_barrier_expires_idx``) is the
-   intended backstop and is future work.
+4. Stuck bound: ``last_progress_at`` is re-stamped to ``now()`` on enqueue AND on
+   every decrement, tracking when a batch last completed. The
+   :mod:`~queue_backend.pg_queue.reaper` marks the stranded execution ERROR once
+   ``last_progress_at`` is older than ``WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS``
+   (default 2.5h, = Celery's per-task ``FILE_PROCESSING_TASK_TIME_LIMIT``) — a
+   per-PROGRESS window, invariant to how many batches run in parallel
+   (``MAX_PARALLEL_FILE_BATCHES`` is dynamic per-org), so it never false-fails a
+   legitimately long multi-batch run. ``expires_at`` (fixed at enqueue,
+   ``WORKER_BARRIER_KEY_TTL_SECONDS``, default 6h) is the absolute last-resort cap
+   the reaper also sweeps.
 
 **Failure-masking guards.** The callback can only fire when ``remaining`` hits
 exactly 0, which requires ALL N header tasks to have decremented — i.e. all
@@ -400,6 +407,8 @@ class PgBarrier:
                 # The decrement (run in-body on the PG path) reads this to
                 # self-chain the callback onto PG rather than Celery.
                 callback_descriptor["transport"] = WorkflowTransport.PG_QUEUE.value
+            # expires_at = absolute orphan cap (6h). last_progress_at = now() (the
+            # reaper's fast stuck signal, re-stamped on every decrement).
             ttl_seconds = barrier_ttl_seconds()
             # Stamp the owning org so the reaper can call the org-scoped status
             # API when recovering this barrier if it strands (it has only the
@@ -424,14 +433,20 @@ class PgBarrier:
                 cur.execute(
                     f"INSERT INTO {qualified('pg_barrier_state')} "
                     "(execution_id, organization_id, remaining, results, "
-                    " created_at, expires_at) "
+                    " created_at, expires_at, last_progress_at) "
                     "VALUES (%s, %s, %s, '[]'::jsonb, now(), "
-                    "        now() + make_interval(secs => %s)) "
+                    "        now() + make_interval(secs => %s), now()) "
                     "ON CONFLICT (execution_id) DO UPDATE SET "
                     "  organization_id = EXCLUDED.organization_id, "
                     "  remaining = EXCLUDED.remaining, results = '[]'::jsonb, "
-                    "  created_at = now(), expires_at = EXCLUDED.expires_at",
-                    (execution_id, organization_id, len(header_tasks), ttl_seconds),
+                    "  created_at = now(), expires_at = EXCLUDED.expires_at, "
+                    "  last_progress_at = now()",
+                    (
+                        execution_id,
+                        organization_id,
+                        len(header_tasks),
+                        ttl_seconds,
+                    ),
                 )
                 # Reset per-batch dedup markers from a prior run reusing this
                 # execution_id, ATOMICALLY with the barrier reset. Without this a
@@ -684,10 +699,17 @@ def _apply_decrement(
     (UN-3654) and the idempotent pre-dispatch write's retry, but phase-split
     because the decrement, unlike those, must never replay a committed write.
     """
+    # ``last_progress_at = now()`` records that a batch just completed — the
+    # reaper's stuck signal (it marks the execution ERROR only once no decrement
+    # has landed for stuck_timeout; see barrier.py / reaper.py). last_progress_at
+    # is UNINDEXED, so — like remaining/results — this stays a heap-only-tuple (HOT)
+    # update: no index churn on the decrement hot path. (expires_at, the indexed
+    # absolute cap, is deliberately NOT touched here, to preserve HOT.)
     sql = (
         f"UPDATE {qualified('pg_barrier_state')} "
         "   SET remaining = remaining - 1, "
-        "       results = results || jsonb_build_array(%s::jsonb) "
+        "       results = results || jsonb_build_array(%s::jsonb), "
+        "       last_progress_at = now() "
         " WHERE execution_id = %s "
         "RETURNING remaining, results"
     )

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -326,7 +326,7 @@ def _mark_stranded_error(
             "the barrier was already torn down (remaining < 0) yet the execution "
             "was left non-terminal — inconsistent state"
         )
-    api_client.update_workflow_execution_status(
+    response = api_client.update_workflow_execution_status(
         execution_id=execution_id,
         status=ExecutionStatus.ERROR.value,
         error_message=f"[reaper-recovery] Execution stranded: {reason}.",
@@ -336,6 +336,17 @@ def _mark_stranded_error(
         # EXECUTING (the b11ba2f3 inconsistency).
         cascade_terminal_files=True,
     )
+    # Mirror the read path (_execution_status): the internal client returns an
+    # APIResponse and may report a failed write via ``success=False`` rather than
+    # raising. Treat a non-success as a hard failure so the caller does NOT proceed
+    # to DELETE the barrier row (erasing the only recovery handle while the
+    # execution stays non-terminal). ``success`` absent → assume raised-on-failure
+    # legacy contract (True).
+    if not getattr(response, "success", True):
+        raise RuntimeError(
+            f"status update for stranded execution {execution_id} reported "
+            f"success=False (refusing to delete the barrier recovery handle)"
+        )
     logger.error(
         "Reaper: marked stranded execution %s ERROR (remaining=%s).",
         execution_id,
@@ -542,10 +553,22 @@ class PgReaper:
         interval_seconds: float | None = None,
         sweep_interval_seconds: float | None = None,
         dedup_retention_seconds: int | None = None,
+        stuck_timeout_seconds: int | None = None,
         sweep_conn: PgConnection | None = None,
         api_client: InternalAPIClient | None = None,
     ) -> None:
         self._lease = lease
+        # Resolve + validate the barrier stuck-timeout ONCE, at construction, so a
+        # garbled WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS crashes loudly at boot rather
+        # than raising inside every tick (where run()'s generic "cycle failed" catch
+        # would silently disable the whole recovery net, looking like a DB blip).
+        self._stuck_timeout_seconds = (
+            stuck_timeout_seconds
+            if stuck_timeout_seconds is not None
+            else barrier_stuck_timeout_seconds()
+        )
+        if self._stuck_timeout_seconds <= 0:
+            raise ValueError("stuck_timeout_seconds must be positive")
         self._interval = (
             interval_seconds
             if interval_seconds is not None
@@ -669,7 +692,11 @@ class PgReaper:
             return TickOutcome(was_leader=False, reclaimed=0)
         try:
             reclaimed = len(
-                recover_expired_barriers(self._get_sweep_conn(), self._get_api_client())
+                recover_expired_barriers(
+                    self._get_sweep_conn(),
+                    self._get_api_client(),
+                    self._stuck_timeout_seconds,
+                )
             )
         except Exception:
             self._discard_owned_sweep_conn()

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -56,6 +56,7 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol, TypeVar
 
 from unstract.core.data_models import ExecutionStatus
 
+from ..barrier import barrier_stuck_timeout_seconds
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id
 from .liveness import LivenessServer as _BaseLivenessServer
@@ -80,6 +81,15 @@ _DEFAULT_SWEEP_INTERVAL_SECONDS = 300.0
 # fan-out — this is operator-enforced, not coupled in code to the actual bound. 24h
 # is comfortably above any single execution.
 _DEFAULT_DEDUP_RETENTION_SECONDS = 86400
+
+# A barrier is "stranded" when it has made no progress for the stuck-timeout (the
+# fast, per-progress signal — UN-3661) OR it has passed its absolute ``expires_at``
+# cap (the last-resort backstop). Both feed the SAME recovery. Defined once so the
+# detection SELECT, the pre-mark re-check, and the cleanup DELETE can't drift.
+# Binds one ``%s`` — the stuck-timeout in seconds (``barrier_stuck_timeout_seconds``).
+_STRANDED_PREDICATE = (
+    "(last_progress_at < now() - make_interval(secs => %s) OR expires_at < now())"
+)
 
 _N = TypeVar("_N", int, float)
 
@@ -274,18 +284,20 @@ def _execution_status(
     return getattr(response, "status", None)
 
 
-def _still_expired(conn: PgConnection, execution_id: str) -> bool:
-    """True iff the barrier row is still present AND still past expiry.
+def _still_stranded(
+    conn: PgConnection, execution_id: str, stuck_timeout_seconds: int
+) -> bool:
+    """True iff the barrier row is still present AND still stranded.
 
     Re-checked immediately before the ERROR mark so a same-id re-enqueue (UPSERT
-    resets ``expires_at`` to the future) between the sweep's SELECT and the mark
-    doesn't get its live run flagged ERROR.
+    resets both ``expires_at`` to the future AND ``last_progress_at`` to now())
+    between the sweep's SELECT and the mark doesn't get its live run flagged ERROR.
     """
     with conn.cursor() as cur:
         cur.execute(
             f"SELECT 1 FROM {qualified('pg_barrier_state')} "
-            "WHERE execution_id = %s AND expires_at < now()",
-            (execution_id,),
+            f"WHERE execution_id = %s AND {_STRANDED_PREDICATE}",
+            (execution_id, stuck_timeout_seconds),
         )
         found = cur.fetchone() is not None
     conn.commit()
@@ -319,6 +331,10 @@ def _mark_stranded_error(
         status=ExecutionStatus.ERROR.value,
         error_message=f"[reaper-recovery] Execution stranded: {reason}.",
         organization_id=organization_id,
+        # Cascade ERROR to the execution's non-terminal file executions in the same
+        # backend transaction — else the execution goes ERROR while its files stay
+        # EXECUTING (the b11ba2f3 inconsistency).
+        cascade_terminal_files=True,
     )
     logger.error(
         "Reaper: marked stranded execution %s ERROR (remaining=%s).",
@@ -333,6 +349,7 @@ def _recover_one_barrier(
     execution_id: str,
     organization_id: str,
     remaining: int,
+    stuck_timeout_seconds: int,
 ) -> bool:
     """Recover one stranded execution; return True iff its barrier row was deleted.
 
@@ -389,7 +406,7 @@ def _recover_one_barrier(
             execution_id,
             status,
         )
-    elif not _still_expired(conn, execution_id):
+    elif not _still_stranded(conn, execution_id, stuck_timeout_seconds):
         # Re-armed (same execution_id re-enqueued) between the read and here —
         # do NOT mark a freshly-running execution ERROR; leave it for the new run.
         logger.warning(
@@ -405,8 +422,8 @@ def _recover_one_barrier(
     with conn.cursor() as cur:
         cur.execute(
             f"DELETE FROM {qualified('pg_barrier_state')} WHERE execution_id = %s "
-            "AND expires_at < now()",
-            (execution_id,),
+            f"AND {_STRANDED_PREDICATE}",
+            (execution_id, stuck_timeout_seconds),
         )
         deleted = cur.rowcount > 0
         if deleted:
@@ -425,11 +442,21 @@ def _recover_one_barrier(
 
 
 def recover_expired_barriers(
-    conn: PgConnection, api_client: InternalAPIClient
+    conn: PgConnection,
+    api_client: InternalAPIClient,
+    stuck_timeout_seconds: int | None = None,
 ) -> list[str]:
-    """Recover executions stranded by an expired barrier. Returns recovered ids.
+    """Recover stranded executions. Returns recovered ids.
 
-    SELECT the expired rows (the reaper is leader-elected → a single active
+    A barrier is stranded when it has made no progress for
+    ``stuck_timeout_seconds`` (the fast per-progress signal — a crashed worker's
+    batch, or a runaway) OR it has passed its absolute ``expires_at`` cap; see
+    :data:`_STRANDED_PREDICATE`. ``stuck_timeout_seconds`` defaults to
+    :func:`~queue_backend.barrier.barrier_stuck_timeout_seconds` (resolved once
+    per sweep and threaded through, so the SELECT and the per-row re-check/DELETE
+    all use the same value).
+
+    SELECT the stranded rows (the reaper is leader-elected → a single active
     sweeper, so a read-then-act is safe from double-claim), then recover each one
     best-effort: mark the execution ERROR if it isn't already terminal, then
     delete its ``pg_batch_dedup`` + ``pg_barrier_state`` rows. One execution
@@ -441,11 +468,14 @@ def recover_expired_barriers(
     ``conn`` runs in manual-commit mode; on any error we roll back before
     continuing/re-raising so the connection isn't left in an aborted-txn state.
     """
+    if stuck_timeout_seconds is None:
+        stuck_timeout_seconds = barrier_stuck_timeout_seconds()
     try:
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT execution_id, organization_id, remaining "
-                f"FROM {qualified('pg_barrier_state')} WHERE expires_at < now()"
+                f"FROM {qualified('pg_barrier_state')} WHERE {_STRANDED_PREDICATE}",
+                (stuck_timeout_seconds,),
             )
             rows = cur.fetchall()
         conn.commit()
@@ -459,7 +489,12 @@ def recover_expired_barriers(
     for execution_id, organization_id, remaining in rows:
         try:
             if _recover_one_barrier(
-                conn, api_client, execution_id, organization_id, remaining
+                conn,
+                api_client,
+                execution_id,
+                organization_id,
+                remaining,
+                stuck_timeout_seconds,
             ):
                 recovered.append(execution_id)
             # else: a benign skip (terminal / re-armed / no-status / no-org) —

--- a/workers/shared/api/internal_client.py
+++ b/workers/shared/api/internal_client.py
@@ -608,8 +608,13 @@ class InternalAPIClient(CachedAPIClientMixin):
         attempts: int | None = None,
         execution_time: float | None = None,
         organization_id: str | None = None,
+        cascade_terminal_files: bool = False,
     ) -> dict[str, Any]:
-        """Update workflow execution status."""
+        """Update workflow execution status.
+
+        ``cascade_terminal_files=True`` also marks the execution's non-terminal file
+        executions to the same terminal status atomically (used by the reaper).
+        """
         return self.execution_client.update_workflow_execution_status(
             execution_id,
             status,
@@ -620,6 +625,7 @@ class InternalAPIClient(CachedAPIClientMixin):
             attempts,
             execution_time,
             organization_id,
+            cascade_terminal_files=cascade_terminal_files,
         )
 
     def create_workflow_execution(self, execution_data: dict[str, Any]) -> dict[str, Any]:

--- a/workers/shared/clients/execution_client.py
+++ b/workers/shared/clients/execution_client.py
@@ -270,6 +270,7 @@ class ExecutionAPIClient(BaseAPIClient):
         attempts: int | None = None,
         execution_time: float | None = None,
         organization_id: str | None = None,
+        cascade_terminal_files: bool = False,
     ) -> APIResponse:
         """Update workflow execution status.
 
@@ -283,6 +284,9 @@ class ExecutionAPIClient(BaseAPIClient):
             attempts: Optional attempts count
             execution_time: Optional execution time
             organization_id: Optional organization ID override
+            cascade_terminal_files: When True and *status* is terminal, the backend
+                also marks this execution's non-terminal file executions to the same
+                terminal status, atomically (the reaper uses this on recovery).
 
         Returns:
             APIResponse with update result
@@ -292,6 +296,8 @@ class ExecutionAPIClient(BaseAPIClient):
 
         data = {"status": status_str}
 
+        if cascade_terminal_files:
+            data["cascade_terminal_files"] = True
         if error_message is not None:
             data["error_message"] = error_message
         if total_files is not None:

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -93,8 +93,8 @@ class TestTtlEnv:
 
 
 class TestStuckTimeoutEnv:
-    # The PG barrier's sliding expires_at window (UN-3661) — distinct from the
-    # Redis-shared TTL above. Default 2.5h = Celery FILE_PROCESSING_TASK_TIME_LIMIT.
+    # The PG barrier's sliding last_progress_at window (UN-3661) — distinct from the
+    # Redis-shared TTL above. Default 2.5h, in Celery's FILE_PROCESSING band (2h–3h).
     def test_default_is_two_and_half_hours(self, monkeypatch):
         monkeypatch.delenv("WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS", raising=False)
         assert barrier_mod.barrier_stuck_timeout_seconds() == 9000

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -92,6 +92,24 @@ class TestTtlEnv:
             barrier_mod.barrier_ttl_seconds()
 
 
+class TestStuckTimeoutEnv:
+    # The PG barrier's sliding expires_at window (UN-3661) — distinct from the
+    # Redis-shared TTL above. Default 2.5h = Celery FILE_PROCESSING_TASK_TIME_LIMIT.
+    def test_default_is_two_and_half_hours(self, monkeypatch):
+        monkeypatch.delenv("WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS", raising=False)
+        assert barrier_mod.barrier_stuck_timeout_seconds() == 9000
+
+    def test_overridable(self, monkeypatch):
+        monkeypatch.setenv("WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS", "120")
+        assert barrier_mod.barrier_stuck_timeout_seconds() == 120
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-5"])
+    def test_invalid_raises(self, monkeypatch, bad):
+        monkeypatch.setenv("WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS", bad)
+        with pytest.raises(ValueError, match="WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS"):
+            barrier_mod.barrier_stuck_timeout_seconds()
+
+
 class TestEnqueueShortCircuits:
     def test_empty_header_returns_none(self):
         # Returns before any DB / dispatch.
@@ -498,6 +516,30 @@ def _org(conn, execution_id):
         return row[0] if row else None
 
 
+def _expires_in_seconds(conn, execution_id):
+    """Seconds from *now* until the barrier's expires_at (DB-side now(), so no
+    client-clock skew) — the fixed 6h absolute cap."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT EXTRACT(EPOCH FROM (expires_at - now())) "
+            "FROM pg_barrier_state WHERE execution_id = %s",
+            (execution_id,),
+        )
+        return float(cur.fetchone()[0])
+
+
+def _last_progress_age_seconds(conn, execution_id):
+    """How long ago (DB-side) the barrier last made progress — the reaper's stuck
+    signal (UN-3661). Small = fresh; large = stalled."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT EXTRACT(EPOCH FROM (now() - last_progress_at)) "
+            "FROM pg_barrier_state WHERE execution_id = %s",
+            (execution_id,),
+        )
+        return float(cur.fetchone()[0])
+
+
 class TestPgBarrierEnqueue:
     def test_upsert_creates_row_and_attaches_links(self, barrier_db):
         tasks = [_mock_header_task() for _ in range(3)]
@@ -514,6 +556,24 @@ class TestPgBarrierEnqueue:
             cloned.link.assert_called_once()
             cloned.link_error.assert_called_once()
             cloned.apply_async.assert_called_once()
+
+    def test_enqueue_sets_expires_cap_and_fresh_progress(
+        self, barrier_db, monkeypatch
+    ):
+        # enqueue stamps expires_at = now()+ttl (the absolute cap) AND
+        # last_progress_at = now() (fresh), so a just-enqueued barrier is neither
+        # expired nor stale. (UN-3661)
+        monkeypatch.setenv("WORKER_BARRIER_KEY_TTL_SECONDS", "600")
+        task, _ = _mock_header_task()
+        PgBarrier().enqueue(
+            [task],
+            callback_task_name="cb",
+            callback_kwargs={"execution_id": "exec-SD"},
+            callback_queue="general",
+            app_instance=None,
+        )
+        assert 590 <= _expires_in_seconds(barrier_db, "exec-SD") <= 600  # ~ttl cap
+        assert _last_progress_age_seconds(barrier_db, "exec-SD") < 5  # fresh
 
     def test_enqueue_self_heals_on_stale_connection(self, barrier_db, monkeypatch):
         # End-to-end through enqueue(): the first barrier write hits a dead cached
@@ -657,6 +717,26 @@ class TestDecrAndCheck:
         remaining, results = _row(barrier_db, "exec-P")
         assert remaining == 2
         assert results == [{"f": 1}]
+
+    def test_decrement_refreshes_last_progress_at(self, barrier_db):
+        # Each decrement re-stamps last_progress_at = now(), so a barrier that IS
+        # making progress never goes stale (the reaper only reaps a stalled one).
+        # Seed a STALE last_progress_at (as if about to be reaped) → decrement must
+        # refresh it. (UN-3661)
+        with barrier_db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO pg_barrier_state "
+                "(execution_id, organization_id, remaining, results, "
+                " created_at, expires_at, last_progress_at) "
+                "VALUES ('exec-SL', '', 2, '[]'::jsonb, "
+                " now() - interval '1 hour', now() + interval '5 hours', "
+                " now() - interval '1 hour')"
+            )
+        assert _last_progress_age_seconds(barrier_db, "exec-SL") > 3000  # ~1h stale
+        barrier_pg_decr_and_check(
+            {"f": 1}, execution_id="exec-SL", callback_descriptor=_CALLBACK
+        )
+        assert _last_progress_age_seconds(barrier_db, "exec-SL") < 5  # refreshed
 
     def test_idle_reaped_conn_self_heals_and_decrements_exactly_once(
         self, barrier_db, monkeypatch

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -546,6 +546,7 @@ class _FakeApiClient:
                 status=status,
                 error_message=error_message,
                 organization_id=organization_id,
+                cascade_terminal_files=kw.get("cascade_terminal_files", False),
             )
         )
         if self._fail_update or execution_id in self._fail_update_for:
@@ -700,6 +701,9 @@ class TestRecoverExpiredBarriers:
         assert call.status == "ERROR"
         assert call.organization_id == "org-1"
         assert "never completed" in call.error_message  # remaining>0
+        # Cascade the terminal status to the stranded execution's non-terminal
+        # files (the b11ba2f3 fix) — else execution=ERROR while files stay EXECUTING.
+        assert call.cascade_terminal_files is True
         assert _ids(barrier_conn) == ["fresh-1"]  # fresh barrier untouched
 
     def test_remaining_zero_uses_callback_stranded_message(self, barrier_conn):

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -517,12 +517,16 @@ class _FakeApiClient:
         fail_read=False,
         fail_update=False,
         fail_update_for=None,
+        update_success=True,
         on_get=None,
     ):
         self._status = status
         self._fail_read = fail_read
         self._fail_update = fail_update
         self._fail_update_for = set(fail_update_for or [])
+        # NON-raising failure: the real update client returns an APIResponse and can
+        # report success=False rather than raising (like the read path).
+        self._update_success = update_success
         self._on_get = on_get  # side-effect hook (e.g. re-arm the row mid-recovery)
         self.get_calls: list = []
         self.update_calls: list = []
@@ -551,7 +555,7 @@ class _FakeApiClient:
         )
         if self._fail_update or execution_id in self._fail_update_for:
             raise RuntimeError("api down")
-        return {"status": "updated"}
+        return SimpleNamespace(success=self._update_success)
 
 
 class TestRecoverConnection:
@@ -649,11 +653,22 @@ def barrier_conn():
     conn.close()
 
 
-def _seed(conn, execution_id, *, expired, organization_id="org-1", remaining=1):
+def _seed(
+    conn,
+    execution_id,
+    *,
+    expired,
+    organization_id="org-1",
+    remaining=1,
+    last_progress="now()",
+):
     # created_at must precede expires_at (CheckConstraint
     # pg_barrier_expires_after_created). Commit so the seed is durable like a
     # real barrier row (written by PgBarrier in another transaction) — and so the
     # manual-commit recovery's own commit is what persists the DELETE.
+    # ``expired`` sets the absolute expires_at cap past/future; ``last_progress`` is
+    # a raw SQL expr (default "now()" = fresh) so a test can seed a STALE
+    # last_progress_at to exercise the fast (per-progress) stuck path independently.
     created_sql, expires_sql = (
         ("now() - interval '2 hours'", "now() - interval '1 hour'")
         if expired
@@ -663,8 +678,9 @@ def _seed(conn, execution_id, *, expired, organization_id="org-1", remaining=1):
         cur.execute(
             "INSERT INTO pg_barrier_state "
             "(execution_id, organization_id, remaining, results, "
-            " created_at, expires_at) "
-            f"VALUES (%s, %s, %s, '[]'::jsonb, {created_sql}, {expires_sql})",
+            " created_at, expires_at, last_progress_at) "
+            f"VALUES (%s, %s, %s, '[]'::jsonb, {created_sql}, {expires_sql}, "
+            f"{last_progress})",
             (execution_id, organization_id, remaining),
         )
     conn.commit()
@@ -792,6 +808,50 @@ class TestRecoverExpiredBarriers:
         assert api.update_calls == []  # the live re-run was NOT marked ERROR
         assert _ids(barrier_conn) == ["exp-rearm"]  # re-armed row left intact
 
+    def test_reaps_stale_last_progress_while_expires_at_future(self, barrier_conn):
+        # THE headline path (UN-3661): a barrier is reaped via a stale
+        # last_progress_at even though its absolute expires_at cap is still 6h in
+        # the FUTURE (a crash mid-run → no 6h wait). And a *progressing* barrier
+        # (fresh last_progress_at, same future cap) is NOT reaped — proving the
+        # last_progress_at clause is load-bearing, not just the expires_at clause.
+        _seed(
+            barrier_conn,
+            "stale-lp",
+            expired=False,  # expires_at = now()+6h (future)
+            remaining=2,
+            last_progress="now() - interval '1 hour'",  # > 120s stuck window
+        )
+        _seed(barrier_conn, "fresh-lp", expired=False, last_progress="now()")
+        api = _FakeApiClient(status="EXECUTING")
+        recovered = recover_expired_barriers(barrier_conn, api, 120)  # stuck=120s
+        assert recovered == ["stale-lp"]
+        (call,) = api.update_calls
+        assert call.execution_id == "stale-lp" and call.status == "ERROR"
+        assert call.cascade_terminal_files is True
+        assert _ids(barrier_conn) == ["fresh-lp"]  # progressing barrier untouched
+
+    def test_progress_refresh_mid_recovery_aborts_the_mark(self, barrier_conn):
+        # The re-arm race for the fast path: a decrement refreshes last_progress_at
+        # to now() between the sweep SELECT and the mark → the barrier is no longer
+        # stranded and the reaper must NOT mark its live run ERROR (mirrors the
+        # expires_at re-arm test, but via last_progress_at).
+        _seed(barrier_conn, "lp-rearm", expired=False, last_progress="now() - interval '1 hour'")
+
+        def refresh(execution_id):
+            with barrier_conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE pg_barrier_state SET last_progress_at = now() "
+                    "WHERE execution_id = %s",
+                    (execution_id,),
+                )
+            barrier_conn.commit()
+
+        api = _FakeApiClient(status="EXECUTING", on_get=refresh)
+        recovered = recover_expired_barriers(barrier_conn, api, 120)
+        assert recovered == []  # progress refreshed → not stranded
+        assert api.update_calls == []  # live run NOT marked ERROR
+        assert _ids(barrier_conn) == ["lp-rearm"]  # row left for the new run
+
     def test_status_none_on_success_does_not_mark(self, barrier_conn):
         # A successful read with no status is anomalous — don't mark on it.
         _seed(barrier_conn, "exp-nostatus", expired=True)
@@ -800,6 +860,19 @@ class TestRecoverExpiredBarriers:
         assert recovered == []
         assert api.update_calls == []
         assert _ids(barrier_conn) == ["exp-nostatus"]  # left for next sweep
+
+    def test_unsuccessful_status_write_does_not_delete_recovery_handle(
+        self, barrier_conn
+    ):
+        # Defensive (mirrors the read path): if the status-update client ever
+        # reports success=False WITHOUT raising, the reaper must NOT proceed to
+        # DELETE the barrier row — that would erase the only recovery handle while
+        # the execution stays non-terminal forever.
+        _seed(barrier_conn, "exp-unsuccess", expired=True)
+        api = _FakeApiClient(status="EXECUTING", update_success=False)
+        recovered = recover_expired_barriers(barrier_conn, api)
+        assert recovered == []  # the RuntimeError → row left for the next sweep
+        assert _ids(barrier_conn) == ["exp-unsuccess"]  # recovery handle preserved
 
     def test_all_skipped_sweep_does_not_log_systemic_error(self, barrier_conn, caplog):
         # org-missing rows are benign skips, not failures — they must NOT trigger


### PR DESCRIPTION
## Problem

The PG reaper only recovered a stranded execution at the **~6h barrier expiry**, and marked the `workflow_execution` ERROR **without touching its file executions**. So a worker that crashed mid-batch (SIGKILL / OOM / eviction) left the execution stuck `EXECUTING` for ~6h, then flipped to ERROR while its files stayed `EXECUTING` — the exec-b11ba2f3 UI inconsistency (execution ERROR, files "Pipeline completed… EXECUTING").

This closes the crash/stuck-recovery gap and brings PG to parity with Celery, whose per-task `FILE_PROCESSING_TASK_TIME_LIMIT` (2.5h) already fails a stuck task fast.

## Part 1 — fast, progress-based detection

- Add `pg_barrier_state.last_progress_at` (**unindexed**), re-stamped to `now()` on enqueue and on every decrement.
  - Unindexed on purpose: the decrement writes it every batch-completion, so indexing it would break the decrement's heap-only-tuple (HOT) update. Unindexed → **no index churn on the hot path**; the reaper seq-scans this tiny (in-flight-only) table cheaply, and it's directly queryable ("when did this barrier last progress?").
- The reaper marks a barrier stranded once `last_progress_at` is older than `WORKER_PG_BATCH_STUCK_TIMEOUT_SECONDS` (default **9000** = 2.5h, matching Celery's file-processing limit) **OR** it passes the fixed 6h `expires_at` cap (last-resort backstop). One shared `_STRANDED_PREDICATE` drives the SELECT, the pre-mark re-check, and the cleanup DELETE.
- A **per-progress** window is invariant to `MAX_PARALLEL_FILE_BATCHES` (a dynamic per-org config), so it **never false-fails a legitimately long multi-batch run** — any completed batch refreshes the deadline; only a genuinely stalled one is reaped.

## Part 2 — atomic file-execution cascade

- The internal `update_status` endpoint gains a `cascade_terminal_files` flag: when set **and** the new status is terminal, it also marks the execution's non-terminal (PENDING/EXECUTING) file executions to the same terminal status **in the same transaction** — so execution + files can't diverge. Terminal files (COMPLETED/ERROR/STOPPED) are left untouched; idempotent.
- The reaper passes the flag on recovery, so a recovered strand's execution and its files reach a consistent terminal state.

Chose the atomic backend endpoint (one transaction, one round trip) over a reaper-side multi-call cascade — better for long-term maintainability, performance under mass-strand recovery, and it has no partial-state window.

## Tests

- **Worker (227 pass):** barrier enqueue/decrement stamp `last_progress_at`; reaper OR-detection (stalled reaped, progressing untouched, all existing recovery guards intact) + cascade flag asserted.
- **Backend:** `test_cascade_terminal_files.py` — non-terminal → terminal, terminal untouched, idempotent.
- **Dev-tested E2E:** reaper detection against **real Postgres** (a stalled barrier reaped, a *progressing* one untouched, marked ERROR + `cascade_terminal_files=True`); the cascade against the **real DB** (2 non-terminal files → ERROR, COMPLETED untouched).

## Notes

- Migration `0011` adds the column (no index — deliberate). PG barrier is not yet on staging, so this is additive.
- No behaviour change on the Celery/chord path; the barrier's fixed 6h `expires_at` backstop is preserved.