### PR TITLE
UN-3680 [FIX] PG queue — seam-audit fixes: poison identity, ack/release retries, callback duplicate guard, compose VT

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -603,7 +603,7 @@ services:
       # bounded-minutes orchestration, and idempotency-guarded (UN-3671) so a vt
       # overrun can't double-orchestrate. Without an explicit vt the consumer
       # defaults to 30s and a slow dispatch redelivers mid-run. 600/660 mirrors the
-      # k8s chart (grace-equivalent handled by restart:unless-stopped here).
+      # k8s deployment defaults (grace-equivalent handled by restart:unless-stopped here).
       - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_ORCHESTRATOR_VT_SECONDS:-600}
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_ORCHESTRATOR_HEALTH_STALE_SECONDS:-660}
     labels:
@@ -636,7 +636,7 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=celery
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
       # Orchestration is bounded-minutes + claim-guarded (see orchestrator-api).
-      # Without an explicit vt it defaults to 30s. 600/660 mirrors the k8s chart.
+      # Without an explicit vt it defaults to 30s. 600/660 matches our k8s deployment defaults (workerPg* values, separate chart repo).
       - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_ORCHESTRATOR_VT_SECONDS:-600}
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_ORCHESTRATOR_HEALTH_STALE_SECONDS:-660}
     labels:
@@ -713,7 +713,7 @@ services:
       # The aggregating callback (fan-in) runs after all batches: aggregate results,
       # update status, push destination, notify. Without an explicit vt it defaults
       # to 30s and a >30s callback redelivers — re-firing webhooks + subscription
-      # billing. 3660/3720 mirrors the k8s chart.
+      # billing. 3660/3720 matches our k8s deployment defaults (separate chart repo).
       - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_CALLBACK_VT_SECONDS:-3660}
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_CALLBACK_HEALTH_STALE_SECONDS:-3720}
     labels:
@@ -750,7 +750,7 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=scheduler
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
       # Scheduled-trigger dispatch is quick (enqueue the execution). Without an
-      # explicit vt it defaults to 30s. 180/240 mirrors the k8s chart.
+      # explicit vt it defaults to 30s. 180/240 matches our k8s deployment defaults (separate chart repo).
       - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_SCHEDULER_VT_SECONDS:-180}
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_SCHEDULER_HEALTH_STALE_SECONDS:-240}
     labels:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -599,6 +599,13 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE=api_deployment
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=celery_api_deployments
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
+      # async_execute_bin arms the barrier + dispatches batches, then returns — a
+      # bounded-minutes orchestration, and idempotency-guarded (UN-3671) so a vt
+      # overrun can't double-orchestrate. Without an explicit vt the consumer
+      # defaults to 30s and a slow dispatch redelivers mid-run. 600/660 mirrors the
+      # k8s chart (grace-equivalent handled by restart:unless-stopped here).
+      - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_ORCHESTRATOR_VT_SECONDS:-600}
+      - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_ORCHESTRATOR_HEALTH_STALE_SECONDS:-660}
     labels:
       - traefik.enable=false
     volumes:
@@ -628,6 +635,10 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE=general
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=celery
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
+      # Orchestration is bounded-minutes + claim-guarded (see orchestrator-api).
+      # Without an explicit vt it defaults to 30s. 600/660 mirrors the k8s chart.
+      - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_ORCHESTRATOR_VT_SECONDS:-600}
+      - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_ORCHESTRATOR_HEALTH_STALE_SECONDS:-660}
     labels:
       - traefik.enable=false
     volumes:
@@ -699,6 +710,12 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE=callback
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=file_processing_callback,api_file_processing_callback
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
+      # The aggregating callback (fan-in) runs after all batches: aggregate results,
+      # update status, push destination, notify. Without an explicit vt it defaults
+      # to 30s and a >30s callback redelivers — re-firing webhooks + subscription
+      # billing. 3660/3720 mirrors the k8s chart.
+      - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_CALLBACK_VT_SECONDS:-3660}
+      - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_CALLBACK_HEALTH_STALE_SECONDS:-3720}
     labels:
       - traefik.enable=false
     volumes:
@@ -732,6 +749,10 @@ services:
       - WORKER_PG_QUEUE_CONSUMER_WORKER_TYPE=scheduler
       - WORKER_PG_QUEUE_CONSUMER_QUEUE=scheduler
       - WORKER_PG_QUEUE_CONSUMER_HEALTH_PORT=8090
+      # Scheduled-trigger dispatch is quick (enqueue the execution). Without an
+      # explicit vt it defaults to 30s. 180/240 mirrors the k8s chart.
+      - WORKER_PG_QUEUE_CONSUMER_VT_SECONDS=${WORKER_PG_SCHEDULER_VT_SECONDS:-180}
+      - WORKER_PG_QUEUE_CONSUMER_HEALTH_STALE_SECONDS=${WORKER_PG_SCHEDULER_HEALTH_STALE_SECONDS:-240}
     labels:
       - traefik.enable=false
     volumes:

--- a/workers/callback/tasks.py
+++ b/workers/callback/tasks.py
@@ -8,6 +8,7 @@ import time
 from typing import Any
 
 from queue_backend import worker_task
+from queue_backend.pg_barrier import PG_TRANSPORT_CALLBACK_KWARG
 
 # Import shared worker infrastructure
 from shared.api import InternalAPIClient
@@ -1360,6 +1361,37 @@ def _track_subscription_usage_if_available(
         }
 
 
+def _pg_execution_already_finalized(
+    api_client: InternalAPIClient, execution_id: str
+) -> bool:
+    """PG at-least-once duplicate guard: ``True`` if the execution is already
+    terminal — a previous delivery of this aggregating callback already ran to
+    completion (the callback is what SETS the terminal status). A redelivered
+    callback (the ``PgQueueClient.send`` commit-retry double-enqueue, an
+    idle-reaped ack, or a vt overrun) must then SKIP its side effects — re-running
+    them re-fires customer webhooks and double-counts subscription-usage billing.
+
+    Best-effort: on any fetch failure return ``False`` (proceed). A missed guard is
+    a tolerable duplicate (the pre-existing behaviour); a wrongful skip would drop a
+    real callback's side effects, which is worse. PG only — the caller gates on the
+    transport marker, so the Celery path never reaches here.
+    """
+    try:
+        response = api_client.get_workflow_execution(execution_id, file_execution=False)
+        if not response.success:
+            return False
+        status = (response.data.get("execution") or {}).get("status")
+        return status in ExecutionStatus.terminal_values()
+    except Exception:
+        logger.warning(
+            "PG callback duplicate-guard: could not read status for execution %s "
+            "— proceeding (a tolerable duplicate beats a wrongful skip).",
+            execution_id,
+            exc_info=True,
+        )
+        return False
+
+
 def _process_batch_callback_core(
     task_instance, results, *args, **kwargs
 ) -> dict[str, Any]:
