### PR TITLE
UN-3672 [FEAT] PG queue — application-level /metrics exporter (queue depth, message age, barriers, reaper outcomes)

### DIFF
--- a/workers/OPERATIONS.md
+++ b/workers/OPERATIONS.md
@@ -70,11 +70,33 @@ curl http://localhost:8083/health  # Callback worker
 
 ### Metrics (Prometheus)
 
-Workers expose metrics on their health ports at `/metrics`:
-- Task execution counts
-- Processing times
-- Queue depths
-- Error rates
+**PG-queue processes** serve Prometheus text-format metrics at `/metrics` on
+their existing health port (`WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT` for
+consumers, `WORKER_PG_REAPER_HEALTH_PORT` for the reaper — same server as
+`/health`; no port configured means neither endpoint):
+
+- Every PG worker (per-pod): `pg_consumer_heartbeat_age_seconds` (poll-loop
+  freshness — the same signal `/health` verdicts on); the fleet supervisor adds
+  `pg_consumer_alive_children` / `pg_consumer_configured_concurrency`.
+- Reaper only (the leader-elected singleton — queue-WIDE state comes from one
+  process): `pg_queue_depth{queue}`, `pg_queue_oldest_message_age_seconds{queue}`,
+  `pg_barrier_live` / `pg_barrier_stranded`, recovery outcome counters
+  (`pg_reaper_barrier_recovered_total`, `pg_reaper_claim_*_total`,
+  `pg_reaper_sweep_failures_total{table}`) and `pg_reaper_is_leader`.
+  Queue gauges are cached snapshots refreshed on the reaper's own cadence —
+  scrapes never touch the DB; `pg_queue_gauges_age_seconds` exposes staleness.
+
+```bash
+curl http://localhost:8090/metrics  # PG consumer / supervisor
+curl http://localhost:8086/metrics  # PG reaper
+```
+
+Nothing scrapes these in cloud yet (no PodMonitoring/alerts — deferred);
+they're for direct curl during incidents, dashboards-to-come, and the
+load-test harness.
+
+**Celery workers** expose no app-level `/metrics`; their queue observability
+comes from RabbitMQ's Prometheus plugin and Flower (below).
 
 ### Logging
 

--- a/workers/OPERATIONS.md
+++ b/workers/OPERATIONS.md
@@ -75,16 +75,22 @@ their existing health port (`WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT` for
 consumers, `WORKER_PG_REAPER_HEALTH_PORT` for the reaper — same server as
 `/health`; no port configured means neither endpoint):
 
