### PR TITLE
UN-3667 [TEST] PG queue — make workers suite deterministic + wire into CI (UN-3666)

### DIFF
--- a/tests/groups.yaml
+++ b/tests/groups.yaml
@@ -70,9 +70,32 @@ groups:
     tier: unit
     workdir: workers
     paths: [tests, shared/tests]
-    markers: "unit"
+    # Run everything that isn't a real-Postgres test. The workers suite doesn't
+    # tag its unit tests with an explicit `unit` marker (there are ~1100 of
+    # them), so select by exclusion: `conftest.py` marks the real-DB tests
+    # `integration`, and this lane runs the rest. (`markers: "unit"` here
+    # previously matched *zero* tests — the suite silently never ran in CI.)
+    markers: "not integration"
     uv_sync_group: test
     coverage_source: shared
+
+  integration-workers:
+    tier: integration
+    workdir: workers
+    paths: [tests, shared/tests]
+    # Real-Postgres tests: barrier-decrement races, reaper, batch dedup, leader
+    # election, result backend. `conftest.py` marks these `integration` (any
+    # test using a real-connection fixture). They skip when Postgres is
+    # unreachable or the pg_queue schema isn't migrated.
+    markers: "integration"
+    uv_sync_group: test
+    coverage_source: shared
+    requires_services: [postgres]
+    # Optional until CI provisions a *migrated* database and sets
+    # REQUIRE_PG_TESTS=1 — that env flips the graceful skips into hard failures
+    # (see conftest `_skip_or_fail_no_pg`) so the lane can't pass having run
+    # nothing. Until then it runs-and-skips against a bare Postgres.
+    optional: true
 
   unit-backend:
     tier: unit

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -410,6 +410,14 @@ def cmd_run(args: argparse.Namespace) -> int:
                 and overall_exit == 0
             ):
                 overall_exit = exit_code
+            # Empty collection (exit 5) is a *failure* for a required group: a
+            # marker filter or path that matches nothing (e.g. the `unit-workers`
+            # regression where `-m "unit"` matched zero tests) would otherwise
+            # pass silently with an empty junit — the whole suite "green" having
+            # run nothing. Optional groups (placeholders / infra-gated) keep
+            # exit 5 as a pass; that's what `not group.optional` guards.
+            if exit_code == 5 and not group.optional and overall_exit == 0:
+                overall_exit = exit_code
             # Belt-and-braces: if the junit attests to errors/failures the exit
             # code didn't (truncated junit → errors=1 with exit 0), the report
             # shows ❌ but exit would otherwise stay 0. Keep them in sync.

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -38,6 +38,9 @@ from tests.rig.selection import resolve
 # Pytest exit codes that the rig treats as non-failure for aggregation:
 #   0 — all tests passed
 #   5 — no tests collected (optional placeholders, empty hurl group, etc.)
+#       NOTE: exit-5 is non-failing here for *optional* groups only. A required
+#       group that collects nothing (exit 5) is caught by the explicit guard in
+#       cmd_run ("Empty collection (exit 5) is a failure…") and fails loudly.
 _NON_FAILING_PYTEST_EXIT_CODES = (0, 5)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3992,6 +3992,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.11.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "responses", specifier = ">=0.23.0" },
 ]
 

--- a/workers/pyproject.toml
+++ b/workers/pyproject.toml
@@ -63,6 +63,7 @@ test = [
     "pytest-asyncio>=0.24.0",
     "pytest-mock>=3.11.0",
     "pytest-cov>=4.1.0",
+    "pytest-timeout>=2.3.1",
     "factory-boy>=3.3.0",
     "responses>=0.23.0"
 ]
@@ -158,6 +159,11 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "--verbose",
+    # Hang safety net: no single test should run for minutes. Catches a wedged
+    # poll loop / deadlock in CI instead of hanging the job until it times out.
+    # Generous enough (120s) that only a genuine hang trips it, not a slow test.
+    "--timeout=120",
+    "--timeout-method=thread",
     "--cov=shared",
     "--cov=api_deployment",
     "--cov=general",

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -58,7 +58,7 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.integration)
 
 
-@pytest.hookimpl(hookwrapper=True)
+@pytest.hookimpl(wrapper=True)
 def pytest_runtest_makereport(item, call):
     """Under ``REQUIRE_PG_TESTS``, a *skipped* integration test is a failure.
 
@@ -71,13 +71,14 @@ def pytest_runtest_makereport(item, call):
     turned into a failure. This closes the "green having exercised none of them"
     gap for the barrier / leader-election / reaper suites regardless of skip
     mechanism.
+
+    Uses the modern ``wrapper=True`` hook (pytest>=8) — ``yield`` returns the
+    report directly, and the wrapper returns it back.
     """