@@ -1378,6 +1410,10 @@ def _process_batch_callback_core(
     """
     # Initialize performance optimizations
     _initialize_performance_managers()
+
+    # PG at-least-once duplicate guard (see _pg_execution_already_finalized).
+    # Popped BEFORE parameter extraction so the marker never flows into the context.
+    is_pg = bool(kwargs.pop(PG_TRANSPORT_CALLBACK_KWARG, False))
 
     # Extract and validate all parameters using single source of truth
     context = _extract_callback_parameters(task_instance, results, kwargs)
@@ -1400,6 +1436,23 @@ def _process_batch_callback_core(
             logger.info(
                 f"Starting batch callback processing for execution {context.execution_id}"
             )
+
+            # Skip a redelivered callback whose execution a prior delivery already
+            # finalized — don't re-fire webhooks / re-count billing. (Returns
+            # through the outer finally, which closes the api_client.)
+            if is_pg and _pg_execution_already_finalized(
+                context.api_client, context.execution_id
+            ):
+                logger.warning(
+                    f"PG callback: execution {context.execution_id} already terminal "
+                    f"— a previous callback completed; skipping duplicate side effects "
+                    f"(status update, subscription billing, webhooks)."
+                )
+                return {
+                    "status": "skipped_duplicate_callback",
+                    "execution_id": context.execution_id,
+                    "duplicate_callback_skipped": True,
+                }
 
             try:
                 # Use unified status determination with timeout detection (shared with API callback)
@@ -1575,6 +1628,8 @@ def process_batch_callback_api(
     execution_id = kwargs.get("execution_id")
     pipeline_id = kwargs.get("pipeline_id")
     organization_id = kwargs.get("organization_id")
+    # PG at-least-once duplicate guard marker (see _pg_execution_already_finalized).
+    is_pg = bool(kwargs.pop(PG_TRANSPORT_CALLBACK_KWARG, False))
 
     if not execution_id:
         raise ValueError("execution_id is required in kwargs")
@@ -1602,6 +1657,25 @@ def process_batch_callback_api(
         execution_context = execution_response.data
         workflow_execution = execution_context.get("execution", {})
         workflow = execution_context.get("workflow", {})
+
+        # PG at-least-once duplicate guard: a redelivered callback whose execution a
+        # prior delivery already finalized must skip its side effects. Reuses the
+        # status just fetched — no extra round-trip. (Returns through the finally
+        # below, which closes the api_client.)
+        if (
+            is_pg
+            and workflow_execution.get("status") in ExecutionStatus.terminal_values()
+        ):
+            logger.warning(
+                f"PG API callback: execution {execution_id} already terminal — a "
+                f"previous callback completed; skipping duplicate side effects "
+                f"(status update, subscription billing, webhooks)."
+            )
+            return {
+                "status": "skipped_duplicate_callback",
+                "execution_id": execution_id,
+                "duplicate_callback_skipped": True,
+            }
 
         # Extract schema_name and workflow_id from context
         schema_name = organization_id  # For API callbacks, schema_name = organization_id

--- a/workers/callback/tasks.py
+++ b/workers/callback/tasks.py
@@ -67,6 +67,10 @@ class CallbackContext:
         self.pipeline_data: dict[str, Any] | None = None
         self.api_client: InternalAPIClient | None = None
         self.file_executions: list[dict[str, Any]] = []
+        # Execution status as of extraction (the source-of-truth fetch already made
+        # here) — lets the PG duplicate guard skip a redelivered callback without a
+        # second round-trip.
+        self.execution_status: str | None = None
 
 
 def _initialize_performance_managers():
@@ -789,6 +793,8 @@ def _extract_callback_parameters(
         context.workflow_id = execution_info.get(
             "workflow_id"
         ) or workflow_definition.get("workflow_id")
+        # Status from the same fetch, for the PG duplicate guard (no extra call).
+        context.execution_status = execution_info.get("status")
 
         # Use existing API detection from source_config (no additional API calls needed)
         is_api_deployment = source_config.get("is_api", False)
@@ -1361,35 +1367,35 @@ def _track_subscription_usage_if_available(
         }
 
 
-def _pg_execution_already_finalized(
-    api_client: InternalAPIClient, execution_id: str
-) -> bool:
-    """PG at-least-once duplicate guard: ``True`` if the execution is already
-    terminal — a previous delivery of this aggregating callback already ran to
-    completion (the callback is what SETS the terminal status). A redelivered
-    callback (the ``PgQueueClient.send`` commit-retry double-enqueue, an
-    idle-reaped ack, or a vt overrun) must then SKIP its side effects — re-running
-    them re-fires customer webhooks and double-counts subscription-usage billing.
+def _callback_already_ran(execution_status: str | None) -> bool:
+    """PG at-least-once duplicate guard: ``True`` if a previous delivery of this
+    aggregating callback already ran to completion.
 
-    Best-effort: on any fetch failure return ``False`` (proceed). A missed guard is
-    a tolerable duplicate (the pre-existing behaviour); a wrongful skip would drop a
-    real callback's side effects, which is worse. PG only — the caller gates on the
-    transport marker, so the Celery path never reaches here.
+    Gated on COMPLETED **only** — that status is set exclusively by a successful
+    callback, so it is the unambiguous "a prior callback finalized this" signal.
+    ERROR / STOPPED are deliberately excluded: they can be set by OTHER paths
+    (external stop, upstream error, the reaper), so treating them as "already ran"
+    would make the *first, legitimate* callback for such an execution skip its side
+    effects (incl. resource cleanup). A redelivered callback (the send commit-retry
+    double-enqueue, an idle-reaped ack, a vt overrun) of a COMPLETED execution must
+    skip — re-running re-fires customer webhooks and double-counts billing.
+
+    A pure predicate over the status the caller already has (no fetch, no ``except``
+    that could silently degrade the guard on a programming error). PG only — the
+    caller gates on the transport marker, so Celery never reaches here.
     """
-    try:
-        response = api_client.get_workflow_execution(execution_id, file_execution=False)
-        if not response.success:
-            return False
-        status = (response.data.get("execution") or {}).get("status")
-        return status in ExecutionStatus.terminal_values()
-    except Exception:
-        logger.warning(
-            "PG callback duplicate-guard: could not read status for execution %s "
-            "— proceeding (a tolerable duplicate beats a wrongful skip).",
-            execution_id,
-            exc_info=True,
-        )
-        return False
+    return execution_status == ExecutionStatus.COMPLETED.value
+
+
+def _skipped_duplicate_callback(execution_id: str) -> dict[str, Any]:
+    """Idempotent result for a PG callback skipped as a duplicate (shared by both
+    callback entry points so the contract can't drift).
+    """
+    return {
+        "status": "skipped_duplicate_callback",
+        "execution_id": execution_id,
+        "duplicate_callback_skipped": True,
+    }
 
 
 def _process_batch_callback_core(
@@ -1411,7 +1417,7 @@ def _process_batch_callback_core(
     # Initialize performance optimizations
     _initialize_performance_managers()
 
-    # PG at-least-once duplicate guard (see _pg_execution_already_finalized).
+    # PG at-least-once duplicate guard (see _callback_already_ran).
     # Popped BEFORE parameter extraction so the marker never flows into the context.
     is_pg = bool(kwargs.pop(PG_TRANSPORT_CALLBACK_KWARG, False))
 
@@ -1438,21 +1444,16 @@ def _process_batch_callback_core(
             )
 
             # Skip a redelivered callback whose execution a prior delivery already
-            # finalized — don't re-fire webhooks / re-count billing. (Returns
-            # through the outer finally, which closes the api_client.)
-            if is_pg and _pg_execution_already_finalized(
-                context.api_client, context.execution_id
-            ):
+            # completed — don't re-fire webhooks / re-count billing. Reuses the
+            # status from _extract_callback_parameters' fetch (no extra call).
+            # (Returns through the outer finally, which closes the api_client.)
+            if is_pg and _callback_already_ran(context.execution_status):
                 logger.warning(
-                    f"PG callback: execution {context.execution_id} already terminal "
-                    f"— a previous callback completed; skipping duplicate side effects "
-                    f"(status update, subscription billing, webhooks)."
+                    f"PG callback: execution {context.execution_id} already COMPLETED "
+                    f"— a previous callback finalized it; skipping duplicate side "
+                    f"effects (status update, subscription billing, webhooks)."
                 )
-                return {
-                    "status": "skipped_duplicate_callback",
-                    "execution_id": context.execution_id,
-                    "duplicate_callback_skipped": True,
-                }
+                return _skipped_duplicate_callback(context.execution_id)
 
             try:
                 # Use unified status determination with timeout detection (shared with API callback)
@@ -1628,7 +1629,7 @@ def process_batch_callback_api(
     execution_id = kwargs.get("execution_id")
     pipeline_id = kwargs.get("pipeline_id")
     organization_id = kwargs.get("organization_id")
-    # PG at-least-once duplicate guard marker (see _pg_execution_already_finalized).
+    # PG at-least-once duplicate guard marker (see _callback_already_ran).
     is_pg = bool(kwargs.pop(PG_TRANSPORT_CALLBACK_KWARG, False))
 
     if not execution_id:
@@ -1659,23 +1660,16 @@ def process_batch_callback_api(
         workflow = execution_context.get("workflow", {})
 
         # PG at-least-once duplicate guard: a redelivered callback whose execution a
-        # prior delivery already finalized must skip its side effects. Reuses the
+        # prior delivery already completed must skip its side effects. Reuses the
         # status just fetched — no extra round-trip. (Returns through the finally
         # below, which closes the api_client.)
-        if (
-            is_pg
-            and workflow_execution.get("status") in ExecutionStatus.terminal_values()
-        ):
+        if is_pg and _callback_already_ran(workflow_execution.get("status")):
             logger.warning(
-                f"PG API callback: execution {execution_id} already terminal — a "
-                f"previous callback completed; skipping duplicate side effects "
+                f"PG API callback: execution {execution_id} already COMPLETED — a "
+                f"previous callback finalized it; skipping duplicate side effects "
                 f"(status update, subscription billing, webhooks)."
             )
-            return {
-                "status": "skipped_duplicate_callback",
-                "execution_id": execution_id,
-                "duplicate_callback_skipped": True,
-            }
+            return _skipped_duplicate_callback(execution_id)
 
         # Extract schema_name and workflow_id from context
         schema_name = organization_id  # For API callbacks, schema_name = organization_id

--- a/workers/general/tasks.py
+++ b/workers/general/tasks.py
@@ -306,6 +306,29 @@ def async_execute_bin_general(
             workflow_id = execution_data.get("workflow_id")
 
             logger.info(f"Execution {execution_id} status: {current_status}")
+            # PG redelivery guard (defense-in-depth): the orchestration claim
+            # tombstone normally blocks re-orchestrating a COMPLETED execution, but
+            # if that tombstone was GC'd (e.g. the reaper's stuck-timeout was lowered
+            # to test) a redelivery could reach here, win a fresh claim, and re-arm +
+            # re-dispatch a finished execution — duplicate (costly) destination
+            # writes when use_file_history=False. Skip if already terminal, keeping
+            # the freshly-won claim so it re-establishes the tombstone. PG only:
+            # Celery has no redelivery, so the orchestrator only ever runs on a
+            # non-terminal execution — the check is a no-op there.
+            if (
+                is_pg_transport(transport)
+                and current_status in ExecutionStatus.terminal_values()
+            ):
+                logger.warning(
+                    f"Execution {execution_id} already terminal ({current_status}) "
+                    f"at orchestration entry — skipping re-orchestration (a PG "
+                    f"redelivery of a finished execution)."
+                )
+                return {
+                    "status": "skipped_terminal_execution",
+                    "execution_id": execution_id,
+                    "workflow_id": workflow_id,
+                }
             # Note: We allow PENDING executions to continue - they should process available files
 
             # NOTE: Concurrent executions are allowed - individual active files are filtered out

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -193,9 +193,9 @@ _BARRIER_RETRY_BACKOFF_SECONDS: Final = 0.5
 
 # Callback kwarg the PG barrier stamps on the aggregating callback's dispatch so
 # the callback can PG-gate its at-least-once duplicate guard (see
-# _fire_barrier_callback). Matched by the same literal in callback/tasks.py — a
-# drift is caught by the callback's PG-guard test (the guard silently stops
-# firing). Underscore-prefixed so it can't collide with a real task kwarg.
+# _fire_barrier_callback). callback/tasks.py IMPORTS this symbol (not a re-typed
+# literal), so the producer and consumer can't drift. Underscore-prefixed so it
+# can't collide with a real task kwarg.
 PG_TRANSPORT_CALLBACK_KWARG: Final = "_pg_transport"
 
 # One retry for the NON-idempotent barrier DECREMENT — but only on an

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -191,6 +191,13 @@ _BARRIER_WRITE_ATTEMPTS: Final = 2  # total attempts: 1 initial + 1 retry
 # errors the broad psycopg2.OperationalError catch also covers.
 _BARRIER_RETRY_BACKOFF_SECONDS: Final = 0.5
 
+# Callback kwarg the PG barrier stamps on the aggregating callback's dispatch so
+# the callback can PG-gate its at-least-once duplicate guard (see
+# _fire_barrier_callback). Matched by the same literal in callback/tasks.py — a
+# drift is caught by the callback's PG-guard test (the guard silently stops
+# firing). Underscore-prefixed so it can't collide with a real task kwarg.
+PG_TRANSPORT_CALLBACK_KWARG: Final = "_pg_transport"
+
 # One retry for the NON-idempotent barrier DECREMENT — but only on an
 # execute-phase failure on a reused connection (see :func:`_apply_decrement`),
 # never on commit (ambiguous). Same one-shot bound as the idempotent write.
@@ -427,12 +434,27 @@ def release_orchestration_claim(execution_id: str) -> None:
     execution). Deleting it on failure restores the retry/redelivery path. A
     successful orchestration does NOT call this — its claim persists as the
     post-completion tombstone. Safe when no row exists (deletes nothing).
+
+    Stale-connection resilience: the claim is taken at orchestration START and
+    released only on the failure path, so the pg_barrier thread-local connection
+    has idled through the entire orchestration attempt — this DELETE is a
+    first-write-after-idle, the one most likely to meet a PgBouncer-reaped
+    connection, in exactly the scenario the release exists for. The caller
+    swallows a raise here (best-effort), so without a retry a single idle-reap
+    leaves the claim committed and suppresses every redelivery. The DELETE is
+    idempotent (deleting an absent row is a no-op), so it reuses the retry-once
+    helper verbatim.
     """
-    with _cursor() as cur:
+
+    def _op(cur: PgCursor) -> None:
         cur.execute(
             f"DELETE FROM {qualified('pg_orchestration_claim')} WHERE execution_id = %s",
             (execution_id,),
         )
+
+    _run_idempotent_pre_dispatch_write(
+        _op, what=f"release orchestration claim [exec:{execution_id}]"
+    )
 
 
 def _dispatch_pg(
@@ -756,12 +778,23 @@ def _fire_barrier_callback(
     - absent / anything else (legacy ``.link`` path): dispatch via
       ``current_app.signature(...).apply_async()`` — byte-identical to pre-9e,
       preserving the ``fairness_headers`` the producer attached.
+
+    On the PG path the callback kwargs carry :data:`PG_TRANSPORT_CALLBACK_KWARG`
+    so the aggregating callback can PG-gate its at-least-once duplicate guard (the
+    callback is unguarded against the redelivery its own dispatch admits; the
+    Celery ``.link`` path never injects it, so the guard is a no-op there).
     """
     if is_pg_transport(callback_descriptor.get("transport")):
+        # Copy (don't mutate the shared descriptor) + tag the PG transport so the
+        # callback can gate its duplicate guard on it.
+        pg_kwargs = {
+            **callback_descriptor["kwargs"],
+            PG_TRANSPORT_CALLBACK_KWARG: True,
+        }
         handle = _dispatch_pg(
             callback_descriptor["task_name"],
             args=[all_results],
-            kwargs=callback_descriptor["kwargs"],
+            kwargs=pg_kwargs,
             queue=callback_descriptor["queue"],
             fairness=_fairness_from_headers(callback_descriptor.get("fairness_headers")),
         )

--- a/workers/queue_backend/pg_queue/client.py
+++ b/workers/queue_backend/pg_queue/client.py
@@ -392,7 +392,41 @@ class PgQueueClient:
         i.e. the work may be processed twice. Logged at DEBUG here; the
         consumer emits the contextual WARNING (it names the task), so this
         avoids a duplicate warning per double-run.
+
+        Reconnect-retry (mirrors :meth:`send`): the consumer connection idles for
+        the ENTIRE wall-clock of the in-process task before this ack — minutes for
+        a file-processing batch — so the ack is the single statement most likely to
+        meet a PgBouncer-reaped connection. Without a retry the ack is lost and an
+        ALREADY-COMPLETED message redelivers at vt expiry: duplicate work (a re-run
+        of the leaf, or the sharp case — re-firing the aggregating callback's
+        webhooks + subscription-usage billing). We retry ONCE, on ``_CONN_DEAD_
+        ERRORS`` and only when the failing connection was **reused** (a fresh conn
+        failing is a genuine error). Unlike :meth:`send`'s at-least-once INSERT this
+        DELETE is idempotent — a re-run can only no-op (the row is already gone),
+        never duplicate — so the retry is safe even in the ambiguous post-commit
+        case (it just returns ``False``, "already gone", within the contract above).
         """
+        reused = self._conn is not None and self._owns_conn
+        try:
+            return self._delete_row(msg_id)
+        except _CONN_DEAD_ERRORS as exc:
+            if not reused:
+                raise
+            logger.warning(
+                "PG-queue: delete(msg_id=%s) failed with a connection-level error "
+                "on a reused cached connection (%s: %s); dropping it and retrying "
+                "the ack once so the completed message isn't redelivered",
+                msg_id,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            time.sleep(_SEND_RETRY_BACKOFF_SECONDS)
+            # _cursor already dropped the dead owned conn, so this reconnects.
+            return self._delete_row(msg_id)
+
+    def _delete_row(self, msg_id: int) -> bool:
+        """One DELETE of a queue row by ``msg_id`` (see :meth:`delete`)."""
         with self._cursor() as cur:
             cur.execute(
                 f"DELETE FROM {qualified('pg_queue_message')} WHERE msg_id = %s",

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -107,39 +107,40 @@ class _PoisonMarkOutcome(Enum):
 # Fire-and-forget tasks that carry their identity POSITIONALLY (in ``args``, not
 # ``kwargs`` / ``_barrier_context``), mapped to ``(execution_id_index,
 # organization_id_index)``. ``async_execute_bin`` is dispatched
-# ``args=[schema_name, workflow_id, execution_id, hash_values]`` — and its poison
-# drop happens BEFORE the barrier is armed AND before the orchestration claim is
-# taken (a circuit-breaker-open drop, or repeated pre-claim failures), so the
-# strand has NO ``pg_barrier_state`` row and NO ``pg_orchestration_claim`` row: it
-# is invisible to every reaper sweep. Without recovering the execution_id here the
-# poison drop can only bare-delete → the execution hangs EXECUTING forever with no
-# handle. ``args[0]`` (org schema) doubles as the org.
+# ``args=[schema_name, workflow_id, execution_id, hash_values]`` by the backend
+# (workflow_helper._dispatch_orchestrator_task) — keep this map in step with that
+# arg layout. Its poison drop happens BEFORE the barrier is armed AND before the
+# orchestration claim is taken (a circuit-breaker-open drop, or repeated pre-claim
+# failures), so the strand has NO ``pg_barrier_state`` row and NO
+# ``pg_orchestration_claim`` row: it is invisible to every reaper sweep. Without
+# recovering the execution_id here the poison drop can only bare-delete → the
+# execution hangs EXECUTING forever with no handle. ``args[0]`` (org schema)
+# doubles as the org.
 _POSITIONAL_IDENTITY_ARGS: dict[str, tuple[int, int]] = {
     "async_execute_bin": (2, 0),
 }
 
 
-def _positional_identity(
-    payload: TaskPayload, task_name: str | None
-) -> tuple[str | None, str | None]:
+def _positional_identity(payload: TaskPayload) -> tuple[str | None, str | None]:
     """``(execution_id, organization_id)`` from a positional-args orchestration
-    payload; ``(None, None)`` when the task doesn't carry identity positionally or
-    ``args`` is too short (defensive — a malformed payload must not ``IndexError``
-    on the poison-drop path). See :data:`_POSITIONAL_IDENTITY_ARGS`.
+    payload, keyed off the payload's own ``task_name`` (no separate arg to drift
+    from it). ``(None, None)`` when the task doesn't carry identity positionally, or
+    ``args`` is not a sequence / is too short (defensive — a malformed payload must
+    not ``IndexError`` on the poison-drop path). See :data:`_POSITIONAL_IDENTITY_ARGS`.
     """
-    indices = _POSITIONAL_IDENTITY_ARGS.get(task_name or "")
+    indices = _POSITIONAL_IDENTITY_ARGS.get(payload.get("task_name") or "")
     if indices is None:
         return (None, None)
     args = payload.get("args") or []
     exec_idx, org_idx = indices
-    execution_id = args[exec_idx] if exec_idx < len(args) else None
-    organization_id = args[org_idx] if org_idx < len(args) else None
-    return (execution_id, organization_id)
+    # Bounds- AND type-check before ANY indexing: a short or non-sequence ``args``
+    # returns (None, None) rather than indexing (no IndexError/TypeError path).
+    if not isinstance(args, (list, tuple)) or len(args) <= max(exec_idx, org_idx):
+        return (None, None)
+    return (args[exec_idx], args[org_idx])
 
 
-def _pipeline_identity(
-    payload: TaskPayload, task_name: str | None = None
-) -> tuple[str | None, str]:
+def _pipeline_identity(payload: TaskPayload) -> tuple[str | None, str]:
     """Best-effort ``(execution_id, organization_id)`` from a fire-and-forget
     payload, for marking the execution ERROR on a poison drop.
 
@@ -148,7 +149,7 @@ def _pipeline_identity(
     strand); on the injected ``_barrier_context``'s callback descriptor (a
     pipeline header); the org on the ``fairness`` payload; or — for orchestration
     messages, which pass identity POSITIONALLY — the task's ``args`` (see
-    :func:`_positional_identity`, why ``task_name`` is threaded in). The callback-
+    :func:`_positional_identity`). The callback-
     descriptor dig goes through :func:`callback_recovery_identity` so it can't
     drift from the barrier abort site. Returns ``(None, "")`` when the payload
     isn't a pipeline message — nothing to mark. ``organization_id`` may be ``""``
@@ -160,7 +161,7 @@ def _pipeline_identity(
     cb_execution_id, cb_org = callback_recovery_identity(
         barrier_ctx.get("callback_descriptor") or {}
     )
-    pos_execution_id, pos_org = _positional_identity(payload, task_name)
+    pos_execution_id, pos_org = _positional_identity(payload)
     execution_id = (
         kwargs.get("execution_id")
         or barrier_ctx.get("execution_id")
@@ -552,7 +553,7 @@ class PgQueueConsumer:
         help; transient (backend down / client build failed) → re-park with a long
         vt rather than delete into a void, bounded by ``poison_repark_budget``.
         """
-        execution_id, organization_id = _pipeline_identity(payload, task_name)
+        execution_id, organization_id = _pipeline_identity(payload)
         logger.error(
             "PG-queue consumer: task %r (msg_id=%s) exceeded max_attempts=%s "
             "(read_ct=%s, execution_id=%s) — poison; full payload: %r",

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -104,14 +104,51 @@ class _PoisonMarkOutcome(Enum):
     TRANSIENT = "transient"  # backend down / client build failed → re-park
 
 
-def _pipeline_identity(payload: TaskPayload) -> tuple[str | None, str]:
+# Fire-and-forget tasks that carry their identity POSITIONALLY (in ``args``, not
+# ``kwargs`` / ``_barrier_context``), mapped to ``(execution_id_index,
+# organization_id_index)``. ``async_execute_bin`` is dispatched
+# ``args=[schema_name, workflow_id, execution_id, hash_values]`` — and its poison
+# drop happens BEFORE the barrier is armed AND before the orchestration claim is
+# taken (a circuit-breaker-open drop, or repeated pre-claim failures), so the
+# strand has NO ``pg_barrier_state`` row and NO ``pg_orchestration_claim`` row: it
+# is invisible to every reaper sweep. Without recovering the execution_id here the
+# poison drop can only bare-delete → the execution hangs EXECUTING forever with no
+# handle. ``args[0]`` (org schema) doubles as the org.
+_POSITIONAL_IDENTITY_ARGS: dict[str, tuple[int, int]] = {
+    "async_execute_bin": (2, 0),
+}
+
+
+def _positional_identity(
+    payload: TaskPayload, task_name: str | None
+) -> tuple[str | None, str | None]:
+    """``(execution_id, organization_id)`` from a positional-args orchestration
+    payload; ``(None, None)`` when the task doesn't carry identity positionally or
+    ``args`` is too short (defensive — a malformed payload must not ``IndexError``
+    on the poison-drop path). See :data:`_POSITIONAL_IDENTITY_ARGS`.
+    """
+    indices = _POSITIONAL_IDENTITY_ARGS.get(task_name or "")
+    if indices is None:
+        return (None, None)
+    args = payload.get("args") or []
+    exec_idx, org_idx = indices
+    execution_id = args[exec_idx] if exec_idx < len(args) else None
+    organization_id = args[org_idx] if org_idx < len(args) else None
+    return (execution_id, organization_id)
+
+
+def _pipeline_identity(
+    payload: TaskPayload, task_name: str | None = None
+) -> tuple[str | None, str]:
     """Best-effort ``(execution_id, organization_id)`` from a fire-and-forget
     payload, for marking the execution ERROR on a poison drop.
 
-    The identity lives in one of three places, tried in order: directly on a
+    The identity lives in one of four places, tried in order: directly on a
     callback payload's ``kwargs`` (the aggregating-callback case — the sharpest
     strand); on the injected ``_barrier_context``'s callback descriptor (a
-    pipeline header); or the org on the ``fairness`` payload. The callback-
+    pipeline header); the org on the ``fairness`` payload; or — for orchestration
+    messages, which pass identity POSITIONALLY — the task's ``args`` (see
+    :func:`_positional_identity`, why ``task_name`` is threaded in). The callback-
     descriptor dig goes through :func:`callback_recovery_identity` so it can't
     drift from the barrier abort site. Returns ``(None, "")`` when the payload
     isn't a pipeline message — nothing to mark. ``organization_id`` may be ``""``
