### PR TITLE
[MISC] Add 'auto' version bump to OSS create-release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       version_bump:
-        description: "Version bump type (hotfix branches force 'patch')"
+        description: "Version bump ('auto' = minor if a FEAT/GATED-FEAT PR merged since the last release, else patch; hotfix branches force 'patch')"
         required: true
-        default: "patch"
+        default: "auto"
         type: choice
         options:
+          - auto
           - patch
           - minor
           - major
@@ -82,7 +83,9 @@ jobs:
         env:
           BUMP: ${{ github.event.inputs.version_bump }}
         run: |
-          if [[ "$BUMP" != "patch" ]]; then
+          # 'auto' is allowed here — the "Resolve auto bump" step maps it to 'patch'
+          # on a hotfix line (hotfixes are patch-only by definition).
+          if [[ "$BUMP" != "patch" && "$BUMP" != "auto" ]]; then
             echo "::error::Hotfix branches only support 'patch' bumps. Got: '$BUMP'"
             exit 1
           fi
@@ -158,11 +161,58 @@ jobs:
             echo "✅ $AHEAD new commit(s) on '$BRANCH' since $LATEST_TAG"
           fi
 
+      - name: Resolve auto bump
+        id: resolve-bump
+        if: github.event.inputs.version_bump == 'auto'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: ${{ steps.branch-mode.outputs.mode }}
+          LATEST_TAG: ${{ steps.get-latest.outputs.latest_tag }}
+        run: |
+          # 'auto' only chooses minor-vs-patch on main; hotfix lines are patch-only.
+          if [[ "$MODE" != "main" ]]; then
+            echo "resolved=patch" >> "$GITHUB_OUTPUT"
+            echo "::notice::auto bump on hotfix line -> patch"
+            exit 0
+          fi
+
+          # Classify PRs merged into main after the base release was published:
+          # any [FEAT]/[GATED-FEAT] title (the only feature PR types in the
+          # contribution guide) => minor, otherwise patch. Fail-safe is always
+          # patch so a query hiccup never over-bumps the public version.
+          SINCE=$(gh api "repos/${{ github.repository }}/releases/tags/$LATEST_TAG" --jq '.published_at' 2>/dev/null || echo "")
+          if [[ -z "$SINCE" ]]; then
+            echo "::warning::Could not resolve publish time for $LATEST_TAG; defaulting to patch."
+            echo "resolved=patch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FEAT_COUNT=$(gh pr list --repo "${{ github.repository }}" \
+            --base main --state merged --limit 200 --search "merged:>$SINCE" \
+            --json title \
+            --jq '[.[] | select(.title | test("\\[(FEAT|GATED-FEAT)\\]"; "i"))] | length' 2>/dev/null || echo "")
+
+          if [[ -z "$FEAT_COUNT" ]]; then
+            echo "::warning::PR classification query failed; defaulting to patch."
+            RESOLVED=patch
+          elif [[ "$FEAT_COUNT" -gt 0 ]]; then
+            RESOLVED=minor
+          else
+            RESOLVED=patch
+          fi
+
+          echo "resolved=$RESOLVED" >> "$GITHUB_OUTPUT"
+          if [[ "$RESOLVED" == "minor" ]]; then
+            echo "::notice::auto bump: $FEAT_COUNT FEAT/GATED-FEAT PR(s) merged since $LATEST_TAG -> minor"
+          else
+            echo "::notice::auto bump: no FEAT/GATED-FEAT PR merged since $LATEST_TAG -> patch. Re-run with version_bump=minor to override."
+          fi
+
       - name: Compute next version
         id: compute-version
         env:
           LATEST_TAG: ${{ steps.get-latest.outputs.latest_tag }}
-          BUMP_TYPE: ${{ github.event.inputs.version_bump }}
+          BUMP_TYPE: ${{ github.event.inputs.version_bump == 'auto' && steps.resolve-bump.outputs.resolved || github.event.inputs.version_bump }}
         run: |
           VERSION="${LATEST_TAG#v}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
@@ -225,9 +275,12 @@ jobs:
           LATEST_TAG: ${{ steps.get-latest.outputs.latest_tag }}
           NEW_TAG: ${{ steps.compute-version.outputs.new_tag }}
           BUMP: ${{ github.event.inputs.version_bump }}