-- Every PG worker (per-pod): `pg_consumer_heartbeat_age_seconds` (poll-loop
-  freshness — the same signal `/health` verdicts on); the fleet supervisor adds
-  `pg_consumer_alive_children` / `pg_consumer_configured_concurrency`.
+- Every PG consumer / the fleet supervisor (per-pod):
+  `pg_consumer_heartbeat_age_seconds` (poll-loop freshness — the same signal
+  `/health` verdicts on); the supervisor adds `pg_consumer_alive_children` /
+  `pg_consumer_configured_concurrency`.
 - Reaper only (the leader-elected singleton — queue-WIDE state comes from one
-  process): `pg_queue_depth{queue}`, `pg_queue_oldest_message_age_seconds{queue}`,
-  `pg_barrier_live` / `pg_barrier_stranded`, recovery outcome counters
-  (`pg_reaper_barrier_recovered_total`, `pg_reaper_claim_*_total`,
-  `pg_reaper_sweep_failures_total{table}`) and `pg_reaper_is_leader`.
-  Queue gauges are cached snapshots refreshed on the reaper's own cadence —
-  scrapes never touch the DB; `pg_queue_gauges_age_seconds` exposes staleness.
+  process): `pg_reaper_heartbeat_age_seconds` (tick-loop freshness),
+  `pg_queue_depth{queue}`, `pg_queue_oldest_message_age_seconds{queue}`,
+  `pg_barrier_live` / `pg_barrier_stranded`, outcome + failure counters
+  (`pg_reaper_barrier_*_total`, `pg_reaper_claim_*_total`,
+  `pg_reaper_sweep_failures_total{table}`, `pg_reaper_tick_failures_total`,
+  `pg_reaper_gauge_refresh_failures_total`) and `pg_reaper_is_leader`.
+  Queue gauges are cached snapshots refreshed on the reaper's own cadence
+  (60s — `_GAUGE_REFRESH_INTERVAL_SECONDS` in `reaper.py`) — scrapes never
+  touch the DB; `pg_queue_gauges_age_seconds` exposes snapshot staleness and
+  keeps growing while refreshes fail or the pod is a standby (alert on it
+  together with `pg_reaper_is_leader == 1`).
 
 ```bash
 curl http://localhost:8090/metrics  # PG consumer / supervisor

--- a/workers/pg_queue_consumer/supervisor.py
+++ b/workers/pg_queue_consumer/supervisor.py
@@ -450,6 +450,13 @@ def _maybe_start_supervisor_health(fleet: _Fleet) -> LivenessServer | None:
             "liveness_probe_bound": True,
         }
 
+    from queue_backend.pg_queue.metrics import ConsumerMetrics
+
+    metrics = ConsumerMetrics(
+        freshness_fn=fleet.freshness,
+        alive_children_fn=lambda: float(fleet.alive_count()),
+        concurrency_fn=lambda: float(fleet.concurrency),
+    )
     server = LivenessServer(
         freshness_fn=fleet.freshness,
         stale_after=stale_after,
@@ -457,6 +464,7 @@ def _maybe_start_supervisor_health(fleet: _Fleet) -> LivenessServer | None:
         check_name="pg_queue_fleet",
         age_key="oldest_child_seconds_since_poll",
         extra_status_fn=_extra_status,
+        metrics_fn=metrics.render,
         thread_name="pg-supervisor-liveness",
         log_label="pg-queue supervisor",
     )

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -867,18 +867,23 @@ class LivenessServer(_BaseLivenessServer):
     """Consumer poll-loop liveness — a thin wrapper over the shared
     :class:`queue_backend.pg_queue.liveness.LivenessServer`, bound to the
     consumer's heartbeat (``seconds_since_last_poll``). Same wire shape as before
-    (``/health`` → 200 fresh / 503 stale, ``check="pg_queue_poll"``).
+    (``/health`` → 200 fresh / 503 stale, ``check="pg_queue_poll"``), plus
+    ``/metrics`` exporting that heartbeat as a scrapeable gauge.
     """
 
     def __init__(
         self, consumer: PgQueueConsumer, *, port: int, stale_after: float
     ) -> None:
+        from .metrics import ConsumerMetrics
+
+        metrics = ConsumerMetrics(freshness_fn=consumer.seconds_since_last_poll)
         super().__init__(
             freshness_fn=consumer.seconds_since_last_poll,
             stale_after=stale_after,
             port=port,
             check_name="pg_queue_poll",
             age_key="seconds_since_last_poll",
+            metrics_fn=metrics.render,
             thread_name="pg-consumer-liveness",
             log_label="pg-queue consumer",
         )

--- a/workers/queue_backend/pg_queue/liveness.py
+++ b/workers/queue_backend/pg_queue/liveness.py
@@ -39,9 +39,19 @@ class LivenessServer:
     ``check_name`` / ``age_key`` label the JSON payload; ``extra_status_fn``
     (optional) merges extra fields in (informational — it never affects the
     200/503 verdict, which is purely the freshness heartbeat).
+
+    ``metrics_fn`` (optional) additionally serves ``/metrics``: it returns the
+    Prometheus text-exposition body (bytes). Kept as an opaque callable so this
+    module stays free of the prometheus dependency; the metric definitions live
+    in :mod:`queue_backend.pg_queue.metrics`. A ``metrics_fn`` failure returns
+    500 on ``/metrics`` only — it can never affect the ``/health`` verdict.
     """
 
     _PATHS = frozenset({"/health", "/healthz", "/livez"})
+    _METRICS_PATH = "/metrics"
+    # Prometheus text exposition format (metrics.METRICS_CONTENT_TYPE — inlined
+    # so this module keeps zero imports from the metrics side).
+    _METRICS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
     def __init__(
         self,
@@ -52,6 +62,7 @@ class LivenessServer:
         check_name: str,
         age_key: str,
         extra_status_fn: Callable[[], dict[str, Any]] | None = None,
+        metrics_fn: Callable[[], bytes] | None = None,
         thread_name: str = "pg-queue-liveness",
         log_label: str = "pg-queue",
     ) -> None:
@@ -66,6 +77,7 @@ class LivenessServer:
         self._check_name = check_name
         self._age_key = age_key
         self._extra_status_fn = extra_status_fn
+        self._metrics_fn = metrics_fn
         self._thread_name = thread_name
         # Prefixes the (now-shared) log messages so they stay attributable to the
         # source process after the consumer/reaper extraction (e.g. "pg-queue
@@ -86,6 +98,9 @@ class LivenessServer:
         freshness_fn = self._freshness_fn
         stale_after = self._stale_after
         paths = self._PATHS
+        metrics_path = self._METRICS_PATH
+        metrics_content_type = self._METRICS_CONTENT_TYPE
+        metrics_fn = self._metrics_fn
         check_name = self._check_name
         age_key = self._age_key
         extra_status_fn = self._extra_status_fn
@@ -94,7 +109,11 @@ class LivenessServer:
         class _Handler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:
                 # Strip any query string — a probe like /health?foo=bar must match.
-                if urlsplit(self.path).path not in paths:
+                path = urlsplit(self.path).path
+                if metrics_fn is not None and path == metrics_path:
+                    self._serve_metrics()
+                    return
+                if path not in paths:
                     self.send_response(404)
                     self.end_headers()
                     return
@@ -125,6 +144,24 @@ class LivenessServer:
                     self.wfile.write(body)
                 except (BrokenPipeError, ConnectionResetError):
                     pass  # client (probe) hung up mid-response — not our problem
+
+            def _serve_metrics(self) -> None:
+                # A broken metrics renderer must degrade to a 500 on /metrics
+                # alone — the probe verdict on /health stays untouched.
+                try:
+                    body = metrics_fn()  # type: ignore[misc]  # guarded by caller
+                except Exception:
+                    logger.exception("%s: /metrics render failed", log_label)
+                    self.send_response(500)
+                    self.end_headers()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", metrics_content_type)
+                self.end_headers()
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass  # scraper hung up mid-response — not our problem
 
             def log_message(self, *_: object) -> None:
                 pass  # silence per-request access logging

--- a/workers/queue_backend/pg_queue/liveness.py
+++ b/workers/queue_backend/pg_queue/liveness.py
@@ -21,6 +21,7 @@ Bind ``port=0`` to let the OS pick a free port (read back via :attr:`bound_port`
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -137,10 +138,13 @@ class LivenessServer:
                     }
                 )
                 body = json.dumps(payload).encode()
-                self.send_response(503 if stale else 200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
+                # Headers too, not just the body write: a client that hangs up
+                # before headers go out would otherwise raise into socketserver's
+                # handle_error, which prints an unattributed traceback to stderr.
                 try:
+                    self.send_response(503 if stale else 200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
                     self.wfile.write(body)
                 except (BrokenPipeError, ConnectionResetError):
                     pass  # client (probe) hung up mid-response — not our problem
@@ -152,13 +156,15 @@ class LivenessServer:
                     body = metrics_fn()  # type: ignore[misc]  # guarded by caller
                 except Exception:
                     logger.exception("%s: /metrics render failed", log_label)
-                    self.send_response(500)
-                    self.end_headers()
+                    with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                        self.send_response(500)
+                        self.end_headers()
                     return
-                self.send_response(200)
-                self.send_header("Content-Type", metrics_content_type)
-                self.end_headers()
+                # Same hung-up-client guard as the /health path above.
                 try:
+                    self.send_response(200)
+                    self.send_header("Content-Type", metrics_content_type)
+                    self.end_headers()
                     self.wfile.write(body)
                 except (BrokenPipeError, ConnectionResetError):
                     pass  # scraper hung up mid-response — not our problem

--- a/workers/queue_backend/pg_queue/metrics.py
+++ b/workers/queue_backend/pg_queue/metrics.py
@@ -1,0 +1,246 @@
+"""Prometheus metrics for PG-queue processes (application-level exporter).
+
+Today's queue observability comes from RabbitMQ's built-in Prometheus plugin;
+Postgres has no such plugin — the pg_queue tables ARE the broker — so the
+exporter is ours. This module holds the metric *definitions*; the SQL that
+feeds the queue-wide gauges lives with its sibling queries in ``reaper.py``
+(it shares the stranded-barrier predicate), and the HTTP surface is the
+existing :class:`~queue_backend.pg_queue.liveness.LivenessServer` ``/metrics``
+route — no new port, no new server, no execution-path changes.
+
+Two exporters, matching the two process shapes:
+
+- :class:`ConsumerMetrics` — per-pod, on every PG worker: poll-loop heartbeat
+  freshness (the same signal ``/health`` verdicts on, as a scrapeable number).
+- :class:`ReaperMetrics` — queue-WIDE state, exported only by the reaper: it is
+  the leader-elected singleton, so queue depth / oldest-message age / barrier
+  counts come from one process instead of N pods running identical SQL and
+  emitting duplicate series. Standbys export zeroed queue gauges and
+  ``is_leader 0``.
+
+Registries are instance-owned (never the ``prometheus_client`` default
+``REGISTRY``): the workers tree is imported under more than one module name in
+places (the bare-``tasks`` sys.path quirk), and module-level collectors would
+double-register on the second import. An instance per process cannot.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from prometheus_client import CollectorRegistry
+
+logger = logging.getLogger(__name__)
+
+# Prometheus text exposition format (the /metrics Content-Type).
+METRICS_CONTENT_TYPE: Final = "text/plain; version=0.0.4; charset=utf-8"
+
+
+def _new_registry() -> CollectorRegistry:
+    from prometheus_client import CollectorRegistry
+
+    return CollectorRegistry()
+
+
+def _render(registry: CollectorRegistry) -> bytes:
+    from prometheus_client import generate_latest
+
+    return generate_latest(registry)
+
+
+class ConsumerMetrics:
+    """Per-pod metrics for a PG-queue consumer (or the fleet supervisor).
+
+    ``freshness_fn`` is the same heartbeat the liveness probe reads —
+    seconds since the poll loop last made progress (for the supervisor, the
+    OLDEST child's, so one wedged child surfaces). The optional fleet hooks
+    exist because the supervisor's ``/health`` JSON already reports them and
+    an operator graphing the fleet needs them as numbers, not JSON.
+    """
+
+    def __init__(
+        self,
+        *,
+        freshness_fn: Callable[[], float],
+        alive_children_fn: Callable[[], float] | None = None,
+        concurrency_fn: Callable[[], float] | None = None,
+    ) -> None:
+        from prometheus_client import Gauge
+
+        self.registry = _new_registry()
+        heartbeat = Gauge(
+            "pg_consumer_heartbeat_age_seconds",
+            "Seconds since the consumer poll loop last made progress "
+            "(the liveness heartbeat; /health goes 503 past its stale window)",
+            registry=self.registry,
+        )
+        heartbeat.set_function(freshness_fn)
+        if alive_children_fn is not None:
+            alive = Gauge(
+                "pg_consumer_alive_children",
+                "Live child consumer processes in the supervisor fleet",
+                registry=self.registry,
+            )
+            alive.set_function(alive_children_fn)
+        if concurrency_fn is not None:
+            conc = Gauge(
+                "pg_consumer_configured_concurrency",
+                "Configured child-process concurrency of the supervisor fleet",
+                registry=self.registry,
+            )
+            conc.set_function(concurrency_fn)
+
+    def render(self) -> bytes:
+        return _render(self.registry)
+
+
+class ReaperMetrics:
+    """Queue-wide + reaper-outcome metrics, exported by the reaper process.
+
+    The queue gauges (`pg_queue_depth`, oldest-message age, barrier counts) are
+    CACHED snapshots — the reaper refreshes them on its own cadence (leader
+    only) and a scrape never touches the DB, so a hot scraper (or a curl loop
+    during an incident) cannot add DB load. ``pg_queue_gauges_age_seconds``
+    exposes the snapshot's staleness so a reader can tell cached-fresh from
+    cached-dead; it reads 0 while no snapshot has ever been taken (standby) —
+    disambiguate with ``pg_reaper_is_leader``.
+
+    Outcome counters are incremented by the recovery/sweep code at the same
+    sites that log the outcomes (see ``reaper.py``).
+    """
+
+    def __init__(
+        self,
+        *,
+        heartbeat_fn: Callable[[], float],
+        is_leader_fn: Callable[[], bool],
+    ) -> None:
+        from prometheus_client import Counter, Gauge
+
+        self.registry = _new_registry()
+
+        heartbeat = Gauge(
+            "pg_reaper_heartbeat_age_seconds",
+            "Seconds since the reaper tick loop last ran (liveness heartbeat)",
+            registry=self.registry,
+        )
+        heartbeat.set_function(heartbeat_fn)
+        leader = Gauge(
+            "pg_reaper_is_leader",
+            "1 while this reaper holds the leader lease, else 0",
+            registry=self.registry,
+        )
+        leader.set_function(lambda: 1.0 if is_leader_fn() else 0.0)
+
+        self.barrier_recovered = Counter(
+            "pg_reaper_barrier_recovered_total",
+            "Stranded barriers recovered (execution marked ERROR + rows removed)",
+            registry=self.registry,
+        )
+        self.barrier_recovery_failures = Counter(
+            "pg_reaper_barrier_recovery_failures_total",
+            "Stranded-barrier recovery attempts that raised (row left for retry)",
+            registry=self.registry,
+        )
+        self.claim_recovered = Counter(
+            "pg_reaper_claim_recovered_total",
+            "Orphan orchestration claims recovered (crash-window execution "
+            "marked ERROR)",
+            registry=self.registry,
+        )
+        self.claim_gc = Counter(
+            "pg_reaper_claim_gc_total",
+            "Orphan orchestration-claim tombstones GC'd (execution already " "terminal)",
+            registry=self.registry,
+        )
+        self.claim_recovery_failures = Counter(
+            "pg_reaper_claim_recovery_failures_total",
+            "Orphan-claim recovery attempts that raised (row left for retry)",
+            registry=self.registry,
+        )
+        self.sweep_failures = Counter(
+            "pg_reaper_sweep_failures_total",
+            "Whole-sweep failures, by swept table (see the reaper fail-streak log)",
+            ["table"],
+            registry=self.registry,
+        )
+        self.gauge_refresh_failures = Counter(
+            "pg_reaper_gauge_refresh_failures_total",
+            "Failed queue-gauge snapshot refreshes (metrics stale, queue unaffected)",
+            registry=self.registry,
+        )
+
+        self._queue_depth = Gauge(
+            "pg_queue_depth",
+            "Messages currently in pg_queue_message, by queue (cached snapshot)",
+            ["queue"],
+            registry=self.registry,
+        )
+        self._oldest_age = Gauge(
+            "pg_queue_oldest_message_age_seconds",
+            "Age of the oldest message in the queue (cached snapshot)",
+            ["queue"],
+            registry=self.registry,
+        )
+        self._barriers_live = Gauge(
+            "pg_barrier_live",
+            "pg_barrier_state rows with remaining > 0 (in-flight fan-outs)",
+            registry=self.registry,
+        )
+        self._barriers_stranded = Gauge(
+            "pg_barrier_stranded",
+            "Live barriers past the stuck-timeout / expiry (reaper will recover)",
+            registry=self.registry,
+        )
+        self._last_refresh_monotonic: float | None = None
+        gauges_age = Gauge(
+            "pg_queue_gauges_age_seconds",
+            "Seconds since the queue gauges were last refreshed (0 = never; "
+            "check pg_reaper_is_leader)",
+            registry=self.registry,
+        )
+        gauges_age.set_function(self._seconds_since_refresh)
+
+    def _seconds_since_refresh(self) -> float:
+        if self._last_refresh_monotonic is None:
+            return 0.0
+        return time.monotonic() - self._last_refresh_monotonic
+
+    def set_queue_snapshot(
+        self,
+        *,
+        depths: dict[str, tuple[int, float]],
+        barriers_live: int,
+        barriers_stranded: int,
+    ) -> None:
+        """Replace the cached queue-wide snapshot.
+
+        ``depths`` maps queue name -> (message count, oldest-message age in
+        seconds). Series are cleared first so a queue that drained to zero
+        drops out rather than freezing at its last non-zero value.
+        """
+        self._queue_depth.clear()
+        self._oldest_age.clear()
+        for queue, (depth, oldest_age) in depths.items():
+            self._queue_depth.labels(queue=queue).set(depth)
+            self._oldest_age.labels(queue=queue).set(oldest_age)
+        self._barriers_live.set(barriers_live)
+        self._barriers_stranded.set(barriers_stranded)
+        self._last_refresh_monotonic = time.monotonic()
+
+    def clear_queue_snapshot(self) -> None:
+        """Zero the queue-wide gauges (called on losing leadership, so a standby
+        never exports a frozen stale snapshot as if it were live).
+        """
+        self._queue_depth.clear()
+        self._oldest_age.clear()
+        self._barriers_live.set(0)
+        self._barriers_stranded.set(0)
+        self._last_refresh_monotonic = None
+
+    def render(self) -> bytes:
+        return _render(self.registry)

--- a/workers/queue_backend/pg_queue/metrics.py
+++ b/workers/queue_backend/pg_queue/metrics.py
@@ -10,13 +10,19 @@ route — no new port, no new server, no execution-path changes.
 
 Two exporters, matching the two process shapes:
 
-- :class:`ConsumerMetrics` — per-pod, on every PG worker: poll-loop heartbeat
+- :class:`ConsumerMetrics` — per-pod, on every PG consumer: poll-loop heartbeat
   freshness (the same signal ``/health`` verdicts on, as a scrapeable number).
 - :class:`ReaperMetrics` — queue-WIDE state, exported only by the reaper: it is
   the leader-elected singleton, so queue depth / oldest-message age / barrier
   counts come from one process instead of N pods running identical SQL and
-  emitting duplicate series. Standbys export zeroed queue gauges and
-  ``is_leader 0``.
+  emitting duplicate series. On a standby the per-queue series are absent and
+  the barrier gauges read 0 — disambiguate with ``pg_reaper_is_leader``.
+
+The queue-wide gauges are backed by ONE immutable snapshot object swapped by
+reference (:class:`_QueueSnapshot`): a scrape reads a single consistent
+snapshot, so it can never observe a torn state (new depths with old barrier
+counts) or race the tick thread's clear — the swap is atomic and the render
+side never reads mutable fields twice.
 
 Registries are instance-owned (never the ``prometheus_client`` default
 ``REGISTRY``): the workers tree is imported under more than one module name in
@@ -28,11 +34,13 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
     from prometheus_client import CollectorRegistry
+    from prometheus_client.core import Metric
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +54,24 @@ def _new_registry() -> CollectorRegistry:
     return CollectorRegistry()
 
 
-def _render(registry: CollectorRegistry) -> bytes:
-    from prometheus_client import generate_latest
+class _Exporter:
+    """Shared exporter shell: an instance-owned registry + text render."""
 
-    return generate_latest(registry)
+    def __init__(self) -> None:
+        self.registry = _new_registry()
+
+    def _function_gauge(self, name: str, doc: str, fn: Callable[[], float]) -> None:
+        from prometheus_client import Gauge
+
+        Gauge(name, doc, registry=self.registry).set_function(fn)
+
+    def render(self) -> bytes:
+        from prometheus_client import generate_latest
+
+        return generate_latest(self.registry)
 
 
-class ConsumerMetrics:
+class ConsumerMetrics(_Exporter):
     """Per-pod metrics for a PG-queue consumer (or the fleet supervisor).
 
     ``freshness_fn`` is the same heartbeat the liveness probe reads —
@@ -69,45 +88,105 @@ class ConsumerMetrics:
         alive_children_fn: Callable[[], float] | None = None,
         concurrency_fn: Callable[[], float] | None = None,
     ) -> None:
-        from prometheus_client import Gauge
-
-        self.registry = _new_registry()
-        heartbeat = Gauge(
+        super().__init__()
+        self._function_gauge(
             "pg_consumer_heartbeat_age_seconds",
             "Seconds since the consumer poll loop last made progress "
             "(the liveness heartbeat; /health goes 503 past its stale window)",
-            registry=self.registry,
+            freshness_fn,
         )
-        heartbeat.set_function(freshness_fn)
         if alive_children_fn is not None:
-            alive = Gauge(
+            self._function_gauge(
                 "pg_consumer_alive_children",
                 "Live child consumer processes in the supervisor fleet",
-                registry=self.registry,
+                alive_children_fn,
             )
-            alive.set_function(alive_children_fn)
         if concurrency_fn is not None:
-            conc = Gauge(
+            self._function_gauge(
                 "pg_consumer_configured_concurrency",
                 "Configured child-process concurrency of the supervisor fleet",
-                registry=self.registry,
+                concurrency_fn,
             )
-            conc.set_function(concurrency_fn)
-
-    def render(self) -> bytes:
-        return _render(self.registry)
 
 
-class ReaperMetrics:
+@dataclass(frozen=True)
+class _QueueSnapshot:
+    """One immutable queue-wide observation, swapped into the collector by
+    reference — the atomicity unit for scrapes.
+
+    ``reference_monotonic`` anchors ``pg_queue_gauges_age_seconds``: the refresh
+    time for a real snapshot, or the construction/step-down time for an empty
+    one — so a leader whose refresh has been failing since boot shows an
+    ever-GROWING age (a staleness alert can fire) instead of a frozen 0.
+    """
+
+    depths: Mapping[str, tuple[int, float]] = field(default_factory=dict)
+    barriers_live: int = 0
+    barriers_stranded: int = 0
+    reference_monotonic: float = field(default_factory=time.monotonic)
+
+
+class _QueueSnapshotCollector:
+    """Custom collector rendering the current :class:`_QueueSnapshot`.
+
+    ``collect`` reads ``self._snapshot`` exactly once, so a concurrent
+    ``replace`` (tick thread) can never tear a scrape (HTTP thread) — the
+    scrape sees the whole old snapshot or the whole new one.
+    """
+
+    def __init__(self) -> None:
+        self._snapshot = _QueueSnapshot()
+
+    def replace(self, snapshot: _QueueSnapshot) -> None:
+        self._snapshot = snapshot  # atomic reference swap
+
+    def collect(self) -> Iterable[Metric]:
+        from prometheus_client.core import GaugeMetricFamily
+
+        snapshot = self._snapshot  # single read — the consistency point
+        depth = GaugeMetricFamily(
+            "pg_queue_depth",
+            "Messages currently in pg_queue_message, by queue (cached snapshot; "
+            "a drained queue's series is absent, not 0)",
+            labels=["queue"],
+        )
+        oldest = GaugeMetricFamily(
+            "pg_queue_oldest_message_age_seconds",
+            "Age of the oldest message in the queue (cached snapshot)",
+            labels=["queue"],
+        )
+        for queue, (msg_count, oldest_age) in snapshot.depths.items():
+            depth.add_metric([queue], msg_count)
+            oldest.add_metric([queue], oldest_age)
+        live = GaugeMetricFamily(
+            "pg_barrier_live",
+            "pg_barrier_state rows with remaining > 0 (in-flight fan-outs)",
+        )
+        live.add_metric([], snapshot.barriers_live)
+        stranded = GaugeMetricFamily(
+            "pg_barrier_stranded",
+            "Barrier rows past the stuck-timeout / expiry — what the next "
+            "recovery pass picks up (includes remaining==0 lingerers)",
+        )
+        stranded.add_metric([], snapshot.barriers_stranded)
+        age = GaugeMetricFamily(
+            "pg_queue_gauges_age_seconds",
+            "Seconds since the queue gauges were last refreshed (since process "
+            "start / leadership step-down if never) — alert on this AND "
+            "pg_reaper_is_leader==1; a standby's age grows by design",
+        )
+        age.add_metric([], time.monotonic() - snapshot.reference_monotonic)
+        return (depth, oldest, live, stranded, age)
+
+
+class ReaperMetrics(_Exporter):
     """Queue-wide + reaper-outcome metrics, exported by the reaper process.
 
-    The queue gauges (`pg_queue_depth`, oldest-message age, barrier counts) are
-    CACHED snapshots — the reaper refreshes them on its own cadence (leader
-    only) and a scrape never touches the DB, so a hot scraper (or a curl loop
-    during an incident) cannot add DB load. ``pg_queue_gauges_age_seconds``
-    exposes the snapshot's staleness so a reader can tell cached-fresh from
-    cached-dead; it reads 0 while no snapshot has ever been taken (standby) —
-    disambiguate with ``pg_reaper_is_leader``.
+    The queue gauges are CACHED snapshots — the reaper refreshes them on its
+    own cadence (leader only) and a scrape never touches the DB, so a hot
+    scraper (or a curl loop during an incident) cannot add DB load.
+    ``pg_queue_gauges_age_seconds`` exposes snapshot staleness and keeps
+    growing while refreshes fail or the process is a standby.
 
     Outcome counters are incremented by the recovery/sweep code at the same
     sites that log the outcomes (see ``reaper.py``).
@@ -119,22 +198,19 @@ class ReaperMetrics:
         heartbeat_fn: Callable[[], float],
         is_leader_fn: Callable[[], bool],
     ) -> None:
-        from prometheus_client import Counter, Gauge
+        from prometheus_client import Counter
 
-        self.registry = _new_registry()
-
-        heartbeat = Gauge(
+        super().__init__()
+        self._function_gauge(
             "pg_reaper_heartbeat_age_seconds",
             "Seconds since the reaper tick loop last ran (liveness heartbeat)",
-            registry=self.registry,
+            heartbeat_fn,
         )
-        heartbeat.set_function(heartbeat_fn)
-        leader = Gauge(
+        self._function_gauge(
             "pg_reaper_is_leader",
             "1 while this reaper holds the leader lease, else 0",
-            registry=self.registry,
+            lambda: 1.0 if is_leader_fn() else 0.0,
         )
-        leader.set_function(lambda: 1.0 if is_leader_fn() else 0.0)
 
         self.barrier_recovered = Counter(
             "pg_reaper_barrier_recovered_total",
@@ -168,47 +244,20 @@ class ReaperMetrics:
             ["table"],
             registry=self.registry,
         )
+        self.tick_failures = Counter(
+            "pg_reaper_tick_failures_total",
+            "Reaper cycles that raised (recovery/scheduler SELECT failures — the "
+            "heartbeat stays fresh through these, so alert on this counter)",
+            registry=self.registry,
+        )
         self.gauge_refresh_failures = Counter(
             "pg_reaper_gauge_refresh_failures_total",
             "Failed queue-gauge snapshot refreshes (metrics stale, queue unaffected)",
             registry=self.registry,
         )
 
-        self._queue_depth = Gauge(
-            "pg_queue_depth",
-            "Messages currently in pg_queue_message, by queue (cached snapshot)",
-            ["queue"],
-            registry=self.registry,
-        )
-        self._oldest_age = Gauge(
-            "pg_queue_oldest_message_age_seconds",
-            "Age of the oldest message in the queue (cached snapshot)",
-            ["queue"],
-            registry=self.registry,
-        )
-        self._barriers_live = Gauge(
-            "pg_barrier_live",
-            "pg_barrier_state rows with remaining > 0 (in-flight fan-outs)",
-            registry=self.registry,
-        )
-        self._barriers_stranded = Gauge(
-            "pg_barrier_stranded",
-            "Live barriers past the stuck-timeout / expiry (reaper will recover)",
-            registry=self.registry,
-        )
-        self._last_refresh_monotonic: float | None = None
-        gauges_age = Gauge(
-            "pg_queue_gauges_age_seconds",
-            "Seconds since the queue gauges were last refreshed (0 = never; "
-            "check pg_reaper_is_leader)",
-            registry=self.registry,
-        )
-        gauges_age.set_function(self._seconds_since_refresh)
-
-    def _seconds_since_refresh(self) -> float:
-        if self._last_refresh_monotonic is None:
-            return 0.0
-        return time.monotonic() - self._last_refresh_monotonic
+        self._queue_collector = _QueueSnapshotCollector()
+        self.registry.register(self._queue_collector)
 
     def set_queue_snapshot(
         self,
@@ -217,30 +266,24 @@ class ReaperMetrics:
         barriers_live: int,
         barriers_stranded: int,
     ) -> None:
-        """Replace the cached queue-wide snapshot.
+        """Publish a fresh queue-wide snapshot (atomic swap; see collector).
 
         ``depths`` maps queue name -> (message count, oldest-message age in
-        seconds). Series are cleared first so a queue that drained to zero
-        drops out rather than freezing at its last non-zero value.
+        seconds). A queue that drained to zero rows simply drops out of the
+        series rather than freezing at its last non-zero value.
         """
-        self._queue_depth.clear()
-        self._oldest_age.clear()
-        for queue, (depth, oldest_age) in depths.items():
-            self._queue_depth.labels(queue=queue).set(depth)
-            self._oldest_age.labels(queue=queue).set(oldest_age)
-        self._barriers_live.set(barriers_live)
-        self._barriers_stranded.set(barriers_stranded)
-        self._last_refresh_monotonic = time.monotonic()
+        self._queue_collector.replace(
+            _QueueSnapshot(
+                depths=dict(depths),
+                barriers_live=barriers_live,
+                barriers_stranded=barriers_stranded,
+            )
+        )
 
     def clear_queue_snapshot(self) -> None:
-        """Zero the queue-wide gauges (called on losing leadership, so a standby
-        never exports a frozen stale snapshot as if it were live).
+        """Drop the per-queue series and zero the barrier gauges (called on
+        losing leadership — a standby must not export a frozen stale snapshot
+        as if it were live; its ``pg_queue_gauges_age_seconds`` restarts from
+        the step-down and keeps growing).
         """
-        self._queue_depth.clear()
-        self._oldest_age.clear()
-        self._barriers_live.set(0)
-        self._barriers_stranded.set(0)
-        self._last_refresh_monotonic = None
-
-    def render(self) -> bytes:
-        return _render(self.registry)
+        self._queue_collector.replace(_QueueSnapshot())

--- a/workers/queue_backend/pg_queue/metrics.py
+++ b/workers/queue_backend/pg_queue/metrics.py
@@ -140,41 +140,57 @@ class _QueueSnapshotCollector:
     def replace(self, snapshot: _QueueSnapshot) -> None:
         self._snapshot = snapshot  # atomic reference swap
 
-    def collect(self) -> Iterable[Metric]:
+    @staticmethod
+    def _families() -> tuple[Metric, ...]:
+        """The five empty metric families — one builder so ``describe`` (names
+        only) and ``collect`` (names + samples) can never drift.
+        """
         from prometheus_client.core import GaugeMetricFamily
 
+        return (
+            GaugeMetricFamily(
+                "pg_queue_depth",
+                "Messages currently in pg_queue_message, by queue (cached "
+                "snapshot; a drained queue's series is absent, not 0)",
+                labels=["queue"],
+            ),
+            GaugeMetricFamily(
+                "pg_queue_oldest_message_age_seconds",
+                "Age of the oldest message in the queue (cached snapshot)",
+                labels=["queue"],
+            ),
+            GaugeMetricFamily(
+                "pg_barrier_live",
+                "pg_barrier_state rows with remaining > 0 (in-flight fan-outs)",
+            ),
+            GaugeMetricFamily(
+                "pg_barrier_stranded",
+                "Barrier rows past the stuck-timeout / expiry — what the next "
+                "recovery pass picks up (includes remaining==0 lingerers)",
+            ),
+            GaugeMetricFamily(
+                "pg_queue_gauges_age_seconds",
+                "Seconds since the queue gauges were last refreshed (since "
+                "process start / leadership step-down if never) — alert on "
+                "this AND pg_reaper_is_leader==1; a standby's age grows by "
+                "design",
+            ),
+        )
+
+    def describe(self) -> Iterable[Metric]:
+        # Registration protocol: with describe() present, register() checks
+        # names against these descriptors instead of invoking the full
+        # collect() render path (and its clock read) as a side effect.
+        return self._families()
+
+    def collect(self) -> Iterable[Metric]:
         snapshot = self._snapshot  # single read — the consistency point
-        depth = GaugeMetricFamily(
-            "pg_queue_depth",
-            "Messages currently in pg_queue_message, by queue (cached snapshot; "
-            "a drained queue's series is absent, not 0)",
-            labels=["queue"],
-        )
-        oldest = GaugeMetricFamily(
-            "pg_queue_oldest_message_age_seconds",
-            "Age of the oldest message in the queue (cached snapshot)",
-            labels=["queue"],
-        )
+        depth, oldest, live, stranded, age = self._families()
         for queue, (msg_count, oldest_age) in snapshot.depths.items():
             depth.add_metric([queue], msg_count)
             oldest.add_metric([queue], oldest_age)
-        live = GaugeMetricFamily(
-            "pg_barrier_live",
-            "pg_barrier_state rows with remaining > 0 (in-flight fan-outs)",
-        )
         live.add_metric([], snapshot.barriers_live)
-        stranded = GaugeMetricFamily(
-            "pg_barrier_stranded",
-            "Barrier rows past the stuck-timeout / expiry — what the next "
-            "recovery pass picks up (includes remaining==0 lingerers)",
-        )
         stranded.add_metric([], snapshot.barriers_stranded)
-        age = GaugeMetricFamily(
-            "pg_queue_gauges_age_seconds",
-            "Seconds since the queue gauges were last refreshed (since process "
-            "start / leadership step-down if never) — alert on this AND "
-            "pg_reaper_is_leader==1; a standby's age grows by design",
-        )
         age.add_metric([], time.monotonic() - snapshot.reference_monotonic)
         return (depth, oldest, live, stranded, age)
 
@@ -230,7 +246,7 @@ class ReaperMetrics(_Exporter):
         )
         self.claim_gc = Counter(
             "pg_reaper_claim_gc_total",
-            "Orphan orchestration-claim tombstones GC'd (execution already " "terminal)",
+            "Orphan orchestration-claim tombstones GC'd (execution terminal)",
             registry=self.registry,
         )
         self.claim_recovery_failures = Counter(

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -827,7 +827,8 @@ def sweep_orphan_claims(
 
 
 # Queue-gauge snapshot cadence. Deliberately a module constant, not an env knob:
-# it only bounds metrics staleness (the tick already runs every ~5s), and the
+# it only bounds metrics staleness (the tick already runs every
+# _DEFAULT_REAPER_INTERVAL_SECONDS by default), and the
 # snapshot is two cheap aggregate reads.
 _GAUGE_REFRESH_INTERVAL_SECONDS: Final = 60.0
 
@@ -840,7 +841,9 @@ def refresh_queue_gauges(
     Two aggregate reads: per-queue depth + oldest-message age over
     ``pg_queue_message`` (all rows — ready and in-flight — since a backlog is a
     backlog either way), and live/stranded counts over ``pg_barrier_state``
-    (stranded = what the next recovery pass would pick up, same predicate).
+    (live = ``remaining > 0`` in-flight fan-outs; stranded = what the next
+    recovery pass would pick up — same predicate, unfiltered by ``remaining``,
+    so it includes ``remaining==0`` delete-failure lingerers).
 
     ``conn`` runs in manual-commit mode; on any error we roll back before
     re-raising so the connection isn't left in an aborted-txn state (the caller
@@ -855,7 +858,7 @@ def refresh_queue_gauges(
             )
             depth_rows = cur.fetchall()
             cur.execute(
-                "SELECT count(*), "
+                "SELECT count(*) FILTER (WHERE remaining > 0), "
                 f"count(*) FILTER (WHERE {_STRANDED_PREDICATE}) "
                 f"FROM {qualified('pg_barrier_state')}",
                 (stuck_timeout_seconds,),
@@ -1023,7 +1026,7 @@ class PgReaper:
                 # A raised renew == "leadership unknown": stop acting (honour the
                 # lease's documented contract) before letting it propagate.
                 self._is_leader = False
-                self._metrics.clear_queue_snapshot()
+                self._step_down_metrics()
                 raise
             if not still_leader:
                 logger.warning(
@@ -1031,9 +1034,7 @@ class PgReaper:
                     "to standby"
                 )
                 self._is_leader = False
-                # A standby must not keep exporting a frozen queue snapshot as if
-                # it were live — the new leader owns those series now.
-                self._metrics.clear_queue_snapshot()
+                self._step_down_metrics()
         if not self._is_leader and self._lease.try_acquire():
             self._is_leader = True
             logger.info("Reaper: acquired leadership")
@@ -1142,6 +1143,16 @@ class PgReaper:
         self._sweep_fail_streak[table] = 0
         return count
 
+    def _step_down_metrics(self) -> None:
+        """On losing leadership: drop the queue snapshot AND reset the refresh
+        cadence. Resetting the cadence is load-bearing — without it, a lease
+        flap that re-acquires within the refresh interval would gate the next
+        refresh out, leaving a re-elected leader exporting the just-cleared
+        (false "empty queue") snapshot for up to a full interval.
+        """
+        self._metrics.clear_queue_snapshot()
+        self._last_gauge_refresh_monotonic = None
+
     def _maybe_refresh_gauges(self) -> None:
         """Refresh the queue-wide metrics snapshot at most once per
         :data:`_GAUGE_REFRESH_INTERVAL_SECONDS` (leader-only, called from
@@ -1190,6 +1201,10 @@ class PgReaper:
                     # A transient DB blip must not tear the loop down — the lease
                     # connection rolls back + discards a dead handle, and a failed
                     # sweep discards its owned connection, so log and keep cycling.
+                    # Counted: the heartbeat is stamped at tick START, so /health
+                    # stays 200 through every-tick failures (schema/grant faults) —
+                    # this counter is the only machine-readable signal for that.
+                    self._metrics.tick_failures.inc()
                     logger.exception("Reaper: cycle failed; continuing")
                 time.sleep(self._interval)
         finally:

--- a/workers/queue_backend/pg_queue/reaper.py
+++ b/workers/queue_backend/pg_queue/reaper.py
@@ -69,6 +69,7 @@ from ..barrier import barrier_stuck_timeout_seconds
 from .connection import create_pg_connection
 from .leader_election import LeaderLease, default_worker_id
 from .liveness import LivenessServer as _BaseLivenessServer
+from .metrics import ReaperMetrics
 from .pg_scheduler import dispatch_due_schedules
 from .recovery import mark_execution_error
 from .schema import qualified
@@ -474,6 +475,7 @@ def recover_expired_barriers(
     conn: PgConnection,
     api_client: InternalAPIClient,
     stuck_timeout_seconds: int | None = None,
+    metrics: ReaperMetrics | None = None,
 ) -> list[str]:
     """Recover stranded executions. Returns recovered ids.
 
@@ -540,6 +542,9 @@ def recover_expired_barriers(
                 execution_id,
             )
 
+    if metrics is not None:
+        metrics.barrier_recovered.inc(len(recovered))
+        metrics.barrier_recovery_failures.inc(failed)
     if rows:
         skipped = len(rows) - len(recovered) - failed
         summary = (
@@ -727,6 +732,7 @@ def sweep_orphan_claims(
     conn: PgConnection,
     api_client: InternalAPIClient,
     stuck_timeout_seconds: int | None = None,
+    metrics: ReaperMetrics | None = None,
 ) -> int:
     """GC / recover orphaned ``pg_orchestration_claim`` rows (UN-3679). Returns the
     number of claim rows removed (terminal-tombstone GCs + crash-window recoveries).
@@ -785,6 +791,10 @@ def sweep_orphan_claims(
             )
 
     removed = gc_count + recovered
+    if metrics is not None:
+        metrics.claim_recovered.inc(recovered)
+        metrics.claim_gc.inc(gc_count)
+        metrics.claim_recovery_failures.inc(failed)
     if removed:
         logger.info(
             "Reaper: orphan-claim sweep removed %d of %d claim(s) — %d GC'd "
@@ -814,6 +824,56 @@ def sweep_orphan_claims(
             removed,
         )
     return removed
+
+
+# Queue-gauge snapshot cadence. Deliberately a module constant, not an env knob:
+# it only bounds metrics staleness (the tick already runs every ~5s), and the
+# snapshot is two cheap aggregate reads.
+_GAUGE_REFRESH_INTERVAL_SECONDS: Final = 60.0
+
+
+def refresh_queue_gauges(
+    conn: PgConnection, metrics: ReaperMetrics, stuck_timeout_seconds: int
+) -> None:
+    """Take one queue-wide snapshot into ``metrics`` (leader-only caller).
+
+    Two aggregate reads: per-queue depth + oldest-message age over
+    ``pg_queue_message`` (all rows — ready and in-flight — since a backlog is a
+    backlog either way), and live/stranded counts over ``pg_barrier_state``
+    (stranded = what the next recovery pass would pick up, same predicate).
+
+    ``conn`` runs in manual-commit mode; on any error we roll back before
+    re-raising so the connection isn't left in an aborted-txn state (the caller
+    counts the failure and discards an owned connection).
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT queue_name, count(*), "
+                "COALESCE(EXTRACT(EPOCH FROM now() - min(enqueued_at)), 0) "
+                f"FROM {qualified('pg_queue_message')} GROUP BY queue_name"
+            )
+            depth_rows = cur.fetchall()
+            cur.execute(
+                "SELECT count(*), "
+                f"count(*) FILTER (WHERE {_STRANDED_PREDICATE}) "
+                f"FROM {qualified('pg_barrier_state')}",
+                (stuck_timeout_seconds,),
+            )
+            barriers_live, barriers_stranded = cur.fetchone()
+        conn.commit()
+    except Exception:
+        with contextlib.suppress(Exception):
+            conn.rollback()
+        raise
+    metrics.set_queue_snapshot(
+        depths={
+            queue: (int(depth), float(oldest_age))
+            for queue, depth, oldest_age in depth_rows
+        },
+        barriers_live=int(barriers_live),
+        barriers_stranded=int(barriers_stranded),
+    )
 
 
 class PgReaper:
@@ -894,6 +954,18 @@ class PgReaper:
         # standby tick counts as progress too (the loop is alive), so this tracks
         # loop liveness, not leadership.
         self._last_tick_monotonic = time.monotonic()
+        # Queue-wide metrics snapshot cadence (same None-sentinel pattern as the
+        # sweep gate: first leader tick refreshes immediately).
+        self._last_gauge_refresh_monotonic: float | None = None
+        self._metrics = ReaperMetrics(
+            heartbeat_fn=self.seconds_since_last_tick,
+            is_leader_fn=lambda: self._is_leader,
+        )
+
+    @property
+    def metrics(self) -> ReaperMetrics:
+        """This process's metrics exporter (served at ``/metrics``)."""
+        return self._metrics
 
     @property
     def is_leader(self) -> bool:
@@ -951,6 +1023,7 @@ class PgReaper:
                 # A raised renew == "leadership unknown": stop acting (honour the
                 # lease's documented contract) before letting it propagate.
                 self._is_leader = False
+                self._metrics.clear_queue_snapshot()
                 raise
             if not still_leader:
                 logger.warning(
@@ -958,6 +1031,9 @@ class PgReaper:
                     "to standby"
                 )
                 self._is_leader = False
+                # A standby must not keep exporting a frozen queue snapshot as if
+                # it were live — the new leader owns those series now.
+                self._metrics.clear_queue_snapshot()
         if not self._is_leader and self._lease.try_acquire():
             self._is_leader = True
             logger.info("Reaper: acquired leadership")
@@ -969,6 +1045,7 @@ class PgReaper:
                     self._get_sweep_conn(),
                     self._get_api_client(),
                     self._stuck_timeout_seconds,
+                    metrics=self._metrics,
                 )
             )
         except Exception:
@@ -987,6 +1064,9 @@ class PgReaper:
         # Orchestrator's third job: retention cleanup (cadence-gated, so it does
         # NOT run every tick). Last so a sweep error can't skip recovery/schedules.
         self._maybe_sweep()
+        # Queue-wide metrics snapshot (cadence-gated, best-effort — a metrics
+        # failure must never fail the tick). After all real work.
+        self._maybe_refresh_gauges()
         return TickOutcome(was_leader=True, reclaimed=reclaimed)
 
     def _maybe_sweep(self) -> None:
@@ -1020,7 +1100,10 @@ class PgReaper:
         claims = self._run_sweep(
             "pg_orchestration_claim",
             lambda conn: sweep_orphan_claims(
-                conn, self._get_api_client(), self._stuck_timeout_seconds
+                conn,
+                self._get_api_client(),
+                self._stuck_timeout_seconds,
+                metrics=self._metrics,
             ),
         )
         if results or dedup or claims:
@@ -1047,6 +1130,7 @@ class PgReaper:
         except Exception:
             streak = self._sweep_fail_streak.get(table, 0) + 1
             self._sweep_fail_streak[table] = streak
+            self._metrics.sweep_failures.labels(table=table).inc()
             logger.exception(
                 "Reaper: retention sweep of %s failed (%s consecutive) — will retry "
                 "after the next sweep interval",
@@ -1057,6 +1141,35 @@ class PgReaper:
             return 0
         self._sweep_fail_streak[table] = 0
         return count
+
+    def _maybe_refresh_gauges(self) -> None:
+        """Refresh the queue-wide metrics snapshot at most once per
+        :data:`_GAUGE_REFRESH_INTERVAL_SECONDS` (leader-only, called from
+        :meth:`tick`). Best-effort: metrics must never fail the tick, so a
+        failure is counted + logged and the snapshot simply goes stale
+        (``pg_queue_gauges_age_seconds`` exposes exactly that). The cadence is
+        advanced BEFORE the read so a persistent failure retries once per
+        interval rather than every tick — same pattern as :meth:`_maybe_sweep`.
+        """
+        now = time.monotonic()
+        if (
+            self._last_gauge_refresh_monotonic is not None
+            and now - self._last_gauge_refresh_monotonic < _GAUGE_REFRESH_INTERVAL_SECONDS
+        ):
+            return
+        self._last_gauge_refresh_monotonic = now
+        try:
+            refresh_queue_gauges(
+                self._get_sweep_conn(), self._metrics, self._stuck_timeout_seconds
+            )
+        except Exception:
+            self._metrics.gauge_refresh_failures.inc()
+            logger.warning(
+                "Reaper: queue-gauge snapshot refresh failed — metrics go stale "
+                "until the next interval; the queue itself is unaffected",
+                exc_info=True,
+            )
+            self._discard_owned_sweep_conn()
 
     def run(self, *, install_signals: bool = True) -> None:
         """Lease-maintenance + recovery loop until stopped; releases on exit."""
@@ -1144,6 +1257,7 @@ class ReaperLivenessServer(_BaseLivenessServer):
             check_name="pg_reaper_tick",
             age_key="seconds_since_last_tick",
             extra_status_fn=lambda: {"is_leader": reaper.is_leader},
+            metrics_fn=reaper.metrics.render,
             thread_name="pg-reaper-liveness",
             log_label="pg-queue reaper",
         )

--- a/workers/tests/test_pg_metrics.py
+++ b/workers/tests/test_pg_metrics.py
@@ -225,6 +225,17 @@ class TestReaperMetrics:
         age = _sample(metrics, "pg_queue_gauges_age_seconds")
         assert age is not None and 0.0 <= age < 5.0
 
+    def test_collector_describe_lists_names_without_samples(self):
+        # Registration protocol: describe() must expose the same names as
+        # collect() (registry duplicate-checking) but with NO samples — so
+        # register() never runs the render path (clock read) as a side effect.
+        metrics = _reaper_metrics()
+        collector = metrics._queue_collector
+        described = {m.name: m for m in collector.describe()}
+        collected = {m.name for m in collector.collect()}
+        assert set(described) == collected
+        assert all(not m.samples for m in described.values())
+
     def test_scrape_is_atomic_snapshot(self):
         # The collector renders from ONE snapshot reference: a replace() during
         # a render can't mix old and new values. Simulate by capturing the

--- a/workers/tests/test_pg_metrics.py
+++ b/workers/tests/test_pg_metrics.py
@@ -1,0 +1,389 @@
+"""PG-queue application-level metrics exporter (UN-3672).
+
+Covers the three layers:
+- the ``/metrics`` route on the shared LivenessServer (opt-in, isolated from
+  ``/health``),
+- the metric definitions (``ConsumerMetrics`` / ``ReaperMetrics`` — instance
+  registries, snapshot set/clear semantics),
+- the reaper wiring (outcome counters threaded into the recovery/sweep
+  functions; the cadence-gated, best-effort queue-gauge refresh in ``tick``).
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import queue_backend.pg_queue.reaper as reaper_mod
+from queue_backend.pg_queue.liveness import LivenessServer
+from queue_backend.pg_queue.metrics import (
+    METRICS_CONTENT_TYPE,
+    ConsumerMetrics,
+    ReaperMetrics,
+)
+from queue_backend.pg_queue.reaper import (
+    PgReaper,
+    recover_expired_barriers,
+    refresh_queue_gauges,
+    sweep_orphan_claims,
+)
+
+from .test_pg_reaper import _FakeLease
+
+
+# Same stubs as test_pg_reaper's autouse fixtures (they're module-local there):
+# tick() also runs the scheduler dispatch + retention sweeps, which would
+# otherwise hit the dummy injected sweep_conn.
+@pytest.fixture(autouse=True)
+def stub_scheduler_and_sweeps(monkeypatch):
+    monkeypatch.setattr(reaper_mod, "dispatch_due_schedules", MagicMock(return_value=0))
+    monkeypatch.setattr(reaper_mod, "sweep_expired_results", MagicMock(return_value=0))
+    monkeypatch.setattr(reaper_mod, "sweep_orphan_dedup", MagicMock(return_value=0))
+    monkeypatch.setattr(reaper_mod, "sweep_orphan_claims", MagicMock(return_value=0))
+
+
+def _get(url: str):
+    return urllib.request.urlopen(url, timeout=5)
+
+
+def _sample(metrics, name: str, labels: dict[str, str] | None = None) -> float | None:
+    return metrics.registry.get_sample_value(name, labels or {})
+
+
+class TestLivenessMetricsRoute:
+    """/metrics on the shared LivenessServer: opt-in, never touching /health."""
+
+    def _server(self, metrics_fn) -> LivenessServer:
+        return LivenessServer(
+            freshness_fn=lambda: 0.0,
+            stale_after=60,
+            port=0,
+            check_name="t",
+            age_key="age",
+            metrics_fn=metrics_fn,
+        )
+
+    def test_404_when_no_metrics_fn(self):
+        server = self._server(None)
+        server.start()
+        try:
+            with pytest.raises(urllib.error.HTTPError) as ei:
+                _get(f"http://127.0.0.1:{server.bound_port}/metrics")
+            assert ei.value.code == 404
+        finally:
+            server.stop()
+
+    def test_serves_prometheus_body_and_content_type(self):
+        server = self._server(lambda: b"pg_test_metric 1.0\n")
+        server.start()
+        try:
+            with _get(f"http://127.0.0.1:{server.bound_port}/metrics") as resp:
+                assert resp.status == 200
+                assert resp.headers["Content-Type"] == METRICS_CONTENT_TYPE
+                assert resp.read() == b"pg_test_metric 1.0\n"
+        finally:
+            server.stop()
+
+    def test_broken_metrics_fn_500s_but_health_still_answers(self):
+        # The whole point of sharing the server: a broken exporter must degrade
+        # to /metrics alone — the probe verdict is untouched.
+        def boom() -> bytes:
+            raise RuntimeError("render failed")
+
+        server = self._server(boom)
+        server.start()
+        try:
+            base = f"http://127.0.0.1:{server.bound_port}"
+            with pytest.raises(urllib.error.HTTPError) as ei:
+                _get(f"{base}/metrics")
+            assert ei.value.code == 500
+            with _get(f"{base}/health") as resp:
+                assert resp.status == 200
+        finally:
+            server.stop()
+
+
+class TestConsumerMetrics:
+    def test_heartbeat_gauge_tracks_freshness_fn(self):
+        age = 7.5
+        metrics = ConsumerMetrics(freshness_fn=lambda: age)
+        assert _sample(metrics, "pg_consumer_heartbeat_age_seconds") == 7.5
+        age = 42.0  # live callback, not a captured constant
+        assert _sample(metrics, "pg_consumer_heartbeat_age_seconds") == 42.0
+
+    def test_fleet_hooks_are_optional(self):
+        plain = ConsumerMetrics(freshness_fn=lambda: 0.0)
+        assert _sample(plain, "pg_consumer_alive_children") is None
+
+        fleet = ConsumerMetrics(
+            freshness_fn=lambda: 0.0,
+            alive_children_fn=lambda: 3.0,
+            concurrency_fn=lambda: 4.0,
+        )
+        assert _sample(fleet, "pg_consumer_alive_children") == 3.0
+        assert _sample(fleet, "pg_consumer_configured_concurrency") == 4.0
+
+    def test_render_is_prometheus_exposition(self):
+        body = ConsumerMetrics(freshness_fn=lambda: 1.0).render()
+        assert b"pg_consumer_heartbeat_age_seconds" in body
+
+    def test_two_instances_do_not_collide(self):
+        # Instance registries: the workers tree can be imported under two module
+        # names (bare-``tasks`` quirk), so module-level collectors would
+        # double-register. Two instances must simply coexist.
+        ConsumerMetrics(freshness_fn=lambda: 0.0)
+        ConsumerMetrics(freshness_fn=lambda: 0.0)
+
+
+def _reaper_metrics(*, leader: bool = True) -> ReaperMetrics:
+    return ReaperMetrics(heartbeat_fn=lambda: 1.0, is_leader_fn=lambda: leader)
+
+
+class TestReaperMetrics:
+    def test_leadership_gauge(self):
+        assert _sample(_reaper_metrics(leader=True), "pg_reaper_is_leader") == 1.0
+        assert _sample(_reaper_metrics(leader=False), "pg_reaper_is_leader") == 0.0
+
+    def test_snapshot_set_then_drained_queue_drops_out(self):
+        metrics = _reaper_metrics()
+        metrics.set_queue_snapshot(
+            depths={"q1": (5, 120.0), "q2": (1, 3.0)},
+            barriers_live=2,
+            barriers_stranded=1,
+        )
+        assert _sample(metrics, "pg_queue_depth", {"queue": "q1"}) == 5.0
+        assert (
+            _sample(metrics, "pg_queue_oldest_message_age_seconds", {"queue": "q1"})
+            == 120.0
+        )
+        assert _sample(metrics, "pg_barrier_live") == 2.0
+        assert _sample(metrics, "pg_barrier_stranded") == 1.0
+
+        # q1 drains: its series must DROP, not freeze at the last non-zero value.
+        metrics.set_queue_snapshot(
+            depths={"q2": (0, 0.0)}, barriers_live=0, barriers_stranded=0
+        )
+        assert _sample(metrics, "pg_queue_depth", {"queue": "q1"}) is None
+        assert _sample(metrics, "pg_queue_depth", {"queue": "q2"}) == 0.0
+
+    def test_clear_zeroes_the_snapshot(self):
+        # On losing leadership a standby must not export a frozen stale snapshot.
+        metrics = _reaper_metrics()
+        metrics.set_queue_snapshot(
+            depths={"q": (9, 10.0)}, barriers_live=1, barriers_stranded=1
+        )
+        metrics.clear_queue_snapshot()
+        assert _sample(metrics, "pg_queue_depth", {"queue": "q"}) is None
+        assert _sample(metrics, "pg_barrier_live") == 0.0
+        assert _sample(metrics, "pg_queue_gauges_age_seconds") == 0.0
+
+    def test_gauges_age_zero_until_first_snapshot_then_positive(self):
+        metrics = _reaper_metrics()
+        assert _sample(metrics, "pg_queue_gauges_age_seconds") == 0.0
+        metrics.set_queue_snapshot(depths={}, barriers_live=0, barriers_stranded=0)
+        age = _sample(metrics, "pg_queue_gauges_age_seconds")
+        assert age is not None and 0.0 <= age < 5.0
+
+
+class _FakeCursor:
+    """Cursor returning one preloaded result set per execute() call."""
+
+    def __init__(self, result_sets):
+        self._result_sets = list(result_sets)
+        self._current = None
+        self.executed: list[str] = []
+
+    def execute(self, sql, params=None):
+        self.executed.append(sql)
+        self._current = self._result_sets.pop(0)
+
+    def fetchall(self):
+        return self._current
+
+    def fetchone(self):
+        return self._current
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, result_sets):
+        self.cursor_obj = _FakeCursor(result_sets)
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+class TestRefreshQueueGauges:
+    def test_snapshot_from_sql_rows(self):
+        metrics = _reaper_metrics()
+        conn = _FakeConn(
+            [
+                [("file_processing", 7, 33.0), ("celery", 0, 0.0)],  # depth rows
+                (4, 2),  # barriers live, stranded
+            ]
+        )
+        refresh_queue_gauges(conn, metrics, stuck_timeout_seconds=9000)
+        assert conn.commits == 1
+        assert (
+            _sample(metrics, "pg_queue_depth", {"queue": "file_processing"}) == 7.0
+        )
+        assert _sample(metrics, "pg_barrier_live") == 4.0
+        assert _sample(metrics, "pg_barrier_stranded") == 2.0
+
+    def test_error_rolls_back_and_reraises(self):
+        metrics = _reaper_metrics()
+        conn = MagicMock()
+        conn.cursor.side_effect = RuntimeError("db down")
+        with pytest.raises(RuntimeError):
+            refresh_queue_gauges(conn, metrics, stuck_timeout_seconds=9000)
+        conn.rollback.assert_called_once()
+        # No partial snapshot: the gauges stay never-refreshed.
+        assert _sample(metrics, "pg_queue_gauges_age_seconds") == 0.0
+
+
+class TestOutcomeCounters:
+    """The recovery/sweep functions increment counters at their summary sites."""
+
+    def test_barrier_recovery_counts(self):
+        metrics = _reaper_metrics()
+        conn = _FakeConn([[("e1", "org", 1), ("e2", "org", 1)]])
+        with patch.object(
+            reaper_mod, "_recover_one_barrier", side_effect=[True, RuntimeError("x")]
+        ):
+            recovered = recover_expired_barriers(
+                conn, api_client=object(), stuck_timeout_seconds=1, metrics=metrics
+            )
+        assert recovered == ["e1"]
+        assert _sample(metrics, "pg_reaper_barrier_recovered_total") == 1.0
+        assert _sample(metrics, "pg_reaper_barrier_recovery_failures_total") == 1.0
+
+    def test_claim_sweep_counts(self):
+        metrics = _reaper_metrics()
+        conn = _FakeConn([[("e1", "org"), ("e2", "org")]])
+        with patch.object(
+            reaper_mod,
+            "_recover_one_claim",
+            side_effect=[reaper_mod._CLAIM_RECOVERED, reaper_mod._CLAIM_GC],
+        ):
+            removed = sweep_orphan_claims(
+                conn, api_client=object(), stuck_timeout_seconds=1, metrics=metrics
+            )
+        assert removed == 2
+        assert _sample(metrics, "pg_reaper_claim_recovered_total") == 1.0
+        assert _sample(metrics, "pg_reaper_claim_gc_total") == 1.0
+        assert _sample(metrics, "pg_reaper_claim_recovery_failures_total") == 0.0
+
+    def test_counters_optional_no_metrics_kwarg(self):
+        # Celery-safety twin: existing callers that pass no metrics still work.
+        conn = _FakeConn([[]])
+        assert (
+            recover_expired_barriers(conn, api_client=object(), stuck_timeout_seconds=1)
+            == []
+        )
+
+
+class TestReaperTickWiring:
+    def _reaper(self, lease, **kw) -> PgReaper:
+        return PgReaper(
+            lease, interval_seconds=0.01, sweep_conn=object(), api_client=object(), **kw
+        )
+
+    def test_leader_tick_refreshes_gauges(self):
+        reaper = self._reaper(_FakeLease(acquires=True))
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            patch.object(reaper_mod, "refresh_queue_gauges") as refresh,
+        ):
+            reaper.tick()
+        refresh.assert_called_once()
+
+    def test_refresh_is_cadence_gated(self):
+        reaper = self._reaper(_FakeLease(acquires=True))
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            patch.object(reaper_mod, "refresh_queue_gauges") as refresh,
+        ):
+            reaper.tick()
+            reaper.tick()  # within the refresh interval → no second refresh
+        refresh.assert_called_once()
+
+    def test_refresh_failure_never_fails_the_tick(self):
+        reaper = self._reaper(_FakeLease(acquires=True))
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            patch.object(
+                reaper_mod, "refresh_queue_gauges", side_effect=RuntimeError("db")
+            ),
+        ):
+            outcome = reaper.tick()  # must not raise
+        assert outcome.was_leader is True
+        assert (
+            _sample(reaper.metrics, "pg_reaper_gauge_refresh_failures_total") == 1.0
+        )
+
+    def test_standby_never_refreshes(self):
+        reaper = self._reaper(_FakeLease(acquires=False))
+        with patch.object(reaper_mod, "refresh_queue_gauges") as refresh:
+            reaper.tick()
+        refresh.assert_not_called()
+
+    def test_lost_leadership_clears_snapshot(self):
+        reaper = self._reaper(_FakeLease(acquires=[True], renews=False))
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            patch.object(reaper_mod, "refresh_queue_gauges"),
+        ):
+            reaper.tick()  # becomes leader
+            reaper.metrics.set_queue_snapshot(
+                depths={"q": (1, 1.0)}, barriers_live=1, barriers_stranded=0
+            )
+            reaper.tick()  # renew fails → steps down → snapshot cleared
+        assert reaper.is_leader is False
+        assert _sample(reaper.metrics, "pg_queue_depth", {"queue": "q"}) is None
+
+    def test_metrics_served_on_liveness_port(self):
+        # End-to-end: the reaper's /metrics answers with its registry content.
+        from queue_backend.pg_queue.reaper import ReaperLivenessServer
+
+        reaper = self._reaper(_FakeLease(acquires=True))
+        server = ReaperLivenessServer(reaper, port=0, stale_after=60)
+        server.start()
+        try:
+            with _get(f"http://127.0.0.1:{server.bound_port}/metrics") as resp:
+                body = resp.read()
+            assert b"pg_reaper_is_leader" in body
+            assert b"pg_reaper_heartbeat_age_seconds" in body
+        finally:
+            server.stop()
+
+
+class TestConsumerServerMetricsRoute:
+    def test_consumer_metrics_served(self):
+        from queue_backend.pg_queue.consumer import LivenessServer as ConsumerServer
+        from queue_backend.pg_queue.consumer import PgQueueConsumer
+
+        consumer = PgQueueConsumer(["q"], client=MagicMock())
+        server = ConsumerServer(consumer, port=0, stale_after=60)
+        server.start()
+        try:
+            with _get(f"http://127.0.0.1:{server.bound_port}/metrics") as resp:
+                assert resp.headers["Content-Type"] == METRICS_CONTENT_TYPE
+                assert b"pg_consumer_heartbeat_age_seconds" in resp.read()
+        finally:
+            server.stop()

--- a/workers/tests/test_pg_metrics.py
+++ b/workers/tests/test_pg_metrics.py
@@ -1,16 +1,22 @@
 """PG-queue application-level metrics exporter (UN-3672).
 
-Covers the three layers:
+Covers the four layers:
 - the ``/metrics`` route on the shared LivenessServer (opt-in, isolated from
   ``/health``),
 - the metric definitions (``ConsumerMetrics`` / ``ReaperMetrics`` — instance
-  registries, snapshot set/clear semantics),
+  registries, atomic snapshot swap semantics),
 - the reaper wiring (outcome counters threaded into the recovery/sweep
-  functions; the cadence-gated, best-effort queue-gauge refresh in ``tick``).
+  functions; the cadence-gated, best-effort queue-gauge refresh in ``tick``;
+  cadence reset on leadership step-down),
+- the supervisor's fleet-metrics wiring (only producer of the fleet gauges).
+
+Float assertions use ``pytest.approx`` throughout — the values are exact
+(set/inc of integers), but approx keeps the comparisons robust and quiet.
 """
 
 from __future__ import annotations
 
+import contextlib
 import urllib.error
 import urllib.request
 from unittest.mock import MagicMock, patch
@@ -53,6 +59,15 @@ def _sample(metrics, name: str, labels: dict[str, str] | None = None) -> float |
     return metrics.registry.get_sample_value(name, labels or {})
 
 
+@contextlib.contextmanager
+def _running(server):
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
 class TestLivenessMetricsRoute:
     """/metrics on the shared LivenessServer: opt-in, never touching /health."""
 
@@ -67,25 +82,25 @@ class TestLivenessMetricsRoute:
         )
 
     def test_404_when_no_metrics_fn(self):
-        server = self._server(None)
-        server.start()
-        try:
+        with _running(self._server(None)) as server:
             with pytest.raises(urllib.error.HTTPError) as ei:
                 _get(f"http://127.0.0.1:{server.bound_port}/metrics")
             assert ei.value.code == 404
-        finally:
-            server.stop()
 
     def test_serves_prometheus_body_and_content_type(self):
-        server = self._server(lambda: b"pg_test_metric 1.0\n")
-        server.start()
-        try:
+        with _running(self._server(lambda: b"pg_test_metric 1.0\n")) as server:
             with _get(f"http://127.0.0.1:{server.bound_port}/metrics") as resp:
                 assert resp.status == 200
                 assert resp.headers["Content-Type"] == METRICS_CONTENT_TYPE
                 assert resp.read() == b"pg_test_metric 1.0\n"
-        finally:
-            server.stop()
+
+    def test_query_string_is_stripped(self):
+        # Mirrors the /health?probe=k8s behavior — self.path includes the query.
+        with _running(self._server(lambda: b"x 1\n")) as server:
+            with _get(
+                f"http://127.0.0.1:{server.bound_port}/metrics?scrape=test"
+            ) as resp:
+                assert resp.status == 200
 
     def test_broken_metrics_fn_500s_but_health_still_answers(self):
         # The whole point of sharing the server: a broken exporter must degrade
@@ -93,26 +108,26 @@ class TestLivenessMetricsRoute:
         def boom() -> bytes:
             raise RuntimeError("render failed")
 
-        server = self._server(boom)
-        server.start()
-        try:
+        with _running(self._server(boom)) as server:
             base = f"http://127.0.0.1:{server.bound_port}"
             with pytest.raises(urllib.error.HTTPError) as ei:
                 _get(f"{base}/metrics")
             assert ei.value.code == 500
             with _get(f"{base}/health") as resp:
                 assert resp.status == 200
-        finally:
-            server.stop()
 
 
 class TestConsumerMetrics:
     def test_heartbeat_gauge_tracks_freshness_fn(self):
         age = 7.5
         metrics = ConsumerMetrics(freshness_fn=lambda: age)
-        assert _sample(metrics, "pg_consumer_heartbeat_age_seconds") == 7.5
+        assert _sample(metrics, "pg_consumer_heartbeat_age_seconds") == pytest.approx(
+            7.5
+        )
         age = 42.0  # live callback, not a captured constant
-        assert _sample(metrics, "pg_consumer_heartbeat_age_seconds") == 42.0
+        assert _sample(metrics, "pg_consumer_heartbeat_age_seconds") == pytest.approx(
+            42.0
+        )
 
     def test_fleet_hooks_are_optional(self):
         plain = ConsumerMetrics(freshness_fn=lambda: 0.0)
@@ -123,8 +138,10 @@ class TestConsumerMetrics:
             alive_children_fn=lambda: 3.0,
             concurrency_fn=lambda: 4.0,
         )
-        assert _sample(fleet, "pg_consumer_alive_children") == 3.0
-        assert _sample(fleet, "pg_consumer_configured_concurrency") == 4.0
+        assert _sample(fleet, "pg_consumer_alive_children") == pytest.approx(3.0)
+        assert _sample(fleet, "pg_consumer_configured_concurrency") == pytest.approx(
+            4.0
+        )
 
     def test_render_is_prometheus_exposition(self):
         body = ConsumerMetrics(freshness_fn=lambda: 1.0).render()
@@ -144,8 +161,12 @@ def _reaper_metrics(*, leader: bool = True) -> ReaperMetrics:
 
 class TestReaperMetrics:
     def test_leadership_gauge(self):
-        assert _sample(_reaper_metrics(leader=True), "pg_reaper_is_leader") == 1.0
-        assert _sample(_reaper_metrics(leader=False), "pg_reaper_is_leader") == 0.0
+        assert _sample(
+            _reaper_metrics(leader=True), "pg_reaper_is_leader"
+        ) == pytest.approx(1.0)
+        assert _sample(
+            _reaper_metrics(leader=False), "pg_reaper_is_leader"
+        ) == pytest.approx(0.0)
 
     def test_snapshot_set_then_drained_queue_drops_out(self):
         metrics = _reaper_metrics()
@@ -154,22 +175,21 @@ class TestReaperMetrics:
             barriers_live=2,
             barriers_stranded=1,
         )
-        assert _sample(metrics, "pg_queue_depth", {"queue": "q1"}) == 5.0
-        assert (
-            _sample(metrics, "pg_queue_oldest_message_age_seconds", {"queue": "q1"})
-            == 120.0
-        )
-        assert _sample(metrics, "pg_barrier_live") == 2.0
-        assert _sample(metrics, "pg_barrier_stranded") == 1.0
+        assert _sample(metrics, "pg_queue_depth", {"queue": "q1"}) == pytest.approx(5.0)
+        assert _sample(
+            metrics, "pg_queue_oldest_message_age_seconds", {"queue": "q1"}
+        ) == pytest.approx(120.0)
+        assert _sample(metrics, "pg_barrier_live") == pytest.approx(2.0)
+        assert _sample(metrics, "pg_barrier_stranded") == pytest.approx(1.0)
 
         # q1 drains: its series must DROP, not freeze at the last non-zero value.
         metrics.set_queue_snapshot(
             depths={"q2": (0, 0.0)}, barriers_live=0, barriers_stranded=0
         )
         assert _sample(metrics, "pg_queue_depth", {"queue": "q1"}) is None
-        assert _sample(metrics, "pg_queue_depth", {"queue": "q2"}) == 0.0
+        assert _sample(metrics, "pg_queue_depth", {"queue": "q2"}) == pytest.approx(0.0)
 
-    def test_clear_zeroes_the_snapshot(self):
+    def test_clear_drops_series_and_zeroes_barriers(self):
         # On losing leadership a standby must not export a frozen stale snapshot.
         metrics = _reaper_metrics()
         metrics.set_queue_snapshot(
@@ -177,27 +197,64 @@ class TestReaperMetrics:
         )
         metrics.clear_queue_snapshot()
         assert _sample(metrics, "pg_queue_depth", {"queue": "q"}) is None
-        assert _sample(metrics, "pg_barrier_live") == 0.0
-        assert _sample(metrics, "pg_queue_gauges_age_seconds") == 0.0
+        assert _sample(metrics, "pg_barrier_live") == pytest.approx(0.0)
 
-    def test_gauges_age_zero_until_first_snapshot_then_positive(self):
+    def test_gauges_age_grows_when_never_refreshed(self):
+        # The staleness metric must never report "fresh" in the maximal-staleness
+        # case: with no snapshot ever taken it grows from construction, so a
+        # leader whose refresh has failed since boot still trips an age alert.
         metrics = _reaper_metrics()
-        assert _sample(metrics, "pg_queue_gauges_age_seconds") == 0.0
+        age = _sample(metrics, "pg_queue_gauges_age_seconds")
+        assert age is not None and age >= 0.0
+        metrics._queue_collector._snapshot = (
+            metrics._queue_collector._snapshot.__class__(
+                reference_monotonic=metrics._queue_collector._snapshot.reference_monotonic
+                - 100.0
+            )
+        )
+        aged = _sample(metrics, "pg_queue_gauges_age_seconds")
+        assert aged is not None and aged >= 100.0
+
+    def test_gauges_age_resets_on_snapshot_and_on_clear(self):
+        metrics = _reaper_metrics()
         metrics.set_queue_snapshot(depths={}, barriers_live=0, barriers_stranded=0)
         age = _sample(metrics, "pg_queue_gauges_age_seconds")
         assert age is not None and 0.0 <= age < 5.0
+        # clear() restarts the age from the step-down instant (not from boot).
+        metrics.clear_queue_snapshot()
+        age = _sample(metrics, "pg_queue_gauges_age_seconds")
+        assert age is not None and 0.0 <= age < 5.0
+
+    def test_scrape_is_atomic_snapshot(self):
+        # The collector renders from ONE snapshot reference: a replace() during
+        # a render can't mix old and new values. Simulate by capturing the
+        # families from collect() and swapping mid-iteration.
+        metrics = _reaper_metrics()
+        metrics.set_queue_snapshot(
+            depths={"q": (5, 50.0)}, barriers_live=5, barriers_stranded=5
+        )
+        collector = metrics._queue_collector
+        families = list(collector.collect())  # snapshot read happens here
+        metrics.set_queue_snapshot(
+            depths={"q": (9, 90.0)}, barriers_live=9, barriers_stranded=9
+        )
+        by_name = {f.name: f for f in families}
+        depth = by_name["pg_queue_depth"].samples[0].value
+        live = by_name["pg_barrier_live"].samples[0].value
+        assert (depth, live) == (pytest.approx(5.0), pytest.approx(5.0))
 
 
 class _FakeCursor:
-    """Cursor returning one preloaded result set per execute() call."""
+    """Cursor returning one preloaded result set per execute() call, recording
+    each ``(sql, params)`` so tests can pin the SQL contract."""
 
     def __init__(self, result_sets):
         self._result_sets = list(result_sets)
         self._current = None
-        self.executed: list[str] = []
+        self.executed: list[tuple[str, object]] = []
 
     def execute(self, sql, params=None):
-        self.executed.append(sql)
+        self.executed.append((sql, params))
         self._current = self._result_sets.pop(0)
 
     def fetchall(self):
@@ -240,11 +297,29 @@ class TestRefreshQueueGauges:
         )
         refresh_queue_gauges(conn, metrics, stuck_timeout_seconds=9000)
         assert conn.commits == 1
-        assert (
-            _sample(metrics, "pg_queue_depth", {"queue": "file_processing"}) == 7.0
+        assert _sample(
+            metrics, "pg_queue_depth", {"queue": "file_processing"}
+        ) == pytest.approx(7.0)
+        assert _sample(metrics, "pg_barrier_live") == pytest.approx(4.0)
+        assert _sample(metrics, "pg_barrier_stranded") == pytest.approx(2.0)
+
+    def test_sql_contract(self):
+        # Pin the queries: wrong table, dropped GROUP BY, a missing stranded
+        # predicate or unbound stuck-timeout would silently diverge the metric
+        # from what the reaper actually recovers.
+        metrics = _reaper_metrics()
+        conn = _FakeConn([[], (0, 0)])
+        refresh_queue_gauges(conn, metrics, stuck_timeout_seconds=9000)
+        (depth_sql, depth_params), (barrier_sql, barrier_params) = (
+            conn.cursor_obj.executed
         )
-        assert _sample(metrics, "pg_barrier_live") == 4.0
-        assert _sample(metrics, "pg_barrier_stranded") == 2.0
+        assert "pg_queue_message" in depth_sql
+        assert "GROUP BY queue_name" in depth_sql
+        assert depth_params is None
+        assert "pg_barrier_state" in barrier_sql
+        assert "remaining > 0" in barrier_sql
+        assert reaper_mod._STRANDED_PREDICATE in barrier_sql
+        assert barrier_params == (9000,)
 
     def test_error_rolls_back_and_reraises(self):
         metrics = _reaper_metrics()
@@ -253,8 +328,8 @@ class TestRefreshQueueGauges:
         with pytest.raises(RuntimeError):
             refresh_queue_gauges(conn, metrics, stuck_timeout_seconds=9000)
         conn.rollback.assert_called_once()
-        # No partial snapshot: the gauges stay never-refreshed.
-        assert _sample(metrics, "pg_queue_gauges_age_seconds") == 0.0
+        # No partial snapshot: the depth series stay absent.
+        assert _sample(metrics, "pg_queue_depth", {"queue": "any"}) is None
 
 
 class TestOutcomeCounters:
@@ -270,8 +345,12 @@ class TestOutcomeCounters:
                 conn, api_client=object(), stuck_timeout_seconds=1, metrics=metrics
             )
         assert recovered == ["e1"]
-        assert _sample(metrics, "pg_reaper_barrier_recovered_total") == 1.0
-        assert _sample(metrics, "pg_reaper_barrier_recovery_failures_total") == 1.0
+        assert _sample(metrics, "pg_reaper_barrier_recovered_total") == pytest.approx(
+            1.0
+        )
+        assert _sample(
+            metrics, "pg_reaper_barrier_recovery_failures_total"
+        ) == pytest.approx(1.0)
 
     def test_claim_sweep_counts(self):
         metrics = _reaper_metrics()
@@ -285,9 +364,11 @@ class TestOutcomeCounters:
                 conn, api_client=object(), stuck_timeout_seconds=1, metrics=metrics
             )
         assert removed == 2
-        assert _sample(metrics, "pg_reaper_claim_recovered_total") == 1.0
-        assert _sample(metrics, "pg_reaper_claim_gc_total") == 1.0
-        assert _sample(metrics, "pg_reaper_claim_recovery_failures_total") == 0.0
+        assert _sample(metrics, "pg_reaper_claim_recovered_total") == pytest.approx(1.0)
+        assert _sample(metrics, "pg_reaper_claim_gc_total") == pytest.approx(1.0)
+        assert _sample(
+            metrics, "pg_reaper_claim_recovery_failures_total"
+        ) == pytest.approx(0.0)
 
     def test_counters_optional_no_metrics_kwarg(self):
         # Celery-safety twin: existing callers that pass no metrics still work.
@@ -311,9 +392,12 @@ class TestReaperTickWiring:
             patch.object(reaper_mod, "refresh_queue_gauges") as refresh,
         ):
             reaper.tick()
-        refresh.assert_called_once()
+        # Pin the args: the reaper must feed ITS OWN exporter with ITS timeout.
+        refresh.assert_called_once_with(
+            reaper._sweep_conn, reaper.metrics, reaper._stuck_timeout_seconds
+        )
 
-    def test_refresh_is_cadence_gated(self):
+    def test_refresh_is_cadence_gated_and_resumes(self):
         reaper = self._reaper(_FakeLease(acquires=True))
         with (
             patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
@@ -321,21 +405,33 @@ class TestReaperTickWiring:
         ):
             reaper.tick()
             reaper.tick()  # within the refresh interval → no second refresh
-        refresh.assert_called_once()
+            assert refresh.call_count == 1
+            # Resumption: once the interval elapses the gate must reopen —
+            # otherwise gauges silently freeze forever after the first snapshot.
+            reaper._last_gauge_refresh_monotonic -= (
+                reaper_mod._GAUGE_REFRESH_INTERVAL_SECONDS + 1
+            )
+            reaper.tick()
+            assert refresh.call_count == 2
 
-    def test_refresh_failure_never_fails_the_tick(self):
+    def test_refresh_failure_never_fails_the_tick_and_consumes_the_interval(self):
         reaper = self._reaper(_FakeLease(acquires=True))
         with (
             patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
             patch.object(
                 reaper_mod, "refresh_queue_gauges", side_effect=RuntimeError("db")
-            ),
+            ) as refresh,
         ):
             outcome = reaper.tick()  # must not raise
-        assert outcome.was_leader is True
-        assert (
-            _sample(reaper.metrics, "pg_reaper_gauge_refresh_failures_total") == 1.0
-        )
+            assert outcome.was_leader is True
+            # Cadence advanced BEFORE the failed read: the immediate next tick
+            # must NOT retry (a persistent failure retries once per interval,
+            # not every tick).
+            reaper.tick()
+            assert refresh.call_count == 1
+        assert _sample(
+            reaper.metrics, "pg_reaper_gauge_refresh_failures_total"
+        ) == pytest.approx(1.0)
 
     def test_standby_never_refreshes(self):
         reaper = self._reaper(_FakeLease(acquires=False))
@@ -343,34 +439,100 @@ class TestReaperTickWiring:
             reaper.tick()
         refresh.assert_not_called()
 
-    def test_lost_leadership_clears_snapshot(self):
-        reaper = self._reaper(_FakeLease(acquires=[True], renews=False))
+    def test_lost_leadership_clears_snapshot_and_resets_cadence(self):
+        reaper = self._reaper(_FakeLease(acquires=[True, True], renews=[False, True]))
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            patch.object(reaper_mod, "refresh_queue_gauges") as refresh,
+        ):
+            reaper.tick()  # becomes leader, refresh #1
+            reaper.metrics.set_queue_snapshot(
+                depths={"q": (1, 1.0)}, barriers_live=1, barriers_stranded=0
+            )
+            reaper.tick()  # renew fails → steps down → snapshot cleared;
+            # re-acquires within the same tick and refreshes IMMEDIATELY —
+            # the cadence reset is load-bearing (else a re-elected leader
+            # exports a false "empty queue" for up to a full interval).
+            assert refresh.call_count == 2
+        assert _sample(reaper.metrics, "pg_queue_depth", {"queue": "q"}) is None
+
+    def test_renew_raise_clears_snapshot_before_propagating(self):
+        # The OTHER step-down path: renew() raising (lost DB mid-lease). The
+        # frozen snapshot must be cleared even though the tick re-raises.
+        lease = _FakeLease(acquires=True)
+        reaper = self._reaper(lease)
         with (
             patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
             patch.object(reaper_mod, "refresh_queue_gauges"),
         ):
             reaper.tick()  # becomes leader
-            reaper.metrics.set_queue_snapshot(
-                depths={"q": (1, 1.0)}, barriers_live=1, barriers_stranded=0
-            )
-            reaper.tick()  # renew fails → steps down → snapshot cleared
+        reaper.metrics.set_queue_snapshot(
+            depths={"q": (3, 1.0)}, barriers_live=1, barriers_stranded=0
+        )
+        lease.renew = MagicMock(side_effect=RuntimeError("db gone"))
+        with pytest.raises(RuntimeError):
+            reaper.tick()
         assert reaper.is_leader is False
         assert _sample(reaper.metrics, "pg_queue_depth", {"queue": "q"}) is None
+
+    def test_sweep_failure_increments_labeled_counter(self, monkeypatch):
+        reaper = self._reaper(_FakeLease(acquires=True))
+        monkeypatch.setattr(
+            reaper_mod, "sweep_expired_results", MagicMock(side_effect=OSError("db"))
+        )
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            patch.object(reaper_mod, "refresh_queue_gauges"),
+        ):
+            reaper.tick()  # first leader tick sweeps immediately
+        assert _sample(
+            reaper.metrics, "pg_reaper_sweep_failures_total", {"table": "pg_task_result"}
+        ) == pytest.approx(1.0)
+        # A later successful sweep must NOT reset the counter (monotonic).
+        monkeypatch.setattr(
+            reaper_mod, "sweep_expired_results", MagicMock(return_value=0)
+        )
+        reaper._last_sweep_monotonic = None  # reopen the sweep cadence gate
+        with (
+            patch.object(reaper_mod, "recover_expired_barriers", return_value=[]),
+            patch.object(reaper_mod, "refresh_queue_gauges"),
+        ):
+            reaper.tick()
+        assert _sample(
+            reaper.metrics, "pg_reaper_sweep_failures_total", {"table": "pg_task_result"}
+        ) == pytest.approx(1.0)
+
+    def test_run_counts_tick_failures(self):
+        # The heartbeat is stamped at tick START, so /health stays 200 through
+        # every-tick failures — this counter is the only machine-readable signal.
+        reaper = self._reaper(_FakeLease(acquires=True))
+        with patch.object(
+            reaper_mod,
+            "recover_expired_barriers",
+            side_effect=RuntimeError("SELECT failed"),
+        ):
+            original_sleep = reaper_mod.time.sleep
+
+            def stop_after_first(_secs):
+                reaper._running = False
+                original_sleep(0)
+
+            with patch.object(reaper_mod.time, "sleep", side_effect=stop_after_first):
+                reaper.run(install_signals=False)
+        assert _sample(reaper.metrics, "pg_reaper_tick_failures_total") == pytest.approx(
+            1.0
+        )
 
     def test_metrics_served_on_liveness_port(self):
         # End-to-end: the reaper's /metrics answers with its registry content.
         from queue_backend.pg_queue.reaper import ReaperLivenessServer
 
         reaper = self._reaper(_FakeLease(acquires=True))
-        server = ReaperLivenessServer(reaper, port=0, stale_after=60)
-        server.start()
-        try:
+        with _running(ReaperLivenessServer(reaper, port=0, stale_after=60)) as server:
             with _get(f"http://127.0.0.1:{server.bound_port}/metrics") as resp:
                 body = resp.read()
             assert b"pg_reaper_is_leader" in body
             assert b"pg_reaper_heartbeat_age_seconds" in body
-        finally:
-            server.stop()
 
 
 class TestConsumerServerMetricsRoute:
@@ -379,11 +541,28 @@ class TestConsumerServerMetricsRoute:
         from queue_backend.pg_queue.consumer import PgQueueConsumer
 
         consumer = PgQueueConsumer(["q"], client=MagicMock())
-        server = ConsumerServer(consumer, port=0, stale_after=60)
-        server.start()
-        try:
+        with _running(ConsumerServer(consumer, port=0, stale_after=60)) as server:
             with _get(f"http://127.0.0.1:{server.bound_port}/metrics") as resp:
                 assert resp.headers["Content-Type"] == METRICS_CONTENT_TYPE
                 assert b"pg_consumer_heartbeat_age_seconds" in resp.read()
+
+
+class TestSupervisorMetricsRoute:
+    def test_supervisor_fleet_metrics_served(self, monkeypatch):
+        # The supervisor is the ONLY producer of the fleet gauges, and its
+        # lambdas defer to scrape time — a _Fleet API rename would pass import
+        # and 500 every scrape at runtime only. Exercise the real wiring.
+        from pg_queue_consumer.supervisor import _Fleet, _maybe_start_supervisor_health
+
+        monkeypatch.setenv("WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT", "0")
+        fleet = _Fleet(2)
+        server = _maybe_start_supervisor_health(fleet)
+        assert server is not None
+        try:
+            with _get(f"http://127.0.0.1:{server.bound_port}/metrics") as resp:
+                body = resp.read()
+            assert b"pg_consumer_heartbeat_age_seconds" in body
+            assert b"pg_consumer_alive_children" in body
+            assert b"pg_consumer_configured_concurrency 2.0" in body
         finally:
             server.stop()

--- a/workers/tests/test_pg_reaper.py
+++ b/workers/tests/test_pg_reaper.py
@@ -301,7 +301,7 @@ class TestSchedulerTick:
         with patch.object(
             reaper_mod,
             "recover_expired_barriers",
-            side_effect=lambda *_: order.append("recover") or [],
+            side_effect=lambda *_, **__: order.append("recover") or [],
         ):
             reaper.tick()
         assert order == ["recover", "schedule"]
@@ -409,9 +409,13 @@ class TestRetentionSweepTick:
             reaper.tick()
         stub_retention_sweep.results.assert_called_once_with(conn)
         stub_retention_sweep.dedup.assert_called_once_with(conn, 86400)
-        # Orphan-claim sweep (UN-3679) is wired with the api client + stuck-timeout.
+        # Orphan-claim sweep (UN-3679) is wired with the api client + stuck-timeout
+        # (+ the metrics exporter, so claim outcomes surface as counters).
         stub_retention_sweep.claims.assert_called_once_with(
-            conn, reaper._get_api_client(), reaper._stuck_timeout_seconds
+            conn,
+            reaper._get_api_client(),
+            reaper._stuck_timeout_seconds,
+            metrics=reaper.metrics,
         )
 
     def test_standby_does_not_sweep(self, stub_retention_sweep):
@@ -440,7 +444,7 @@ class TestRetentionSweepTick:
         with patch.object(
             reaper_mod,
             "recover_expired_barriers",
-            side_effect=lambda *_: order.append("recover") or [],
+            side_effect=lambda *_, **__: order.append("recover") or [],
         ):
             reaper.tick()
         assert order == ["recover", "schedule", "sweep"]


### PR DESCRIPTION
## What

**UN-3672** — the PG queue path emitted **zero metrics**; detecting an outage meant "a user complains". This adds an **application-level Prometheus `/metrics` exporter** on the existing health server of every PG-queue process. Application-level ONLY by design — no chart/infra changes; the scrape config (PodMonitoring) + alert rules are deferred to a follow-up pending infra alignment. Until then the endpoint is curl-able (incident debugging; the load-test harness consumes it directly), but nothing collects it in cloud.

## Why the exporter must be ours

Today's queue observability comes from **RabbitMQ's built-in Prometheus plugin** (scraped via a GMP PodMonitoring). Postgres has no such plugin — the pg_queue tables ARE the broker — so replacing RabbitMQ means replacing its metrics source too. This is that replacement.

## Design

- **`/metrics` on the existing LivenessServer** — same port as `/health` (consumer `WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT`, reaper `WORKER_PG_REAPER_HEALTH_PORT`), opt-in via `metrics_fn`, kept as an opaque callable so `liveness.py` stays prometheus-free. A broken renderer 500s `/metrics` only — the `/health` verdict is untouched (tested).
- **Per-pod (every PG worker):** `pg_consumer_heartbeat_age_seconds` — the same poll-loop freshness `/health` verdicts on, as a scrapeable number. The fleet supervisor adds `pg_consumer_alive_children` / `pg_consumer_configured_concurrency`.
- **Queue-wide (reaper only — the leader-elected singleton, so N pods don't run identical SQL and emit duplicate series):**
  - `pg_queue_depth{queue}` + `pg_queue_oldest_message_age_seconds{queue}`
  - `pg_barrier_live` / `pg_barrier_stranded` (same stranded predicate the recovery uses)
  - `pg_reaper_barrier_recovered_total`, `pg_reaper_claim_{recovered,gc}_total`, `*_recovery_failures_total`, `pg_reaper_sweep_failures_total{table}`, `pg_reaper_is_leader`
- **Cached snapshots, not scrape-time SQL:** the leader refreshes the queue gauges every 60s inside its tick; a scrape (or a curl loop mid-incident) never touches the DB. `pg_queue_gauges_age_seconds` exposes snapshot staleness. Snapshot is cleared on losing leadership (a standby must not export a frozen stale snapshot); a refresh failure is counted + logged and never fails the tick; a drained queue's series drops out instead of freezing at its last non-zero value.
- **Instance-owned registries** (never the `prometheus_client` default `REGISTRY`): the workers tree imports under two module names in places (the bare-`tasks` sys.path quirk) — module-level collectors would double-register.
- `prometheus-client` was already a declared (unused) dependency — no new deps. `OPERATIONS.md`'s false "metrics endpoint" claim replaced with the real endpoints.

## Celery safety

All changes live in PG-only modules (`queue_backend/pg_queue/*`, `pg_queue_consumer/`) that Celery workers never import. The full workers unit lane (1192 tests) passes untouched.

## Testing

- **23 new tests**: route isolation (404/200/500, `/health` unaffected), snapshot set/clear/drain semantics, counter threading through the recovery/sweep functions, tick wiring (cadence-gated, standby-never-refreshes, failure-never-fails-the-tick, leadership-loss clears), end-to-end HTTP on both server subclasses.
- **1192 unit + 123 integration** (real Postgres) pass. (The 1 pre-existing flaky `test_exactly_one_task_fires_the_callback` passes solo — known UN-3676 shared-lane race.)
- **Live smoke against the real dev Postgres**: rendered real values — and immediately surfaced a 15-day-old stranded dev `notifications` backlog (41 messages), the exact silent-failure class this exporter exists to catch:

```
pg_reaper_is_leader 1.0
pg_queue_depth{queue="notifications"} 41.0
pg_queue_oldest_message_age_seconds{queue="notifications"} 1.328512e+06
pg_barrier_live 0.0
pg_barrier_stranded 0.0
```

## Out of scope (deferred follow-up)

- GMP PodMonitoring scrape config in the cloud chart + Cloud Monitoring alert rules (infra alignment).
- Grafana dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