@@ -123,13 +160,18 @@ def _pipeline_identity(payload: TaskPayload) -> tuple[str | None, str]:
     cb_execution_id, cb_org = callback_recovery_identity(
         barrier_ctx.get("callback_descriptor") or {}
     )
+    pos_execution_id, pos_org = _positional_identity(payload, task_name)
     execution_id = (
-        kwargs.get("execution_id") or barrier_ctx.get("execution_id") or cb_execution_id
+        kwargs.get("execution_id")
+        or barrier_ctx.get("execution_id")
+        or cb_execution_id
+        or pos_execution_id
     )
     organization_id = (
         kwargs.get("organization_id")
         or cb_org
         or (payload.get("fairness") or {}).get("org_id")
+        or pos_org
     )
     return (
         str(execution_id) if execution_id else None,
@@ -510,7 +552,7 @@ class PgQueueConsumer:
         help; transient (backend down / client build failed) → re-park with a long
         vt rather than delete into a void, bounded by ``poison_repark_budget``.
         """
-        execution_id, organization_id = _pipeline_identity(payload)
+        execution_id, organization_id = _pipeline_identity(payload, task_name)
         logger.error(
             "PG-queue consumer: task %r (msg_id=%s) exceeded max_attempts=%s "
             "(read_ct=%s, execution_id=%s) — poison; full payload: %r",

--- a/workers/tests/test_orchestration_idempotency.py
+++ b/workers/tests/test_orchestration_idempotency.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import psycopg2
 import pytest
@@ -171,6 +171,83 @@ class TestOrchestratorShortCircuit:
                         transport="pg_queue",
                     )
         assert released == ["e-y"]  # claimed then failed → released
+
+    def test_terminal_execution_skips_and_keeps_claim(self):
+        # L1: a PG redelivery that WON a fresh claim (the tombstone had been GC'd)
+        # but finds the execution already terminal must skip re-orchestration
+        # WITHOUT releasing the claim (re-establishing the tombstone), and never
+        # reach the status-update / arm / dispatch below the guard.
+        released: list[str] = []
+        api_client = MagicMock()
+        api_client.get_workflow_execution.return_value = MagicMock(
+            success=True,
+            data={
+                "execution": {
+                    "status": tasks.ExecutionStatus.COMPLETED.value,
+                    "workflow_id": "wf",
+                }
+            },
+        )
+        with patch.dict(
+            self._task_globals(),
+            {
+                "try_claim_orchestration": lambda _eid, _org: True,  # won the claim
+                "release_orchestration_claim": lambda eid: released.append(eid),
+            },
+        ):
+            with patch.object(
+                tasks.WorkerExecutionContext,
+                "setup_execution_context",
+                return_value=(MagicMock(), api_client),
+            ):
+                out = tasks.async_execute_bin_general(
+                    schema_name="org",
+                    workflow_id="wf",
+                    execution_id="e-term",
+                    hash_values_of_files={},
+                    transport="pg_queue",
+                )
+        assert out["status"] == "skipped_terminal_execution"
+        assert released == []  # claim kept → tombstone re-established
+        api_client.update_workflow_execution_status.assert_not_called()  # never re-armed
+
+    def test_terminal_execution_not_skipped_on_celery(self):
+        # Celery has no redelivery, so the terminal guard is is_pg-gated → a no-op.
+        # A terminal status on the Celery path must NOT short-circuit: we prove the
+        # task runs PAST the guard by making the next step (tool validation, called
+        # right after the guard) raise a sentinel. Patched via the task's own
+        # globals — the bare-``tasks`` module the worker bootstrap loads, not
+        # ``general.tasks`` (the sys.path quirk; a module-attr patch would miss it).
+        api_client = MagicMock()
+        api_client.get_workflow_execution.return_value = MagicMock(
+            success=True,
+            data={
+                "execution": {
+                    "status": tasks.ExecutionStatus.COMPLETED.value,
+                    "workflow_id": "wf",
+                }
+            },
+        )
+
+        def _sentinel(**_kwargs):
+            raise RuntimeError("reached past the guard")
+
+        with patch.dict(
+            self._task_globals(), {"validate_workflow_tool_instances": _sentinel}
+        ):
+            with patch.object(
+                tasks.WorkerExecutionContext,
+                "setup_execution_context",
+                return_value=(MagicMock(), api_client),
+            ):
+                with pytest.raises(RuntimeError, match="reached past the guard"):
+                    tasks.async_execute_bin_general(
+                        schema_name="org",
+                        workflow_id="wf",
+                        execution_id="e-term-celery",
+                        hash_values_of_files={},
+                        transport="celery",
+                    )
 
 
 # --- Layer 2: claim primitive against real Postgres ---

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -550,6 +550,44 @@ class TestClaimOrchestrationRetry:
             try_claim_orchestration("exec-1", "org-1")
 
 
+class TestReleaseOrchestrationClaimRetry:
+    """``release_orchestration_claim`` is a first-write-after-idle on the failure
+    path whose raise the caller swallows — an un-retried idle-reap would leave the
+    claim committed and suppress every redelivery. Its DELETE is idempotent, so it
+    reuses the retry-once helper.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self, monkeypatch):
+        monkeypatch.setattr(pg_barrier.time, "sleep", lambda *_a, **_k: None)
+
+    def test_retries_once_on_reaped_cached_conn(self, _clean_local, monkeypatch, caplog):
+        dead = _FakeConn(
+            execute_error=psycopg2.InterfaceError("connection already closed")
+        )
+        healthy = _FakeConn()
+        pg_barrier._local.conn = dead
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
+
+        with caplog.at_level("WARNING"):
+            pg_barrier.release_orchestration_claim("exec-1")
+
+        assert dead.executes == 1 and healthy.executes == 1  # exactly one retry
+        assert dead.closed is True  # stale conn discarded
+        assert healthy.commits == 1  # committed on the retry
+        assert "release orchestration claim" in caplog.text
+
+    def test_non_connection_error_surfaces(self, _clean_local, monkeypatch):
+        # A real (non-connection) error must not be silently retried away — it
+        # propagates so the best-effort caller logs it.
+        pg_barrier._local.conn = _FakeConn(execute_error=ValueError("logic"))
+        monkeypatch.setattr(
+            pg_barrier, "create_pg_connection", lambda **_k: pytest.fail("no reconnect")
+        )
+        with pytest.raises(ValueError, match="logic"):
+            pg_barrier.release_orchestration_claim("exec-1")
+
+
 # --- Layer 2: enqueue + link/abort with a real injected connection ---
 
 