-    outcome = yield
-    if not os.getenv("REQUIRE_PG_TESTS"):
-        return
-    report = outcome.get_result()
+    report = yield
     if (
-        report.when == "setup"
+        os.getenv("REQUIRE_PG_TESTS")
+        and report.when == "setup"
         and report.skipped
         and item.get_closest_marker("integration") is not None
     ):
@@ -87,6 +88,7 @@ def pytest_runtest_makereport(item, call):
             f"(Postgres unreachable/unmigrated): {item.nodeid}. The integration "
             f"lane must exercise the real-Postgres paths, not skip them."
         )
+    return report
 
 
 # --- Isolation: keep the suite deterministic in a single process ---

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -6,6 +6,8 @@ shared/constants/api_endpoints.py raises ValueError at import
 time if INTERNAL_API_BASE_URL is not set.
 """
 
+import contextlib
+import importlib
 import os
 from pathlib import Path
 
@@ -54,6 +56,37 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if pg_fixtures & set(getattr(item, "fixturenames", ())):
             item.add_marker(pytest.mark.integration)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Under ``REQUIRE_PG_TESTS``, a *skipped* integration test is a failure.
+
+    The integration lane sets ``REQUIRE_PG_TESTS`` precisely so it can't pass
+    having run nothing. Real-Postgres fixtures skip when the DB is unreachable or
+    unmigrated, and not all of them route through ``_skip_or_fail_no_pg`` (some
+    call ``pytest.skip`` directly). Rather than depend on every fixture — present
+    and future — using the right helper, enforce the guarantee centrally: any
+    ``integration``-marked test that skips during setup while the flag is set is
+    turned into a failure. This closes the "green having exercised none of them"
+    gap for the barrier / leader-election / reaper suites regardless of skip
+    mechanism.
+    """
+    outcome = yield
+    if not os.getenv("REQUIRE_PG_TESTS"):
+        return
+    report = outcome.get_result()
+    if (
+        report.when == "setup"
+        and report.skipped
+        and item.get_closest_marker("integration") is not None
+    ):
+        report.outcome = "failed"
+        report.longrepr = (
+            f"REQUIRE_PG_TESTS is set but integration test skipped "
+            f"(Postgres unreachable/unmigrated): {item.nodeid}. The integration "
+            f"lane must exercise the real-Postgres paths, not skip them."
+        )
 
 
 # --- Isolation: keep the suite deterministic in a single process ---
@@ -166,8 +199,10 @@ def isolated_celery_registry():
     enters its poll loop, and the test hangs).
 
     This fixture snapshots and clears that backlog for the test's duration, so a
-    ``Celery(...)`` created inside the test starts with only ``celery.*``
-    built-ins, then restores it so the backlog isn't mutated for other tests.
+    ``Celery(...)`` created inside the test starts with *no tasks at all* —
+    neither the worker's shared tasks nor Celery's own ``celery.*`` built-ins,
+    since both are registered through this same finalizer backlog — then restores
+    it so the backlog isn't mutated for other tests.
     """
     import celery._state as celery_state
 
@@ -192,29 +227,36 @@ def _reset_queue_backend_state():
     order-dependent (green alone, failing in a full run). Reset on teardown so
     each test starts from the same clean module state regardless of order.
 
-    Each reset is guarded independently: a module that fails to import (missing
-    optional dep in a given lane) must not break the autouse fixture for the
-    whole suite.
+    Only the *import* is guarded (a module absent in a given lane must not break
+    the autouse fixture). The resets run outside that guard on purpose: if a
+    reset target is ever renamed/removed, the resulting AttributeError surfaces
+    loudly here rather than turning the whole fixture into a silent no-op — which
+    would let order-dependence and hangs creep back with no failing test.
     """
     yield
-    try:
+    with contextlib.suppress(ImportError):
         import queue_backend.routing as _routing
 
         _routing._allow_list_logged = False
-    except Exception:
-        pass
-    try:
-        import queue_backend.dispatch as _dispatch
+    with contextlib.suppress(ImportError):
+        # queue_backend re-exports a ``dispatch`` *function*, which shadows the
+        # submodule as a package attribute — so ``import queue_backend.dispatch``
+        # would bind the function, not the module. Load the module explicitly.
+        _dispatch = importlib.import_module("queue_backend.dispatch")
 
         _dispatch._pg_routing_logged.clear()
-        if hasattr(_dispatch._pg_local, "client"):
+        client = getattr(_dispatch._pg_local, "client", None)
+        if client is not None:
+            # Close before dropping so a real libpq connection isn't leaked to
+            # GC/__del__ (matters in a large real-Postgres run).
+            with contextlib.suppress(Exception):
+                client.close()
             del _dispatch._pg_local.client
-    except Exception:
-        pass
-    try:
+    with contextlib.suppress(ImportError):
         import queue_backend.pg_barrier as _pg_barrier
 
