### PR TITLE
UN-3684 [FIX] PG barrier — claim_batch idle-reap: execute-phase reconnect-retry

### DIFF
--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -278,17 +278,77 @@ def claim_batch(execution_id: str, batch_index: int) -> bool:
     Called on the in-body PG path from :func:`run_batch_with_barrier` (claim at
     batch start), alongside the in-body decrement. The companion
     :func:`clear_execution_batches` reclaims the markers at barrier finalise.
+
+    **Execute-phase reconnect-retry** (mirrors :func:`try_claim_orchestration`,
+    the execution-level claim one level up). This module's thread-local connection
+    sits idle between batches — a scheduled pipeline fires one only ~every 30 min,
+    well past PgBouncer's ``server_idle_timeout`` — so the FIRST ``INSERT`` after
+    the gap can hit an idle-reaped handle (``server closed the connection
+    unexpectedly``). Retrying a **reused-conn execute-phase** death is safe: the
+    INSERT never committed, so the retry's win/lost ``RETURNING`` answer is
+    authoritative. A **commit-phase** failure is ambiguous (the row may be
+    persisted) — re-running could flip the claim (``True`` → ``False`` → the caller
+    skips and strands the barrier, or a re-claim double-decrements), so it is NOT
+    retried; it propagates to vt-expiry redelivery. A fresh-conn failure is a real
+    DB error, likewise not retried.
     """
-    with _cursor() as cur:
-        cur.execute(
-            f"INSERT INTO {qualified('pg_batch_dedup')} "
-            "(execution_id, batch_index, created_at) "
-            "VALUES (%s, %s, now()) "
-            "ON CONFLICT (execution_id, batch_index) DO NOTHING "
-            "RETURNING execution_id",
-            (execution_id, batch_index),
-        )
-        return cur.fetchone() is not None
+    # Only a CACHED handle can be a stale idle-reap; sample before _get_conn()
+    # below materialises one, so a fresh-conn failure isn't misread as a reap
+    # (mirrors try_claim_orchestration / the decrement phase-split).
+    reused = getattr(_local, "conn", None) is not None and not _local.conn.closed
+    for attempt in range(1, _BARRIER_WRITE_ATTEMPTS + 1):
+        conn = _get_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"INSERT INTO {qualified('pg_batch_dedup')} "
+                    "(execution_id, batch_index, created_at) "
+                    "VALUES (%s, %s, now()) "
+                    "ON CONFLICT (execution_id, batch_index) DO NOTHING "
+                    "RETURNING execution_id",
+                    (execution_id, batch_index),
+                )
+                claimed = cur.fetchone() is not None
+        except Exception as exc:
+            conn_dead = _recover_after_error(conn, exc)
+            # Reused-conn execute-phase death (idle reap): the INSERT never
+            # committed, so the retry on a fresh conn is authoritative. A
+            # fresh-conn failure or a non-conn error propagates.
+            if conn_dead and reused and attempt < _BARRIER_WRITE_ATTEMPTS:
+                logger.warning(
+                    "[exec:%s] claim_batch(%d): execute failed on a cached "
+                    "connection (%s) — reconnecting and retrying once (attempt "
+                    "%d/%d); the INSERT never committed.",
+                    execution_id,
+                    batch_index,
+                    type(exc).__name__,
+                    attempt,
+                    _BARRIER_WRITE_ATTEMPTS,
+                    exc_info=True,
+                )
+                time.sleep(_BARRIER_RETRY_BACKOFF_SECONDS)
+                continue
+            raise
+        try:
+            conn.commit()
+        except Exception as exc:
+            # AMBIGUOUS commit — the dedup row may be persisted. Re-running could
+            # flip the RETURNING claim (skip-and-strand, or double-decrement), so
+            # NEVER retry; propagate to redelivery.
+            _recover_after_error(conn, exc)
+            logger.warning(
+                "[exec:%s] claim_batch(%d): commit failed (%s) — NOT retrying (the "
+                "server may already have committed; a re-run could flip the claim). "
+                "Propagating.",
+                execution_id,
+                batch_index,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            raise
+        return claimed
+    # Unreachable: the loop either returns or raises.
+    raise AssertionError("claim_batch loop fell through")
 
 
 def clear_execution_batches(execution_id: str) -> int:

--- a/workers/queue_backend/pg_barrier.py
+++ b/workers/queue_backend/pg_barrier.py
@@ -183,7 +183,11 @@ def _cursor() -> Iterator[Any]:
 # dead conn, so a single retry runs against a freshly reconnected one. This turns
 # a transient blip (which previously aborted the whole execution at barrier
 # enqueue) into a self-heal. Kept a literal (not env-driven) so the idempotency
-# bound can't be weakened operationally.
+# bound can't be weakened operationally. Also bounds the phase-split RETURNING
+# claims (``claim_batch`` / ``try_claim_orchestration`` via
+# :func:`_run_returning_claim_with_reconnect`); they are non-idempotent but retry
+# ONLY the provably-uncommitted execute phase, so the same one-retry bound holds
+# without reopening a claim-flip.
 _BARRIER_WRITE_ATTEMPTS: Final = 2  # total attempts: 1 initial + 1 retry
 # Small fixed pause before the retry. The idle-reap case reconnects instantly
 # regardless; this only widens the self-heal window for a brief DB failover, and
@@ -223,8 +227,11 @@ def _run_idempotent_pre_dispatch_write(
     remaining - 1``): it is not idempotent — a re-applied decrement can fire the
     callback **prematurely with incomplete results**, or skip past 0 and
     **strand the barrier** to expiry — so it stays on the plain :func:`_cursor`
-    (recover-but-don't-retry). Same for ``claim_batch``, whose ``RETURNING``
-    answer flips on a retry.
+    (recover-but-don't-retry). The RETURNING claims (``claim_batch`` /
+    ``try_claim_orchestration``) are likewise non-idempotent — a committed claim's
+    win/lost answer flips on a naive re-run — so they retry via
+    :func:`_run_returning_claim_with_reconnect`, which retries ONLY the
+    provably-uncommitted execute phase.
     """
     for attempt in range(1, _BARRIER_WRITE_ATTEMPTS + 1):
         try:
@@ -261,6 +268,77 @@ def _delete_barrier(execution_id: str) -> None:
         )
 
 
+def _run_returning_claim_with_reconnect(
+    operation: Callable[[PgCursor], bool], *, what: str
+) -> bool:
+    """Run a single ``INSERT … ON CONFLICT DO NOTHING RETURNING`` claim
+    (``operation(cur)`` → did-I-win), with the **phase-split reconnect-retry**
+    shared by :func:`claim_batch` and :func:`try_claim_orchestration`.
+
+    These are the FIRST DB write of their task, so on an idle worker they most
+    often meet a PgBouncer-reaped *cached* connection. The claim is retried ONCE,
+    but ONLY on an **execute-phase** failure of a cached connection: the statement
+    never committed (rolled back on disconnect), so re-running lands exactly once
+    and the retry's ``RETURNING`` answer is authoritative — no win→lost flip.
+
+    NOT retried (each propagates):
+    - **commit-phase** failure — AMBIGUOUS (the server may have committed). A re-run
+      could flip ``True`` → ``False`` → the caller skips and the barrier/claim
+      strands; and if the row *did* persist, the redelivery's claim likewise returns
+      ``False``, so the reaper recovers at expiry either way.
+    - **fresh-conn** failure — a real DB error; reconnecting buys nothing.
+
+    (This is why the idempotent ``-> None`` pre-dispatch helper can't be reused: a
+    RETURNING claim is non-idempotent.) ``what`` is a caller-formatted log label,
+    e.g. ``[exec:<id>] claim_batch(<n>)``.
+    """
+    # Only a CACHED handle can be a stale idle-reap; sample before _get_conn()
+    # materialises one, so a fresh-conn failure isn't misread as a reap.
+    reused = getattr(_local, "conn", None) is not None and not _local.conn.closed
+    for attempt in range(1, _BARRIER_WRITE_ATTEMPTS + 1):
+        conn = _get_conn()
+        try:
+            with conn.cursor() as cur:
+                won = operation(cur)
+        except Exception as exc:
+            conn_dead = _recover_after_error(conn, exc)
+            if conn_dead and reused and attempt < _BARRIER_WRITE_ATTEMPTS:
+                logger.warning(
+                    "%s: execute failed on a cached connection (%s) — reconnecting "
+                    "and retrying once (attempt %d/%d); the INSERT never committed.",
+                    what,
+                    type(exc).__name__,
+                    attempt,
+                    _BARRIER_WRITE_ATTEMPTS,
+                    exc_info=True,
+                )
+                # The dead handle was discarded, so the next _get_conn() reconnects
+                # — clear `reused` so a fresh-conn death on a later attempt is never
+                # retried. Keeps the invariant structural, not merely masked by
+                # _BARRIER_WRITE_ATTEMPTS == 2.
+                reused = False
+                time.sleep(_BARRIER_RETRY_BACKOFF_SECONDS)
+                continue
+            raise
+        try:
+            conn.commit()
+        except Exception as exc:
+            _recover_after_error(conn, exc)
+            logger.warning(
+                "%s: commit failed (%s) — NOT retrying (the server may already have "
+                "committed; a re-run could flip the claim → the caller skips and the "
+                "barrier strands; if the row persisted, the redelivery skips and the "
+                "reaper recovers at expiry). Propagating.",
+                what,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            raise
+        return won
+    # Unreachable: the loop either returns or raises.
+    raise AssertionError(f"{what}: claim loop fell through")
+
+
 def claim_batch(execution_id: str, batch_index: int) -> bool:
     """Claim ``(execution_id, batch_index)`` for processing — the per-batch
     idempotency gate for the at-least-once PG pipeline.
@@ -279,76 +357,28 @@ def claim_batch(execution_id: str, batch_index: int) -> bool:
     batch start), alongside the in-body decrement. The companion
     :func:`clear_execution_batches` reclaims the markers at barrier finalise.
 
-    **Execute-phase reconnect-retry** (mirrors :func:`try_claim_orchestration`,
-    the execution-level claim one level up). This module's thread-local connection
-    sits idle between batches — a scheduled pipeline fires one only ~every 30 min,
-    well past PgBouncer's ``server_idle_timeout`` — so the FIRST ``INSERT`` after
-    the gap can hit an idle-reaped handle (``server closed the connection
-    unexpectedly``). Retrying a **reused-conn execute-phase** death is safe: the
-    INSERT never committed, so the retry's win/lost ``RETURNING`` answer is
-    authoritative. A **commit-phase** failure is ambiguous (the row may be
-    persisted) — re-running could flip the claim (``True`` → ``False`` → the caller
-    skips and strands the barrier, or a re-claim double-decrements), so it is NOT
-    retried; it propagates to vt-expiry redelivery. A fresh-conn failure is a real
-    DB error, likewise not retried.
+    Runs through the shared phase-split reconnect-retry
+    (:func:`_run_returning_claim_with_reconnect`): the module's thread-local
+    connection sits idle **between pipeline runs** (a scheduled pipeline can idle
+    for tens of minutes, past PgBouncer's ``server_idle_timeout``), so the FIRST
+    ``INSERT`` of a run can hit an idle-reaped handle; that execute-phase reap
+    self-heals on one reconnect (UN-3684). See the helper for the full rationale.
     """
-    # Only a CACHED handle can be a stale idle-reap; sample before _get_conn()
-    # below materialises one, so a fresh-conn failure isn't misread as a reap
-    # (mirrors try_claim_orchestration / the decrement phase-split).
-    reused = getattr(_local, "conn", None) is not None and not _local.conn.closed
-    for attempt in range(1, _BARRIER_WRITE_ATTEMPTS + 1):
-        conn = _get_conn()
-        try:
-            with conn.cursor() as cur:
-                cur.execute(
-                    f"INSERT INTO {qualified('pg_batch_dedup')} "
-                    "(execution_id, batch_index, created_at) "
-                    "VALUES (%s, %s, now()) "
-                    "ON CONFLICT (execution_id, batch_index) DO NOTHING "
-                    "RETURNING execution_id",
-                    (execution_id, batch_index),
-                )
-                claimed = cur.fetchone() is not None
-        except Exception as exc:
-            conn_dead = _recover_after_error(conn, exc)
-            # Reused-conn execute-phase death (idle reap): the INSERT never
-            # committed, so the retry on a fresh conn is authoritative. A
-            # fresh-conn failure or a non-conn error propagates.
-            if conn_dead and reused and attempt < _BARRIER_WRITE_ATTEMPTS:
-                logger.warning(
-                    "[exec:%s] claim_batch(%d): execute failed on a cached "
-                    "connection (%s) — reconnecting and retrying once (attempt "
-                    "%d/%d); the INSERT never committed.",
-                    execution_id,
-                    batch_index,
-                    type(exc).__name__,
-                    attempt,
-                    _BARRIER_WRITE_ATTEMPTS,
-                    exc_info=True,
-                )
-                time.sleep(_BARRIER_RETRY_BACKOFF_SECONDS)
-                continue
-            raise
-        try:
-            conn.commit()
-        except Exception as exc:
-            # AMBIGUOUS commit — the dedup row may be persisted. Re-running could
-            # flip the RETURNING claim (skip-and-strand, or double-decrement), so
-            # NEVER retry; propagate to redelivery.
-            _recover_after_error(conn, exc)
-            logger.warning(
-                "[exec:%s] claim_batch(%d): commit failed (%s) — NOT retrying (the "
-                "server may already have committed; a re-run could flip the claim). "
-                "Propagating.",
-                execution_id,
-                batch_index,
-                type(exc).__name__,
-                exc_info=True,
-            )
-            raise
-        return claimed
-    # Unreachable: the loop either returns or raises.
-    raise AssertionError("claim_batch loop fell through")
+
+    def _op(cur: PgCursor) -> bool:
+        cur.execute(
+            f"INSERT INTO {qualified('pg_batch_dedup')} "
+            "(execution_id, batch_index, created_at) "
+            "VALUES (%s, %s, now()) "
+            "ON CONFLICT (execution_id, batch_index) DO NOTHING "
+            "RETURNING execution_id",
+            (execution_id, batch_index),
+        )
+        return cur.fetchone() is not None
+
+    return _run_returning_claim_with_reconnect(
+        _op, what=f"[exec:{execution_id}] claim_batch({batch_index})"
+    )
 
 
 def clear_execution_batches(execution_id: str) -> int:
@@ -416,60 +446,22 @@ def try_claim_orchestration(execution_id: str, organization_id: str) -> bool:
     orchestrator marks ERROR and the redelivery re-orchestrates). This is why the
     idempotent-pre-dispatch helper (``-> None``, no RETURNING) can't be reused here.
     """
-    # Sample cached-ness BEFORE _get_conn() below materialises a connection: only a
-    # cached handle can be a stale idle-reap, so a fresh-conn failure is a genuine
-    # DB error, not a reap (mirrors _apply_decrement / pg_queue.client.send).
-    reused = getattr(_local, "conn", None) is not None and not _local.conn.closed
+
+    def _op(cur: PgCursor) -> bool:
+        cur.execute(
+            f"INSERT INTO {qualified('pg_orchestration_claim')} "
+            "(execution_id, organization_id, claimed_at) "
+            "VALUES (%s, %s, now()) "
+            "ON CONFLICT (execution_id) DO NOTHING "
+            "RETURNING execution_id",
+            (execution_id, organization_id),
+        )
+        return cur.fetchone() is not None
+
     try:
-        for attempt in range(1, _BARRIER_WRITE_ATTEMPTS + 1):
-            conn = _get_conn()
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        f"INSERT INTO {qualified('pg_orchestration_claim')} "
-                        "(execution_id, organization_id, claimed_at) "
-                        "VALUES (%s, %s, now()) "
-                        "ON CONFLICT (execution_id) DO NOTHING "
-                        "RETURNING execution_id",
-                        (execution_id, organization_id),
-                    )
-                    won = cur.fetchone() is not None
-            except Exception as exc:
-                conn_dead = _recover_after_error(conn, exc)
-                # Retry ONLY a reused-conn death on the execute phase: it never
-                # committed, so the retry (on a fresh conn) is authoritative.
-                if conn_dead and reused and attempt < _BARRIER_WRITE_ATTEMPTS:
-                    logger.warning(
-                        "[exec:%s] orchestration claim: execute failed on a cached "
-                        "connection (%s) — reconnecting and retrying once "
-                        "(attempt %d/%d); the INSERT never committed.",
-                        execution_id,
-                        type(exc).__name__,
-                        attempt,
-                        _BARRIER_WRITE_ATTEMPTS,
-                        exc_info=True,
-                    )
-                    time.sleep(_BARRIER_RETRY_BACKOFF_SECONDS)
-                    continue
-                raise
-            try:
-                conn.commit()
-            except Exception as exc:
-                # AMBIGUOUS commit — the row may be persisted. Re-running could flip
-                # a real winner to a loser (→ strand), so NEVER retry; propagate.
-                _recover_after_error(conn, exc)
-                logger.warning(
-                    "[exec:%s] orchestration claim: commit failed (%s) — NOT "
-                    "retrying (the server may already have committed; a re-run "
-                    "could flip the winner). Propagating.",
-                    execution_id,
-                    type(exc).__name__,
-                    exc_info=True,
-                )
-                raise
-            return won
-        # Unreachable: the loop either returns or raises.
-        raise AssertionError("try_claim_orchestration loop fell through")
+        return _run_returning_claim_with_reconnect(
+            _op, what=f"[exec:{execution_id}] orchestration claim"
+        )
     except (psycopg2.errors.UndefinedTable, psycopg2.errors.UndefinedColumn) as exc:
         # Fail fast with an actionable message instead of a generic per-execution
         # stack trace when the schema is behind: UndefinedTable (0012 missing) OR

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -526,12 +526,19 @@ class TestReturningClaimReconnect:
         monkeypatch.setattr(pg_barrier.time, "sleep", calls.append)
         return calls
 
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [psycopg2.OperationalError, psycopg2.InterfaceError],
+        ids=["OperationalError", "InterfaceError"],
+    )
     def test_execute_phase_reaped_cached_conn_retries_once(
-        self, claim, _clean_local, monkeypatch, caplog, sleeps
+        self, claim, exc_cls, _clean_local, monkeypatch, caplog, sleeps
     ):
-        dead = _FakeConn(
-            execute_error=psycopg2.OperationalError("server closed the connection")
-        )
+        # Both _CONN_DEAD_ERRORS symptoms of an idle reap must be recognised and
+        # retried: OperationalError ("server closed …") and InterfaceError
+        # ("connection already closed") — libpq surfaces the broken socket either
+        # way depending on timing (mirrors TestDecrementPhaseSplitRetry).
+        dead = _FakeConn(execute_error=exc_cls("connection already closed"))
         healthy = _FakeConn()
         pg_barrier._local.conn = dead  # cached → "reused"
         monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -550,6 +550,76 @@ class TestClaimOrchestrationRetry:
             try_claim_orchestration("exec-1", "org-1")
 
 
+class TestClaimBatchRetry:
+    """``claim_batch`` is a RETURNING claim, sibling to ``try_claim_orchestration``
+    one level up, so it self-heals ONLY the provably-safe case: an execute-phase
+    failure on a *cached* connection (the idle reap that stranded scheduled ETL
+    batches — the ~30-min-idle barrier connection past ``server_idle_timeout``; the
+    INSERT never committed, so the retry's claim answer is authoritative). A
+    commit-phase failure is ambiguous and a fresh-conn failure is a real error —
+    neither is retried, else a claim could flip ``True``→``False`` and strand the
+    barrier (or double-decrement).
+    """
+
+    @pytest.fixture
+    def sleeps(self, monkeypatch):
+        calls: list[float] = []
+        monkeypatch.setattr(pg_barrier.time, "sleep", calls.append)
+        return calls
+
+    def test_execute_phase_reaped_cached_conn_retries_once(
+        self, _clean_local, monkeypatch, caplog, sleeps
+    ):
+        dead = _FakeConn(
+            execute_error=psycopg2.OperationalError("server closed the connection")
+        )
+        healthy = _FakeConn()
+        pg_barrier._local.conn = dead  # cached → "reused"
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
+
+        with caplog.at_level("WARNING"):
+            claimed = claim_batch("exec-1", 0)
+
+        assert claimed is True  # authoritative answer taken from the retry
+        assert dead.executes == 1 and healthy.executes == 1  # exactly one extra try
+        assert dead.commits == 0  # the reaped attempt never committed
+        assert dead.closed is True  # stale conn discarded
+        assert healthy.commits == 1  # committed exactly once, on the retry
+        assert pg_barrier._local.conn is healthy
+        assert sleeps == [pg_barrier._BARRIER_RETRY_BACKOFF_SECONDS]
+        assert "execute failed on a cached connection" in caplog.text
+
+    def test_commit_phase_failure_is_not_retried(self, _clean_local, monkeypatch, sleeps):
+        # Ambiguous commit (server may have committed) → NOT retried, or a re-run
+        # could flip the claim and strand the barrier. Propagates; no reconnect.
+        conn = _FakeConn(
+            commit_error=psycopg2.OperationalError("server closed during commit")
+        )
+        pg_barrier._local.conn = conn
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: pytest.fail("must not reconnect on a commit-phase failure"),
+        )
+        with pytest.raises(psycopg2.OperationalError):
+            claim_batch("exec-1", 0)
+        assert conn.executes == 1 and conn.commits == 1  # tried once, no retry
+        assert sleeps == []  # no backoff → no retry
+
+    def test_fresh_conn_execute_failure_is_not_retried(
+        self, _clean_local, monkeypatch, sleeps
+    ):
+        # A freshly-created connection failing is a real DB error, not an idle reap
+        # (reused is False when _local.conn starts empty) → not retried.
+        dead = _FakeConn(execute_error=psycopg2.OperationalError("connection refused"))
+        pg_barrier._local.conn = None  # → reused False
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: dead)
+        with pytest.raises(psycopg2.OperationalError):
+            claim_batch("exec-1", 0)
+        assert dead.executes == 1  # no retry
+        assert sleeps == []
+
+
 class TestReleaseOrchestrationClaimRetry:
     """``release_orchestration_claim`` is a first-write-after-idle on the failure
     path whose raise the caller swallows — an un-retried idle-reap would leave the

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -478,72 +478,11 @@ def test_create_pg_connection_is_non_autocommit():
         conn.close()
 
 
-class TestClaimOrchestrationRetry:
-    """``try_claim_orchestration`` is a RETURNING claim, so — like the decrement,
-    and unlike the idempotent pre-dispatch write — it self-heals ONLY the
-    provably-safe case: an execute-phase failure on a *cached* connection (idle
-    reap; the INSERT never committed, so the retry's win/lost answer is
-    authoritative). A commit-phase failure is ambiguous and a fresh-conn failure
-    is a real error — neither is retried, so a real winner is never flipped to a
-    loser (which would strand the execution). Guards UN-3671's PR-review fix.
+class TestClaimOrchestrationSchemaGuard:
+    """``try_claim_orchestration``-specific: a schema behind the code fails fast with
+    an actionable message. The shared execute-phase reconnect-retry is covered once,
+    over both claim callers, by :class:`TestReturningClaimReconnect`.
     """
-
-    @pytest.fixture
-    def sleeps(self, monkeypatch):
-        calls: list[float] = []
-        monkeypatch.setattr(pg_barrier.time, "sleep", calls.append)
-        return calls
-
-    def test_execute_phase_reaped_cached_conn_retries_once(
-        self, _clean_local, monkeypatch, caplog, sleeps
-    ):
-        dead = _FakeConn(
-            execute_error=psycopg2.OperationalError("server closed the connection")
-        )
-        healthy = _FakeConn()
-        pg_barrier._local.conn = dead  # cached → "reused"
-        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
-
-        with caplog.at_level("WARNING"):
-            try_claim_orchestration("exec-1", "org-1")
-
-        assert dead.executes == 1 and healthy.executes == 1  # exactly one extra try
-        assert dead.commits == 0  # the reaped attempt never committed
-        assert dead.closed is True  # stale conn discarded
-        assert healthy.commits == 1  # committed exactly once, on the retry
-        assert pg_barrier._local.conn is healthy
-        assert sleeps == [pg_barrier._BARRIER_RETRY_BACKOFF_SECONDS]
-        assert "execute failed on a cached connection" in caplog.text
-
-    def test_commit_phase_failure_is_not_retried(self, _clean_local, monkeypatch, sleeps):
-        # Ambiguous commit (the server may have committed) → NOT retried, or a real
-        # winner could be flipped to a loser. Propagates; no reconnect.
-        conn = _FakeConn(
-            commit_error=psycopg2.OperationalError("server closed during commit")
-        )
-        pg_barrier._local.conn = conn
-        monkeypatch.setattr(
-            pg_barrier,
-            "create_pg_connection",
-            lambda **_k: pytest.fail("must not reconnect on a commit-phase failure"),
-        )
-        with pytest.raises(psycopg2.OperationalError):
-            try_claim_orchestration("exec-1", "org-1")
-        assert conn.executes == 1 and conn.commits == 1  # tried once, no retry
-        assert sleeps == []  # no backoff → no retry
-
-    def test_fresh_conn_execute_failure_is_not_retried(
-        self, _clean_local, monkeypatch, sleeps
-    ):
-        # A freshly-created connection failing is a real DB error, not an idle reap
-        # (reused is False when _local.conn starts empty) → not retried.
-        dead = _FakeConn(execute_error=psycopg2.OperationalError("connection refused"))
-        pg_barrier._local.conn = None  # → reused False
-        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: dead)
-        with pytest.raises(psycopg2.OperationalError):
-            try_claim_orchestration("exec-1", "org-1")
-        assert dead.executes == 1  # no retry
-        assert sleeps == []
 
     @pytest.mark.parametrize(
         "exc_cls",
@@ -559,16 +498,26 @@ class TestClaimOrchestrationRetry:
             try_claim_orchestration("exec-1", "org-1")
 
 
-class TestClaimBatchRetry:
-    """``claim_batch`` is a RETURNING claim (via the shared
-    ``_run_returning_claim_with_reconnect``), so it self-heals ONLY the
-    provably-safe case: an execute-phase failure on a *cached* connection — the idle
-    reap that stranded scheduled ETL batches (UN-3684: a barrier connection idle
+@pytest.mark.parametrize(
+    "claim",
+    [
+        pytest.param(lambda: claim_batch("exec-1", 0), id="claim_batch"),
+        pytest.param(
+            lambda: try_claim_orchestration("exec-1", "org-1"),
+            id="try_claim_orchestration",
+        ),
+    ],
+)
+class TestReturningClaimReconnect:
+    """The shared phase-split reconnect-retry
+    (``_run_returning_claim_with_reconnect``), exercised through BOTH RETURNING-claim
+    callers. Self-heals ONLY an execute-phase failure on a *cached* connection — the
+    idle reap that stranded scheduled ETL batches (UN-3684: a barrier connection idle
     ~30 min between pipeline runs, past ``server_idle_timeout``; the INSERT never
-    committed, so the retry's claim answer is authoritative). NOT retried, for two
+    committed, so the retry's win/lost answer is authoritative). NOT retried, for two
     distinct reasons: a **commit-phase** failure is ambiguous — a re-run could flip
-    ``True``→``False`` and strand the barrier; a **fresh-conn** failure is a real DB
-    error — reconnecting buys nothing.
+    ``True``→``False`` and strand; a **fresh-conn** failure is a real DB error —
+    reconnecting buys nothing.
     """
 
     @pytest.fixture
@@ -578,7 +527,7 @@ class TestClaimBatchRetry:
         return calls
 
     def test_execute_phase_reaped_cached_conn_retries_once(
-        self, _clean_local, monkeypatch, caplog, sleeps
+        self, claim, _clean_local, monkeypatch, caplog, sleeps
     ):
         dead = _FakeConn(
             execute_error=psycopg2.OperationalError("server closed the connection")
@@ -588,9 +537,8 @@ class TestClaimBatchRetry:
         monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
 
         with caplog.at_level("WARNING"):
-            claimed = claim_batch("exec-1", 0)
+            assert claim() is True  # authoritative answer taken from the retry
 
-        assert claimed is True  # authoritative answer taken from the retry
         assert dead.executes == 1 and healthy.executes == 1  # exactly one extra try
         assert dead.commits == 0  # the reaped attempt never committed
         assert dead.closed is True  # stale conn discarded
@@ -599,9 +547,11 @@ class TestClaimBatchRetry:
         assert sleeps == [pg_barrier._BARRIER_RETRY_BACKOFF_SECONDS]
         assert "execute failed on a cached connection" in caplog.text
 
-    def test_commit_phase_failure_is_not_retried(self, _clean_local, monkeypatch, sleeps):
-        # Ambiguous commit (server may have committed) → NOT retried, or a re-run
-        # could flip the claim and strand the barrier. Propagates; no reconnect.
+    def test_commit_phase_failure_is_not_retried(
+        self, claim, _clean_local, monkeypatch, sleeps
+    ):
+        # Ambiguous commit (server may have committed) → NOT retried; a re-run could
+        # flip the answer and strand. Propagates; no reconnect.
         conn = _FakeConn(
             commit_error=psycopg2.OperationalError("server closed during commit")
         )
@@ -612,12 +562,12 @@ class TestClaimBatchRetry:
             lambda **_k: pytest.fail("must not reconnect on a commit-phase failure"),
         )
         with pytest.raises(psycopg2.OperationalError):
-            claim_batch("exec-1", 0)
+            claim()
         assert conn.executes == 1 and conn.commits == 1  # tried once, no retry
         assert sleeps == []  # no backoff → no retry
 
     def test_fresh_conn_execute_failure_is_not_retried(
-        self, _clean_local, monkeypatch, sleeps
+        self, claim, _clean_local, monkeypatch, sleeps
     ):
         # A freshly-created connection failing is a real DB error, not an idle reap
         # (reused is False when _local.conn starts empty) → not retried.
@@ -625,25 +575,26 @@ class TestClaimBatchRetry:
         pg_barrier._local.conn = None  # → reused False
         monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: dead)
         with pytest.raises(psycopg2.OperationalError):
-            claim_batch("exec-1", 0)
+            claim()
         assert dead.executes == 1  # no retry
         assert sleeps == []
 
-    def test_second_conn_dead_failure_propagates(self, _clean_local, monkeypatch, sleeps):
+    def test_second_conn_dead_failure_propagates(
+        self, claim, _clean_local, monkeypatch, sleeps
+    ):
         # Retry is bounded to ONE: a cached reap retries onto a fresh conn that also
         # dies → propagate (don't loop, don't hit the AssertionError fall-through).
-        # Pins the boundary that `attempt < _BARRIER_WRITE_ATTEMPTS` enforces.
         dead1 = _FakeConn(execute_error=psycopg2.OperationalError("reaped"))
         dead2 = _FakeConn(execute_error=psycopg2.OperationalError("still down"))
         pg_barrier._local.conn = dead1  # cached → reused
         monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: dead2)
         with pytest.raises(psycopg2.OperationalError):