@@ -1315,6 +1353,27 @@ class TestPgFireAndForgetMode:
         assert cb_id == "pg-cb-1"
         assert mock_dispatch.call_args.kwargs["backend"] is QueueBackend.PG
         assert mock_dispatch.call_args.kwargs["args"] == [[{"r": 1}]]
+
+    def test_fire_barrier_callback_pg_tags_transport_marker(self):
+        # The PG callback carries the _pg_transport marker so the aggregating
+        # callback can gate its at-least-once duplicate guard on it. The shared
+        # descriptor must NOT be mutated (a copy is dispatched).
+        descriptor = {**_CALLBACK, "transport": "pg_queue"}
+        with patch("queue_backend.dispatch.dispatch") as mock_dispatch:
+            mock_dispatch.return_value = MagicMock(id="pg-cb")
+            _fire_barrier_callback(descriptor, [{"r": 1}])
+        dispatched = mock_dispatch.call_args.kwargs["kwargs"]
+        assert dispatched.get(pg_barrier.PG_TRANSPORT_CALLBACK_KWARG) is True
+        assert pg_barrier.PG_TRANSPORT_CALLBACK_KWARG not in descriptor["kwargs"]
+
+    def test_fire_barrier_callback_legacy_omits_transport_marker(self):
+        # The Celery .link path must NOT inject the marker → the callback's PG
+        # guard stays a no-op on Celery (no redelivery to guard).
+        with patch("celery.current_app.signature") as sig:
+            sig.return_value.apply_async.return_value = MagicMock(id="celery-cb")
+            _fire_barrier_callback(_CALLBACK, [{"r": 1}])
+        passed = sig.call_args.kwargs["kwargs"]
+        assert pg_barrier.PG_TRANSPORT_CALLBACK_KWARG not in passed
 
     def test_fire_barrier_callback_pg_carries_fairness(self):
         # greptile: the PG callback must ride the producer's org/priority (parity

