### PR TITLE
UN-3683 [FIX] PG executor result backend — clear result on consume + schema-drift guard

### DIFF
--- a/backend/pg_queue/executor_rpc.py
+++ b/backend/pg_queue/executor_rpc.py
@@ -13,6 +13,7 @@ delegates every mode to the unchanged Celery ``ExecutionDispatcher`` and no
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from django.db import close_old_connections
@@ -33,6 +34,8 @@ from unstract.workflow_execution.executor_rpc import (
 if TYPE_CHECKING:
     from unstract.core.data_models import ContinuationSpec
     from unstract.sdk1.execution.context import ExecutionContext
+
+logger = logging.getLogger(__name__)
 
 # Re-exported so existing ``from pg_queue.executor_rpc import …`` imports keep working.
 __all__ = [
@@ -99,7 +102,24 @@ class DjangoQueueTransport(QueueTransport):
                 return None
             return ExecResultRow(status=row.status, result=row.result, error=row.error)
 
-        return poll_for_row(_fetch, timeout, between_polls=close_old_connections)
+        row = poll_for_row(_fetch, timeout, between_polls=close_old_connections)
+        if row is not None:
+            # Reply consumed: clear the payload (result + error) so PII doesn't sit
+            # in pg_task_result for the full retention TTL — mirrors the workers
+            # transport's PgResultBackend.forget so both dispatch paths behave alike.
+            # Best-effort: runs after the caller holds the result, inside
+            # PgExecutionDispatcher.dispatch's never-raises guard, so a cleanup miss
+            # must not fail a good RPC; the reaper's retention sweep is the backstop.
+            try:
+                PgTaskResult.objects.filter(pk=reply_key).update(result=None, error="")
+            except Exception:
+                logger.warning(
+                    "DjangoQueueTransport: could not clear pg_task_result for "
+                    "reply_key=%s after consume; the retention sweep will flush it",
+                    reply_key,
+                    exc_info=True,
+                )
+        return row
 
 
 def get_executor_dispatcher(

--- a/backend/pg_queue/tests/test_executor_rpc.py
+++ b/backend/pg_queue/tests/test_executor_rpc.py
@@ -93,6 +93,28 @@ class TestDjangoQueueTransportWait:
         cl.assert_called_once()  # between_polls released the conn on the miss
         slp.assert_called_once()  # slept once between the two polls
 
+    def test_present_row_clears_payload_after_consume(self):
+        # Mirrors the workers' PgResultBackend.forget: once the reply is read, both
+        # payload channels are nulled so PII doesn't sit for the full retention TTL.
+        row = MagicMock(status="completed", result={"a": 1}, error="")
+        qs = MagicMock()
+        qs.filter.return_value.first.return_value = row
+        with patch(f"{_MOD}.PgTaskResult", MagicMock(objects=qs)):
+            DjangoQueueTransport().wait_for_result("rk", timeout=5)
+        qs.filter.return_value.update.assert_called_once_with(result=None, error="")
+
+    def test_timeout_does_not_clear(self):
+        # Nothing consumed on timeout — no clear (the executor may still write the
+        # row under this reply_key; the reaper sweeps the orphan at TTL).
+        qs = MagicMock()
+        qs.filter.return_value.first.return_value = None
+        with (
+            patch(f"{_MOD}.PgTaskResult", MagicMock(objects=qs)),
+            patch(f"{_MOD}.close_old_connections"),
+        ):
+            DjangoQueueTransport().wait_for_result("rk", timeout=0)
+        qs.filter.return_value.update.assert_not_called()
+
 
 class TestResolveExecutorTransport:
     def test_delegates_to_shared_flipt_resolver_true(self):

--- a/workers/queue_backend/pg_queue/executor_rpc.py
+++ b/workers/queue_backend/pg_queue/executor_rpc.py
@@ -96,6 +96,13 @@ class PgClientQueueTransport(QueueTransport):
         """
         with PgResultBackend() as rb:
             row = rb.wait_for_result(reply_key, timeout)
+            if row is not None:
+                # Reply consumed: drop the payload now so customer extraction data
+                # (PII) doesn't sit in pg_task_result for the whole retention TTL.
+                # Keep the row as a tombstone (blocks at-least-once re-insert); the
+                # reaper deletes it at expires_at. Best-effort — forget never raises,
+                # so a cleanup miss can't fail an otherwise successful dispatch.
+                rb.forget(reply_key)
         if row is None:
             return None
         return ExecResultRow(

--- a/workers/queue_backend/pg_queue/executor_rpc.py
+++ b/workers/queue_backend/pg_queue/executor_rpc.py
@@ -97,11 +97,8 @@ class PgClientQueueTransport(QueueTransport):
         with PgResultBackend() as rb:
             row = rb.wait_for_result(reply_key, timeout)
             if row is not None:
-                # Reply consumed: drop the payload now so customer extraction data
-                # (PII) doesn't sit in pg_task_result for the whole retention TTL.
-                # Keep the row as a tombstone (blocks at-least-once re-insert); the
-                # reaper deletes it at expires_at. Best-effort — forget never raises,
-                # so a cleanup miss can't fail an otherwise successful dispatch.
+                # Reply consumed: drop the payload now so PII doesn't sit in
+                # pg_task_result for the full retention TTL. Best-effort (see forget()).
                 rb.forget(reply_key)
         if row is None:
             return None

--- a/workers/queue_backend/pg_queue/result_backend.py
+++ b/workers/queue_backend/pg_queue/result_backend.py
@@ -83,6 +83,14 @@ def _get_sql() -> str:
     )
 
 
+def _forget_sql() -> str:
+    # Null the payload but KEEP the row: the tombstone makes a redelivered
+    # ``store_result`` a ``ON CONFLICT DO NOTHING`` no-op (can't re-insert the
+    # payload), and ``expires_at`` is left untouched so the reaper still deletes
+    # the empty row at retention.
+    return f"UPDATE {qualified('pg_task_result')} SET result = NULL WHERE task_id = %s"
+
+
 # Poll cadence for wait_for_result: start tight (low latency for fast tasks),
 # back off to a ceiling so a long-running task doesn't hammer the DB.
 _POLL_INITIAL_SECONDS = 0.2
@@ -257,6 +265,34 @@ class PgResultBackend:
             initial=poll_interval,
             maximum=_POLL_MAX_SECONDS,
         )
+
+    def forget(self, task_id: str) -> None:
+        """Drop the stored payload once the blocking caller has consumed it.
+
+        Nulls the ``result`` column but keeps the row as a tombstone (see
+        :func:`_forget_sql`), so a redelivered executor message can't re-insert
+        the payload and the reaper still flushes the empty row at ``expires_at``.
+        Cutting the payload here shrinks the window that customer extraction data
+        (PII) sits in ``pg_task_result`` from the full retention TTL down to the
+        read-and-clear latency; the TTL sweep remains the backstop for any result
+        that is never consumed (caller crash / timeout).
+
+        **Best-effort by contract — never raises.** It runs AFTER the caller
+        already holds the result, and its call site is inside
+        ``PgExecutionDispatcher.dispatch``'s ``except Exception -> failure`` guard;
+        a raise here would turn a successful RPC into a failure. Any error is
+        logged and swallowed — the retention sweep still bounds the exposure.
+        """
+        try:
+            with self._cursor() as cur:
+                cur.execute(_forget_sql(), (str(task_id),))
+        except Exception:
+            logger.warning(
+                "PgResultBackend.forget: could not clear result for task_id=%s; "
+                "the retention sweep will flush it at expires_at",
+                task_id,
+                exc_info=True,
+            )
 
     def close(self) -> None:
         """Close an owned connection (injected connections are the caller's)."""

--- a/workers/queue_backend/pg_queue/result_backend.py
+++ b/workers/queue_backend/pg_queue/result_backend.py
@@ -161,7 +161,7 @@ class PgResultBackend:
             raise
 
     def _store_with_reconnect(self, operation: Callable[[Any], None]) -> None:
-        """Run an idempotent store ``operation(cur)`` in a committed cursor,
+        """Run an idempotent write ``operation(cur)`` in a committed cursor,
         retrying ONCE if the cached connection was reaped while idle.
 
         The executor consumer caches one ``PgResultBackend`` for its lifetime
@@ -181,9 +181,13 @@ class PgResultBackend:
         executor consumer constructs ``PgResultBackend()``).
 
         Safe to retry unconditionally (no reused-vs-fresh guard needed, unlike
-        the non-idempotent ``PgQueueClient.send``): the write is
-        ``INSERT … ON CONFLICT (task_id) DO NOTHING``, so re-running after an
-        ambiguous failure can neither duplicate nor clobber a recorded result.
+        the non-idempotent ``PgQueueClient.send``) because **every** write routed
+        through here is idempotent: ``store_result``'s
+        ``INSERT … ON CONFLICT (task_id) DO NOTHING`` and ``forget``'s
+        ``UPDATE … SET result = NULL, error = ''`` (re-nulling an already-nulled
+        tombstone is a no-op). Re-running either after an ambiguous failure can
+        neither duplicate nor clobber a recorded result. Keep this invariant if a
+        third caller is added — a non-idempotent write must NOT use this helper.
         """
         for attempt in range(1, _STORE_RETRY_ATTEMPTS + 1):
             try:

--- a/workers/queue_backend/pg_queue/result_backend.py
+++ b/workers/queue_backend/pg_queue/result_backend.py
@@ -11,6 +11,11 @@ A row appears ONLY when the task finishes — ``status="completed"`` carrying th
 text if the task raised. Absence of a row means "not done yet"; there is
 deliberately no ``pending`` state to maintain.
 
+Once the blocking caller consumes the reply, :meth:`PgResultBackend.forget` nulls
+the payload in place — a third legal shape: ``completed``/``failed`` with
+``result`` and ``error`` cleared (a tombstone the reaper deletes at
+``expires_at``). Readers must not assume a finished row still carries a payload.
+
 Two deliberate properties:
 
 - **Idempotent writes** (``INSERT … ON CONFLICT DO NOTHING``): the PG queue is
@@ -84,11 +89,17 @@ def _get_sql() -> str:
 
 
 def _forget_sql() -> str:
-    # Null the payload but KEEP the row: the tombstone makes a redelivered
-    # ``store_result`` a ``ON CONFLICT DO NOTHING`` no-op (can't re-insert the
-    # payload), and ``expires_at`` is left untouched so the reaper still deletes
-    # the empty row at retention.
-    return f"UPDATE {qualified('pg_task_result')} SET result = NULL WHERE task_id = %s"
+    # Null BOTH payload channels but KEEP the row: ``result`` (success payload) and
+    # ``error`` (failure text — an extraction error can embed document content too),
+    # so the PII scrub covers the failure channel, not just the success one. The
+    # tombstone makes a redelivered ``store_result`` a ``ON CONFLICT DO NOTHING``
+    # no-op (can't re-insert the payload); ``status`` still distinguishes the outcome
+    # and ``expires_at`` is left untouched so the reaper still deletes the row at
+    # retention.
+    return (
+        f"UPDATE {qualified('pg_task_result')} "
+        "SET result = NULL, error = '' WHERE task_id = %s"
+    )
 
 
 # Poll cadence for wait_for_result: start tight (low latency for fast tasks),
@@ -225,7 +236,11 @@ class PgResultBackend:
         """Return ``{status, result, error}`` if the row exists, else ``None``.
 
         ``result`` is the decoded JSONB dict (psycopg2 parses ``jsonb`` to a
-        Python ``dict``); ``None`` means the task has not finished yet.
+        Python ``dict``) or ``None``. A *missing* row (this returns ``None``) means
+        the task has not finished. A *present* row with ``result is None`` is either
+        a ``failed`` outcome or a ``completed`` **tombstone** whose payload was
+        already cleared by :meth:`forget` post-consume — ``status`` distinguishes
+        them, so a payload-poll must not treat a completed row as carrying a result.
 
         No reconnect-retry here (unlike :meth:`store_result`). The invariant it
         relies on: the sole entry point into a wait (``executor_rpc.wait_for_result``
@@ -269,27 +284,36 @@ class PgResultBackend:
     def forget(self, task_id: str) -> None:
         """Drop the stored payload once the blocking caller has consumed it.
 
-        Nulls the ``result`` column but keeps the row as a tombstone (see
-        :func:`_forget_sql`), so a redelivered executor message can't re-insert
-        the payload and the reaper still flushes the empty row at ``expires_at``.
-        Cutting the payload here shrinks the window that customer extraction data
-        (PII) sits in ``pg_task_result`` from the full retention TTL down to the
-        read-and-clear latency; the TTL sweep remains the backstop for any result
-        that is never consumed (caller crash / timeout).
+        Nulls both payload columns (``result`` and ``error``) but keeps the row as a
+        tombstone (see :func:`_forget_sql`), so a redelivered executor message can't
+        re-insert the payload and the reaper still flushes the empty row at
+        ``expires_at``. Cutting the payload here shrinks the window that customer
+        extraction data (PII) sits in ``pg_task_result`` from the full retention TTL
+        down to the read-and-clear latency; the TTL sweep remains the backstop for
+        any result that is never consumed (caller crash / timeout).
 
-        **Best-effort by contract — never raises.** It runs AFTER the caller
-        already holds the result, and its call site is inside
-        ``PgExecutionDispatcher.dispatch``'s ``except Exception -> failure`` guard;
-        a raise here would turn a successful RPC into a failure. Any error is
-        logged and swallowed — the retention sweep still bounds the exposure.
+        Runs through :meth:`_store_with_reconnect` because the UPDATE is idempotent
+        (same rationale as ``store_result``): a transient dead-connection blip
+        self-heals on the one-shot retry rather than silently costing the full TTL.
+
+        **Best-effort by contract — never raises.** Every caller must sit under a
+        never-raises guard (today: ``PgExecutionDispatcher.dispatch``'s
+        ``except Exception -> failure``), because ``forget`` runs AFTER the caller
+        already holds the result — a raise here would turn a successful RPC into a
+        failure. A failure that survives the retry is logged and swallowed; the
+        retention sweep still bounds the exposure. A *systematic* failure (revoked
+        UPDATE privilege, recurring errors) is therefore observable only as a stream
+        of this WARNING — alert on the ``"could not clear result"`` string until a
+        ``forget_failures`` metric is wired (deferred to the pg_queue metrics work).
         """
         try:
-            with self._cursor() as cur:
-                cur.execute(_forget_sql(), (str(task_id),))
+            self._store_with_reconnect(
+                lambda cur: cur.execute(_forget_sql(), (str(task_id),))
+            )
         except Exception:
             logger.warning(
-                "PgResultBackend.forget: could not clear result for task_id=%s; "
-                "the retention sweep will flush it at expires_at",
+                "PgResultBackend.forget: could not clear result for task_id=%s "
+                "after retry; the retention sweep will flush it at expires_at",
                 task_id,
                 exc_info=True,
             )

--- a/workers/tests/test_executor_rpc.py
+++ b/workers/tests/test_executor_rpc.py
@@ -323,6 +323,30 @@ class TestWorkersAdapter:
         with patch(f"{_WMOD}.PgResultBackend", return_value=rb):
             assert PgClientQueueTransport().wait_for_result("rk", 5) is None
 
+    def test_wait_for_result_forgets_payload_after_consume(self):
+        # Once the reply is read, drop the payload so PII doesn't linger in
+        # pg_task_result for the full retention TTL (reaper is the backstop).
+        rb = MagicMock()
+        rb.__enter__.return_value = rb
+        rb.wait_for_result.return_value = {
+            "status": "completed",
+            "result": {"a": 1},
+            "error": "",
+        }
+        with patch(f"{_WMOD}.PgResultBackend", return_value=rb):
+            PgClientQueueTransport().wait_for_result("rk", 5)
+        rb.forget.assert_called_once_with("rk")
+
+    def test_wait_for_result_timeout_does_not_forget(self):
+        # On timeout nothing was consumed — leave the row for the reaper (the
+        # executor may still write it under this reply_key); do not clear.
+        rb = MagicMock()
+        rb.__enter__.return_value = rb
+        rb.wait_for_result.return_value = None
+        with patch(f"{_WMOD}.PgResultBackend", return_value=rb):
+            PgClientQueueTransport().wait_for_result("rk", 5)
+        rb.forget.assert_not_called()
+
     def test_resolve_delegates_to_shared_flipt_resolver_true(self):
         with patch(f"{_WMOD}.resolve_pg_transport", return_value=True) as r:
             assert resolve_executor_transport(self._ctx()) is True

--- a/workers/tests/test_executor_rpc.py
+++ b/workers/tests/test_executor_rpc.py
@@ -336,6 +336,11 @@ class TestWorkersAdapter:
         with patch(f"{_WMOD}.PgResultBackend", return_value=rb):
             PgClientQueueTransport().wait_for_result("rk", 5)
         rb.forget.assert_called_once_with("rk")
+        # forget MUST run inside the `with` (before __exit__): moving it after the
+        # block would clear the payload against a reopened owned connection that
+        # nothing closes — a per-dispatch connection leak invisible to the mock.
+        names = [c[0] for c in rb.mock_calls]
+        assert names.index("forget") < names.index("__exit__")
 
     def test_wait_for_result_timeout_does_not_forget(self):
         # On timeout nothing was consumed — leave the row for the reaper (the

--- a/workers/tests/test_pg_result_backend.py
+++ b/workers/tests/test_pg_result_backend.py
@@ -7,6 +7,7 @@ wait returns when present, wait times out, and wait picks up a late write from
 *another* connection (the cross-process request-reply path).
 """
 
+import logging
 import os
 import threading
 import time
@@ -28,6 +29,15 @@ _MARK = "pgtaskresult-test"
 
 def _key() -> str:
     return f"{_MARK}-{uuid.uuid4()}"
+
+
+def _expires_at(pg_conn, task_id):
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT expires_at FROM pg_task_result WHERE task_id = %s", (task_id,)
+        )
+        row = cur.fetchone()
+    return row[0] if row else None
 
 
 @pytest.fixture
@@ -111,17 +121,42 @@ class TestForget:
     redelivery can't re-insert it and the reaper still flushes it at expires_at.
     """
 
-    def test_forget_nulls_result_keeps_row(self, result_backend):
+    def test_forget_nulls_result_keeps_row_and_preserves_expiry(
+        self, result_backend, pg_conn
+    ):
         k = _key()
         result_backend.store_result(k, result={"data": {"pii": "secret"}})
+        before = _expires_at(pg_conn, k)
         result_backend.forget(k)
         row = result_backend.get_result(k)
         assert row is not None  # row kept (tombstone), not deleted
         assert row["result"] is None  # payload dropped
         assert row["status"] == STATUS_COMPLETED  # status preserved
+        # expires_at untouched — the reaper must still delete at the ORIGINAL TTL,
+        # so a future edit that also SETs expires_at would (correctly) fail this.
+        assert _expires_at(pg_conn, k) == before
 
-    def test_forget_absent_is_noop(self, result_backend):
-        result_backend.forget(_key())  # must not raise; UPDATE matches no row
+    def test_forget_clears_error_channel_too(self, result_backend):
+        """Failed replies store error text that can embed document content, so the
+        PII scrub must clear ``error`` as well — not just the success payload.
+        """
+        k = _key()
+        result_backend.store_result(k, error="boom: <customer doc snippet>")
+        result_backend.forget(k)
+        row = result_backend.get_result(k)
+        assert row is not None
+        assert row["error"] == ""  # error text scrubbed
+        assert row["result"] is None
+        assert row["status"] == STATUS_FAILED  # status still distinguishes outcome
+
+    def test_forget_absent_is_clean_noop(self, result_backend, caplog):
+        """An absent row is a clean UPDATE-matches-nothing, NOT a swallowed error:
+        because forget() catches Exception, a broken UPDATE would look identical to
+        success — so pin that NO warning fires here (the UPDATE really ran).
+        """
+        with caplog.at_level(logging.WARNING):
+            result_backend.forget(_key())  # must not raise
+        assert "could not clear result" not in caplog.text
 
     def test_forget_blocks_redelivery_repopulation(self, result_backend):
         """After forget, an at-least-once redelivery of the executor message must
@@ -133,16 +168,23 @@ class TestForget:
         result_backend.store_result(k, result={"pii": "again"})  # redelivery
         assert result_backend.get_result(k)["result"] is None  # stays cleared
 
-    def test_forget_is_best_effort_swallows_errors(self, monkeypatch):
-        """A cleanup failure must not propagate: forget runs inside
-        PgExecutionDispatcher.dispatch's ``except -> failure`` guard AFTER the
-        caller already holds the result, so a raise would fail a good RPC.
+    def test_forget_is_best_effort_logs_and_swallows(self, monkeypatch, caplog):
+        """Contract is *logged AND swallowed*: a failure that survives the retry
+        must not propagate (it runs inside dispatch's except->failure guard AFTER
+        the caller holds the result) AND must emit the WARNING — a silent
+        ``contextlib.suppress`` refactor would break the log-based alert and this
+        pins against it.
         """
         rb = PgResultBackend()
         monkeypatch.setattr(
-            rb, "_cursor", MagicMock(side_effect=psycopg2.OperationalError("dead"))
+            rb,
+            "_store_with_reconnect",
+            MagicMock(side_effect=psycopg2.OperationalError("dead")),
         )
-        rb.forget("k")  # must NOT raise
+        with caplog.at_level(logging.WARNING):
+            rb.forget("task-xyz")  # must NOT raise
+        assert "could not clear result" in caplog.text
+        assert "task-xyz" in caplog.text
 
 
 # --- Unit: store_result reconnect-retry on a stale cached connection (UN-3659) ---

--- a/workers/tests/test_pg_result_backend.py
+++ b/workers/tests/test_pg_result_backend.py
@@ -106,6 +106,45 @@ class TestWait:
         assert row["result"] == {"late": True}
 
 
+class TestForget:
+    """forget() drops the consumed payload but keeps the row as a tombstone, so a
+    redelivery can't re-insert it and the reaper still flushes it at expires_at.
+    """
+
+    def test_forget_nulls_result_keeps_row(self, result_backend):
+        k = _key()
+        result_backend.store_result(k, result={"data": {"pii": "secret"}})
+        result_backend.forget(k)
+        row = result_backend.get_result(k)
+        assert row is not None  # row kept (tombstone), not deleted
+        assert row["result"] is None  # payload dropped
+        assert row["status"] == STATUS_COMPLETED  # status preserved
+
+    def test_forget_absent_is_noop(self, result_backend):
+        result_backend.forget(_key())  # must not raise; UPDATE matches no row
+
+    def test_forget_blocks_redelivery_repopulation(self, result_backend):
+        """After forget, an at-least-once redelivery of the executor message must
+        not bring the payload back — the tombstone wins ON CONFLICT DO NOTHING.
+        """
+        k = _key()
+        result_backend.store_result(k, result={"pii": "first"})
+        result_backend.forget(k)
+        result_backend.store_result(k, result={"pii": "again"})  # redelivery
+        assert result_backend.get_result(k)["result"] is None  # stays cleared
+
+    def test_forget_is_best_effort_swallows_errors(self, monkeypatch):
+        """A cleanup failure must not propagate: forget runs inside
+        PgExecutionDispatcher.dispatch's ``except -> failure`` guard AFTER the
+        caller already holds the result, so a raise would fail a good RPC.
+        """
+        rb = PgResultBackend()
+        monkeypatch.setattr(
+            rb, "_cursor", MagicMock(side_effect=psycopg2.OperationalError("dead"))
+        )
+        rb.forget("k")  # must NOT raise
+
+
 # --- Unit: store_result reconnect-retry on a stale cached connection (UN-3659) ---
 
 

--- a/workers/tests/test_pg_schema_drift.py
+++ b/workers/tests/test_pg_schema_drift.py
@@ -3,29 +3,37 @@
 The workers speak to Postgres with **raw psycopg2 SQL, no Django ORM** — they run
 in Docker decoupled from the backend by design, so they cannot import the models
 as a source of truth. Column names therefore live as **string literals** across
-``queue_backend/pg_queue/*``. A change in ``backend/pg_queue`` that renames or
-drops one of those columns would NOT fail at import/compile time — it would only
-surface at runtime as a SQL error.
+``queue_backend/`` — ``queue_backend/pg_queue/*`` plus ``queue_backend/pg_barrier.py``
+(the raw SQL for ``pg_barrier_state`` / ``pg_orchestration_claim`` lives there, one
+directory up). A change in ``backend/pg_queue`` that renames or drops one of those
+columns would NOT fail at import/compile time — only at runtime as a SQL error.
 
-This DB-gated test closes that gap: it asserts every column the workers depend on
-still exists in the live schema, so a model rename/removal fails in CI instead of
-in production.
+This DB-gated test closes that gap by asserting every column the workers depend on
+still exists in the live schema. **Scope of enforcement:** it runs only against a
+*migrated* Postgres — a dev machine with the ``pg_queue`` migration applied, or a CI
+lane that provisions one and sets ``REQUIRE_PG_TESTS=1`` (conftest already turns the
+``pg_conn`` skip into a failure there). The ``integration-workers`` CI lane is
+currently ``optional`` and un-migrated, so ``pg_conn`` skips these there — wiring a
+migrated lane is a follow-up. Until then, treat this as a dev/CI-lane guard, not a
+production merge gate.
 
 Semantics — **expected ⊆ actual**:
-  * A renamed/removed column that the workers use → **fails** (the intended
-    signal: update the raw SQL in ``queue_backend/pg_queue/`` and this contract).
-  * A newly *added* column → does **not** fail: the queue SQL uses explicit
-    column lists (never ``SELECT *``), so a new column can't break a worker.
+  * A renamed/removed column listed here → **fails** (the intended signal: update
+    the raw SQL in ``queue_backend/`` and this contract together).
+  * A newly *added* column → does **not** fail: the queue SQL uses explicit column
+    lists (never ``SELECT *``), so a new column can't break a worker.
 
-Mirror of the ``backend/pg_queue`` models (the queue owns these tables). Keep in
-sync only when a queue column is **renamed or removed** — that is exactly the
-drift this guard is here to catch.
+The manifest is the **full model mirror** of each queue-owned table (the workers
+use ~all columns of these purpose-built tables; a couple — e.g.
+``pg_periodic_schedule.created_at``/``updated_at`` — may not appear in any current
+SQL, so the guard errs toward flagging any rename/removal on these tables for
+review). Keep in sync only when a queue column is **renamed or removed**.
 """
 
 import pytest
-from queue_backend.pg_queue.schema import QUEUE_TABLES
+from queue_backend.pg_queue.schema import QUEUE_TABLES, queue_schema
 
-# table -> columns the workers' raw SQL relies on.
+# table -> columns the workers expect to exist (full model mirror; see module doc).
 WORKER_SCHEMA_CONTRACT = {
     "pg_queue_message": {
         "msg_id",
@@ -73,13 +81,21 @@ WORKER_SCHEMA_CONTRACT = {
 }
 
 
-def _actual_columns(pg_conn, table: str) -> set[str]:
-    """Columns present for *table* in the live schema (search-path resolved, so it
-    matches how the workers' unqualified/qualified SQL sees the table)."""
+def _actual_columns(pg_conn, schema: str, table: str) -> set[str]:
+    """Columns present for *schema.table* in the live DB.
+
+    ``information_schema.columns`` is **privilege-filtered, not search_path-filtered**,
+    so the schema is pinned explicitly: an unqualified ``table_name`` match would
+    union columns from every visible schema (e.g. a stale per-developer sibling
+    schema alongside ``unstract``) and mask a column dropped in the target schema.
+    The schema is ``queue_schema()`` — exactly what the workers' ``qualified()`` SQL
+    resolves to.
+    """
     with pg_conn.cursor() as cur:
         cur.execute(
-            "SELECT column_name FROM information_schema.columns WHERE table_name = %s",
-            (table,),
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = %s AND table_name = %s",
+            (schema, table),
         )
         return {row[0] for row in cur.fetchall()}
 
@@ -93,11 +109,12 @@ def test_contract_covers_every_registered_queue_table():
 
 @pytest.mark.parametrize("table", sorted(WORKER_SCHEMA_CONTRACT))
 def test_worker_required_columns_exist(pg_conn, table):
-    actual = _actual_columns(pg_conn, table)
-    assert actual, f"{table} not found in the live schema (migration applied?)"
+    schema = queue_schema()  # the schema the workers' qualified() SQL targets
+    actual = _actual_columns(pg_conn, schema, table)
+    assert actual, f"{schema}.{table} not found in the live schema (migration applied?)"
     missing = WORKER_SCHEMA_CONTRACT[table] - actual
     assert not missing, (
-        f"{table} is missing worker-required column(s) {sorted(missing)}: a model "
-        f"rename/removal in backend/pg_queue broke the workers' raw SQL. Update the "
-        f"SQL in queue_backend/pg_queue/ and WORKER_SCHEMA_CONTRACT together."
+        f"{schema}.{table} is missing worker-required column(s) {sorted(missing)}: a "
+        f"model rename/removal in backend/pg_queue broke the workers' raw SQL. Update "
+        f"the SQL in queue_backend/ and WORKER_SCHEMA_CONTRACT together."
     )

--- a/workers/tests/test_pg_schema_drift.py
+++ b/workers/tests/test_pg_schema_drift.py
@@ -1,0 +1,103 @@
+"""Schema-drift guard for the PG-queue tables the workers hit with raw SQL.
+
+The workers speak to Postgres with **raw psycopg2 SQL, no Django ORM** — they run
+in Docker decoupled from the backend by design, so they cannot import the models
+as a source of truth. Column names therefore live as **string literals** across
+``queue_backend/pg_queue/*``. A change in ``backend/pg_queue`` that renames or
+drops one of those columns would NOT fail at import/compile time — it would only
+surface at runtime as a SQL error.
+
+This DB-gated test closes that gap: it asserts every column the workers depend on
+still exists in the live schema, so a model rename/removal fails in CI instead of
+in production.
+
+Semantics — **expected ⊆ actual**:
+  * A renamed/removed column that the workers use → **fails** (the intended
+    signal: update the raw SQL in ``queue_backend/pg_queue/`` and this contract).
+  * A newly *added* column → does **not** fail: the queue SQL uses explicit
+    column lists (never ``SELECT *``), so a new column can't break a worker.
+
+Mirror of the ``backend/pg_queue`` models (the queue owns these tables). Keep in
+sync only when a queue column is **renamed or removed** — that is exactly the
+drift this guard is here to catch.
+"""
+
+import pytest
+from queue_backend.pg_queue.schema import QUEUE_TABLES
+
+# table -> columns the workers' raw SQL relies on.
+WORKER_SCHEMA_CONTRACT = {
+    "pg_queue_message": {
+        "msg_id",
+        "queue_name",
+        "message",
+        "org_id",
+        "enqueued_at",
+        "vt",
+        "read_ct",
+        "priority",
+    },
+    "pg_task_result": {
+        "task_id",
+        "status",
+        "result",
+        "error",
+        "created_at",
+        "expires_at",
+    },
+    "pg_barrier_state": {
+        "execution_id",
+        "organization_id",
+        "remaining",
+        "results",
+        "created_at",
+        "expires_at",
+        "last_progress_at",
+    },
+    "pg_batch_dedup": {"execution_id", "batch_index", "created_at"},
+    "pg_orchestration_claim": {"execution_id", "organization_id", "claimed_at"},
+    "pg_orchestrator_lock": {"id", "leader", "acquired_at"},
+    "pg_periodic_schedule": {
+        "pipeline_id",
+        "organization_id",
+        "workflow_id",
+        "pipeline_name",
+        "cron_string",
+        "enabled",
+        "pg_owned",
+        "last_run_at",
+        "next_run_at",
+        "created_at",
+        "updated_at",
+    },
+}
+
+
+def _actual_columns(pg_conn, table: str) -> set[str]:
+    """Columns present for *table* in the live schema (search-path resolved, so it
+    matches how the workers' unqualified/qualified SQL sees the table)."""
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = %s",
+            (table,),
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+def test_contract_covers_every_registered_queue_table():
+    """The manifest must list exactly the tables the workers register in
+    ``QUEUE_TABLES`` — so adding a queue table forces a column contract for it and
+    the drift guard can never silently skip one."""
+    assert set(WORKER_SCHEMA_CONTRACT) == set(QUEUE_TABLES)
+
+
+@pytest.mark.parametrize("table", sorted(WORKER_SCHEMA_CONTRACT))
+def test_worker_required_columns_exist(pg_conn, table):
+    actual = _actual_columns(pg_conn, table)
+    assert actual, f"{table} not found in the live schema (migration applied?)"
+    missing = WORKER_SCHEMA_CONTRACT[table] - actual
+    assert not missing, (
+        f"{table} is missing worker-required column(s) {sorted(missing)}: a model "
+        f"rename/removal in backend/pg_queue broke the workers' raw SQL. Update the "
+        f"SQL in queue_backend/pg_queue/ and WORKER_SCHEMA_CONTRACT together."
+    )


### PR DESCRIPTION
## What & why

The PG executor RPC reply store (`pg_task_result`) holds the executor's full return value — the extraction output, including raw document text — for the whole retention TTL (~1h) before the reaper sweeps it. It's a **transient request-reply channel**: once the blocking caller has read the reply, the payload no longer needs to exist. This shrinks that window, and adds a guard so a model schema change can't silently break the workers' raw SQL.

## Changes

**1. Clear-on-consume for `pg_task_result`**
- `PgResultBackend.forget(task_id)` → `UPDATE pg_task_result SET result = NULL`. Nulls the payload but **keeps the row as a tombstone** so an at-least-once redelivery can't re-insert it (`store_result` is `ON CONFLICT DO NOTHING`); `expires_at` is untouched so the reaper still deletes the empty row at TTL.
- Wired at the single consume point (`PgClientQueueTransport.wait_for_result`), right after the reply is read; skipped on timeout.
- **Best-effort — never raises**: it runs after the caller already holds the result, inside `PgExecutionDispatcher.dispatch`'s `except → failure` guard, so a cleanup miss can't turn a successful RPC into a failure. The TTL sweep stays the backstop for unconsumed rows (crash/timeout).
- Net: the window the payload sits in `pg_task_result` drops from ~1h to read-and-clear latency. Flag off → Celery path → no `pg_task_result` row → **zero change**.

**2. Schema-drift guard for the queue tables**
- The workers issue raw psycopg2 SQL (Docker-decoupled from Django), so a model column rename/removal fails only at runtime, not at compile time. New DB-gated test asserts every worker-required column (per-table manifest for all 7 `QUEUE_TABLES`) exists in the live schema — **expected ⊆ actual**, so it catches renames/removals but ignores safe additions (queue SQL uses explicit column lists, never `SELECT *`) — plus a guard that the manifest covers exactly `QUEUE_TABLES`.

## Tests
- `forget`: unit + DB-gated (null-keeps-row, absent-noop, redelivery-blocked, best-effort swallow)
- transport wiring (forgets after consume / not on timeout)
- schema-drift (per-table + registry coverage)
- Full local suite green; DB-gated tests ran against real Postgres.

## Out of scope (follow-ups)
- Celery-side `AsyncResult.forget()` symmetry (touches shared sdk1 / Prompt Studio — larger blast radius).
- `file_history.result` cleartext-at-rest review (durable, always-on for ETL, pre-existing — not introduced here).

## Remaining before ready
- Dev-test against the running integration stack: run one PG ETL, confirm `pg_task_result.result` nulls out after the execution consumes the reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