+          RESOLVED: ${{ steps.resolve-bump.outputs.resolved }}
           PRERELEASE: ${{ github.event.inputs.pre_release }}
           MODE: ${{ steps.branch-mode.outputs.mode }}
         run: |
+          BUMP_DISPLAY="$BUMP"
+          [[ "$BUMP" == "auto" ]] && BUMP_DISPLAY="auto -> ${RESOLVED}"
           {
             echo "## Dry Run Summary"
             echo ""
@@ -235,7 +288,7 @@ jobs:
             echo "|-------|-------|"
             echo "| Mode | $MODE |"
             echo "| Current version | $LATEST_TAG |"
-            echo "| Bump type | $BUMP |"
+            echo "| Bump type | $BUMP_DISPLAY |"
             echo "| Next version | $NEW_TAG |"
             echo "| Pre-release | $PRERELEASE |"
             echo ""
@@ -324,9 +377,12 @@ jobs:
           LATEST_TAG: ${{ steps.get-latest.outputs.latest_tag }}
           NEW_TAG: ${{ steps.compute-version.outputs.new_tag }}
           BUMP: ${{ github.event.inputs.version_bump }}
+          RESOLVED: ${{ steps.resolve-bump.outputs.resolved }}
           PRERELEASE: ${{ github.event.inputs.pre_release }}
           MODE: ${{ steps.branch-mode.outputs.mode }}
         run: |
+          BUMP_DISPLAY="$BUMP"
+          [[ "$BUMP" == "auto" ]] && BUMP_DISPLAY="auto -> ${RESOLVED}"
           {
             echo "## Release Created"
             echo ""
@@ -335,7 +391,7 @@ jobs:
             echo "| Mode | $MODE |"
             echo "| Previous version | $LATEST_TAG |"
             echo "| New version | $NEW_TAG |"
-            echo "| Bump type | $BUMP |"
+            echo "| Bump type | $BUMP_DISPLAY |"
             echo "| Pre-release | $PRERELEASE |"
             echo "| Triggered by | ${{ github.actor }} |"
             echo ""

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -41,9 +41,9 @@ jobs:
     permissions:
       contents: write
       # 'auto' version_bump classifies merged PR titles via `gh pr list`, which
-      # needs read access to pull requests (the permissions block above sets every
-      # unlisted scope to 'none', so this must be explicit or the query 403s and
-      # 'auto' would silently fall back to patch every time).
+      # needs read access to pull requests. Declaring an explicit permissions
+      # block sets every unlisted scope to 'none', so without this the query 403s
+      # and 'auto' falls back to patch (with a warning) on every run.
       pull-requests: read
     defaults:
       run:
@@ -183,36 +183,43 @@ jobs:
 
           # Classify PRs merged into main after the base release was published:
           # any [FEAT]/[GATED-FEAT] title (the only feature PR types in the
-          # contribution guide) => minor, otherwise patch. Fail-safe is always
-          # patch so a query hiccup never over-bumps the public version.
-          SINCE=$(gh api "repos/${{ github.repository }}/releases/tags/$LATEST_TAG" --jq '.published_at' 2>/dev/null || echo "")
+          # contribution guide) => minor, otherwise patch. Every failure below
+          # degrades to patch — never over-bump the public version, and never
+          # hard-fail the release on a transient query hiccup. '// empty' keeps a
+          # JSON null from leaking through as the literal "null" (matches the
+          # get-latest step's convention).
+          SINCE=$(gh api "repos/${{ github.repository }}/releases/tags/$LATEST_TAG" --jq '.published_at // empty' 2>/tmp/gh_since.err || echo "")
           if [[ -z "$SINCE" ]]; then
             echo "::warning::Could not resolve publish time for $LATEST_TAG; defaulting to patch."
+            cat /tmp/gh_since.err >&2 || true
             echo "resolved=patch" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           LIMIT=200
-          PR_JSON=$(gh pr list --repo "${{ github.repository }}" \
-            --base main --state merged --limit "$LIMIT" --search "merged:>$SINCE" \
-            --json title 2>/dev/null || echo "")
-
-          if [[ -z "$PR_JSON" ]]; then
-            # Empty only on command failure; a no-PR result is the JSON literal "[]".
+          if ! PR_JSON=$(gh pr list --repo "${{ github.repository }}" \
+              --base main --state merged --limit "$LIMIT" --search "merged:>$SINCE" \
+              --json title 2>/tmp/gh_pr.err); then
             echo "::warning::PR classification query failed; defaulting to patch."
+            cat /tmp/gh_pr.err >&2 || true   # surface 403/permission vs rate-limit/5xx
             RESOLVED=patch
           else
-            TOTAL=$(echo "$PR_JSON" | jq 'length')
-            FEAT_COUNT=$(echo "$PR_JSON" | jq '[.[] | select(.title | test("\\[(FEAT|GATED-FEAT)\\]"; "i"))] | length')
-            # Surface truncation rather than silently under-counting: if we hit the cap,
-            # a FEAT PR beyond it could be missed (biasing toward patch).
-            if [[ "$TOTAL" -ge "$LIMIT" ]]; then
-              echo "::warning::merged-PR query hit the $LIMIT-result cap since $SINCE; FEAT detection may under-count — double-check the bump (override with version_bump=minor if needed)."
-            fi
-            if [[ "$FEAT_COUNT" -gt 0 ]]; then
+            # Parse defensively: malformed/non-array stdout must degrade to patch,
+            # not crash the job under `set -e`/pipefail.
+            TOTAL=$(jq 'length' <<<"$PR_JSON" 2>/dev/null) || TOTAL=""
+            FEAT_COUNT=$(jq '[.[] | select(.title | test("\\[(FEAT|GATED-FEAT)\\]"; "i"))] | length' <<<"$PR_JSON" 2>/dev/null) || FEAT_COUNT=""
+            if ! [[ "$TOTAL" =~ ^[0-9]+$ && "$FEAT_COUNT" =~ ^[0-9]+$ ]]; then
+              echo "::warning::PR classification returned unparseable output; defaulting to patch."
+              RESOLVED=patch
+            elif [[ "$FEAT_COUNT" -gt 0 ]]; then
               RESOLVED=minor
             else
               RESOLVED=patch
+              # Truncation only changes the outcome when no FEAT was found within
+              # the cap, so only warn in that case (a FEAT beyond it could be missed).
+              if [[ "$TOTAL" -ge "$LIMIT" ]]; then
+                echo "::warning::merged-PR query hit the $LIMIT-result cap since $SINCE; a FEAT PR beyond it may be missed — double-check the bump (override with version_bump=minor if needed)."
+              fi
             fi
           fi
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -40,6 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # 'auto' version_bump classifies merged PR titles via `gh pr list`, which
+      # needs read access to pull requests (the permissions block above sets every
+      # unlisted scope to 'none', so this must be explicit or the query 403s and
+      # 'auto' would silently fall back to patch every time).
+      pull-requests: read
     defaults:
       run:
         shell: bash -euo pipefail {0}
@@ -187,18 +192,28 @@ jobs:
             exit 0
           fi
 
-          FEAT_COUNT=$(gh pr list --repo "${{ github.repository }}" \
-            --base main --state merged --limit 200 --search "merged:>$SINCE" \
-            --json title \
-            --jq '[.[] | select(.title | test("\\[(FEAT|GATED-FEAT)\\]"; "i"))] | length' 2>/dev/null || echo "")
+          LIMIT=200
+          PR_JSON=$(gh pr list --repo "${{ github.repository }}" \
+            --base main --state merged --limit "$LIMIT" --search "merged:>$SINCE" \
+            --json title 2>/dev/null || echo "")
 
-          if [[ -z "$FEAT_COUNT" ]]; then
+          if [[ -z "$PR_JSON" ]]; then
+            # Empty only on command failure; a no-PR result is the JSON literal "[]".
             echo "::warning::PR classification query failed; defaulting to patch."
             RESOLVED=patch
-          elif [[ "$FEAT_COUNT" -gt 0 ]]; then
-            RESOLVED=minor
           else
-            RESOLVED=patch
+            TOTAL=$(echo "$PR_JSON" | jq 'length')
+            FEAT_COUNT=$(echo "$PR_JSON" | jq '[.[] | select(.title | test("\\[(FEAT|GATED-FEAT)\\]"; "i"))] | length')
+            # Surface truncation rather than silently under-counting: if we hit the cap,
+            # a FEAT PR beyond it could be missed (biasing toward patch).
+            if [[ "$TOTAL" -ge "$LIMIT" ]]; then
+              echo "::warning::merged-PR query hit the $LIMIT-result cap since $SINCE; FEAT detection may under-count — double-check the bump (override with version_bump=minor if needed)."
+            fi
+            if [[ "$FEAT_COUNT" -gt 0 ]]; then
+              RESOLVED=minor
+            else
+              RESOLVED=patch
+            fi
           fi
 
           echo "resolved=$RESOLVED" >> "$GITHUB_OUTPUT"
@@ -212,7 +227,10 @@ jobs:
         id: compute-version
         env:
           LATEST_TAG: ${{ steps.get-latest.outputs.latest_tag }}
-          BUMP_TYPE: ${{ github.event.inputs.version_bump == 'auto' && steps.resolve-bump.outputs.resolved || github.event.inputs.version_bump }}
+          # Non-auto: use the raw input. Auto: use the resolved value, falling back
+          # to 'patch' (never back to 'auto', which would hit compute-version's
+          # unknown-bump error).
+          BUMP_TYPE: ${{ github.event.inputs.version_bump != 'auto' && github.event.inputs.version_bump || steps.resolve-bump.outputs.resolved || 'patch' }}
         run: |
           VERSION="${LATEST_TAG#v}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)


### PR DESCRIPTION
## What

Adds an **`auto`** choice (now the default) to `version_bump` in `create-release.yaml`. When `auto` is selected, the workflow derives the OSS bump from merged PR titles:

- a **`[FEAT]`** or **`[GATED-FEAT]`** PR merged since the last release → **minor**
- otherwise → **patch**

These are the only feature PR types in the Contribution Guidelines, so this matches the documented SemVer intent with no new labeling discipline.

## Why

Cutting an OSS release currently requires a human to pick `patch`/`minor` every time — an easy thing to get wrong (a feature shipped as a patch drifts the public version). This is also a prerequisite for making the enterprise RC build trigger OSS releases hands-free: the RC workflow can dispatch `version_bump=auto` instead of guessing.

## How

- New **`Resolve auto bump`** step (runs only when `version_bump == 'auto'`), placed after the existing `Ensure there are new commits` no-op guard:
  - main mode only — hotfix lines are patch-only, so `auto` maps to `patch` there.
  - counts `[FEAT]`/`[GATED-FEAT]` PRs merged into `main` after the base release's `published_at`.
  - **fail-safe is always `patch`** — a compare/PR-list query hiccup never over-bumps the public version.
  - emits a `::notice` with the decision, including a "re-run with `version_bump=minor` to override" hint when it lands on patch.
- Hotfix-mode input validation now accepts `auto` (maps to `patch`).
- `compute-version` consumes the resolved bump via a passthrough expression (`auto` → resolved, otherwise the raw input).
- Dry-run and final summaries render `auto -> minor/patch` for an explicit audit trail.
- `auto` never selects `major` — that stays behind the `confirm_major` gate.

## Can this PR break any existing features?

Low risk. `patch`/`minor`/`major` behave exactly as before (the resolve step is gated on `auto` and the passthrough expression falls through for non-auto). Only the **default** changes from `patch` to `auto`. Worst case for `auto` is a query failure, which deterministically falls back to `patch` — the pre-existing behavior — and is still overridable by selecting a bump explicitly.

## Notes on Testing

- YAML validated; the exact `gh`/`jq` commands in the resolve step were run against the live repo and return the expected result (`v0.177.6` → `patch`, 0 FEAT PRs since).
- Classifier replayed over the last 13 real releases: **12/13 matched** the human bump. The single divergence was a discretionary minor (`v0.176.5 → v0.177.0`) with **zero** `FEAT`/`GATED-FEAT` PRs across the whole `0.176.x` line — i.e. a bump not driven by the convention, recoverable via the manual `minor` override the notice points to.
- Recommend a **`dry_run=true`** dispatch after merge to eyeball the resolved bump before a real release.

## Related Issues or PRs

Enables defaulting the enterprise RC build's OSS-release trigger to `auto` (follow-up in `unstract-cloud`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)