--- a/workers/tests/test_pg_callback_duplicate_guard.py
+++ b/workers/tests/test_pg_callback_duplicate_guard.py
@@ -1,0 +1,146 @@
+"""PG at-least-once duplicate guard for the aggregating callback (H1).
+
+The callback (``process_batch_callback`` / ``_api``) re-runs status update,
+subscription-usage billing and customer webhooks wholesale; on the PG path it can
+be REDELIVERED (the ``PgQueueClient.send`` commit-retry double-enqueue, an
+idle-reaped ack, a vt overrun). When a prior delivery already finalized the
+execution, the redelivery must SKIP its side effects. The guard is PG-gated by the
+``_pg_transport`` marker the barrier stamps on the PG dispatch, so the Celery
+``.link`` path (no redelivery) is a strict no-op.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import callback.tasks as cb
+from queue_backend.pg_barrier import PG_TRANSPORT_CALLBACK_KWARG
+from unstract.core.data_models import ExecutionStatus
+
+
+def _exec_response(status: str, *, success: bool = True):
+    return MagicMock(success=success, data={"execution": {"status": status}})
+
+
+class TestExecutionAlreadyFinalized:
+    def test_terminal_is_true(self):
+        api = MagicMock()
+        api.get_workflow_execution.return_value = _exec_response(
+            ExecutionStatus.COMPLETED.value
+        )
+        assert cb._pg_execution_already_finalized(api, "e1") is True
+
+    def test_non_terminal_is_false(self):
+        api = MagicMock()
+        api.get_workflow_execution.return_value = _exec_response(
+            ExecutionStatus.EXECUTING.value
+        )
+        assert cb._pg_execution_already_finalized(api, "e1") is False
+
+    def test_unsuccessful_fetch_proceeds(self):
+        api = MagicMock()
+        api.get_workflow_execution.return_value = _exec_response("x", success=False)
+        assert cb._pg_execution_already_finalized(api, "e1") is False
+
+    def test_fetch_error_proceeds_not_raises(self):
+        # Best-effort: a fetch failure must proceed (tolerable duplicate), never
+        # raise (which would fail the callback) or wrongly skip a real callback.
+        api = MagicMock()
+        api.get_workflow_execution.side_effect = RuntimeError("api down")
+        assert cb._pg_execution_already_finalized(api, "e1") is False
+
+
+class TestCoreCallbackGuard:
+    """``_process_batch_callback_core`` short-circuits a PG duplicate before any
+    side effect, and only on the PG path.
+    """
+
+    def _context(self):
+        ctx = MagicMock()
+        ctx.organization_id = "org-1"
+        ctx.api_client = MagicMock()
+        ctx.execution_id = "e1"
+        return ctx
+
+    def _run(self, *, is_pg: bool, terminal: bool):
+        kwargs = {"execution_id": "e1"}
+        if is_pg:
+            kwargs[PG_TRANSPORT_CALLBACK_KWARG] = True
+        with (
+            patch.object(cb, "_initialize_performance_managers"),
+            patch.object(cb, "_extract_callback_parameters", return_value=self._context()),
+            patch.object(
+                cb, "_pg_execution_already_finalized", return_value=terminal
+            ) as finalized,
+            patch.object(cb, "_determine_execution_status_unified") as determine,
+        ):
+            determine.side_effect = AssertionError("side effects must not run")
+            out = cb._process_batch_callback_core(MagicMock(), [], **kwargs)
+        return out, finalized, determine
+
+    def test_pg_duplicate_skips_side_effects(self):
+        out, finalized, determine = self._run(is_pg=True, terminal=True)
+        assert out["status"] == "skipped_duplicate_callback"
+        assert out["duplicate_callback_skipped"] is True
+        finalized.assert_called_once()
+        determine.assert_not_called()  # no status update / billing / webhooks
+
+    def test_pg_non_terminal_proceeds(self):
+        # Not yet finalized → the guard must let the callback run (reaches the
+        # side-effect step, which we stubbed to raise as the proof-of-reach).
+        import pytest
+
+        with pytest.raises(AssertionError, match="side effects must not run"):
+            self._run(is_pg=True, terminal=False)
+
+    def test_celery_never_checks_or_skips(self):
+        # No marker → the guard is skipped entirely (finalized never called) and
+        # the callback proceeds — proving zero Celery regression.
+        import pytest
+
+        with pytest.raises(AssertionError, match="side effects must not run"):
+            _, finalized, _ = self._run(is_pg=False, terminal=True)
+
+
+class TestApiCallbackGuard:
+    """``process_batch_callback_api`` short-circuits a PG duplicate using the
+    execution status it already fetches (no extra round-trip).
+    """
+
+    def _run(self, *, is_pg: bool, terminal: bool):
+        status = (
+            ExecutionStatus.COMPLETED.value if terminal else ExecutionStatus.EXECUTING.value
+        )
+        api = MagicMock()
+        api.get_workflow_execution.return_value = MagicMock(
+            success=True,
+            data={
+                "execution": {"status": status, "workflow_id": "wf"},
+                "workflow": {"id": "wf"},
+            },
+        )
+        kwargs = {"execution_id": "e1", "organization_id": "org-1", "pipeline_id": "p"}
+        if is_pg:
+            kwargs[PG_TRANSPORT_CALLBACK_KWARG] = True
+        task = MagicMock()
+        task.request.id = "t1"
+        with (
+            patch.object(cb, "create_api_client", return_value=api),
+            patch.object(
+                cb, "_determine_execution_status_unified"
+            ) as determine,
+        ):
+            determine.side_effect = AssertionError("side effects must not run")
+            out = cb.process_batch_callback_api(task, [], **kwargs)
+        return out, determine
+
+    def test_pg_duplicate_skips_side_effects(self):
+        out, determine = self._run(is_pg=True, terminal=True)
+        assert out["status"] == "skipped_duplicate_callback"
+        determine.assert_not_called()
+
+    def test_celery_never_skips(self):
+        import pytest
+
+        with pytest.raises(AssertionError, match="side effects must not run"):
+            self._run(is_pg=False, terminal=True)

--- a/workers/tests/test_pg_callback_duplicate_guard.py
+++ b/workers/tests/test_pg_callback_duplicate_guard.py
@@ -3,7 +3,7 @@
 The callback (``process_batch_callback`` / ``_api``) re-runs status update,
 subscription-usage billing and customer webhooks wholesale; on the PG path it can
 be REDELIVERED (the ``PgQueueClient.send`` commit-retry double-enqueue, an
-idle-reaped ack, a vt overrun). When a prior delivery already finalized the
+idle-reaped ack, a vt overrun). When a prior delivery already COMPLETED the
 execution, the redelivery must SKIP its side effects. The guard is PG-gated by the
 ``_pg_transport`` marker the barrier stamps on the PG dispatch, so the Celery
 ``.link`` path (no redelivery) is a strict no-op.
@@ -11,6 +11,7 @@ execution, the redelivery must SKIP its side effects. The guard is PG-gated by t
 
 from __future__ import annotations
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 import callback.tasks as cb
@@ -18,88 +19,80 @@ from queue_backend.pg_barrier import PG_TRANSPORT_CALLBACK_KWARG
 from unstract.core.data_models import ExecutionStatus
 
 
-def _exec_response(status: str, *, success: bool = True):
-    return MagicMock(success=success, data={"execution": {"status": status}})
+class TestCallbackAlreadyRan:
+    """The pure predicate: COMPLETED only (a status a prior callback alone sets)."""
 
+    def test_completed_is_true(self):
+        assert cb._callback_already_ran(ExecutionStatus.COMPLETED.value) is True
 
-class TestExecutionAlreadyFinalized:
-    def test_terminal_is_true(self):
-        api = MagicMock()
-        api.get_workflow_execution.return_value = _exec_response(
-            ExecutionStatus.COMPLETED.value
-        )
-        assert cb._pg_execution_already_finalized(api, "e1") is True
-
-    def test_non_terminal_is_false(self):
-        api = MagicMock()
-        api.get_workflow_execution.return_value = _exec_response(
-            ExecutionStatus.EXECUTING.value
-        )
-        assert cb._pg_execution_already_finalized(api, "e1") is False
-
-    def test_unsuccessful_fetch_proceeds(self):
-        api = MagicMock()
-        api.get_workflow_execution.return_value = _exec_response("x", success=False)
-        assert cb._pg_execution_already_finalized(api, "e1") is False
-
-    def test_fetch_error_proceeds_not_raises(self):
-        # Best-effort: a fetch failure must proceed (tolerable duplicate), never
-        # raise (which would fail the callback) or wrongly skip a real callback.
-        api = MagicMock()
-        api.get_workflow_execution.side_effect = RuntimeError("api down")
-        assert cb._pg_execution_already_finalized(api, "e1") is False
+    @pytest.mark.parametrize(
+        "status",
+        [
+            ExecutionStatus.EXECUTING.value,
+            ExecutionStatus.PENDING.value,
+            # ERROR / STOPPED can be set by OTHER paths → NOT "a prior callback ran".
+            ExecutionStatus.ERROR.value,
+            ExecutionStatus.STOPPED.value,
+            None,
+        ],
+    )
+    def test_non_completed_is_false(self, status):
+        assert cb._callback_already_ran(status) is False
 
 
 class TestCoreCallbackGuard:
     """``_process_batch_callback_core`` short-circuits a PG duplicate before any