-        if hasattr(_pg_barrier._local, "conn"):
-            del _pg_barrier._local.conn
-    except Exception:
-        pass
+        conn = getattr(_pg_barrier._local, "conn", None)
+        if conn is not None:
+            with contextlib.suppress(Exception):
+                conn.close()
+            _pg_barrier._local.conn = None

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -16,6 +16,77 @@ from dotenv import load_dotenv
 _env_test = Path(__file__).resolve().parent.parent / ".env.test"
 load_dotenv(_env_test)
 
+# Pristine baseline: the environment right after .env.test loads, captured before
+# pytest collection imports any worker module. Some worker modules call
+# ``load_dotenv(<workers>/.env)`` at import time, so on a developer machine the
+# ambient dev ``.env`` (e.g. WORKER_BARRIER_KEY_TTL_SECONDS=180) bleeds into the
+# process during collection and silently overrides test defaults — green in CI
+# (no ``.env``), red locally. ``_restore_os_environ`` resets to this baseline
+# around every test so the suite is deterministic regardless of ambient ``.env``.
+_PRISTINE_ENVIRON = dict(os.environ)
+
+
+# --- Collection: separate real-Postgres tests from the unit lane ---
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-mark real-Postgres tests as ``integration``.
+
+    Any test that requests a real-Postgres fixture needs a live database.
+    Marking those ``integration`` here — rather than by hand on each of ~100 tests
+    scattered across mixed unit/integration files — lets the fast lane run
+    ``-m "not integration"`` (DB-free, deterministic) while a dedicated
+    integration lane runs ``-m integration`` against a provisioned Postgres.
+
+    The set lists every fixture that opens a real connection directly; fixtures
+    layered on top of these (e.g. ``pg_client``/``result_backend`` build on
+    ``pg_conn``) are covered transitively because ``fixturenames`` includes the
+    whole dependency graph.
+    """
+    pg_fixtures = {
+        "pg_conn",
+        "pg_client",
+        "barrier_db",
+        "dedup_db",
+        "lock_db",
+        "barrier_conn",
+    }
+    for item in items:
+        if pg_fixtures & set(getattr(item, "fixturenames", ())):
+            item.add_marker(pytest.mark.integration)
+
+
+# --- Isolation: keep the suite deterministic in a single process ---
+
+
+@pytest.fixture(autouse=True)
+def _restore_os_environ():
+    """Reset ``os.environ`` to the ``.env.test`` baseline around every test.
+
+    Two leaks are neutralised: (1) a test that mutates the environment (a bare
+    ``os.environ[...] =`` rather than ``monkeypatch.setenv``) leaking into later
+    tests, and (2) the ambient dev ``.env`` pulled in during collection (see
+    ``_PRISTINE_ENVIRON``) silently overriding test defaults. Resetting to the
+    pristine baseline both before and after each test makes every test start from
+    the same environment regardless of run order or the developer's ``.env``.
+    Defined first so it wraps every other autouse fixture.
+    """
+
+    def _reset_to_pristine():
+        # Preserve pytest's own bookkeeping (e.g. PYTEST_CURRENT_TEST, which
+        # pytest sets per-test and deletes itself at teardown) — clearing it
+        # would make pytest's teardown KeyError.
+        preserved = {k: v for k, v in os.environ.items() if k.startswith("PYTEST")}
+        os.environ.clear()
+        os.environ.update(_PRISTINE_ENVIRON)
+        os.environ.update(preserved)
+
+    _reset_to_pristine()
+    try:
+        yield
+    finally:
+        _reset_to_pristine()
+
 
 # --- Shared PG-queue integration fixtures (real Postgres) ---
 #
@@ -33,18 +104,34 @@ def integration_pg_conn():
     return create_pg_connection(env_prefix="TEST_DB_")
 
 
+def _skip_or_fail_no_pg(reason: str):
+    """Skip the test, or fail loudly when ``REQUIRE_PG_TESTS`` is set.
+
+    The unit lane skips real-Postgres tests when no DB is around. The dedicated
+    integration lane sets ``REQUIRE_PG_TESTS=1`` so a missing/misconfigured
+    Postgres is a hard failure instead of a green-but-silent skip — otherwise the
+    integration lane could pass having run nothing.
+    """
+    if os.getenv("REQUIRE_PG_TESTS"):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
+
 @pytest.fixture
 def pg_conn():
-    """A real connection; skips if Postgres is unreachable or unmigrated."""
+    """A real connection; skips if Postgres is unreachable or unmigrated.
+
+    Fails instead of skipping when ``REQUIRE_PG_TESTS`` is set (integration lane).
+    """
     try:
         conn = integration_pg_conn()
     except psycopg2.OperationalError as exc:
-        pytest.skip(f"Postgres not reachable: {exc}")
+        _skip_or_fail_no_pg(f"Postgres not reachable: {exc}")
     with conn.cursor() as cur:
         cur.execute("SELECT to_regclass('pg_queue_message')")
         if cur.fetchone()[0] is None:
             conn.close()
-            pytest.skip("pg_queue migration not applied (run backend migrate)")
+            _skip_or_fail_no_pg("pg_queue migration not applied (run backend migrate)")
     yield conn
     conn.rollback()
     conn.close()
@@ -56,3 +143,78 @@ def pg_client(pg_conn):
     from queue_backend.pg_queue import PgQueueClient
 
     return PgQueueClient(conn=pg_conn)
+
+
+# --- Test-isolation fixtures (deterministic single-process runs) ---
+#
+# The workers suite carries several process-global registries/singletons that
+# leak state across tests when the whole suite runs in one process (green in
+# isolation, order-dependent failures / hangs together). The fixtures below
+# snapshot-and-restore them so the suite is deterministic regardless of order.
+
+
+@pytest.fixture
+def isolated_celery_registry():
+    """Give the test a genuinely empty Celery task registry.
+
+    A truly empty ``Celery(...)`` app is impossible once any ``@shared_task``
+    has been imported: Celery keeps a *process-global* finalizer backlog
+    (``celery._state._on_app_finalizers``) and injects every declared shared
+    task into every *new* app on finalize. So ``Celery("empty")`` created in a
+    full-suite run actually carries the worker's shared tasks — which silently
+    defeats the consumer's empty-registry guard (the guard passes, ``run()``
+    enters its poll loop, and the test hangs).
+
+    This fixture snapshots and clears that backlog for the test's duration, so a
+    ``Celery(...)`` created inside the test starts with only ``celery.*``
+    built-ins, then restores it so the backlog isn't mutated for other tests.
+    """
+    import celery._state as celery_state
+
+    saved = set(celery_state._on_app_finalizers)
+    celery_state._on_app_finalizers.clear()
+    try:
+        yield
+    finally:
+        celery_state._on_app_finalizers.clear()
+        celery_state._on_app_finalizers.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _reset_queue_backend_state():
+    """Reset process-global queue_backend state after every test.
+
+    ``queue_backend`` caches a PG dispatch client and a barrier connection in
+    thread-locals, and trips one-shot "log this once" flags (routing allow-list,
+    per-task PG-routing notice). These are lazily populated on first use, so a
+    test that seeds a fake client or trips a log-once flag would otherwise change
+    what every later test in the same process observes — making the suite
+    order-dependent (green alone, failing in a full run). Reset on teardown so
+    each test starts from the same clean module state regardless of order.
+
+    Each reset is guarded independently: a module that fails to import (missing
+    optional dep in a given lane) must not break the autouse fixture for the
+    whole suite.
+    """
+    yield
+    try:
+        import queue_backend.routing as _routing
+
+        _routing._allow_list_logged = False
+    except Exception:
+        pass
+    try:
+        import queue_backend.dispatch as _dispatch
+
+        _dispatch._pg_routing_logged.clear()
+        if hasattr(_dispatch._pg_local, "client"):
+            del _dispatch._pg_local.client
+    except Exception:
+        pass
+    try:
+        import queue_backend.pg_barrier as _pg_barrier
+
+        if hasattr(_pg_barrier._local, "conn"):
+            del _pg_barrier._local.conn
+    except Exception:
+        pass

--- a/workers/tests/test_barrier.py
+++ b/workers/tests/test_barrier.py
@@ -93,6 +93,7 @@ class TestBarrierProtocolShape:
         tests pass identically even if ``BarrierHandle`` were
         deleted; this one is load-bearing.
         """