-            claim_batch("exec-1", 0)
+            claim()
         assert dead1.executes == 1 and dead2.executes == 1  # exactly one retry
         assert sleeps == [pg_barrier._BARRIER_RETRY_BACKOFF_SECONDS]
 
     def test_non_connection_execute_error_on_reused_conn_not_retried(
-        self, _clean_local, monkeypatch, sleeps
+        self, claim, _clean_local, monkeypatch, sleeps
     ):
         # The `conn_dead` conjunct is the only guard against retrying a real SQL
         # error on a cached conn — a regression dropping it would silently re-run a
@@ -656,12 +607,12 @@ class TestClaimBatchRetry:
             lambda **_k: pytest.fail("must not reconnect on a non-connection error"),
         )
         with pytest.raises(psycopg2.DataError):
-            claim_batch("exec-1", 0)
+            claim()
         assert bad.executes == 1  # no retry
         assert sleeps == []
 
     def test_retry_returns_the_lost_answer_authoritatively(
-        self, _clean_local, monkeypatch, sleeps
+        self, claim, _clean_local, monkeypatch, sleeps
     ):
         # The "win/LOST answer is authoritative" half: after a reaped-conn retry, a
         # fresh conn whose RETURNING yields no row → claim already held → returns
@@ -670,7 +621,7 @@ class TestClaimBatchRetry:
         healthy = _FakeConn(fetchone_result=None)  # ON CONFLICT DO NOTHING: no row
         pg_barrier._local.conn = dead
         monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