-    side effect, and only on the PG path.
+    side effect (using the status the context already carries), and only on PG.
     """
 
-    def _context(self):
+    def _context(self, status):
         ctx = MagicMock()
         ctx.organization_id = "org-1"
         ctx.api_client = MagicMock()
         ctx.execution_id = "e1"
+        ctx.execution_status = status
         return ctx
 
-    def _run(self, *, is_pg: bool, terminal: bool):
+    def _run(self, *, is_pg: bool, status: str):
         kwargs = {"execution_id": "e1"}
         if is_pg:
             kwargs[PG_TRANSPORT_CALLBACK_KWARG] = True
+        extract = MagicMock(return_value=self._context(status))
         with (
             patch.object(cb, "_initialize_performance_managers"),
-            patch.object(cb, "_extract_callback_parameters", return_value=self._context()),
-            patch.object(
-                cb, "_pg_execution_already_finalized", return_value=terminal
-            ) as finalized,
+            patch.object(cb, "_extract_callback_parameters", extract),
             patch.object(cb, "_determine_execution_status_unified") as determine,
         ):
             determine.side_effect = AssertionError("side effects must not run")
             out = cb._process_batch_callback_core(MagicMock(), [], **kwargs)
-        return out, finalized, determine
+        return out, extract, determine
 
     def test_pg_duplicate_skips_side_effects(self):
-        out, finalized, determine = self._run(is_pg=True, terminal=True)
+        out, extract, determine = self._run(
+            is_pg=True, status=ExecutionStatus.COMPLETED.value
+        )
         assert out["status"] == "skipped_duplicate_callback"
         assert out["duplicate_callback_skipped"] is True
-        finalized.assert_called_once()
         determine.assert_not_called()  # no status update / billing / webhooks
+        # The marker must be popped BEFORE extraction — never leak into the context.
+        assert PG_TRANSPORT_CALLBACK_KWARG not in extract.call_args.args[2]
 
-    def test_pg_non_terminal_proceeds(self):
-        # Not yet finalized → the guard must let the callback run (reaches the
-        # side-effect step, which we stubbed to raise as the proof-of-reach).
-        import pytest
-
+    def test_pg_non_completed_proceeds(self):
+        # Not COMPLETED → the guard lets the callback run (reaches the side-effect
+        # step, stubbed to raise as the proof-of-reach).
         with pytest.raises(AssertionError, match="side effects must not run"):
-            self._run(is_pg=True, terminal=False)
+            self._run(is_pg=True, status=ExecutionStatus.EXECUTING.value)
 
-    def test_celery_never_checks_or_skips(self):
-        # No marker → the guard is skipped entirely (finalized never called) and
-        # the callback proceeds — proving zero Celery regression.
-        import pytest
-
+    def test_pg_error_status_proceeds(self):
+        # ERROR is excluded (may be external) → the first callback must still run.
         with pytest.raises(AssertionError, match="side effects must not run"):
-            _, finalized, _ = self._run(is_pg=False, terminal=True)
+            self._run(is_pg=True, status=ExecutionStatus.ERROR.value)
+
+    def test_celery_never_skips(self):
+        # No marker → guard skipped entirely; the callback proceeds even on a
+        # COMPLETED status — proving zero Celery regression.
+        with pytest.raises(AssertionError, match="side effects must not run"):
+            self._run(is_pg=False, status=ExecutionStatus.COMPLETED.value)
 
 
 class TestApiCallbackGuard:
@@ -107,10 +100,7 @@ class TestApiCallbackGuard:
     execution status it already fetches (no extra round-trip).
     """
 