+        from celery import Celery
         from celery.result import AsyncResult
 
         # Assert against a real ``AsyncResult`` *instance* — that's
@@ -101,6 +102,14 @@ class TestBarrierProtocolShape:
         # a property, or set in ``__init__``; the instance check is
         # the smallest-blast-radius equivalent of "production sees
         # this object and reads ``.id``".
+        #
+        # Bind to an explicit backend-less probe app (not the ambient
+        # ``current_app``): whichever worker app happens to be current in a
+        # full-suite run may carry a real ``db+postgresql://`` result backend,
+        # and binding ``AsyncResult`` to it would try to connect. ``.id`` is the
+        # constructor argument and needs no backend, so this stays a pure
+        # protocol-shape check.
+        probe_app = Celery("barrier-protocol-probe", set_as_current=False)
         #
         # ``required_attrs`` is hand-maintained: if a future refactor
         # adds a required attribute to ``TaskHandle`` /
@@ -111,7 +120,7 @@ class TestBarrierProtocolShape:
         # ``__annotations__`` introspection would also work (and
         # doesn't require ``@runtime_checkable``), but the explicit
         # tuple keeps the contract surface explicit.
-        async_result_instance = AsyncResult("placeholder-task-id")
+        async_result_instance = AsyncResult("placeholder-task-id", app=probe_app)
         required_attrs = ("id",)
         missing = [
             a for a in required_attrs if not hasattr(async_result_instance, a)

--- a/workers/tests/test_legacy_executor_scaffold.py
+++ b/workers/tests/test_legacy_executor_scaffold.py
@@ -22,10 +22,21 @@ from unstract.sdk1.execution.result import ExecutionResult
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    """Ensure a clean executor registry for every test."""
+    """Give each test a clean executor registry, then restore the prior state.
+
+    ``ExecutorRegistry`` is a process-global singleton that worker modules
+    populate at import (e.g. ``executor.worker`` registers ``legacy``). A bare
+    ``clear()`` on teardown would wipe those registrations for every later test
+    in the suite — breaking structure-tool/dispatch tests that rely on a
+    populated registry, and causing "already registered" collisions. Snapshot
+    the registry, clear it for this test, then restore the snapshot so the global
+    state is left exactly as we found it.
+    """
+    saved = dict(ExecutorRegistry._registry)
     ExecutorRegistry.clear()
     yield
-    ExecutorRegistry.clear()
+    ExecutorRegistry._registry.clear()
+    ExecutorRegistry._registry.update(saved)
 
 
 def _register_legacy():
@@ -254,18 +265,31 @@ class TestExceptions:
         import importlib
         import sys
 
-        # Ensure fresh import
+        # Reload to re-run the module's imports so a stray Flask import would
+        # re-populate sys.modules. But reloading rebinds the module's classes
+        # (LegacyExecutorError etc.) to new objects, which breaks ``isinstance``
+        # / ``pytest.raises`` identity for every other test/module that imported
+        # them earlier. So snapshot the module namespace and restore it in a
+        # ``finally`` — the exception classes stay identical for the rest of the
+        # suite.
         mod_name = "executor.executors.exceptions"
-        if mod_name in sys.modules:
-            importlib.reload(sys.modules[mod_name])
-        else:
-            importlib.import_module(mod_name)
+        mod = sys.modules.get(mod_name)
+        saved = dict(mod.__dict__) if mod is not None else None
+        try:
+            if mod is not None:
+                importlib.reload(mod)
+            else:
+                importlib.import_module(mod_name)
 
-        # Check that no flask modules were pulled in
-        flask_modules = [m for m in sys.modules if m.startswith("flask")]
-        assert flask_modules == [], (
-            f"Flask modules imported: {flask_modules}"
-        )
+            # Check that no flask modules were pulled in
+            flask_modules = [m for m in sys.modules if m.startswith("flask")]
+            assert flask_modules == [], (
+                f"Flask modules imported: {flask_modules}"
+            )
+        finally:
+            if saved is not None:
+                mod.__dict__.clear()
+                mod.__dict__.update(saved)
 
     def test_custom_data_error_signature(self):
         from executor.executors.exceptions import CustomDataError

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -448,13 +448,18 @@ class TestDecrementPhaseSplitRetry:
         assert sleeps == []  # a fresh-conn death is not retried → no backoff
 
 
+@pytest.mark.integration
 def test_create_pg_connection_is_non_autocommit():
     """The decrement phase-split's exactly-once safety rests on the connection
     being non-autocommit (an uncommitted UPDATE rolls back on disconnect, so an
     execute-phase failure is never durable). Pin that at its SOURCE — a future
     ``conn.autocommit = True`` in ``create_pg_connection`` would silently
     reintroduce the double-count the split exists to prevent, and no other test
-    would catch it (the barrier_db fixture sets autocommit itself)."""
+    would catch it (the barrier_db fixture sets autocommit itself).
+
+    Opens a real connection inline (no fixture), so it's marked ``integration``
+    explicitly — the collection hook keys off fixture names and wouldn't catch
+    it, which would otherwise leave it in the DB-free unit lane."""
     os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
     try:
         conn = create_pg_connection(env_prefix="TEST_DB_")

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -217,12 +217,14 @@ class TestRunLoop:
         consumer.run(install_signals=False)  # must not raise
         assert client.read.call_count == 2  # kept polling after the error
 
-    def test_run_refuses_to_start_with_empty_registry(self):
+    def test_run_refuses_to_start_with_empty_registry(self, isolated_celery_registry):
         # A non-bootstrapped consumer would drop every message as "unknown" —
-        # fail loudly instead.
+        # fail loudly instead. isolated_celery_registry makes "empty" genuinely
+        # empty (Celery's global shared_task backlog would otherwise leak the
+        # worker's tasks in and let the guard pass → infinite poll loop / hang).
         from celery import Celery
 
-        empty_app = Celery("empty-no-tasks")  # only celery.* built-ins
+        empty_app = Celery("empty-no-tasks", set_as_current=False)  # only celery.* built-ins
         consumer = PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)
         with pytest.raises(RuntimeError, match="no application tasks"):
             consumer.run(install_signals=False)
@@ -239,12 +241,14 @@ class TestRunLoop:
         consumer.run(install_signals=False)  # must not raise
         assert client.read.called
 
-    def test_run_bypasses_guard_when_require_tasks_false(self, monkeypatch):
+    def test_run_bypasses_guard_when_require_tasks_false(
+        self, monkeypatch, isolated_celery_registry
+    ):
         # require_tasks=False skips the guard even on an empty registry (lets a
         # caller opt out, e.g. a deliberately task-less smoke run).
         from celery import Celery
 
-        empty_app = Celery("empty-no-tasks")
+        empty_app = Celery("empty-no-tasks", set_as_current=False)
         client = MagicMock()
         client.read.return_value = []
         consumer = PgQueueConsumer(["q"], client=client, app=empty_app)
@@ -254,12 +258,14 @@ class TestRunLoop:
         consumer.run(install_signals=False, require_tasks=False)  # must not raise
         assert client.read.called
 
-    def test_registered_task_count_excludes_celery_builtins(self):
+    def test_registered_task_count_excludes_celery_builtins(
+        self, isolated_celery_registry
+    ):
         # The guard counts application tasks only — celery.* built-ins (present
         # in every app) must not mask an un-bootstrapped registry.
         from celery import Celery
 
-        empty_app = Celery("empty-no-tasks")
+        empty_app = Celery("empty-no-tasks", set_as_current=False)
         assert (
             PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)._registered_task_count()
             == 0

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -224,7 +224,9 @@ class TestRunLoop:
         # worker's tasks in and let the guard pass → infinite poll loop / hang).
         from celery import Celery
 
-        empty_app = Celery("empty-no-tasks", set_as_current=False)  # only celery.* built-ins
+        # No tasks at all: isolated_celery_registry cleared the finalizer backlog,
+        # which holds the worker's shared tasks *and* Celery's celery.* built-ins.
+        empty_app = Celery("empty-no-tasks", set_as_current=False)
         consumer = PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)
         with pytest.raises(RuntimeError, match="no application tasks"):
             consumer.run(install_signals=False)
@@ -261,24 +263,29 @@ class TestRunLoop:
     def test_registered_task_count_excludes_celery_builtins(
         self, isolated_celery_registry
     ):
-        # The guard counts application tasks only — celery.* built-ins (present
-        # in every app) must not mask an un-bootstrapped registry.
+        # The guard counts *application* tasks only — a celery.*-named task must
+        # not count toward the total. isolated_celery_registry clears the
+        # finalizer backlog so the app starts genuinely empty; we then register
+        # one celery.*-named task and one application task and assert only the
+        # latter is counted (exercising the exclusion filter under test).
         from celery import Celery
 
         empty_app = Celery("empty-no-tasks", set_as_current=False)
-        assert (
-            PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)._registered_task_count()
-            == 0
-        )
+        consumer = PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)
+        assert consumer._registered_task_count() == 0  # genuinely empty
+
+        @empty_app.task(name="celery.builtin_like")
+        def _builtin_like():
+            return 0
+
+        # A celery.*-named task is excluded → still zero application tasks.
+        assert consumer._registered_task_count() == 0
 
         @empty_app.task(name="test_pg_consumer.demo")
         def _demo():
             return 1
 
-        assert (
-            PgQueueConsumer(["q"], client=MagicMock(), app=empty_app)._registered_task_count()
-            == 1
-        )
+        assert consumer._registered_task_count() == 1
 
 
 # --- Liveness heartbeat (drives the health endpoint) ---

--- a/workers/tests/test_phase1_log_streaming.py
+++ b/workers/tests/test_phase1_log_streaming.py
@@ -347,11 +347,18 @@ class TestLegacyExecutorLogPassthrough:
         result = executor.execute(ctx)
 
         assert result.success
-        mock_shim_cls.assert_called_once_with(
-            platform_api_key="sk-test",
-            log_events_id="session-abc",
-            component={"tool_id": "t1", "run_id": "r1", "doc_name": "test.pdf"},
-        )
+        # Assert the log-info kwargs specifically (the point of this test) rather
+        # than the full constructor — the shim gained execution/org/file-exec ids
+        # unrelated to log passthrough.
+        mock_shim_cls.assert_called_once()
+        shim_kwargs = mock_shim_cls.call_args.kwargs
+        assert shim_kwargs["platform_api_key"] == "sk-test"
+        assert shim_kwargs["log_events_id"] == "session-abc"
+        assert shim_kwargs["component"] == {
+            "tool_id": "t1",
+            "run_id": "r1",
+            "doc_name": "test.pdf",
+        }
 
     @patch("executor.executors.legacy_executor.FileUtils.get_fs_instance")
     @patch("executor.executors.legacy_executor.X2Text")
@@ -389,11 +396,13 @@ class TestLegacyExecutorLogPassthrough:
         result = executor.execute(ctx)
 
         assert result.success
-        mock_shim_cls.assert_called_once_with(
-            platform_api_key="sk-test",
-            log_events_id="",
-            component={},
-        )
+        # Assert the log-info kwargs specifically (see sibling test); the shim's
+        # other constructor args are unrelated to this test's concern.
+        mock_shim_cls.assert_called_once()
+        shim_kwargs = mock_shim_cls.call_args.kwargs
+        assert shim_kwargs["platform_api_key"] == "sk-test"
+        assert shim_kwargs["log_events_id"] == ""
+        assert shim_kwargs["component"] == {}
 
     @patch(
         "executor.executors.legacy_executor.LegacyExecutor._get_prompt_deps"

--- a/workers/tests/test_queue_backend_seam.py
+++ b/workers/tests/test_queue_backend_seam.py
@@ -287,16 +287,22 @@ class TestPublicSurface:
         # Phase 8a adds QueueBackend + select_backend — the queue-transport
         # routing gate that the WORKER_PG_QUEUE_ENABLED_TASKS allow-list
         # drives.
+        # The PG-queue barrier work adds the Postgres barrier surface:
+        # PgBarrier + its barrier_pg_decr_and_check / barrier_pg_abort tasks,
+        # selected when WORKER_BARRIER_BACKEND routes to the PG backend.
         assert set(queue_backend.__all__) == {
             "Barrier",
             "BarrierBackend",
             "BarrierHandle",
             "CeleryChordBarrier",
             "FairnessKey",
+            "PgBarrier",
             "QueueBackend",
             "RedisDecrBarrier",
             "barrier_abort",
             "barrier_decr_and_check",
+            "barrier_pg_abort",
+            "barrier_pg_decr_and_check",
             "dispatch",
             "get_barrier",
             "select_backend",

--- a/workers/tests/test_sanity_phase2.py
+++ b/workers/tests/test_sanity_phase2.py
@@ -629,7 +629,12 @@ class TestSanityResponseContracts:
         mock_index_cls.return_value = mock_index
 
         mock_emb_cls = MagicMock()
-        mock_emb_cls.return_value = MagicMock()
+        mock_emb = MagicMock()
+        # Production records embedding usage via flush_pending_usage() into the
+        # result metadata; stub it to a JSON-serialisable value so the round-trip
+        # below doesn't choke on a bare MagicMock.
+        mock_emb.flush_pending_usage.return_value = []
+        mock_emb_cls.return_value = mock_emb
         mock_vdb_cls = MagicMock()
         mock_vdb_cls.return_value = MagicMock()
 

--- a/workers/tests/test_sanity_phase3.py
+++ b/workers/tests/test_sanity_phase3.py
@@ -19,7 +19,7 @@ from unstract.sdk1.execution.result import ExecutionResult
 # ---------------------------------------------------------------------------
 
 _PATCH_DISPATCHER = (
-    "file_processing.structure_tool_task.ExecutionDispatcher"
+    "file_processing.structure_tool_task.get_executor_dispatcher"
 )
 _PATCH_PLATFORM_HELPER = (
     "file_processing.structure_tool_task._create_platform_helper"

--- a/workers/tests/test_sanity_phase5.py
+++ b/workers/tests/test_sanity_phase5.py
@@ -866,7 +866,7 @@ class TestStructureToolSingleDispatch:
         "file_processing.structure_tool_task._create_platform_helper"
     )
     @patch(
-        "file_processing.structure_tool_task.ExecutionDispatcher"
+        "file_processing.structure_tool_task.get_executor_dispatcher"
     )
     def test_single_dispatch_normal(
         self,

--- a/workers/tests/test_sanity_phase6c.py
+++ b/workers/tests/test_sanity_phase6c.py
@@ -435,13 +435,17 @@ class TestHandleAnswerPromptHighlight:
         # The highlight plugin must NOT be loaded when highlight is disabled.
         # Other plugins (e.g. lookup-enrichment) load independently of highlight,
         # so assert on the highlight plugin specifically rather than "never
-        # called".
-        highlight_loads = [
-            call
+        # called". Read the plugin name from positional *or* keyword args so the
+        # check can't silently pass if the call form changes.
+        loaded_plugins = [
+            (call.args[0] if call.args else call.kwargs.get("name"))
             for call in mock_plugin_get.call_args_list
-            if call.args and call.args[0] == "highlight-data"
         ]
-        assert not highlight_loads
+        assert "highlight-data" not in loaded_plugins
+        # Guard against a vacuous pass: the loader IS exercised on this path —
+        # lookup-enrichment loads regardless of highlight — so if nothing shows
+        # up here the filter above would be meaningless.
+        assert "lookup-enrichment" in loaded_plugins
         # process_text should be None
         llm_complete_call = mock_llm.complete.call_args
         assert llm_complete_call.kwargs.get("process_text") is None

--- a/workers/tests/test_sanity_phase6c.py
+++ b/workers/tests/test_sanity_phase6c.py
@@ -432,8 +432,16 @@ class TestHandleAnswerPromptHighlight:
             result = executor._handle_answer_prompt(ctx)
 
         assert result.success
-        # Plugin loader should NOT have been called
-        mock_plugin_get.assert_not_called()
+        # The highlight plugin must NOT be loaded when highlight is disabled.
+        # Other plugins (e.g. lookup-enrichment) load independently of highlight,
+        # so assert on the highlight plugin specifically rather than "never
+        # called".
+        highlight_loads = [
+            call
+            for call in mock_plugin_get.call_args_list
+            if call.args and call.args[0] == "highlight-data"
+        ]
+        assert not highlight_loads
         # process_text should be None
         llm_complete_call = mock_llm.complete.call_args
         assert llm_complete_call.kwargs.get("process_text") is None

--- a/workers/tests/test_sanity_phase6h.py
+++ b/workers/tests/test_sanity_phase6h.py
@@ -224,6 +224,7 @@ class TestStructureToolAgenticRouting:
             dispatcher=mock_dispatcher,
             shim=MagicMock(),
             file_execution_id="exec-001",
+            execution_id="wf-exec-001",
             organization_id="org-001",
             source_file_name="test.pdf",
             fs=MagicMock(),


### PR DESCRIPTION
## What & why

The workers test suite has **never run in CI**: the rig's `unit-workers` group filtered `-m "unit"`, but no workers test carries that marker — so zero tests were collected and exit-5 mapped to success. ~1,100 tests were silently not running. Turning the lane on surfaced a **hang** plus **~28 order-dependent failures**.

This PR makes the suite deterministic in a single process and wires it into the rig. **Tests/CI only — no runtime or production code changes, no Celery-path impact.**

## Changes

**Determinism (`workers/tests/conftest.py`)**
- Reset `os.environ` to the `.env.test` baseline around every test — kills the ambient dev-`.env` bleed (green in CI, red locally) and bare-env-write leaks.
- Reset `queue_backend` thread-locals + one-shot log-once flags between tests.
- `isolated_celery_registry` fixture — a genuinely-empty Celery app for the empty-registry guard tests. Fixes the **hang**: Celery's process-global `@shared_task` finalizer backlog injects the worker's tasks into every new app, defeating the guard and sending `run()` into an infinite poll loop.
- Collection hook auto-marks real-Postgres tests `integration`; the unit lane runs `-m "not integration"`.

**Isolation fixes**
- Empty-app consumer tests use `set_as_current=False` (stop `current_app` hijack).
- `test_legacy_executor_scaffold`: snapshot/restore `ExecutorRegistry` (was wiping the global registry on teardown); restore the exceptions-module namespace after `importlib.reload` (was rebinding exception classes and breaking `pytest.raises` identity suite-wide).
- Barrier protocol test binds `AsyncResult` to a backend-less probe app (was connecting to a polluted PG result backend).

**Drifted tests** (production refactored, tests never updated because they never ran)
- `ExecutionDispatcher` → `get_executor_dispatcher` (sanity phase3/phase5); new `execution_id` arg (phase6h); `lookup-enrichment` plugin (phase6c); `flush_pending_usage` stub (phase2); shim-kwargs subset (phase1); PG-barrier `__all__` exports (queue_backend_seam).

**CI wiring**
- `groups.yaml`: `unit-workers` → `-m "not integration"`; new `integration-workers` lane (requires postgres; `optional` until CI provisions a migrated DB and sets `REQUIRE_PG_TESTS=1`).
- `rig/cli.py`: exit-5 (no tests collected) now **fails** a required group — prevents this class of silent regression.
- `pyproject.toml`: `--timeout=120` hang safety net + `pytest-timeout` dep.

## Results
- **Unit lane: 1133 passed, 0 failed, deterministic** (was 28 failing + a hang) — verified across repeated runs.
- **Integration lane: 103/104** — the one failure is a pre-existing real-PG concurrency test, now correctly isolated to the integration lane (passes alone).

## Follow-ups (not blockers)
- The flaky integration concurrency test needs DB-state isolation between integration tests.
- Activating the integration lane for real needs the `pg_queue` migration + `REQUIRE_PG_TESTS=1` wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)