### PR TITLE
UN-3662 [FIX] PG queue — skip stale/redelivered batch for a reaper-recovered (terminal) execution

### DIFF
--- a/workers/file_processing/tasks.py
+++ b/workers/file_processing/tasks.py
@@ -12,7 +12,10 @@ from typing import Any
 
 from queue_backend import worker_task
 from queue_backend.barrier import BarrierContext
-from queue_backend.pg_barrier import run_batch_with_barrier
+from queue_backend.pg_barrier import (
+    SKIPPED_TERMINAL_EXECUTION_KEY,
+    run_batch_with_barrier,
+)
 
 # Import shared worker infrastructure
 from shared.api import InternalAPIClient
@@ -267,16 +270,24 @@ def _raise_if_execution_terminal(
 
 
 def _terminal_skip_result(batch_data: FileBatchData) -> dict[str, Any]:
-    """Benign zero-work batch result for a batch skipped because its execution
-    is already terminal (UN-3662) — no files processed, all counts zero.
+    """Batch result for a batch skipped because its execution is already terminal
+    (UN-3662). The files were never attempted; per the accounting contract from
+    68d137a8 (unaccounted files count as failed, not in-progress) they are
+    reported as failed, so a consumer that ever aggregates this result does not
+    render them as perpetually in-progress. The ``SKIPPED_TERMINAL_EXECUTION_KEY``
+    marker tells ``run_batch_with_barrier`` to bypass the barrier decrement (the
+    reaper has by definition already torn the barrier down).
     """
-    return BatchExecutionResult(
-        total_files=len(batch_data.files),
+    n_files = len(batch_data.files)
+    result = BatchExecutionResult(
+        total_files=n_files,
         successful_files=0,
-        failed_files=0,
+        failed_files=n_files,
         execution_time=0.0,
         organization_id=batch_data.file_data.organization_id,
     ).to_dict()
+    result[SKIPPED_TERMINAL_EXECUTION_KEY] = True
+    return result
 
 
 def _run_batch_stages(

--- a/workers/file_processing/tasks.py
+++ b/workers/file_processing/tasks.py
@@ -224,8 +224,63 @@ def _enhance_batch_with_mrq_flags(
         )
 
 
+class _TerminalExecutionSkip(Exception):
+    """A batch was delivered for an execution already in a terminal state.
+
+    Raised by :func:`_setup_execution_context` when the execution's status is
+    COMPLETED/ERROR/STOPPED. On the PG queue (at-least-once), a batch can be
+    redelivered — or a stale batch consumed — *after* the reaper has recovered
+    the execution (marked it ERROR) and deleted its barrier. Reprocessing would
+    resurrect the execution back to EXECUTING and re-run its files (double LLM /
+    destination write). The batch is skipped instead (UN-3662).
+
+    The guard is gated to the PG path (``is_pg``) so the Celery flow is
+    byte-for-byte unchanged — the resurrection it prevents is PG-specific
+    (Celery lost tasks are never redelivered, so they can't be resurrected).
+    """
+
+    def __init__(self, execution_id: str, status: str | None) -> None:
+        self.execution_id = execution_id
+        self.status = status
+        super().__init__(
+            f"Execution {execution_id} already terminal ({status}); "
+            f"skipping stale/redelivered batch"
+        )
+
+
+def _raise_if_execution_terminal(
+    workflow_execution: dict[str, Any], execution_id: str, *, is_pg: bool
+) -> None:
+    """PG-path-only validate-first guard: refuse to (re)process a batch whose
+    execution is already terminal. See :class:`_TerminalExecutionSkip`.
+
+    No-op on the Celery path (``is_pg=False``) — the resurrection this prevents
+    is PG-specific, so gating keeps the Celery flow byte-for-byte unchanged
+    (UN-3662). A missing/unknown status is treated as non-terminal (fail open —
+    proceed as normal).
+    """
+    if not is_pg:
+        return
+    status = workflow_execution.get("status")
+    if status in ExecutionStatus.terminal_values():
+        raise _TerminalExecutionSkip(execution_id, status)
+
+
+def _terminal_skip_result(batch_data: FileBatchData) -> dict[str, Any]:
+    """Benign zero-work batch result for a batch skipped because its execution
+    is already terminal (UN-3662) — no files processed, all counts zero.
+    """
+    return BatchExecutionResult(
+        total_files=len(batch_data.files),
+        successful_files=0,
+        failed_files=0,
+        execution_time=0.0,
+        organization_id=batch_data.file_data.organization_id,
+    ).to_dict()
+
+
 def _run_batch_stages(
-    file_batch_data: dict[str, Any], celery_task_id: str
+    file_batch_data: dict[str, Any], celery_task_id: str, is_pg: bool = False
 ) -> dict[str, Any]:
     """The actual batch work (validate → setup → pre-create → process → compile).
 
@@ -237,8 +292,21 @@ def _run_batch_stages(
     # Step 1: Validate and parse input data
     batch_data = _validate_and_parse_batch_data(file_batch_data)
 
-    # Step 2: Setup execution context
-    context = _setup_execution_context(batch_data, celery_task_id)
+    # Step 2: Setup execution context. Validate-first (PG path only): a batch
+    # delivered for an already-terminal execution is a stale/redelivered task
+    # arriving after the reaper recovered the execution — skip it rather than
+    # resurrect the execution and re-run its files (UN-3662). The guard is gated
+    # inside _setup_execution_context via is_pg, so on Celery this never fires.
+    try:
+        context = _setup_execution_context(batch_data, celery_task_id, is_pg=is_pg)
+    except _TerminalExecutionSkip as skip:
+        logger.warning(
+            f"[exec:{skip.execution_id}] Skipping batch of "
+            f"{len(batch_data.files)} file(s): execution already terminal "
+            f"({skip.status}) — stale/redelivered after reaper-recovery; not "
+            f"reprocessing (UN-3662)."
+        )
+        return _terminal_skip_result(batch_data)
 
     # Step 3: Handle manual review logic
     # context = _handle_manual_review_logic(context)
@@ -281,13 +349,16 @@ def _process_file_batch_core(
 
     if barrier_context is None:
         # Celery chord path — the chord's .link runs the decrement after this.
-        return _run_batch_stages(file_batch_data, celery_task_id)
+        # is_pg=False disables the UN-3662 terminal guard → Celery flow unchanged.
+        return _run_batch_stages(file_batch_data, celery_task_id, is_pg=False)
 
     # PG fire-and-forget path — claim the batch (idempotent on redelivery), run
     # the stages, then decrement the barrier in-body / self-chain the callback.
+    # is_pg=True enables the UN-3662 terminal guard (skip stale/redelivered
+    # batches for a reaper-recovered execution).
     return run_batch_with_barrier(
         barrier_context,
-        lambda: _run_batch_stages(file_batch_data, celery_task_id),
+        lambda: _run_batch_stages(file_batch_data, celery_task_id, is_pg=True),
     )
 
 
@@ -359,7 +430,7 @@ def _validate_and_parse_batch_data(file_batch_data: dict[str, Any]) -> FileBatch
 
 
 def _setup_execution_context(
-    batch_data: FileBatchData, celery_task_id: str
+    batch_data: FileBatchData, celery_task_id: str, is_pg: bool = False
 ) -> WorkflowContextData:
     """Setup execution context with validation and API client initialization.
 
@@ -410,6 +481,14 @@ def _setup_execution_context(
         raise Exception(f"Failed to get execution context: {execution_response.error}")
     execution_context = execution_response.data
     workflow_execution = execution_context.get("execution", {})
+
+    # UN-3662: validate-first terminal guard (PG path only, gated by is_pg). If
+    # the execution is already terminal (COMPLETED/ERROR/STOPPED), this batch is
+    # a stale/redelivered task arriving after the reaper recovered the execution
+    # — reprocessing would resurrect it to EXECUTING and re-run its files. Skip
+    # before we touch status or process anything. On Celery (is_pg=False) this is
+    # a no-op, so the existing Celery flow is unchanged.
+    _raise_if_execution_terminal(workflow_execution, execution_id, is_pg=is_pg)
 
     # Set LOG_EVENTS_ID in StateStore for WebSocket messaging (critical for UI logs)
     # This enables the WorkerWorkflowLogger to send logs to the UI via WebSocket

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -1037,6 +1037,14 @@ def _abort_barrier_in_body(execution_id: str, *, reason: str) -> None:
         )
 
 
+# A batch whose execution is already terminal (UN-3662) returns its result with
+# this marker set. run_batch_with_barrier bypasses the barrier decrement for it:
+# the reaper has by definition already torn the barrier down, so decrementing
+# would only log a spurious "decrement found no row" ERROR (false alert noise),
+# and an already-terminal execution must not have its aggregating callback fired.
+SKIPPED_TERMINAL_EXECUTION_KEY = "skipped_terminal_execution"
+
+
 def run_batch_with_barrier(
     barrier_context: BarrierContext, work_fn: Callable[[], dict[str, Any]]
 ) -> dict[str, Any]:
@@ -1103,6 +1111,18 @@ def run_batch_with_barrier(
     # redelivery is blocked, and the barrier strands to expiry.
     try:
         result = work_fn()
+        if result.get(SKIPPED_TERMINAL_EXECUTION_KEY):
+            # UN-3662: the batch's execution is already terminal, so the reaper
+            # has by definition already torn the barrier down. Bypass the
+            # decrement — decrementing a gone barrier only logs a spurious
+            # "decrement found no row" ERROR (false alert noise) — and do NOT
+            # abort (nothing to tear down; and an already-terminal execution
+            # must not have its aggregating callback re-fired).
+            logger.info(
+                f"[exec:{execution_id}] batch {batch_index} skipped — execution "
+                f"already terminal; barrier decrement bypassed (UN-3662)."
+            )
+            return result
         _barrier_pg_decrement(
             result,
             execution_id=execution_id,

--- a/workers/tests/test_chord_callback_boundary.py
+++ b/workers/tests/test_chord_callback_boundary.py
@@ -776,7 +776,13 @@ class TestProcessFileBatchTransportRouting:
     def test_celery_path_runs_stages_directly(self, monkeypatch):
         from file_processing import tasks as tasks_mod
 
-        monkeypatch.setattr(tasks_mod, "_run_batch_stages", lambda *a: {"r": "celery"})
+        stages_kwargs = {}
+
+        def fake_stages(*a, **k):
+            stages_kwargs.update(k)
+            return {"r": "celery"}
+
+        monkeypatch.setattr(tasks_mod, "_run_batch_stages", fake_stages)
         barrier_calls = []
         monkeypatch.setattr(
             tasks_mod,
@@ -786,11 +792,18 @@ class TestProcessFileBatchTransportRouting:
         out = tasks_mod._process_file_batch_core(MagicMock(), {"fb": 1}, None)
         assert out == {"r": "celery"}
         assert barrier_calls == []  # barrier path NOT taken on the celery transport
+        assert stages_kwargs.get("is_pg") is False  # UN-3662 guard OFF on Celery
 
     def test_pg_path_routes_through_barrier(self, monkeypatch):
         from file_processing import tasks as tasks_mod
 
-        monkeypatch.setattr(tasks_mod, "_run_batch_stages", lambda *a: {"r": "work"})
+        stages_kwargs = {}
+
+        def fake_stages(*a, **k):
+            stages_kwargs.update(k)
+            return {"r": "work"}
+
+        monkeypatch.setattr(tasks_mod, "_run_batch_stages", fake_stages)
         captured = {}
 
         def fake_run_batch_with_barrier(ctx, work_fn):
@@ -805,6 +818,7 @@ class TestProcessFileBatchTransportRouting:
         assert captured["ctx"] is ctx
         assert out["via"] == "barrier"
         assert out["work"] == {"r": "work"}  # work_fn runs the real stages
+        assert stages_kwargs.get("is_pg") is True  # UN-3662 guard ON on PG
 
 
 if __name__ == "__main__":

--- a/workers/tests/test_terminal_execution_guard.py
+++ b/workers/tests/test_terminal_execution_guard.py
@@ -1,0 +1,123 @@
+"""UN-3662: validate-first terminal guard on the file-processing batch path.
+
+A batch delivered for an execution that is already terminal (COMPLETED/ERROR/
+STOPPED) must be skipped, not reprocessed — otherwise a stale/redelivered batch
+arriving after the reaper recovered the execution resurrects it to EXECUTING and
+re-runs its files (double LLM / destination write). These tests pin:
+  * the guard fires for terminal statuses and passes for active/unknown ones,
+  * a terminal batch is skipped WITHOUT pre-create / processing,
+  * the skip result is a benign zero-work batch result.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from unstract.core.data_models import ExecutionStatus
+
+from file_processing.tasks import (
+    _raise_if_execution_terminal,
+    _run_batch_stages,
+    _terminal_skip_result,
+    _TerminalExecutionSkip,
+)
+
+TERMINAL = [
+    ExecutionStatus.COMPLETED.value,
+    ExecutionStatus.ERROR.value,
+    ExecutionStatus.STOPPED.value,
+]
+ACTIVE = [ExecutionStatus.PENDING.value, ExecutionStatus.EXECUTING.value]
+
+
+@pytest.mark.parametrize("status", TERMINAL)
+def test_guard_raises_for_terminal_on_pg(status):
+    with pytest.raises(_TerminalExecutionSkip) as exc:
+        _raise_if_execution_terminal({"status": status}, "exec-1", is_pg=True)
+    assert exc.value.execution_id == "exec-1"
+    assert exc.value.status == status
+
+
+@pytest.mark.parametrize("status", [*ACTIVE, None, ""])
+def test_guard_passes_for_active_or_unknown_on_pg(status):
+    # Must NOT raise for PENDING/EXECUTING (or a missing status → fail open).
+    _raise_if_execution_terminal({"status": status}, "exec-1", is_pg=True)
+
+
+@pytest.mark.parametrize("status", TERMINAL)
+def test_guard_is_noop_on_celery_path(status):
+    # is_pg=False (Celery) → NEVER raises, even for terminal statuses. This is
+    # what keeps the Celery flow byte-for-byte unchanged (UN-3662).
+    _raise_if_execution_terminal({"status": status}, "exec-1", is_pg=False)
+
+
+def _fake_batch_data(n_files: int = 3, org: str = "org-1"):
+    """A FileBatchData stand-in: real list for len(), mock file_data for org."""
+    file_data = mock.Mock()
+    file_data.organization_id = org
+    return mock.Mock(files=[mock.Mock() for _ in range(n_files)], file_data=file_data)
+
+
+def test_terminal_skip_result_is_zero_work():
+    result = _terminal_skip_result(_fake_batch_data(n_files=4, org="org-9"))
+    assert result["total_files"] == 4
+    assert result["successful_files"] == 0
+    assert result["failed_files"] == 0
+
+
+def test_run_batch_stages_skips_terminal_without_processing():
+    """Terminal execution → benign skip result, and NO pre-create / processing."""
+    bd = _fake_batch_data(n_files=2, org="org-2")
+    with (
+        mock.patch(
+            "file_processing.tasks._validate_and_parse_batch_data", return_value=bd
+        ),
+        mock.patch(
+            "file_processing.tasks._setup_execution_context",
+            side_effect=_TerminalExecutionSkip("exec-2", "ERROR"),
+        ),
+        mock.patch(
+            "file_processing.tasks._refactored_pre_create_file_executions"
+        ) as pre_create,
+        mock.patch(
+            "file_processing.tasks._process_individual_files"
+        ) as process_files,
+    ):
+        result = _run_batch_stages({"any": "payload"}, "task-1")
+
+    pre_create.assert_not_called()
+    process_files.assert_not_called()
+    assert result["total_files"] == 2
+    assert result["successful_files"] == 0
+    assert result["failed_files"] == 0
+
+
+def test_run_batch_stages_proceeds_when_not_terminal():
+    """Non-terminal execution → normal flow (setup → pre-create → process)."""
+    bd = _fake_batch_data(n_files=1)
+    with (
+        mock.patch(
+            "file_processing.tasks._validate_and_parse_batch_data", return_value=bd
+        ),
+        mock.patch(
+            "file_processing.tasks._setup_execution_context",
+            return_value="ctx",
+        ),
+        mock.patch(
+            "file_processing.tasks._refactored_pre_create_file_executions",
+            return_value="ctx",
+        ) as pre_create,
+        mock.patch(
+            "file_processing.tasks._process_individual_files", return_value="ctx"
+        ) as process_files,
+        mock.patch(
+            "file_processing.tasks._compile_batch_result",
+            return_value={"total_files": 1, "successful_files": 1, "failed_files": 0},
+        ),
+    ):
+        result = _run_batch_stages({"any": "payload"}, "task-1")
+
+    pre_create.assert_called_once()
+    process_files.assert_called_once()
+    assert result["successful_files"] == 1

--- a/workers/tests/test_terminal_execution_guard.py
+++ b/workers/tests/test_terminal_execution_guard.py
@@ -16,6 +16,8 @@ from unittest import mock
 import pytest
 from unstract.core.data_models import ExecutionStatus
 
+from queue_backend.pg_barrier import SKIPPED_TERMINAL_EXECUTION_KEY
+
 from file_processing.tasks import (
     _raise_if_execution_terminal,
     _run_batch_stages,
@@ -59,15 +61,19 @@ def _fake_batch_data(n_files: int = 3, org: str = "org-1"):
     return mock.Mock(files=[mock.Mock() for _ in range(n_files)], file_data=file_data)
 
 
-def test_terminal_skip_result_is_zero_work():
+def test_terminal_skip_result_counts_and_marker():
     result = _terminal_skip_result(_fake_batch_data(n_files=4, org="org-9"))
     assert result["total_files"] == 4
     assert result["successful_files"] == 0
-    assert result["failed_files"] == 0
+    # Unaccounted files count as failed (68d137a8), not in-progress → in-progress
+    # (total - successful - failed) is 0, and they don't silently vanish.
+    assert result["failed_files"] == 4
+    # Marker tells run_batch_with_barrier to bypass the (already-gone) decrement.
+    assert result[SKIPPED_TERMINAL_EXECUTION_KEY] is True
 
 
 def test_run_batch_stages_skips_terminal_without_processing():
-    """Terminal execution → benign skip result, and NO pre-create / processing."""
+    """Terminal execution → skip result (failed=N + marker), NO pre-create / processing."""
     bd = _fake_batch_data(n_files=2, org="org-2")
     with (
         mock.patch(
@@ -90,7 +96,45 @@ def test_run_batch_stages_skips_terminal_without_processing():
     process_files.assert_not_called()
     assert result["total_files"] == 2
     assert result["successful_files"] == 0
-    assert result["failed_files"] == 0
+    assert result["failed_files"] == 2
+    assert result[SKIPPED_TERMINAL_EXECUTION_KEY] is True
+
+
+def test_barrier_bypasses_decrement_on_terminal_skip():
+    """UN-3662: a terminal-skip result (marker set) must NOT decrement the barrier
+    (the reaper already tore it down → a decrement would log a spurious ERROR) and
+    must NOT abort. Directly guards the Comment-2 fix in run_batch_with_barrier."""
+    from queue_backend import pg_barrier
+
+    skip_result = {"failed_files": 2, SKIPPED_TERMINAL_EXECUTION_KEY: True}
+    ctx = {"execution_id": "e", "batch_index": 0, "callback_descriptor": {}}
+    with (
+        mock.patch.object(pg_barrier, "claim_batch", return_value=True),
+        mock.patch.object(pg_barrier, "_barrier_pg_decrement") as decrement,
+        mock.patch.object(pg_barrier, "_abort_barrier_in_body") as abort,
+    ):
+        out = pg_barrier.run_batch_with_barrier(ctx, lambda: skip_result)
+
+    decrement.assert_not_called()
+    abort.assert_not_called()
+    assert out is skip_result
+
+
+def test_barrier_decrements_on_normal_result():
+    """A normal (non-skip) result still decrements the barrier — the bypass is
+    scoped strictly to the terminal-skip marker."""
+    from queue_backend import pg_barrier
+
+    normal = {"total_files": 1, "successful_files": 1, "failed_files": 0}
+    ctx = {"execution_id": "e", "batch_index": 0, "callback_descriptor": {}}
+    with (
+        mock.patch.object(pg_barrier, "claim_batch", return_value=True),
+        mock.patch.object(pg_barrier, "_barrier_pg_decrement") as decrement,
+    ):
+        out = pg_barrier.run_batch_with_barrier(ctx, lambda: normal)
+
+    decrement.assert_called_once()
+    assert out is normal
 
 
 def test_run_batch_stages_proceeds_when_not_terminal():


### PR DESCRIPTION
## What

On the PG queue (at-least-once delivery), a file batch can be redelivered — or a stale batch consumed — *after* the reaper has recovered the execution (marked it ERROR) and deleted its barrier. Reprocessing **resurrected** the execution back to EXECUTING and re-ran its files (double LLM / destination write), ending in an inconsistent state: execution=EXECUTING, files=COMPLETED, with a stale reaper-recovery error message. This breaks the reaper's terminal state being one-way.

This adds a **validate-first terminal guard** on the file-processing batch path:

- `_setup_execution_context` raises `_TerminalExecutionSkip` when the fetched execution is already terminal (COMPLETED/ERROR/STOPPED), *before* touching status or processing.
- `_run_batch_stages` catches it and returns a benign zero-work result — no EXECUTING flip, no file pre-create, no LLM/destination work.

## Why it's safe for the Celery path

The guard is gated to the PG path via `is_pg` (`barrier_context` present == the transport the `pg_queue` flag selects). On Celery, `is_pg=False` and the guard returns immediately, so the existing flow is byte-for-byte unchanged. The resurrection it prevents is PG-specific: Celery lost tasks are never redelivered, so they can't be resurrected.

## Testing

- New `test_terminal_execution_guard.py`: guard raises for terminal on PG, **no-ops for terminal on Celery** (regression-safety), passes for active/unknown status, skips-without-processing, and proceeds normally when active.
- `test_chord_callback_boundary.py` transport-routing tests strengthened to assert `is_pg=False` on Celery / `is_pg=True` on PG.
- Full worker suite shows **no new failures vs baseline** — the pre-existing order-dependent flakes and one hanging consumer test are unrelated (verified identical with these changes stashed).

Manual verification of the resurrection scenario will follow in the dev environment (reap → redeliver → confirm the execution stays ERROR).

Part of the PG-queue crash-recovery work (follows UN-3661). Companion exactly-once hardening tracked separately (UN-3663).

🤖 Generated with [Claude Code](https://claude.com/claude-code)