### PR TITLE
UN-3669 [FIX] PG queue — barrier abort + poison-drop leave a recoverable terminal handle (UN-3670)

### DIFF
--- a/workers/queue_backend/barrier.py
+++ b/workers/queue_backend/barrier.py
@@ -161,6 +161,24 @@ class BarrierContext(TypedDict):
     callback_descriptor: CallbackDescriptor
 
 
+def callback_recovery_identity(
+    callback_descriptor: CallbackDescriptor,
+) -> tuple[str | None, str | None]:
+    """``(execution_id, organization_id)`` from a callback descriptor's kwargs.
+
+    The barrier's recovery net (mark the execution ERROR when a batch strands)
+    needs the execution's identity, which the fan-out stamps into the callback's
+    ``kwargs`` (they are the aggregating callback's own arguments). Both recovery
+    sites — the in-body abort in :mod:`queue_backend.pg_barrier` and the consumer
+    poison-drop in :mod:`queue_backend.pg_queue.consumer` — read it through this
+    one accessor, so a producer-side kwarg rename is caught here rather than
+    silently regressing the safety net in two places. Either field may be ``None``
+    (a malformed/legacy descriptor); the callers handle a missing org.
+    """
+    kwargs = callback_descriptor.get("kwargs") or {}
+    return kwargs.get("execution_id"), kwargs.get("organization_id")
+
+
 class Barrier(Protocol):
     """Fan-out-then-callback primitive.
 

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -1082,7 +1082,10 @@ def _mark_execution_error_on_abort(
     same values the enqueue stamped onto ``pg_barrier_state``.
     """
     execution_id = str(barrier_context["execution_id"])