-        assert claim_batch("exec-1", 0) is False  # authoritative "lost" from retry
+        assert claim() is False  # authoritative "lost" from the retry
         assert healthy.commits == 1
 
 

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -139,13 +139,21 @@ class TestEnqueueShortCircuits:
 # --- Idempotent-write reconnect-retry (no DB) ---
 
 
+_UNSET = object()
+
+
 class _FakeCursorCtx:
-    def __init__(self, on_execute):
+    def __init__(self, on_execute, fetchone_result=_UNSET):
         self._on_execute = on_execute
+        self._fetchone_result = fetchone_result
 
     def __enter__(self):
         cur = MagicMock(name="cursor")
         cur.execute.side_effect = self._on_execute
+        # Default (unset): fetchone() returns a truthy MagicMock (claim won). Pass
+        # fetchone_result=None to exercise the "lost" answer (claim already held).
+        if self._fetchone_result is not _UNSET:
+            cur.fetchone.return_value = self._fetchone_result
         return cur
 
     def __exit__(self, *exc):
@@ -159,10 +167,11 @@ class _FakeConn:
     the ambiguous "reaped during commit" case the decrement must NOT retry.
     """
 
-    def __init__(self, *, execute_error=None, commit_error=None):
+    def __init__(self, *, execute_error=None, commit_error=None, fetchone_result=_UNSET):
         self.closed = False
         self._execute_error = execute_error
         self._commit_error = commit_error
+        self._fetchone_result = fetchone_result
         self.commits = 0
         self.rollbacks = 0
         self.executes = 0
@@ -173,7 +182,7 @@ class _FakeConn:
             if self._execute_error is not None:
                 raise self._execute_error
 
-        return _FakeCursorCtx(_on_execute)
+        return _FakeCursorCtx(_on_execute, self._fetchone_result)
 
     def commit(self):
         self.commits += 1
@@ -551,14 +560,15 @@ class TestClaimOrchestrationRetry:
 
 
 class TestClaimBatchRetry:
-    """``claim_batch`` is a RETURNING claim, sibling to ``try_claim_orchestration``
-    one level up, so it self-heals ONLY the provably-safe case: an execute-phase
-    failure on a *cached* connection (the idle reap that stranded scheduled ETL
-    batches — the ~30-min-idle barrier connection past ``server_idle_timeout``; the
-    INSERT never committed, so the retry's claim answer is authoritative). A
-    commit-phase failure is ambiguous and a fresh-conn failure is a real error —
-    neither is retried, else a claim could flip ``True``→``False`` and strand the
-    barrier (or double-decrement).
+    """``claim_batch`` is a RETURNING claim (via the shared
+    ``_run_returning_claim_with_reconnect``), so it self-heals ONLY the
+    provably-safe case: an execute-phase failure on a *cached* connection — the idle
+    reap that stranded scheduled ETL batches (UN-3684: a barrier connection idle
+    ~30 min between pipeline runs, past ``server_idle_timeout``; the INSERT never
+    committed, so the retry's claim answer is authoritative). NOT retried, for two
+    distinct reasons: a **commit-phase** failure is ambiguous — a re-run could flip
+    ``True``→``False`` and strand the barrier; a **fresh-conn** failure is a real DB
+    error — reconnecting buys nothing.
     """
 
     @pytest.fixture
@@ -618,6 +628,50 @@ class TestClaimBatchRetry:
             claim_batch("exec-1", 0)
         assert dead.executes == 1  # no retry
         assert sleeps == []
+
+    def test_second_conn_dead_failure_propagates(self, _clean_local, monkeypatch, sleeps):
+        # Retry is bounded to ONE: a cached reap retries onto a fresh conn that also
+        # dies → propagate (don't loop, don't hit the AssertionError fall-through).
+        # Pins the boundary that `attempt < _BARRIER_WRITE_ATTEMPTS` enforces.
+        dead1 = _FakeConn(execute_error=psycopg2.OperationalError("reaped"))
+        dead2 = _FakeConn(execute_error=psycopg2.OperationalError("still down"))
+        pg_barrier._local.conn = dead1  # cached → reused
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: dead2)
+        with pytest.raises(psycopg2.OperationalError):
+            claim_batch("exec-1", 0)
+        assert dead1.executes == 1 and dead2.executes == 1  # exactly one retry
+        assert sleeps == [pg_barrier._BARRIER_RETRY_BACKOFF_SECONDS]
+
+    def test_non_connection_execute_error_on_reused_conn_not_retried(
+        self, _clean_local, monkeypatch, sleeps
+    ):
+        # The `conn_dead` conjunct is the only guard against retrying a real SQL
+        # error on a cached conn — a regression dropping it would silently re-run a
+        # DataError. Pin: reused conn, non-conn error → NOT retried.
+        bad = _FakeConn(execute_error=psycopg2.DataError("invalid byte 0x00"))
+        pg_barrier._local.conn = bad  # cached → reused True
+        monkeypatch.setattr(
+            pg_barrier,
+            "create_pg_connection",
+            lambda **_k: pytest.fail("must not reconnect on a non-connection error"),
+        )
+        with pytest.raises(psycopg2.DataError):
+            claim_batch("exec-1", 0)
+        assert bad.executes == 1  # no retry
+        assert sleeps == []
+
+    def test_retry_returns_the_lost_answer_authoritatively(
+        self, _clean_local, monkeypatch, sleeps
+    ):
+        # The "win/LOST answer is authoritative" half: after a reaped-conn retry, a
+        # fresh conn whose RETURNING yields no row → claim already held → returns
+        # False (not the truthy MagicMock default the happy-path test can only see).
+        dead = _FakeConn(execute_error=psycopg2.OperationalError("reaped"))
+        healthy = _FakeConn(fetchone_result=None)  # ON CONFLICT DO NOTHING: no row
+        pg_barrier._local.conn = dead
+        monkeypatch.setattr(pg_barrier, "create_pg_connection", lambda **_k: healthy)
+        assert claim_batch("exec-1", 0) is False  # authoritative "lost" from retry
+        assert healthy.commits == 1
 
 
 class TestReleaseOrchestrationClaimRetry:


### PR DESCRIPTION
## What & why

Scheduled ETL executions on the PG queue intermittently **stranded for ~2.5h** and then got reaper-marked **ERROR** (`[reaper-recovery] … barrier expired`). Root cause (confirmed via GCP logs + DB + code): the `pg_barrier` module's **thread-local DB connection sits idle between infrequent scheduled batches** — a pipeline fires one only ~every 30 min, past PgBouncer's `server_idle_timeout`. The server reaps it; the next batch's `claim_batch` runs its `INSERT … RETURNING` on the **stale handle** → `server closed the connection unexpectedly` (execute phase — nothing committed). `claim_batch` was on plain `_cursor()` with **no reconnect-retry**, so it failed outright; the batch never started, and (fileproc `vt` ≈ reaper timeout ≈ 2.5h, no fast retry) it stranded until the reaper.

This is the **idle-reap connection-resilience family** (UN-3654/3651/3659/3660) — `claim_batch` is the one member that never got hardened. Its sibling one level up, `try_claim_orchestration`, already implements the correct pattern.

## Change

Give `claim_batch` the same **execute-phase reconnect-retry** as `try_claim_orchestration` (phase-split):

| Failure | Behavior | Why safe |
|---|---|---|
| **reused-conn, execute-phase** (the idle-reap) | reconnect + retry once | the INSERT never committed → the retry's `RETURNING` claim answer is authoritative |
| **commit-phase** (ambiguous) | **not** retried, propagates | a re-run could flip the claim (`True`→`False` → skip-and-strand, or re-claim → double-decrement) |
| **fresh-conn** failure | **not** retried, propagates | a real DB error, not a reap |

An idle-reaped batch connection now self-heals in ~0.5s at claim time — the batch starts on first delivery, **no 2.5h strand, the reaper never involved.**

## Tests
`TestClaimBatchRetry`: execute-phase reaped-cached-conn retries once and returns the authoritative claim; commit-phase failure is **not** retried; fresh-conn failure is **not** retried. Full `pg_barrier` suite: **91 passed**.

## Considered and dropped
A consumer-side fast-redeliver + dedicated conn-death budget. `claim_batch`'s dedup marker is an at-most-once gate, so it can't recover a *post-claim* strand anyway — this fix covers 100% of the observed failure (idle-reap at the claim) with far less risk. Revisit only if strands persist after this.

## Remaining before ready
Dev-test against the running stack: let a scheduled ETL run after an idle gap (or bounce PgBouncer to force a reap); confirm the `claim_batch(...): execute failed on a cached connection — reconnecting` warning fires and the execution **COMPLETES** instead of stranding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