-    def _run(self, *, is_pg: bool, terminal: bool):
-        status = (
-            ExecutionStatus.COMPLETED.value if terminal else ExecutionStatus.EXECUTING.value
-        )
+    def _run(self, *, is_pg: bool, status: str):
         api = MagicMock()
         api.get_workflow_execution.return_value = MagicMock(
             success=True,
@@ -126,21 +116,21 @@ class TestApiCallbackGuard:
         task.request.id = "t1"
         with (
             patch.object(cb, "create_api_client", return_value=api),
-            patch.object(
-                cb, "_determine_execution_status_unified"
-            ) as determine,
+            patch.object(cb, "_determine_execution_status_unified") as determine,
         ):
             determine.side_effect = AssertionError("side effects must not run")
             out = cb.process_batch_callback_api(task, [], **kwargs)
         return out, determine
 
     def test_pg_duplicate_skips_side_effects(self):
-        out, determine = self._run(is_pg=True, terminal=True)
+        out, determine = self._run(is_pg=True, status=ExecutionStatus.COMPLETED.value)
         assert out["status"] == "skipped_duplicate_callback"
         determine.assert_not_called()
 
-    def test_celery_never_skips(self):
-        import pytest
-
+    def test_pg_non_completed_proceeds(self):
         with pytest.raises(AssertionError, match="side effects must not run"):
-            self._run(is_pg=False, terminal=True)
+            self._run(is_pg=True, status=ExecutionStatus.EXECUTING.value)
+
+    def test_celery_never_skips(self):
+        with pytest.raises(AssertionError, match="side effects must not run"):
+            self._run(is_pg=False, status=ExecutionStatus.COMPLETED.value)

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -338,6 +338,74 @@ class TestSendReconnectRetry:
         sleep.assert_not_called()
 
 
+class TestDeleteReconnectRetry:
+    """``delete()``'s (ack) one-shot reconnect-retry — the systematic first-write-
+    after-idle site: the consumer connection idles for the whole task wall-clock,
+    so a reaped conn kills the ack and redelivers an ALREADY-COMPLETED message
+    (duplicate work / double-fired callback). Unlike ``send()`` the DELETE is
+    idempotent, so retrying is safe even post-commit.
+    """
+
+    @staticmethod
+    def _conn(*, execute_side_effect=None, rowcount=1):
+        cur = MagicMock()
+        if execute_side_effect is not None:
+            cur.execute.side_effect = execute_side_effect
+        cur.rowcount = rowcount
+        conn = MagicMock()
+        conn.closed = 0
+        conn.cursor.return_value = _CursorCtx(cur)
+        return conn, cur
+
+    @staticmethod
+    def _no_sleep(monkeypatch):
+        sleep = MagicMock()
+        monkeypatch.setattr("queue_backend.pg_queue.client.time.sleep", sleep)
+        return sleep
+
+    @pytest.mark.parametrize(
+        "exc_type", [psycopg2.OperationalError, psycopg2.InterfaceError]
+    )
+    def test_reused_stale_conn_retries_and_acks(self, monkeypatch, caplog, exc_type):
+        dead, _ = self._conn(execute_side_effect=exc_type("idle reap"))
+        fresh, fresh_cur = self._conn(rowcount=1)
+        factory = MagicMock(return_value=fresh)
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        sleep = self._no_sleep(monkeypatch)
+        client = PgQueueClient()
+        client._conn = dead  # cached (reused) connection
+
+        with caplog.at_level(logging.WARNING, logger="queue_backend.pg_queue.client"):
+            assert client.delete(42) is True  # ack landed on the retry
+        dead.close.assert_called_once()  # stale conn discarded
+        factory.assert_called_once()  # reconnected exactly once
+        sleep.assert_called_once_with(_SEND_RETRY_BACKOFF_SECONDS)
+        _, params = fresh_cur.execute.call_args.args
+        assert params == (42,)  # the msg_id passed through to the retry
+        assert "retrying the ack once" in caplog.text
+
+    def test_fresh_conn_failure_does_not_retry(self, monkeypatch):
+        dead, _ = self._conn(execute_side_effect=psycopg2.OperationalError("down"))
+        factory = MagicMock(return_value=dead)
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        sleep = self._no_sleep(monkeypatch)
+        client = PgQueueClient()
+
+        with pytest.raises(psycopg2.OperationalError):
+            client.delete(1)
+        factory.assert_called_once()  # created once, NOT retried
+        sleep.assert_not_called()
+
+    def test_injected_conn_not_retried(self, monkeypatch):
+        conn, _ = self._conn(execute_side_effect=psycopg2.OperationalError("dead"))
+        self._no_sleep(monkeypatch)
+        client = PgQueueClient(conn=conn)
+
+        with pytest.raises(psycopg2.OperationalError):
+            client.delete(1)
+        conn.close.assert_not_called()  # caller's connection untouched
+
+
 class TestCreatePgConnection:
     """Unit coverage for the connection factory (no real DB)."""
 

--- a/workers/tests/test_pg_queue_client.py
+++ b/workers/tests/test_pg_queue_client.py
@@ -405,6 +405,36 @@ class TestDeleteReconnectRetry:
             client.delete(1)
         conn.close.assert_not_called()  # caller's connection untouched
 
+    def test_reused_conn_non_connection_error_not_retried(self, monkeypatch):
+        # A logical error (not Operational/Interface) on a reused conn is not a
+        # stale-connection symptom → re-raise, no reconnect (parity with send()).
+        bad, _ = self._conn(execute_side_effect=RuntimeError("logic"))
+        factory = MagicMock()
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        sleep = self._no_sleep(monkeypatch)
+        client = PgQueueClient()
+        client._conn = bad
+
+        with pytest.raises(RuntimeError):
+            client.delete(1)
+        factory.assert_not_called()
+        sleep.assert_not_called()
+
+    def test_retry_failure_reraises_once(self, monkeypatch):
+        # The retry is bounded to exactly one reconnect: if the reconnected conn
+        # also dies, re-raise (no loop) — parity with send().
+        dead1, _ = self._conn(execute_side_effect=psycopg2.OperationalError("reap"))
+        dead2, _ = self._conn(execute_side_effect=psycopg2.OperationalError("still"))
+        factory = MagicMock(return_value=dead2)
+        monkeypatch.setattr("queue_backend.pg_queue.client.create_pg_connection", factory)
+        self._no_sleep(monkeypatch)
+        client = PgQueueClient()
+        client._conn = dead1
+
+        with pytest.raises(psycopg2.OperationalError):
+            client.delete(1)
+        factory.assert_called_once()  # one reconnect only, no loop
+
 
 class TestCreatePgConnection:
     """Unit coverage for the connection factory (no real DB)."""

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -215,6 +215,30 @@ class TestPipelineIdentity:
         payload = {"kwargs": {"execution_id": "e4"}}
         assert _pipeline_identity(payload) == ("e4", "")
 
+    def test_from_positional_orchestration_args(self):
+        # async_execute_bin passes identity POSITIONALLY: args=[schema, workflow,
+        # execution_id, hash]. The fallback needs the task_name to apply.
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        payload = {
+            "task_name": "async_execute_bin",
+            "args": ["org-schema", "wf-1", "exec-9", {}],
+            "kwargs": {"pipeline_id": "p"},
+        }
+        assert _pipeline_identity(payload, "async_execute_bin") == (
+            "exec-9",
+            "org-schema",
+        )
+        # Without the task_name the positional map is inert (unknown task).
+        assert _pipeline_identity(payload) == (None, "")
+
+    def test_positional_short_args_no_indexerror(self):
+        # A malformed/short args list must not IndexError on the poison-drop path.
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        payload = {"task_name": "async_execute_bin", "args": ["org-schema"]}
+        assert _pipeline_identity(payload, "async_execute_bin") == (None, "org-schema")
+
 
 class TestPoisonDropMarksExecution:
     """UN-3670: a poison drop with no reply channel marks the execution ERROR
@@ -238,6 +262,29 @@ class TestPoisonDropMarksExecution:
         assert marks == [("exec-1", "org-1")]  # marked ERROR
         client.delete.assert_called_once_with(5)  # then dropped
         client.set_vt.assert_not_called()
+
+    def test_positional_orchestration_poison_marks_error(self, monkeypatch):
+        # H2 regression: a poisoned async_execute_bin carries execution_id
+        # POSITIONALLY (args[2]) with no _barrier_context and — since its poison
+        # precedes barrier arm + claim — no reaper handle at all. It must still
+        # recover its identity and mark ERROR, not bare-delete into a silent strand.
+        marks = []
+        monkeypatch.setattr(
+            "queue_backend.pg_queue.recovery.mark_execution_error",
+            lambda client, eid, org, *, error_message: marks.append((eid, org)) or True,
+        )
+        payload = {
+            "task_name": "async_execute_bin",
+            "args": ["org-schema", "wf-1", "exec-9", {}],
+            "kwargs": {"pipeline_id": "p"},
+        }
+        client = MagicMock()
+        client.read.return_value = [_msg(7, payload, read_ct=6)]
+        PgQueueConsumer(
+            ["q"], client=client, api_client=MagicMock(), max_attempts=5
+        ).poll_once()
+        assert marks == [("exec-9", "org-schema")]  # recovered + marked
+        client.delete.assert_called_once_with(7)  # then dropped
 
     def test_reparks_when_mark_unconfirmed(self, monkeypatch):
         monkeypatch.setattr(

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -217,7 +217,7 @@ class TestPipelineIdentity:
 
     def test_from_positional_orchestration_args(self):
         # async_execute_bin passes identity POSITIONALLY: args=[schema, workflow,
-        # execution_id, hash]. The fallback needs the task_name to apply.
+        # execution_id, hash]. The fallback keys off the payload's own task_name.
         from queue_backend.pg_queue.consumer import _pipeline_identity
 
         payload = {
@@ -225,19 +225,25 @@ class TestPipelineIdentity:
             "args": ["org-schema", "wf-1", "exec-9", {}],
             "kwargs": {"pipeline_id": "p"},
         }
-        assert _pipeline_identity(payload, "async_execute_bin") == (
-            "exec-9",
-            "org-schema",
-        )
-        # Without the task_name the positional map is inert (unknown task).
-        assert _pipeline_identity(payload) == (None, "")
+        assert _pipeline_identity(payload) == ("exec-9", "org-schema")
+        # An unknown task_name leaves the positional map inert.
+        assert _pipeline_identity({**payload, "task_name": "some.other"}) == (None, "")
 
     def test_positional_short_args_no_indexerror(self):
-        # A malformed/short args list must not IndexError on the poison-drop path.
+        # A short args list (missing the execution_id index) must not IndexError;
+        # it yields no identity — harmless, since with no execution_id the poison
+        # drop bare-deletes anyway (the org is only used alongside an execution_id).
         from queue_backend.pg_queue.consumer import _pipeline_identity
 
         payload = {"task_name": "async_execute_bin", "args": ["org-schema"]}
-        assert _pipeline_identity(payload, "async_execute_bin") == (None, "org-schema")
+        assert _pipeline_identity(payload) == (None, "")
+
+    def test_positional_non_sequence_args_no_crash(self):
+        # A non-list args (malformed payload) must not TypeError/IndexError.
+        from queue_backend.pg_queue.consumer import _pipeline_identity
+
+        payload = {"task_name": "async_execute_bin", "args": {"not": "a list"}}
+        assert _pipeline_identity(payload) == (None, "")
 
 
 class TestPoisonDropMarksExecution:


### PR DESCRIPTION
## What

Post-merge **seam audit** of the PG-queue epic surfaced interaction bugs *between* individually-reviewed features — the class no single-PR review could see. This closes the **runtime (OSS)** findings before the UN-3675 load-test gate. Every runtime change is PG-gated with a Celery no-op proven by test. The chart-side vt/runbook fixes ship as a separate unstract-cloud PR (repo boundary).

## Fixes

| | Severity | Fix |
|---|---|---|
| **A1** | blocker | **Poison drop couldn't identify orchestration messages.** The backend dispatches `async_execute_bin` with `execution_id` **positionally** (`args[2]`); the poison-drop identity reader only read kwargs. A poisoned orchestration (a circuit-breaker-open drop, *before* the barrier is armed and *before* the claim is taken) had no barrier row and no claim row → invisible to every reaper sweep, a **permanent silent strand**. `_pipeline_identity` now takes a positional fallback keyed by task name. |
| **A2** | medium | **Consumer ack (`client.delete`) lacked the reconnect-retry** every producer-side write already had. The consumer connection idles the whole task wall-clock, so the ack is the likeliest statement to meet a reaped connection; a lost ack redelivers an already-completed message. One-shot reused-gate retry; the DELETE is idempotent (safe even post-commit, unlike `send`'s at-least-once INSERT). |
| **A3** | medium | **`release_orchestration_claim` lacked the retry.** A first-write-after-idle on the failure path whose raise the caller swallows → an idle-reap left the claim committed and suppressed every redelivery. Wrapped in the existing idempotent retry helper. |
| **A4** | medium | **docker-compose PG consumers at the 30s vt default.** The callback + both orchestrators + scheduler had no vt env → a >30s task redelivered mid-run. Added vt/health-stale (env-overridable), mirroring the k8s chart. fileproc/executor left as-is (correctly sized to `EXECUTOR_RESULT_TIMEOUT`). |
| **L1** | low | **Orchestration-entry terminal skip (defense-in-depth).** The claim tombstone normally blocks re-orchestrating a COMPLETED execution; if it was GC'd (a lowered stuck-timeout) a redelivery could re-arm/re-dispatch a finished execution. Skip if already terminal, keeping the freshly-won claim to re-establish the tombstone. PG-gated. |
| **H1** | blocker | **The aggregating callback re-ran webhooks + subscription-usage billing wholesale on redelivery** (the `send` commit-retry double-enqueue, an idle-reaped ack, a vt overrun). Added a terminal re-check that skips the side effects when a prior delivery already finalized the execution. PG-gated via a `_pg_transport` marker the barrier stamps on the PG callback dispatch; the Celery `.link` path never injects it → strict no-op. |

## Celery safety

Every runtime change gates on the PG transport (`is_pg_transport` / the barrier marker) and ships with a Celery-no-op test. The full workers unit lane is untouched.

## Testing

- **1223 unit + real-Postgres integration pass**; pre-commit clean.
- New tests: positional-identity poison recovery, ack-retry (×3 error arms), release-retry, L1 PG-skip + Celery-no-op, H1 duplicate-guard (helper + both callback entry points + barrier marker injection/omission).
- The one in-lane integration failure (`test_exactly_one_task_fires_the_callback`) is the pre-existing UN-3676 shared-lane flaky (passes solo).

## Notes / follow-ups (filed separately, don't block)

- Confirmed while sizing A4: `process_file_batch` iterates files serially at `EXECUTOR_TIMEOUT`, and the PG path's `task.apply()` doesn't enforce the Celery `time_limit` SIGKILL — so a batch can run toward the task time limit. This validates the separate chart PR's fileproc-vt bump.
- H1's minimal terminal re-check does not close the *concurrent*-redelivery race (two callbacks in flight at once); a per-execution callback claim would — deferred unless review wants it here.
- Follow-ups: M1 file-execution terminal-status guard, memory-recycle parity, dead `process_file_batch` endpoint, CI `REQUIRE_PG_TESTS` + real-PG tests for the newest guards, rollback-drain runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