-    _, org = callback_recovery_identity(barrier_context["callback_descriptor"])
+    # .get(): this runs inside run_batch_with_barrier's except block, so a missing
+    # callback_descriptor (a future/legacy dispatch path) must not raise a KeyError
+    # that would mask the original batch exception before the re-raise.
+    _, org = callback_recovery_identity(barrier_context.get("callback_descriptor") or {})
     organization_id = str(org or "")
     if not organization_id:
         logger.error(

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -82,7 +82,12 @@ from unstract.core.data_models import (
     is_pg_transport,
 )
 
-from .barrier import BarrierContext, CallbackDescriptor, barrier_ttl_seconds
+from .barrier import (
+    BarrierContext,
+    CallbackDescriptor,
+    barrier_ttl_seconds,
+    callback_recovery_identity,
+)
 from .decorator import worker_task
 from .fairness import (
     DEFAULT_PRIORITY,
@@ -1077,8 +1082,8 @@ def _mark_execution_error_on_abort(
     same values the enqueue stamped onto ``pg_barrier_state``.
     """
     execution_id = str(barrier_context["execution_id"])
-    callback_kwargs = barrier_context["callback_descriptor"].get("kwargs") or {}
-    organization_id = str(callback_kwargs.get("organization_id") or "")
+    _, org = callback_recovery_identity(barrier_context["callback_descriptor"])
+    organization_id = str(org or "")
     if not organization_id:
         logger.error(
             f"[exec:{execution_id}] {reason} but the barrier carries no "

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -969,6 +969,7 @@ def barrier_pg_abort(
     traceback: Any = None,
     *,
     execution_id: str,
+    preserve_dedup_markers: bool = False,
 ) -> dict[str, Any]:
     """``link_error`` callback: a header task failed → tear down barrier state.
 
@@ -982,10 +983,20 @@ def barrier_pg_abort(
     in-flight successful decrement then finds no row and abandons (no partial
     fire).
 
+    ``preserve_dedup_markers`` keeps the per-batch ``pg_batch_dedup`` markers in
+    place (default ``False`` — the Celery ``link_error`` path writes no markers,
+    so clearing them is a harmless no-op there). The in-body PG path passes
+    ``True``: the failed message can still redeliver, and a surviving marker makes
+    ``claim_batch`` return ``False`` on redelivery → the batch is skipped, not
+    re-run wholesale (real LLM spend). The markers are reclaimed later by the
+    barrier re-arm (same execution_id) or the dedup-orphan sweep; they can never
+    re-run anything on their own.
+
     The ``request``/``exc``/``traceback`` defaults keep the old-style
     ``errback(task_id)`` invocation (mixed-version deploy / ``bind=True``) from
     raising a ``TypeError``. This task does NOT drive workflow terminal status —
-    the outer orchestrators own that.
+    the outer orchestrators own that (the in-body PG path marks the execution
+    ERROR before calling here; see :func:`run_batch_with_barrier`).
     """
     del request, exc, traceback  # logged by the outer task; unused here
     with _cursor() as cur:
@@ -1002,29 +1013,39 @@ def barrier_pg_abort(
         # Another failure already aborted this execution (or it's already gone).
         return {"status": "already_aborted", "execution_id": execution_id}
 
-    # We won the abort: reclaim the per-batch dedup markers too (best-effort —
-    # the barrier is already torn down). A leftover marker would otherwise linger
-    # until the future dedup-orphan sweep; it can never re-run anything.
-    with contextlib.suppress(Exception):
-        clear_execution_batches(execution_id)
+    if not preserve_dedup_markers:
+        # We won the abort: reclaim the per-batch dedup markers too (best-effort —
+        # the barrier is already torn down). A leftover marker would otherwise
+        # linger until the future dedup-orphan sweep; it can never re-run anything.
+        with contextlib.suppress(Exception):
+            clear_execution_batches(execution_id)
 
     logger.error(
         f"[exec:{execution_id}] PgBarrier aborted — a header task failed; "
-        f"barrier state cleaned up (aggregating callback will not fire)."
+        f"barrier state cleaned up (aggregating callback will not fire; "
+        f"dedup markers {'preserved' if preserve_dedup_markers else 'cleared'})."
     )
     return {"status": "aborted", "execution_id": execution_id}
 
 
-def _abort_barrier_in_body(execution_id: str, *, reason: str) -> None:
+def _abort_barrier_in_body(
+    execution_id: str, *, reason: str, preserve_dedup_markers: bool = False
+) -> None:
     """Tear the barrier down from the in-body PG path (no ``.link_error`` here).
 
     Best-effort: a batch failure and a DB failure are correlated, so the abort
     itself can fail — that's logged (not swallowed silently) so a stuck barrier
     isn't masked by a misleading "torn down" message. A failed teardown bottoms
     out at the barrier's ``expires_at`` and is reclaimed by the reaper.
+
+    ``preserve_dedup_markers`` forwards to :func:`barrier_pg_abort` — the in-body
+    path keeps the per-batch markers so a redelivered batch is skipped by
+    ``claim_batch`` rather than re-run wholesale.
     """
     try:
-        barrier_pg_abort(execution_id=execution_id)
+        barrier_pg_abort(
+            execution_id=execution_id, preserve_dedup_markers=preserve_dedup_markers
+        )
         logger.error(
             f"[exec:{execution_id}] {reason} — barrier teardown attempted in-body "
             f"(no .link_error on the PG path); aggregating callback won't fire."
@@ -1035,6 +1056,56 @@ def _abort_barrier_in_body(execution_id: str, *, reason: str) -> None:
             f"itself failed — barrier will hang until expiry and be reclaimed by "
             f"the reaper (max_retries=0, no replay)."
         )
+
+
+def _mark_execution_error_on_abort(
+    barrier_context: BarrierContext, *, reason: str
+) -> bool:
+    """Best-effort: mark the execution ERROR (+cascade files) on an in-body PG
+    batch failure, so a failed batch reaches a terminal state instead of being
+    stranded ``EXECUTING`` forever with no handle the reaper can find.
+
+    Returns ``True`` iff the execution is now terminal (the mark was confirmed) —
+    only then is it safe for the caller to tear the barrier row down. On failure
+    (backend unreachable, or no ``organization_id`` to scope the org API) returns
+    ``False``: the caller must leave the barrier row so the reaper recovers it at
+    expiry, rather than erasing the only recovery handle.
+
+    PG path only — ``run_batch_with_barrier`` is the fire-and-forget substrate;
+    the Celery path never reaches here (its outer orchestrator owns terminal
+    status). The org and execution id come off the barrier's callback kwargs, the
+    same values the enqueue stamped onto ``pg_barrier_state``.
+    """
+    execution_id = str(barrier_context["execution_id"])
+    callback_kwargs = barrier_context["callback_descriptor"].get("kwargs") or {}
+    organization_id = str(callback_kwargs.get("organization_id") or "")
+    if not organization_id:
+        logger.error(
+            f"[exec:{execution_id}] {reason} but the barrier carries no "
+            f"organization_id — cannot mark it ERROR via the org-scoped API; "
+            f"leaving the barrier row for the reaper (not erasing the handle)."
+        )
+        return False
+    # Lazy import: keep this module free of the HTTP/env client at import time
+    # (mirrors the reaper) and avoid an import cycle via shared.api.
+    from shared.api import InternalAPIClient
+
+    from .pg_queue.recovery import mark_execution_error
+
+    try:
+        api_client = InternalAPIClient()
+    except Exception:
+        logger.exception(
+            f"[exec:{execution_id}] {reason} and building the internal API client "
+            f"to mark it ERROR failed — leaving the barrier row for the reaper."
+        )
+        return False
+    return mark_execution_error(
+        api_client,
+        execution_id,
+        organization_id,
+        error_message=f"[pg-barrier-abort] {reason}.",
+    )
 
 
 # A batch whose execution is already terminal returns its result with this
@@ -1129,6 +1200,25 @@ def run_batch_with_barrier(
             callback_descriptor=barrier_context["callback_descriptor"],
         )
     except Exception:
-        _abort_barrier_in_body(execution_id, reason=f"batch {batch_index} failed")
+        reason = f"batch {batch_index} failed"
+        # Mark the execution ERROR FIRST (+cascade files) so it reaches a terminal
+        # state. Only if that's confirmed do we tear the barrier row down — the
+        # row is the reaper's only recovery handle, so we must not delete it while
+        # the execution is still non-terminal. On a confirmed mark, keep the dedup
+        # markers so this message's redelivery is skipped by claim_batch (belt-and-
+        # braces with the terminal-execution guard) rather than re-run wholesale.
+        if _mark_execution_error_on_abort(barrier_context, reason=reason):
+            _abort_barrier_in_body(
+                execution_id, reason=reason, preserve_dedup_markers=True
+            )
+        else:
+            # Mark unconfirmed (backend down / no org): leave the barrier row so
+            # the reaper marks it ERROR and reclaims it at expiry. Do NOT erase the
+            # handle — that's the strand this ticket fixes.
+            logger.error(
+                f"[exec:{execution_id}] {reason} and could not confirm the ERROR "
+                f"mark — leaving the barrier row intact for the reaper (barrier "
+                f"hangs to expiry rather than stranding non-terminal)."
+            )
         raise
     return result

--- a/workers/queue_backend/pg_queue/client.py
+++ b/workers/queue_backend/pg_queue/client.py
@@ -362,6 +362,28 @@ class PgQueueClient:
             QueueMessage(msg_id=int(r[0]), message=r[1], read_ct=int(r[2])) for r in rows
         ]
 
+    def set_vt(self, msg_id: int, vt_seconds: int) -> bool:
+        """Re-park a claimed message: hide it for another ``vt_seconds``.
+
+        Returns ``True`` if a row was updated (``False`` = the row is already gone,
+        e.g. its vt expired and another reader deleted it). Does NOT touch
+        ``read_ct`` — the increment happens on the next :meth:`read` when the row
+        reappears, so a re-park loop is naturally bounded by ``read_ct`` climbing.
+
+        Used by the consumer to defer a poison message whose terminal-ERROR mark
+        could not be confirmed (backend down), so the drop never races a dead
+        backend and the payload isn't discarded into a void.
+        """
+        if vt_seconds <= 0:
+            raise ValueError(f"vt_seconds must be positive, got {vt_seconds}")
+        with self._cursor() as cur:
+            cur.execute(
+                f"UPDATE {qualified('pg_queue_message')} "
+                "SET vt = now() + make_interval(secs => %s) WHERE msg_id = %s",
+                (vt_seconds, msg_id),
+            )
+            return cur.rowcount == 1
+
     def delete(self, msg_id: int) -> bool:
         """Ack a processed message. Returns ``True`` if a row was removed.
 

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -26,12 +26,14 @@ import os
 import signal
 import time
 from collections.abc import Callable
+from enum import Enum
 from typing import TYPE_CHECKING, TypeVar
 
 from celery import current_app
 
 from unstract.core.data_models import ContinuationSpec, TaskPayload
 
+from ..barrier import callback_recovery_identity
 from ..fairness import FAIRNESS_HEADER_NAME
 from .client import PgQueueClient
 from .liveness import LivenessServer as _BaseLivenessServer
@@ -92,25 +94,43 @@ def _json_safe(value: object) -> object:
     return json.loads(json.dumps(value, default=str))
 
 
+class _PoisonMarkOutcome(Enum):
+    """Result of trying to mark a poison-dropped execution ERROR (drives whether
+    the consumer drops the message now or re-parks it).
+    """
+
+    CONFIRMED = "confirmed"  # marked terminal → safe to drop the message
+    UNMARKABLE = "unmarkable"  # permanent (no org) → drop now; re-park can't help
+    TRANSIENT = "transient"  # backend down / client build failed → re-park
+
+
 def _pipeline_identity(payload: TaskPayload) -> tuple[str | None, str]:
     """Best-effort ``(execution_id, organization_id)`` from a fire-and-forget
     payload, for marking the execution ERROR on a poison drop.
 
-    Barrier callbacks carry both directly in ``kwargs`` (the sharpest strand
-    case). Pipeline headers carry ``execution_id`` in the injected
-    ``_barrier_context`` and the org on the ``fairness`` payload. Returns
-    ``(None, "")`` when the payload isn't a pipeline message — nothing to mark.
-    ``organization_id`` may be ``""`` even with an ``execution_id`` (the caller
-    logs and skips the mark, since the status API is org-scoped).
+    The identity lives in one of three places, tried in order: directly on a
+    callback payload's ``kwargs`` (the aggregating-callback case — the sharpest
+    strand); on the injected ``_barrier_context``'s callback descriptor (a
+    pipeline header); or the org on the ``fairness`` payload. The callback-
+    descriptor dig goes through :func:`callback_recovery_identity` so it can't
+    drift from the barrier abort site. Returns ``(None, "")`` when the payload
+    isn't a pipeline message — nothing to mark. ``organization_id`` may be ``""``
+    even with an ``execution_id`` (the caller drops, since the status API is
+    org-scoped and re-parking can't conjure an org).
     """
     kwargs = payload.get("kwargs") or {}
     barrier_ctx = kwargs.get("_barrier_context") or {}
-    execution_id = kwargs.get("execution_id") or barrier_ctx.get("execution_id")
-    organization_id = kwargs.get("organization_id") or (
-        (barrier_ctx.get("callback_descriptor") or {}).get("kwargs") or {}
-    ).get("organization_id")
-    if not organization_id:
-        organization_id = (payload.get("fairness") or {}).get("org_id")
+    cb_execution_id, cb_org = callback_recovery_identity(
+        barrier_ctx.get("callback_descriptor") or {}
+    )
+    execution_id = (
+        kwargs.get("execution_id") or barrier_ctx.get("execution_id") or cb_execution_id
+    )
+    organization_id = (
+        kwargs.get("organization_id")
+        or cb_org
+        or (payload.get("fairness") or {}).get("org_id")
+    )
     return (
         str(execution_id) if execution_id else None,
         str(organization_id or ""),
@@ -251,66 +271,7 @@ class PgQueueConsumer:
         # it (with the payload, so it's recoverable from logs) instead of
         # redelivering on every vt expiry forever.
         if message.read_ct > self.max_attempts:
-            execution_id, organization_id = _pipeline_identity(payload)
-            logger.error(
-                "PG-queue consumer: task %r (msg_id=%s) exceeded max_attempts=%s "
-                "(read_ct=%s, execution_id=%s) — poison; full payload: %r",
-                task_name,
-                message.msg_id,
-                self.max_attempts,
-                message.read_ct,
-                execution_id,
-                payload,
-            )
-            # Messages with a failure channel (request-reply / on_error callback)
-            # surface the failure there — existing behavior, drop after.
-            if reply_key or on_error:
-                self._fail_dispatch(
-                    payload,
-                    error=f"task {task_name} exceeded max_attempts={self.max_attempts}",
-                )
-                self._client.delete(message.msg_id)
-                return
-            # No failure channel. A pipeline header / barrier callback carries an
-            # execution_id but neither reply_key nor on_error, so a bare delete
-            # silently strands the execution EXECUTING-forever (barrier row already
-            # gone → the reaper has no handle). Mark it ERROR first so the failure
-            # is visible and re-runnable.
-            if execution_id is None:
-                # Not a pipeline message and no failure channel — nothing to mark.
-                self._client.delete(message.msg_id)
-                return
-            if self._mark_poison_execution_error(
-                execution_id, organization_id, task_name
-            ):
-                self._client.delete(message.msg_id)  # terminal → safe to drop
-                return
-            # Mark unconfirmed (backend down): re-park with a long vt rather than
-            # delete into a void, so the poison drop never races a dead backend —
-            # bounded so a permanently-unmarkable message can't re-park forever.
-            if message.read_ct > self.max_attempts + self._poison_repark_budget:
-                logger.error(
-                    "PG-queue consumer: exhausted poison re-park budget for "
-                    "execution %s (msg_id=%s, read_ct=%s) — dropping despite an "
-                    "unconfirmed ERROR mark; the reaper is the last net. Full "
-                    "payload: %r",
-                    execution_id,
-                    message.msg_id,
-                    message.read_ct,
-                    payload,
-                )
-                self._client.delete(message.msg_id)
-                return
-            self._client.set_vt(message.msg_id, self._poison_repark_vt_seconds)
-            logger.warning(
-                "PG-queue consumer: could not confirm ERROR mark for poison "
-                "execution %s (msg_id=%s, read_ct=%s) — re-parked for %ss "
-                "(backend down?) instead of dropping.",
-                execution_id,
-                message.msg_id,
-                message.read_ct,
-                self._poison_repark_vt_seconds,
-            )
+            self._drop_poison_message(message, payload, task_name)
             return
 
         task = self._app.tasks.get(task_name)
@@ -534,6 +495,94 @@ class PgQueueConsumer:
                 error=error,
             )
 
+    def _drop_poison_message(
+        self, message: QueueMessage, payload: TaskPayload, task_name: str | None
+    ) -> None:
+        """Handle a message that exceeded ``max_attempts`` (poison).
+
+        A message with a failure channel (``reply_key`` / ``on_error``) surfaces
+        the failure there and is dropped — existing behavior. A pipeline header /
+        barrier callback has neither but carries an ``execution_id``: a bare delete
+        would silently strand the execution EXECUTING-forever (the barrier row is
+        already gone → the reaper has no handle), so mark it ERROR first. The mark
+        has three outcomes (see :class:`_PoisonMarkOutcome`): confirmed → drop;
+        permanently unmarkable (no org) → drop now, since re-parking can never
+        help; transient (backend down / client build failed) → re-park with a long
+        vt rather than delete into a void, bounded by ``poison_repark_budget``.
+        """
+        execution_id, organization_id = _pipeline_identity(payload)
+        logger.error(
+            "PG-queue consumer: task %r (msg_id=%s) exceeded max_attempts=%s "
+            "(read_ct=%s, execution_id=%s) — poison; full payload: %r",
+            task_name,
+            message.msg_id,
+            self.max_attempts,
+            message.read_ct,
+            execution_id,
+            payload,
+        )
+        # Failure channel (request-reply / on_error) → surface there, then drop.
+        if payload.get("reply_key") or payload.get("on_error"):
+            self._fail_dispatch(
+                payload,
+                error=f"task {task_name} exceeded max_attempts={self.max_attempts}",
+            )
+            self._client.delete(message.msg_id)
+            return
+        # No failure channel and not a pipeline message → nothing to mark; drop.
+        if execution_id is None:
+            self._client.delete(message.msg_id)
+            return
+        # Pipeline strand: mark ERROR so the failure is visible and re-runnable.
+        outcome = self._mark_poison_execution_error(
+            execution_id, organization_id, task_name
+        )
+        if outcome is _PoisonMarkOutcome.CONFIRMED:
+            self._client.delete(message.msg_id)  # terminal → safe to drop
+            return
+        if outcome is _PoisonMarkOutcome.UNMARKABLE:
+            # Permanent (no org): re-parking can never change the outcome, so drop
+            # now rather than burn the whole budget. The full payload was logged
+            # above for manual recovery.
+            self._client.delete(message.msg_id)
+            return
+        # TRANSIENT (backend down / client build failed): re-park rather than
+        # delete into a void, bounded so a permanently-stuck message can't re-park
+        # forever. NOTE: the reaper only recovers executions that still have a
+        # pg_barrier_state row; an aggregating-callback message is enqueued AFTER
+        # that row is deleted, so on budget exhaustion here it has no reaper handle
+        # and needs manual replay from the logged payload — the bound is a
+        # backstop, not a guaranteed reaper recovery for the callback case.
+        if message.read_ct > self.max_attempts + self._poison_repark_budget:
+            logger.error(
+                "PG-queue consumer: exhausted poison re-park budget for execution "
+                "%s (msg_id=%s, read_ct=%s) — dropping with an unconfirmed ERROR "
+                "mark. If this was an aggregating callback its barrier row is "
+                "already gone, so the reaper cannot recover it: manual replay from "
+                "the full payload logged above may be required.",
+                execution_id,
+                message.msg_id,
+                message.read_ct,
+            )
+            self._client.delete(message.msg_id)
+            return
+        if not self._client.set_vt(message.msg_id, self._poison_repark_vt_seconds):
+            # Row already gone (vt expired and another reader deleted it) — nothing
+            # to re-park; don't log a re-park that didn't happen.
+            logger.info(
+                "PG-queue consumer: poison message %s already gone before re-park.",
+                message.msg_id,
+            )
+            return
+        logger.warning(
+            "PG-queue consumer: could not confirm ERROR mark for poison execution "
+            "%s (msg_id=%s, read_ct=%s) — re-parked for %ss instead of dropping.",
+            execution_id,
+            message.msg_id,
+            message.read_ct,
+            self._poison_repark_vt_seconds,
+        )
+
     def _get_api_client(self) -> InternalAPIClient:
         # Lazy import + build (mirrors the reaper): keeps a fire-and-forget
         # consumer that never poisons free of the HTTP/env client, and avoids a
@@ -546,33 +595,37 @@ class PgQueueConsumer:
 
     def _mark_poison_execution_error(
         self, execution_id: str, organization_id: str, task_name: str | None
-    ) -> bool:
+    ) -> _PoisonMarkOutcome:
         """Best-effort: mark a poison-dropped pipeline execution ERROR (+cascade).
 
-        Returns ``True`` iff the mark is confirmed (safe to delete the message);
-        ``False`` when it can't be confirmed (no org, or the backend is down) so
-        the caller re-parks instead of dropping into a void.
+        Returns a :class:`_PoisonMarkOutcome`: ``CONFIRMED`` when the backend
+        confirmed the mark (safe to drop); ``UNMARKABLE`` when it can never be
+        marked (no org to scope the status API — re-parking is pointless, drop
+        now); ``TRANSIENT`` when the mark failed for a possibly-recoverable reason
+        (backend down, or the API client couldn't be built) so the caller re-parks
+        rather than dropping into a void.
         """
         if not organization_id:
             logger.error(
                 "PG-queue consumer: poison message for execution %s carries no "
                 "organization_id — cannot mark it ERROR via the org-scoped API; "
-                "dropping (the reaper is the recovery net).",
+                "dropping now (re-parking cannot help). Manual recovery from the "
+                "logged payload may be required.",
                 execution_id,
             )
-            return False
+            return _PoisonMarkOutcome.UNMARKABLE
         try:
             api_client = self._get_api_client()
         except Exception:
             logger.exception(
                 "PG-queue consumer: could not build the internal API client to "
-                "mark poison execution %s ERROR",
+                "mark poison execution %s ERROR — will re-park",
                 execution_id,
             )
-            return False
+            return _PoisonMarkOutcome.TRANSIENT
         from .recovery import mark_execution_error
 
-        return mark_execution_error(
+        confirmed = mark_execution_error(
             api_client,
             execution_id,
             organization_id,
@@ -581,6 +634,7 @@ class PgQueueConsumer:
                 f"max_attempts={self.max_attempts}."
             ),
         )
+        return _PoisonMarkOutcome.CONFIRMED if confirmed else _PoisonMarkOutcome.TRANSIENT
 
     def _fail_reply(self, reply_key: str | None, error: str) -> None:
         """Best-effort failure reply for a request-reply message that can't run

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -40,6 +40,7 @@ from .task_payload import to_payload
 
 if TYPE_CHECKING:
     from celery import Celery
+    from shared.api import InternalAPIClient
 
     from .client import QueueMessage
 
@@ -59,6 +60,14 @@ _DEFAULT_BACKOFF_MAX = 2.0
 # A task claimed more than this many times keeps failing — drop it (poison)
 # rather than redeliver forever.
 _DEFAULT_MAX_ATTEMPTS = 5
+# When a poison drop's terminal-ERROR mark can't be confirmed (backend down), the
+# message is re-parked this long instead of deleted into a void — so the drop
+# never races a dead backend. Comfortably above a brief backend restart.
+_DEFAULT_POISON_REPARK_VT_SECONDS = 300
+# ...and give up (delete despite an unconfirmed mark, leaving the reaper as the
+# last net) after this many extra reads past max_attempts, so a permanently
+# unmarkable pipeline message can't re-park forever.
+_DEFAULT_POISON_REPARK_BUDGET = 5
 # Liveness: a poll loop that hasn't cycled in this many seconds is reported
 # unhealthy. The heartbeat is stamped at the top of each poll_once and frozen
 # during task execution, so this threshold doubles as an UPPER BOUND on a single
@@ -83,6 +92,31 @@ def _json_safe(value: object) -> object:
     return json.loads(json.dumps(value, default=str))
 
 
+def _pipeline_identity(payload: TaskPayload) -> tuple[str | None, str]:
+    """Best-effort ``(execution_id, organization_id)`` from a fire-and-forget
+    payload, for marking the execution ERROR on a poison drop.
+
+    Barrier callbacks carry both directly in ``kwargs`` (the sharpest strand
+    case). Pipeline headers carry ``execution_id`` in the injected
+    ``_barrier_context`` and the org on the ``fairness`` payload. Returns
+    ``(None, "")`` when the payload isn't a pipeline message — nothing to mark.
+    ``organization_id`` may be ``""`` even with an ``execution_id`` (the caller
+    logs and skips the mark, since the status API is org-scoped).
+    """
+    kwargs = payload.get("kwargs") or {}
+    barrier_ctx = kwargs.get("_barrier_context") or {}
+    execution_id = kwargs.get("execution_id") or barrier_ctx.get("execution_id")
+    organization_id = kwargs.get("organization_id") or (
+        (barrier_ctx.get("callback_descriptor") or {}).get("kwargs") or {}
+    ).get("organization_id")
+    if not organization_id:
+        organization_id = (payload.get("fairness") or {}).get("org_id")
+    return (
+        str(execution_id) if execution_id else None,
+        str(organization_id or ""),
+    )
+
+
 class PgQueueConsumer:
     """Polls one PG queue, runs each claimed task in-process, acks on success."""
 
@@ -92,11 +126,14 @@ class PgQueueConsumer:
         *,
         client: PgQueueClient | None = None,
         app: Celery | None = None,
+        api_client: InternalAPIClient | None = None,
         batch_size: int = _DEFAULT_BATCH,
         vt_seconds: int = _DEFAULT_VT_SECONDS,
         poll_interval: float = _DEFAULT_POLL_INTERVAL,
         backoff_max: float = _DEFAULT_BACKOFF_MAX,
         max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+        poison_repark_vt_seconds: int = _DEFAULT_POISON_REPARK_VT_SECONDS,
+        poison_repark_budget: int = _DEFAULT_POISON_REPARK_BUDGET,
     ) -> None:
         # Validate at construction so a misconfigured consumer fails here
         # rather than batch-after-batch once the loop starts.
@@ -106,6 +143,8 @@ class PgQueueConsumer:
             ("poll_interval", poll_interval),
             ("backoff_max", backoff_max),
             ("max_attempts", max_attempts),
+            ("poison_repark_vt_seconds", poison_repark_vt_seconds),
+            ("poison_repark_budget", poison_repark_budget),
         ):
             if value <= 0:
                 raise ValueError(f"{name} must be positive, got {value!r}")
@@ -128,11 +167,17 @@ class PgQueueConsumer:
         self.queue_names = list(dict.fromkeys(queue_names))
         self._client = client if client is not None else PgQueueClient()
         self._app = app if app is not None else current_app
+        # Lazily built the first time a poison drop needs to mark an execution
+        # ERROR (fire-and-forget consumers with no poison never build it); an
+        # injected client short-circuits the build (tests / DI).
+        self._api_client = api_client
         self.batch_size = batch_size
         self.vt_seconds = vt_seconds
         self.poll_interval = poll_interval
         self.backoff_max = backoff_max
         self.max_attempts = max_attempts
+        self._poison_repark_vt_seconds = poison_repark_vt_seconds
+        self._poison_repark_budget = poison_repark_budget
         self._running = False
         # Request-reply (executor RPC) result store — lazily created the first
         # time a message carries a ``reply_key``; fire-and-forget consumers
@@ -206,20 +251,66 @@ class PgQueueConsumer:
         # it (with the payload, so it's recoverable from logs) instead of
         # redelivering on every vt expiry forever.
         if message.read_ct > self.max_attempts:
+            execution_id, organization_id = _pipeline_identity(payload)
             logger.error(
                 "PG-queue consumer: task %r (msg_id=%s) exceeded max_attempts=%s "
-                "(read_ct=%s) — dropping poison message: %r",
+                "(read_ct=%s, execution_id=%s) — poison; full payload: %r",
                 task_name,
                 message.msg_id,
                 self.max_attempts,
                 message.read_ct,
+                execution_id,
                 payload,
             )
-            self._fail_dispatch(
-                payload,
-                error=f"task {task_name} exceeded max_attempts={self.max_attempts}",
+            # Messages with a failure channel (request-reply / on_error callback)
+            # surface the failure there — existing behavior, drop after.
+            if reply_key or on_error:
+                self._fail_dispatch(
+                    payload,
+                    error=f"task {task_name} exceeded max_attempts={self.max_attempts}",
+                )
+                self._client.delete(message.msg_id)
+                return
+            # No failure channel. A pipeline header / barrier callback carries an
+            # execution_id but neither reply_key nor on_error, so a bare delete
+            # silently strands the execution EXECUTING-forever (barrier row already
+            # gone → the reaper has no handle). Mark it ERROR first so the failure
+            # is visible and re-runnable.
+            if execution_id is None:
+                # Not a pipeline message and no failure channel — nothing to mark.
+                self._client.delete(message.msg_id)
+                return
+            if self._mark_poison_execution_error(
+                execution_id, organization_id, task_name
+            ):
+                self._client.delete(message.msg_id)  # terminal → safe to drop
+                return
+            # Mark unconfirmed (backend down): re-park with a long vt rather than
+            # delete into a void, so the poison drop never races a dead backend —
+            # bounded so a permanently-unmarkable message can't re-park forever.
+            if message.read_ct > self.max_attempts + self._poison_repark_budget:
+                logger.error(
+                    "PG-queue consumer: exhausted poison re-park budget for "
+                    "execution %s (msg_id=%s, read_ct=%s) — dropping despite an "
+                    "unconfirmed ERROR mark; the reaper is the last net. Full "
+                    "payload: %r",
+                    execution_id,
+                    message.msg_id,
+                    message.read_ct,
+                    payload,
+                )
+                self._client.delete(message.msg_id)
+                return
+            self._client.set_vt(message.msg_id, self._poison_repark_vt_seconds)
+            logger.warning(
+                "PG-queue consumer: could not confirm ERROR mark for poison "
+                "execution %s (msg_id=%s, read_ct=%s) — re-parked for %ss "
+                "(backend down?) instead of dropping.",
+                execution_id,
+                message.msg_id,
+                message.read_ct,
+                self._poison_repark_vt_seconds,
             )
-            self._client.delete(message.msg_id)
             return
 
         task = self._app.tasks.get(task_name)
@@ -442,6 +533,54 @@ class PgQueueConsumer:
                 payload=payload,
                 error=error,
             )
+
+    def _get_api_client(self) -> InternalAPIClient:
+        # Lazy import + build (mirrors the reaper): keeps a fire-and-forget
+        # consumer that never poisons free of the HTTP/env client, and avoids a
+        # module-load import cycle via shared.api.
+        if self._api_client is None:
+            from shared.api import InternalAPIClient
+
+            self._api_client = InternalAPIClient()
+        return self._api_client
+
+    def _mark_poison_execution_error(
+        self, execution_id: str, organization_id: str, task_name: str | None
+    ) -> bool:
+        """Best-effort: mark a poison-dropped pipeline execution ERROR (+cascade).
+
+        Returns ``True`` iff the mark is confirmed (safe to delete the message);
+        ``False`` when it can't be confirmed (no org, or the backend is down) so
+        the caller re-parks instead of dropping into a void.
+        """
+        if not organization_id:
+            logger.error(
+                "PG-queue consumer: poison message for execution %s carries no "
+                "organization_id — cannot mark it ERROR via the org-scoped API; "
+                "dropping (the reaper is the recovery net).",
+                execution_id,
+            )
+            return False
+        try:
+            api_client = self._get_api_client()
+        except Exception:
+            logger.exception(
+                "PG-queue consumer: could not build the internal API client to "
+                "mark poison execution %s ERROR",
+                execution_id,
+            )
+            return False
+        from .recovery import mark_execution_error
+
+        return mark_execution_error(
+            api_client,
+            execution_id,
+            organization_id,
+            error_message=(
+                f"[pg-poison-drop] task {task_name} exceeded "
+                f"max_attempts={self.max_attempts}."
+            ),
+        )
 
     def _fail_reply(self, reply_key: str | None, error: str) -> None:
         """Best-effort failure reply for a request-reply message that can't run

--- a/workers/queue_backend/pg_queue/recovery.py
+++ b/workers/queue_backend/pg_queue/recovery.py
@@ -72,7 +72,11 @@ def mark_execution_error(
             execution_id,
         )
         return False
-    logger.error(
+    # WARNING, not ERROR: this line records a successful recovery *action*; the
+    # underlying failure that caused the strand is already logged at ERROR by the
+    # caller (the batch failure / the poison drop), so ERROR here would double-
+    # count as alert noise for a non-error outcome.
+    logger.warning(
         "Marked stranded execution %s ERROR (+cascade files): %s",
         execution_id,
         error_message,

--- a/workers/queue_backend/pg_queue/recovery.py
+++ b/workers/queue_backend/pg_queue/recovery.py
@@ -1,0 +1,80 @@
+"""Best-effort terminal-ERROR marking for stranded PG-path executions.
+
+Any PG failure that tears down its own recovery handle — the barrier abort
+deletes ``pg_barrier_state``; the consumer poison-drop deletes the queue
+message — must first make the workflow execution terminal, or the execution is
+stranded ``EXECUTING`` forever with nothing left for the reaper to find (the
+reaper only recovers executions that still have a barrier row).
+
+:func:`mark_execution_error` centralises that mark: set the execution ERROR via
+the internal API, cascading to its non-terminal file executions in the same
+backend transaction (so the execution never goes ERROR while its files stay
+EXECUTING). It is deliberately best-effort and returns a bool so the caller can
+decide what to do on failure (leave the barrier row / re-park the message)
+rather than erase the only recovery handle.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from unstract.core.data_models import ExecutionStatus
+
+if TYPE_CHECKING:
+    from shared.api import InternalAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+def mark_execution_error(
+    api_client: InternalAPIClient,
+    execution_id: str,
+    organization_id: str,
+    *,
+    error_message: str,
+) -> bool:
+    """Mark ``execution_id`` ERROR (+cascade non-terminal files); return success.
+
+    Returns ``True`` iff the backend confirmed the write. NEVER raises: any
+    failure — a raised exception, or a ``success=False`` response (the internal
+    client reports some write failures that way rather than raising, mirroring
+    the reaper / read path) — is logged and returns ``False`` so the caller keeps
+    the recovery handle instead of erasing it.
+
+    ``cascade_terminal_files=True`` marks the execution's non-terminal file
+    executions to ERROR atomically with the execution, so the two can't drift.
+
+    The reaper keeps its own raise-on-failure variant (``_mark_stranded_error``):
+    its delete-guard needs the exception to refuse the barrier-row DELETE, whereas
+    the callers here branch on the returned bool.
+    """
+    try:
+        response = api_client.update_workflow_execution_status(
+            execution_id=execution_id,
+            status=ExecutionStatus.ERROR.value,
+            error_message=error_message,
+            organization_id=organization_id,
+            cascade_terminal_files=True,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to mark execution %s ERROR (internal API raised) — leaving the "
+            "recovery handle in place for the reaper.",
+            execution_id,
+        )
+        return False
+    # ``success`` absent → assume the raised-on-failure legacy contract (True).
+    if not getattr(response, "success", True):
+        logger.error(
+            "Marking execution %s ERROR reported success=False — leaving the "
+            "recovery handle in place for the reaper.",
+            execution_id,
+        )
+        return False
+    logger.error(
+        "Marked stranded execution %s ERROR (+cascade files): %s",
+        execution_id,
+        error_message,
+    )
+    return True

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -329,9 +329,7 @@ class TestDecrementPhaseSplitRetry:
         assert "execute failed on a cached connection" in caplog.text
         assert type(exc).__name__ in caplog.text
 
-    def test_commit_phase_failure_is_not_retried(
-        self, _clean_local, monkeypatch, sleeps
-    ):
+    def test_commit_phase_failure_is_not_retried(self, _clean_local, monkeypatch, sleeps):
         # A commit failure is AMBIGUOUS (the server may have applied it) → must
         # NOT retry, or the decrement could land twice. It propagates; the dead
         # conn is discarded; no reconnect is attempted.
@@ -377,9 +375,7 @@ class TestDecrementPhaseSplitRetry:
         assert reconnects == []  # fresh-conn death is not retried
         assert sleeps == []  # …so no backoff either
 
-    def test_non_connection_error_is_not_retried(
-        self, _clean_local, monkeypatch, sleeps
-    ):
+    def test_non_connection_error_is_not_retried(self, _clean_local, monkeypatch, sleeps):
         # A DataError (e.g. a NUL byte rejected by the jsonb cast) is not a
         # connection death → propagate immediately so the caller tears the barrier
         # down. A live conn after a logical error is NOT discarded.
@@ -459,7 +455,8 @@ def test_create_pg_connection_is_non_autocommit():
 
     Opens a real connection inline (no fixture), so it's marked ``integration``
     explicitly — the collection hook keys off fixture names and wouldn't catch
-    it, which would otherwise leave it in the DB-free unit lane."""
+    it, which would otherwise leave it in the DB-free unit lane.
+    """
     os.environ.setdefault("TEST_DB_HOST", "127.0.0.1")
     try:
         conn = create_pg_connection(env_prefix="TEST_DB_")
@@ -523,7 +520,8 @@ def _org(conn, execution_id):
 
 def _expires_in_seconds(conn, execution_id):
     """Seconds from *now* until the barrier's expires_at (DB-side now(), so no
-    client-clock skew) — the fixed 6h absolute cap."""
+    client-clock skew) — the fixed 6h absolute cap.
+    """
     with conn.cursor() as cur:
         cur.execute(
             "SELECT EXTRACT(EPOCH FROM (expires_at - now())) "
@@ -535,7 +533,8 @@ def _expires_in_seconds(conn, execution_id):
 
 def _last_progress_age_seconds(conn, execution_id):
     """How long ago (DB-side) the barrier last made progress — the reaper's stuck
-    signal (UN-3661). Small = fresh; large = stalled."""
+    signal (UN-3661). Small = fresh; large = stalled.
+    """
     with conn.cursor() as cur:
         cur.execute(
             "SELECT EXTRACT(EPOCH FROM (now() - last_progress_at)) "
@@ -562,9 +561,7 @@ class TestPgBarrierEnqueue:
             cloned.link_error.assert_called_once()
             cloned.apply_async.assert_called_once()
 
-    def test_enqueue_sets_expires_cap_and_fresh_progress(
-        self, barrier_db, monkeypatch
-    ):
+    def test_enqueue_sets_expires_cap_and_fresh_progress(self, barrier_db, monkeypatch):
         # enqueue stamps expires_at = now()+ttl (the absolute cap) AND
         # last_progress_at = now() (fresh), so a just-enqueued barrier is neither
         # expired nor stale. (UN-3661)
@@ -1161,10 +1158,29 @@ class TestPgFireAndForgetMode:
         remaining, _ = _row(barrier_db, "exec-re")
         assert remaining == 2  # NOT decremented again
 
-    def test_run_batch_with_barrier_exception_aborts_barrier(self, barrier_db):
+    def _dedup_count(self, conn, execution_id):
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pg_batch_dedup WHERE execution_id = %s",
+                (execution_id,),
+            )
+            return cur.fetchone()[0]
+
+    def test_exception_marks_error_then_tears_down_keeping_markers(
+        self, barrier_db, monkeypatch
+    ):
+        # Confirmed ERROR mark → safe to tear the barrier row down, but KEEP the
+        # per-batch dedup marker so this message's redelivery is skipped by
+        # claim_batch (not re-run wholesale).
         with barrier_db.cursor() as cur:
             cur.execute("DELETE FROM pg_batch_dedup")
         _seed(barrier_db, "exec-err", 2)
+        marked = []
+        monkeypatch.setattr(
+            pg_barrier,
+            "_mark_execution_error_on_abort",
+            lambda ctx, *, reason: marked.append(reason) or True,
+        )
         ctx = {
             "execution_id": "exec-err",
             "batch_index": 0,
@@ -1176,8 +1192,38 @@ class TestPgFireAndForgetMode:
 
         with pytest.raises(RuntimeError, match="batch failed"):
             run_batch_with_barrier(ctx, boom)
-        # No .link_error on the PG path → torn down in-body (mirror chord abort).
+        assert marked  # execution marked ERROR before teardown
+        # Row torn down (mirror chord abort) but the dedup marker survives.
         assert _row(barrier_db, "exec-err") is None
+        assert self._dedup_count(barrier_db, "exec-err") == 1  # claim marker kept
+
+    def test_exception_with_unconfirmed_mark_leaves_barrier_row(
+        self, barrier_db, monkeypatch
+    ):
+        # ERROR mark NOT confirmed (backend down / no org) → the barrier row is the
+        # reaper's only recovery handle, so it must be LEFT intact, not deleted.
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-strand", 2)
+        monkeypatch.setattr(
+            pg_barrier,
+            "_mark_execution_error_on_abort",
+            lambda ctx, *, reason: False,
+        )
+        ctx = {
+            "execution_id": "exec-strand",
+            "batch_index": 0,
+            "callback_descriptor": _CALLBACK,
+        }
+
+        def boom():
+            raise RuntimeError("batch failed")
+
+        with pytest.raises(RuntimeError, match="batch failed"):
+            run_batch_with_barrier(ctx, boom)
+        # Barrier row preserved for the reaper (remaining untouched).
+        remaining, _ = _row(barrier_db, "exec-strand")
+        assert remaining == 2
 
     def test_fire_barrier_callback_pg_self_chains_via_dispatch(self):
         descriptor = {**_CALLBACK, "transport": "pg_queue"}
@@ -1239,6 +1285,24 @@ class TestPgFireAndForgetMode:
             )
             assert cur.fetchone()[0] == 0
 
+    def test_abort_preserve_flag_keeps_dedup_markers(self, barrier_db):
+        # preserve_dedup_markers=True (the in-body PG path): the barrier row is
+        # still deleted, but the marker survives so a redelivered batch is skipped
+        # by claim_batch rather than re-run wholesale.
+        with barrier_db.cursor() as cur:
+            cur.execute("DELETE FROM pg_batch_dedup")
+        _seed(barrier_db, "exec-keep", 2)
+        claim_batch("exec-keep", 0)
+        barrier_pg_abort(execution_id="exec-keep", preserve_dedup_markers=True)
+        assert _row(barrier_db, "exec-keep") is None  # barrier row still deleted
+        with barrier_db.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM pg_batch_dedup WHERE execution_id = %s",
+                ("exec-keep",),
+            )
+            assert cur.fetchone()[0] == 1  # marker preserved
+        assert claim_batch("exec-keep", 0) is False  # redelivery would be skipped
+
     def test_last_batch_self_chains_callback_to_pg_and_cleans_up(self, barrier_db):
         # The PR's core promise, end to end: the batch that drives remaining → 0
         # self-chains the aggregating callback onto PG (backend=PG, args=[results])
@@ -1275,13 +1339,17 @@ class TestPgFireAndForgetMode:
             )
             assert cur.fetchone()[0] == 0
 
-    def test_decrement_failure_aborts_barrier(self, barrier_db):
+    def test_decrement_failure_aborts_barrier(self, barrier_db, monkeypatch):
         # #69: a decrement-side failure (after the work succeeded) must tear the
         # barrier down in-body — else the dedup marker is committed, redelivery is
-        # blocked, and the barrier strands to expiry.
+        # blocked, and the barrier strands to expiry. With a confirmed ERROR mark
+        # the row is torn down (same path as a work failure).
         with barrier_db.cursor() as cur:
             cur.execute("DELETE FROM pg_batch_dedup")
         _seed(barrier_db, "exec-decfail", 2)
+        monkeypatch.setattr(
+            pg_barrier, "_mark_execution_error_on_abort", lambda ctx, *, reason: True
+        )
         ctx = {
             "execution_id": "exec-decfail",
             "batch_index": 0,
@@ -1335,6 +1403,74 @@ class TestPgFireAndForgetMode:
             # The marker existed post-UPSERT and was removed by the mid-loop
             # clear_execution_batches under test (not by the UPSERT reset).
             assert cur.fetchone()[0] == 0
+
+
+class TestMarkExecutionErrorOnAbort:
+    """``_mark_execution_error_on_abort`` — the in-body PG failure → terminal mark
+    (no DB; the internal API client + mark helper are mocked).
+    """
+
+    def _ctx(self, *, org):
+        kwargs = {"execution_id": "exec-1", "pipeline_id": "pipe-1"}
+        if org is not None:
+            kwargs["organization_id"] = org
+        return {
+            "execution_id": "exec-1",
+            "batch_index": 0,
+            "callback_descriptor": {**_CALLBACK, "kwargs": kwargs},
+        }
+
+    def test_no_org_returns_false_without_building_client(self, monkeypatch):
+        # No org → can't call the org-scoped API; must NOT build a client or mark.
+        built = MagicMock(side_effect=AssertionError("client built without org"))
+        monkeypatch.setattr("shared.api.InternalAPIClient", built)
+        assert (
+            pg_barrier._mark_execution_error_on_abort(
+                self._ctx(org=None), reason="batch 0 failed"
+            )
+            is False
+        )
+
+    def test_org_present_marks_error_and_returns_helper_result(self, monkeypatch):
+        client = MagicMock(name="api_client")
+        monkeypatch.setattr(
+            "shared.api.InternalAPIClient", MagicMock(return_value=client)
+        )
+        mark = MagicMock(return_value=True)
+        monkeypatch.setattr("queue_backend.pg_queue.recovery.mark_execution_error", mark)
+        out = pg_barrier._mark_execution_error_on_abort(
+            self._ctx(org="org-9"), reason="batch 0 failed"
+        )
+        assert out is True
+        mark.assert_called_once()
+        args, kwargs = mark.call_args
+        assert args[0] is client
+        assert args[1] == "exec-1"
+        assert args[2] == "org-9"
+        assert kwargs["error_message"] == "[pg-barrier-abort] batch 0 failed."
+
+    def test_helper_false_propagates(self, monkeypatch):
+        monkeypatch.setattr(
+            "shared.api.InternalAPIClient", MagicMock(return_value=MagicMock())
+        )
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error",
+            MagicMock(return_value=False),
+        )
+        assert (
+            pg_barrier._mark_execution_error_on_abort(self._ctx(org="org-9"), reason="x")
+            is False
+        )
+
+    def test_client_build_failure_returns_false(self, monkeypatch):
+        monkeypatch.setattr(
+            "shared.api.InternalAPIClient",
+            MagicMock(side_effect=RuntimeError("no config")),
+        )
+        assert (
+            pg_barrier._mark_execution_error_on_abort(self._ctx(org="org-9"), reason="x")
+            is False
+        )
 
 
 if __name__ == "__main__":

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -133,8 +133,9 @@ class TestPgQueueClientUnit:
 
     def test_set_vt_rejects_non_positive(self):
         conn, _ = _mock_conn()
+        client = PgQueueClient(conn=conn)
         with pytest.raises(ValueError, match="vt_seconds"):
-            PgQueueClient(conn=conn).set_vt(1, 0)
+            client.set_vt(1, 0)
 
     def test_read_rejects_non_positive_vt(self):
         conn, _ = _mock_conn()

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -117,6 +117,25 @@ class TestPgQueueClientUnit:
         conn, _ = _mock_conn(rowcount=0)
         assert PgQueueClient(conn=conn).delete(999) is False
 
+    def test_set_vt_reparks_message(self):
+        conn, cur = _mock_conn(rowcount=1)
+        assert PgQueueClient(conn=conn).set_vt(42, 300) is True
+        sql, params = cur.execute.call_args.args
+        assert f"UPDATE {qualified('pg_queue_message')}" in sql
+        assert "SET vt = now() + make_interval(secs => %s)" in sql
+        assert "read_ct" not in sql  # re-park must NOT bump the delivery count
+        assert params == (300, 42)
+        conn.commit.assert_called_once()
+
+    def test_set_vt_returns_false_when_no_row(self):
+        conn, _ = _mock_conn(rowcount=0)
+        assert PgQueueClient(conn=conn).set_vt(999, 300) is False
+
+    def test_set_vt_rejects_non_positive(self):
+        conn, _ = _mock_conn()
+        with pytest.raises(ValueError, match="vt_seconds"):
+            PgQueueClient(conn=conn).set_vt(1, 0)
+
     def test_read_rejects_non_positive_vt(self):
         conn, _ = _mock_conn()
         with pytest.raises(ValueError, match="vt_seconds"):

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -306,9 +306,70 @@ class TestPoisonDropMarksExecution:
         marked.assert_not_called()
         client.delete.assert_called_once_with(5)
 
+    def test_repark_budget_boundary_still_reparks(self, monkeypatch):
+        # Gap A: at exactly read_ct == max_attempts + budget (10) the message must
+        # still re-park; only strictly beyond it drops. Guards the >/>= boundary.
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error",
+            lambda *a, **k: False,
+        )
+        client = MagicMock()
+        client.read.return_value = [self._poison(read_ct=10)]  # 5 + 5
+        PgQueueConsumer(
+            ["q"],
+            client=client,
+            api_client=MagicMock(),
+            max_attempts=5,
+            poison_repark_budget=5,
+        ).poll_once()
+        client.set_vt.assert_called_once_with(5, 300)  # re-parked, not dropped
+        client.delete.assert_not_called()
+
+    def test_no_org_poison_drops_immediately_without_marking(self, monkeypatch):
+        # Gap B: an execution_id but no org can never be marked (org-scoped API),
+        # so it drops immediately — no wasted re-park budget, no mark attempt.
+        marked = MagicMock()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error", marked
+        )
+        client = MagicMock()
+        client.read.return_value = [
+            self._poison(
+                payload={
+                    "task_name": "process_file_batch",
+                    "kwargs": {"execution_id": "e4"},
+                }
+            )
+        ]
+        PgQueueConsumer(
+            ["q"], client=client, api_client=MagicMock(), max_attempts=5
+        ).poll_once()
+        marked.assert_not_called()  # never attempted (no org)
+        client.set_vt.assert_not_called()  # not re-parked (permanent)
+        client.delete.assert_called_once_with(5)  # dropped now
+
+    def test_api_client_build_failure_reparks(self, monkeypatch):
+        # Gap C: with no injected api_client, a build failure is transient — the
+        # message re-parks (not drops) so a recovered backend can still mark it.
+        monkeypatch.setattr(
+            "shared.api.InternalAPIClient",
+            MagicMock(side_effect=RuntimeError("no config")),
+        )
+        marked = MagicMock()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error", marked
+        )
+        client = MagicMock()
+        client.read.return_value = [self._poison(read_ct=6)]  # org present
+        PgQueueConsumer(["q"], client=client, max_attempts=5).poll_once()
+        marked.assert_not_called()  # never reached — client build raised first
+        client.set_vt.assert_called_once_with(5, 300)  # re-parked
+        client.delete.assert_not_called()
+
 
 class TestConstruction:
     def test_rejects_non_positive_params(self):
+        client = MagicMock()
         for kw in (
             {"batch_size": 0},
             {"vt_seconds": -1},
@@ -319,7 +380,7 @@ class TestConstruction:
             {"poison_repark_budget": -1},
         ):
             with pytest.raises(ValueError):
-                PgQueueConsumer(["q"], client=MagicMock(), **kw)
+                PgQueueConsumer(["q"], client=client, **kw)
 
     def test_rejects_backoff_max_below_poll_interval(self):
         # Otherwise backoff would shrink below poll_interval instead of growing.

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -384,8 +384,9 @@ class TestConstruction:
 
     def test_rejects_backoff_max_below_poll_interval(self):
         # Otherwise backoff would shrink below poll_interval instead of growing.
+        client = MagicMock()
         with pytest.raises(ValueError, match="backoff_max"):
-            PgQueueConsumer(["q"], client=MagicMock(), poll_interval=0.5, backoff_max=0.1)
+            PgQueueConsumer(["q"], client=client, poll_interval=0.5, backoff_max=0.1)
 
 
 class TestRunLoop:

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -114,7 +114,15 @@ class TestPollOnce:
         app.tasks.get.return_value = task
         client = MagicMock()
         client.read.return_value = [
-            _msg(6, {"task_name": "t", "args": [1], "kwargs": {"k": "v"}, "fairness": fairness})
+            _msg(
+                6,
+                {
+                    "task_name": "t",
+                    "args": [1],
+                    "kwargs": {"k": "v"},
+                    "fairness": fairness,
+                },
+            )
         ]
         PgQueueConsumer(["q"], client=client, app=app).poll_once()
         kwargs = task.apply.call_args.kwargs
@@ -150,6 +158,155 @@ class TestPollOnce:
         client.delete.assert_not_called()
 
 
+def _callback_payload(execution_id="exec-1", organization_id="org-1"):
+    """A barrier aggregating-callback payload: execution identity in kwargs, no
+    reply_key / on_error (the sharpest silent-strand case).
+    """
+    return {
+        "task_name": "process_batch_callback_api",
+        "args": [[]],
+        "kwargs": {
+            "execution_id": execution_id,
+            "organization_id": organization_id,
+            "pipeline_id": "pipe-1",
+        },
+    }
+
+
+class TestPipelineIdentity:
+    """``_pipeline_identity`` extraction across the payload shapes."""
+
+    def test_from_callback_kwargs(self):
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        assert _pipeline_identity(_callback_payload("e", "o")) == ("e", "o")
+
+    def test_from_barrier_context_and_fairness(self):
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        payload = {
+            "task_name": "process_file_batch",
+            "kwargs": {"_barrier_context": {"execution_id": "e2"}},
+            "fairness": {"org_id": "o2", "workload_type": "api"},
+        }
+        assert _pipeline_identity(payload) == ("e2", "o2")
+
+    def test_org_from_barrier_callback_descriptor(self):
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        payload = {
+            "kwargs": {
+                "_barrier_context": {
+                    "execution_id": "e3",
+                    "callback_descriptor": {"kwargs": {"organization_id": "o3"}},
+                }
+            }
+        }
+        assert _pipeline_identity(payload) == ("e3", "o3")
+
+    def test_non_pipeline_returns_none(self):
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        assert _pipeline_identity({"task_name": "t", "kwargs": {}}) == (None, "")
+
+    def test_execution_without_org_returns_empty_org(self):
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        payload = {"kwargs": {"execution_id": "e4"}}
+        assert _pipeline_identity(payload) == ("e4", "")
+
+
+class TestPoisonDropMarksExecution:
+    """UN-3670: a poison drop with no reply channel marks the execution ERROR
+    (or re-parks if the mark can't be confirmed) instead of silently discarding.
+    """
+
+    def _poison(self, msg_id=5, payload=None, read_ct=6):
+        return _msg(msg_id, payload or _callback_payload(), read_ct=read_ct)
+
+    def test_marks_error_then_deletes(self, monkeypatch):
+        marks = []
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error",
+            lambda client, eid, org, *, error_message: marks.append((eid, org)) or True,
+        )
+        client = MagicMock()
+        client.read.return_value = [self._poison()]
+        PgQueueConsumer(
+            ["q"], client=client, api_client=MagicMock(), max_attempts=5
+        ).poll_once()
+        assert marks == [("exec-1", "org-1")]  # marked ERROR
+        client.delete.assert_called_once_with(5)  # then dropped
+        client.set_vt.assert_not_called()
+
+    def test_reparks_when_mark_unconfirmed(self, monkeypatch):
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error",
+            lambda *a, **k: False,  # backend down
+        )
+        client = MagicMock()
+        client.read.return_value = [self._poison(read_ct=6)]
+        PgQueueConsumer(
+            ["q"], client=client, api_client=MagicMock(), max_attempts=5
+        ).poll_once()
+        client.delete.assert_not_called()  # NOT dropped into a void
+        client.set_vt.assert_called_once_with(5, 300)  # re-parked long
+
+    def test_drops_after_repark_budget_exhausted(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error",
+            lambda *a, **k: False,
+        )
+        client = MagicMock()
+        # read_ct beyond max_attempts + budget → give up and drop.
+        client.read.return_value = [self._poison(read_ct=11)]
+        with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
+            PgQueueConsumer(
+                ["q"],
+                client=client,
+                api_client=MagicMock(),
+                max_attempts=5,
+                poison_repark_budget=5,
+            ).poll_once()
+        client.set_vt.assert_not_called()
+        client.delete.assert_called_once_with(5)
+        assert "re-park budget" in caplog.text
+
+    def test_reply_channel_keeps_existing_behavior(self, monkeypatch):
+        # A message with on_error surfaces on its channel and is dropped — NOT
+        # marked ERROR (it already has a failure channel).
+        marked = MagicMock()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error", marked
+        )
+        payload = {
+            "task_name": "some.executor",
+            "on_error": {"task_name": "cb", "queue": "q"},
+            "kwargs": {"execution_id": "exec-1", "organization_id": "org-1"},
+        }
+        client = MagicMock()
+        client.read.return_value = [self._poison(payload=payload)]
+        consumer = PgQueueConsumer(["q"], client=client, max_attempts=5)
+        monkeypatch.setattr(consumer, "_chain_continuation", MagicMock())
+        consumer.poll_once()
+        marked.assert_not_called()  # reply channel path, no execution mark
+        client.delete.assert_called_once_with(5)
+        client.set_vt.assert_not_called()
+
+    def test_no_execution_id_drops_without_marking(self, monkeypatch):
+        marked = MagicMock()
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error", marked
+        )
+        client = MagicMock()
+        client.read.return_value = [
+            _msg(5, {"task_name": "test_pg_consumer.boom"}, read_ct=6)
+        ]
+        PgQueueConsumer(["q"], client=client, max_attempts=5).poll_once()
+        marked.assert_not_called()
+        client.delete.assert_called_once_with(5)
+
+
 class TestConstruction:
     def test_rejects_non_positive_params(self):
         for kw in (
@@ -158,6 +315,8 @@ class TestConstruction:
             {"poll_interval": 0},
             {"backoff_max": 0},
             {"max_attempts": 0},
+            {"poison_repark_vt_seconds": 0},
+            {"poison_repark_budget": -1},
         ):
             with pytest.raises(ValueError):
                 PgQueueConsumer(["q"], client=MagicMock(), **kw)
@@ -165,9 +324,7 @@ class TestConstruction:
     def test_rejects_backoff_max_below_poll_interval(self):
         # Otherwise backoff would shrink below poll_interval instead of growing.
         with pytest.raises(ValueError, match="backoff_max"):
-            PgQueueConsumer(
-                ["q"], client=MagicMock(), poll_interval=0.5, backoff_max=0.1
-            )
+            PgQueueConsumer(["q"], client=MagicMock(), poll_interval=0.5, backoff_max=0.1)
 
 
 class TestRunLoop:
@@ -389,7 +546,9 @@ class TestPollHeartbeat:
     def test_double_start_is_rejected(self):
         from queue_backend.pg_queue.consumer import LivenessServer
 
-        server = LivenessServer(PgQueueConsumer(["q"], client=MagicMock()), port=0, stale_after=60)
+        server = LivenessServer(
+            PgQueueConsumer(["q"], client=MagicMock()), port=0, stale_after=60
+        )
         server.start()
         try:
             with pytest.raises(RuntimeError, match="already started"):
@@ -453,7 +612,8 @@ class TestMultiQueue:
     def test_one_queue_failing_does_not_abort_the_others(self):
         """A read failure on one queue is isolated: the already-acked work this
         cycle still counts (so run() doesn't take the empty backoff path), and
-        the failure doesn't propagate out of poll_once."""
+        the failure doesn't propagate out of poll_once.
+        """
         client = MagicMock()
         client.read.side_effect = [[_msg(1, _ok_payload(1))], RuntimeError("boom")]
         claimed = PgQueueConsumer(["qa", "qb"], client=client).poll_once()
@@ -534,9 +694,7 @@ class TestRequestReply:
         client.read.return_value = [_msg(4, {**_ok_payload(1, 1), "reply_key": "rk4"})]
         with patch(self._RB) as rb_cls:
             rb_cls.return_value.store_result.side_effect = RuntimeError("db down")
-            with caplog.at_level(
-                logging.ERROR, logger="queue_backend.pg_queue.consumer"
-            ):
+            with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.consumer"):
                 PgQueueConsumer(["q"], client=client).poll_once()
         # A store failure must NOT block the ack (avoids an expensive re-run).
         client.delete.assert_called_once_with(4)
@@ -598,7 +756,11 @@ class TestSelfChain:
             # (msg_id, payload, read_ct)  — malformed / unknown / poison
             (10, {"on_error": err, "task_id": "t"}, 1),
             (11, {"task_name": "nope.nope", "on_error": err, "task_id": "t"}, 1),
-            (12, {"task_name": "test_pg_consumer.boom", "on_error": err, "task_id": "t"}, 99),
+            (
+                12,
+                {"task_name": "test_pg_consumer.boom", "on_error": err, "task_id": "t"},
+                99,
+            ),
         ]
         for msg_id, payload, read_ct in cases:
             client = MagicMock()

--- a/workers/tests/test_pg_recovery.py
+++ b/workers/tests/test_pg_recovery.py
@@ -1,0 +1,63 @@
+"""Tests for the shared terminal-ERROR recovery helper (mark_execution_error).
+
+Pure unit tests with a mocked internal API client — no Postgres, no HTTP.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from queue_backend.pg_queue.recovery import mark_execution_error
+from unstract.core.data_models import ExecutionStatus
+
+
+def _api(*, success=True, raises=None):
+    client = MagicMock()
+    if raises is not None:
+        client.update_workflow_execution_status.side_effect = raises
+    else:
+        client.update_workflow_execution_status.return_value = SimpleNamespace(
+            success=success
+        )
+    return client
+
+
+def test_marks_error_with_cascade_and_returns_true():
+    client = _api(success=True)
+    ok = mark_execution_error(client, "exec-1", "org-1", error_message="batch failed")
+    assert ok is True
+    client.update_workflow_execution_status.assert_called_once()
+    _, kwargs = client.update_workflow_execution_status.call_args
+    assert kwargs["execution_id"] == "exec-1"
+    assert kwargs["organization_id"] == "org-1"
+    assert kwargs["status"] == ExecutionStatus.ERROR.value
+    assert kwargs["error_message"] == "batch failed"
+    # Cascade is the whole point — files must not be left EXECUTING.
+    assert kwargs["cascade_terminal_files"] is True
+
+
+def test_success_false_returns_false_and_logs(caplog):
+    client = _api(success=False)
+    with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.recovery"):
+        ok = mark_execution_error(client, "exec-2", "org-1", error_message="x")
+    assert ok is False
+    assert "success=False" in caplog.text
+
+
+def test_exception_is_swallowed_and_returns_false(caplog):
+    client = _api(raises=RuntimeError("backend down"))
+    with caplog.at_level(logging.ERROR, logger="queue_backend.pg_queue.recovery"):
+        ok = mark_execution_error(client, "exec-3", "org-1", error_message="x")
+    # Never raises — the caller keeps its recovery handle instead of crashing.
+    assert ok is False
+    assert "internal API raised" in caplog.text
+
+
+def test_absent_success_attr_assumed_true():
+    # A legacy raise-on-failure response with no ``success`` attribute is treated
+    # as success (it would have raised otherwise).
+    client = MagicMock()
+    client.update_workflow_execution_status.return_value = object()
+    assert mark_execution_error(client, "e", "o", error_message="x") is True


### PR DESCRIPTION
## What & why

Two PG-path failures could strand an execution `EXECUTING` forever with no handle the reaper can find. Both are pre-rollout blockers (HIGH).

### UN-3669 — barrier abort leaves no recoverable handle
On any batch exception, the in-body abort deleted the `pg_barrier_state` row **and** cleared the per-batch `pg_batch_dedup` markers **without** marking the execution terminal. Consequences:
1. **Permanent EXECUTING strand** — after abort nothing marks the execution, and the reaper only recovers executions that still have a barrier row.
2. **Zombie batch re-run** — because the markers were cleared, a vt-redelivered message re-claimed and re-ran the **whole batch** (real LLM spend + destination writes) against a torn-down barrier.

### UN-3670 — poison-drop silently discards the execution
When `read_ct > max_attempts`, the consumer deleted the message with only a log line. Pipeline headers and barrier callbacks have no `reply_key`/`on_error`, so their work was silently discarded. Sharpest case: the aggregating callback — the barrier row is deleted right after the callback is *enqueued*, so a ~3-minute backend/internal-API outage while callbacks are in flight permanently stranded every affected execution.

## Fix

Both paths now mark the execution **ERROR** (`+cascade_terminal_files`) **before** erasing their recovery handle:

- **Barrier abort** (`pg_barrier.py`): mark ERROR first; only on a *confirmed* mark tear the barrier row down, keeping the dedup markers so a redelivered batch is skipped by `claim_batch` (belt-and-braces with the terminal-execution guard) rather than re-run wholesale. If the mark can't be confirmed (backend down / no org) the barrier row is **left intact for the reaper**.
- **Poison-drop** (`consumer.py`): for a message carrying `execution_id` with no failure channel, mark ERROR; if the mark can't be confirmed, **re-park** the message with a long vt (bounded budget) instead of deleting into a void, so the drop never races a dead backend. Messages with `reply_key`/`on_error` keep existing behavior.

Shared `mark_execution_error` helper (`queue_backend/pg_queue/recovery.py`) + new `PgQueueClient.set_vt` re-park primitive.

## Safety — zero Celery regression
Everything lives in `queue_backend/` + the internal-API client, reachable only on the PG transport. `barrier_pg_abort` defaults `preserve_dedup_markers=False`, so the Celery `link_error` path is byte-unchanged; the reply-channel poison path is unchanged. Both covered by tests.

## Testing
Dev-tested locally (worker venv against local Postgres):
- **Unit lane: 1128 passed / 0 failed** (deterministic).
- **Touched integration lane green** against local Postgres (`test_pg_barrier`, `test_pg_batch_dedup`, `test_pg_queue_client`).
- New tests: recovery helper (4); barrier mark-first + preserve-markers + unconfirmed-strand (7); consumer poison mark/re-park/budget/reply-channel (5) + `_pipeline_identity` (5); client `set_vt` (3).

Live acceptance repro (kill a batch mid-run; block the internal API mid-callback) is deferred to the Integration deploy + load-test phase, where the PG fleet and raised VT are available.

## Follow-up
PR-C (UN-3671, orchestration idempotency claim) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
