### PR TITLE
UN-3690 [FIX] PG scheduler — recompute next_run_at on cron edit (Beat parity)

### DIFF
--- a/backend/scheduler/tasks.py
+++ b/backend/scheduler/tasks.py
@@ -34,6 +34,49 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _retargeted_next_run_at(pipeline_id: str, cron_string: str) -> datetime | None:
+    """The ``next_run_at`` a cron EDIT should set for Beat parity, or ``None`` to
+    leave it as the PG scheduler's baseline owns it.
+
+    Returns a recomputed next-match ONLY when ``cron_string`` differs from an
+    already-baselined mirror row (``next_run_at`` set). Returns ``None`` for a
+    brand-new row (no mirror yet) and a not-yet-baselined one (``next_run_at``
+    NULL) so the scheduler's no-burst baseline records the first next-time.
+
+    Fully guarded on purpose: this is an OPTIONAL enhancement over the mandatory
+    ``cron_string``/``enabled`` mirror write, so a read failure, a ``None``/invalid
+    cron (normally rejected upstream by ``PipelineSerializer.validate_cron_string``
+    in ``pipeline_v2``), or a croniter error must degrade to ``None`` — never take
+    the base mirror write down with it.
+    """
+    try:
+        existing = (
+            PgPeriodicSchedule.objects.filter(pipeline_id=pipeline_id)
+            .values("cron_string", "next_run_at")
+            .first()
+        )
+        if (
+            existing is None
+            or existing["next_run_at"] is None
+            or existing["cron_string"] == cron_string
+        ):
+            return None
+        return croniter(cron_string, timezone.now()).get_next(datetime)
+    except Exception as exc:
+        # Log the ACTUAL cause (bad read; cron=None → AttributeError;
+        # CroniterBadCronError / CroniterBadDateError; a croniter API change) — a
+        # generic "could not recompute" is a dead end when debugging a stale fire.
+        logger.warning(
+            "pg_periodic_schedule: could not retarget next_run_at for pipeline %s "
+            "(cron %r): %s",
+            pipeline_id,
+            cron_string,
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
 def mirror_periodic_schedule_upsert(
     *,
     pipeline_id: str,
@@ -44,46 +87,26 @@ def mirror_periodic_schedule_upsert(
     enabled: bool,
 ) -> None:
     try:
-        defaults: dict = {
+        defaults: dict[str, Any] = {
             "organization_id": organization_id or "",
             "workflow_id": workflow_id or None,
             "pipeline_name": pipeline_name or "",
             "cron_string": cron_string,
             "enabled": enabled,
         }
-        # Beat parity: when the cron CHANGES on an already-baselined row
-        # (next_run_at set), retarget next_run_at to the new cron's next match so
-        # the edit takes effect this cycle. The PG scheduler fires on the
-        # materialised next_run_at; Beat instead recomputes due-ness live from the
-        # crontab each tick, so without this the pipeline fires once more at the
-        # STALE old-cron time and the edit is ignored for a cycle (UN-3690).
-        # Deliberately left untouched (NULL) for a brand-new row — the scheduler's
-        # no-burst baseline is correct there (a new schedule fires at its next
-        # match) — and for a Beat→PG hand-over, where ownership nulls it.
-        existing = (
-            PgPeriodicSchedule.objects.filter(pipeline_id=pipeline_id)
-            .values("cron_string", "next_run_at")
-            .first()
-        )
-        if (
-            existing is not None
-            and existing["next_run_at"] is not None
-            and existing["cron_string"] != cron_string
-        ):
-            try:
-                defaults["next_run_at"] = croniter(cron_string, timezone.now()).get_next(
-                    datetime
-                )
-            except Exception:
-                # Unparseable cron (should be caught by the serializer's validation
-                # upstream) — leave next_run_at stale rather than block the mirror;
-                # the scheduler quiesces a bad cron on its own tick.
-                logger.warning(
-                    "pg_periodic_schedule: could not recompute next_run_at for "
-                    "pipeline %s (cron %r) — leaving the existing value",
-                    pipeline_id,
-                    cron_string,
-                )
+        # Beat parity: a cron EDIT on an already-baselined row must retarget
+        # next_run_at to the new cron's next match, else the PG scheduler fires
+        # once more at the STALE old-cron time — Beat has no such staleness, it
+        # recomputes due-ness live from the crontab each tick (UN-3690). Left
+        # untouched (NULL) for a brand-new row — the scheduler's no-burst baseline
+        # is correct there (a new schedule fires at its next match) — and for a
+        # Beat→PG hand-over, where next_run_at is already NULL (never set while
+        # Beat-owned; ownership clears it only on rollback to Beat, see
+        # reconcile_ownership_for). Computed via a fully-guarded helper so it can
+        # never take down the mandatory cron_string/enabled mirror write below.
+        next_run_at = _retargeted_next_run_at(pipeline_id, cron_string)
+        if next_run_at is not None:
+            defaults["next_run_at"] = next_run_at
         PgPeriodicSchedule.objects.update_or_create(
             pipeline_id=pipeline_id,
             defaults=defaults,

--- a/backend/scheduler/tasks.py
+++ b/backend/scheduler/tasks.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import traceback
+from datetime import datetime
 from typing import Any
 
 from celery import shared_task
+from croniter import croniter
 from django.db import transaction
 from django.utils import timezone
 from django_celery_beat.models import CrontabSchedule, PeriodicTask
@@ -42,15 +44,49 @@ def mirror_periodic_schedule_upsert(
     enabled: bool,
 ) -> None:
     try:
+        defaults: dict = {
+            "organization_id": organization_id or "",
+            "workflow_id": workflow_id or None,
+            "pipeline_name": pipeline_name or "",
+            "cron_string": cron_string,
+            "enabled": enabled,
+        }
+        # Beat parity: when the cron CHANGES on an already-baselined row
+        # (next_run_at set), retarget next_run_at to the new cron's next match so
+        # the edit takes effect this cycle. The PG scheduler fires on the
+        # materialised next_run_at; Beat instead recomputes due-ness live from the
+        # crontab each tick, so without this the pipeline fires once more at the
+        # STALE old-cron time and the edit is ignored for a cycle (UN-3690).
+        # Deliberately left untouched (NULL) for a brand-new row — the scheduler's
+        # no-burst baseline is correct there (a new schedule fires at its next
+        # match) — and for a Beat→PG hand-over, where ownership nulls it.
+        existing = (
+            PgPeriodicSchedule.objects.filter(pipeline_id=pipeline_id)
+            .values("cron_string", "next_run_at")
+            .first()
+        )
+        if (
+            existing is not None
+            and existing["next_run_at"] is not None
+            and existing["cron_string"] != cron_string
+        ):
+            try:
+                defaults["next_run_at"] = croniter(cron_string, timezone.now()).get_next(
+                    datetime
+                )
+            except Exception:
+                # Unparseable cron (should be caught by the serializer's validation
+                # upstream) — leave next_run_at stale rather than block the mirror;
+                # the scheduler quiesces a bad cron on its own tick.
+                logger.warning(
+                    "pg_periodic_schedule: could not recompute next_run_at for "
+                    "pipeline %s (cron %r) — leaving the existing value",
+                    pipeline_id,
+                    cron_string,
+                )
         PgPeriodicSchedule.objects.update_or_create(
             pipeline_id=pipeline_id,
-            defaults={
-                "organization_id": organization_id or "",
-                "workflow_id": workflow_id or None,
-                "pipeline_name": pipeline_name or "",
-                "cron_string": cron_string,
-                "enabled": enabled,
-            },
+            defaults=defaults,
         )
     except Exception:
         logger.exception(

--- a/backend/scheduler/tests/test_pg_periodic_schedule_mirror.py
+++ b/backend/scheduler/tests/test_pg_periodic_schedule_mirror.py
@@ -13,8 +13,6 @@ from datetime import datetime
 from datetime import timezone as dt_timezone
 from unittest.mock import MagicMock, patch
 
-from croniter import croniter
-
 from scheduler import tasks
 from scheduler.helper import SchedulerHelper
 
@@ -28,10 +26,18 @@ class _DoesNotExist(Exception):
     """Stand-in for PeriodicTask.DoesNotExist when the model is mocked."""
 
 
+def _stub_existing_row(sched, row=None):
+    """Stub the ``.filter().values().first()`` read of the existing mirror row
+    (``None`` = no row yet). The one place the read shape lives, so a change to how
+    the code reads the row (e.g. ``.only()`` instead of ``.values()``) is a
+    one-line edit here."""
+    sched.objects.filter.return_value.values.return_value.first.return_value = row
+
+
 class TestUpsertMirror:
     def test_upserts_with_given_fields(self):
         with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
-            sched.objects.filter.return_value.values.return_value.first.return_value = None
+            _stub_existing_row(sched)
             tasks.mirror_periodic_schedule_upsert(
                 pipeline_id=_PIPELINE_ID,
                 organization_id=_ORG,
@@ -51,7 +57,7 @@ class TestUpsertMirror:
 
     def test_disabled_pipeline_mirrors_enabled_false(self):
         with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
-            sched.objects.filter.return_value.values.return_value.first.return_value = None
+            _stub_existing_row(sched)
             tasks.mirror_periodic_schedule_upsert(
                 pipeline_id=_PIPELINE_ID,
                 organization_id=_ORG,
@@ -64,7 +70,7 @@ class TestUpsertMirror:
 
     def test_failure_is_swallowed(self):
         with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
-            sched.objects.filter.return_value.values.return_value.first.return_value = None
+            _stub_existing_row(sched)
             sched.objects.update_or_create.side_effect = RuntimeError("db down")
             # Must not raise.
             tasks.mirror_periodic_schedule_upsert(
@@ -89,10 +95,11 @@ class TestUpsertNextRunRecompute:
 
     @staticmethod
     def _mock_existing(sched, *, cron_string, next_run_at):
-        sched.objects.filter.return_value.values.return_value.first.return_value = (
-            {"cron_string": cron_string, "next_run_at": next_run_at}
-            if cron_string is not None
-            else None
+        _stub_existing_row(
+            sched,
+            None
+            if cron_string is None
+            else {"cron_string": cron_string, "next_run_at": next_run_at},
         )
 
     @staticmethod
@@ -118,10 +125,11 @@ class TestUpsertNextRunRecompute:
         ):
             self._mock_existing(sched, cron_string="0 9 * * *", next_run_at=self._OLD)
             self._upsert("0 10 * * *")  # edited to a new time
-        # recomputed from the NEW cron + now (not the stale 09:00)
-        assert self._defaults(sched)["next_run_at"] == croniter(
-            "0 10 * * *", now
-        ).get_next(datetime)
+        defaults = self._defaults(sched)
+        # Assert the concrete constant (not a croniter self-echo) — pins both the
+        # value AND tz-awareness: the next 10:00 UTC after 08:00, off the NEW cron.
+        assert defaults["next_run_at"] == datetime(2026, 1, 1, 10, 0, tzinfo=dt_timezone.utc)
+        assert defaults["cron_string"] == "0 10 * * *"  # retarget ships with new cron
 
     def test_unchanged_cron_leaves_next_run_at_untouched(self):
         with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
@@ -150,6 +158,17 @@ class TestUpsertNextRunRecompute:
             self._mock_existing(sched, cron_string="0 9 * * *", next_run_at=self._OLD)
             self._upsert("not a cron")
         assert sched.objects.update_or_create.called
+        assert "next_run_at" not in self._defaults(sched)
+
+    def test_read_failure_degrades_to_plain_upsert(self):
+        # The optional next_run_at recompute must NEVER take down the mandatory
+        # cron_string/enabled mirror write: a failure in the existing-row read
+        # degrades to exactly the pre-PR behaviour (plain upsert, no next_run_at)
+        # and never raises (the "never break Beat" guarantee) — UN-3690.
+        with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            sched.objects.filter.side_effect = RuntimeError("db down")
+            self._upsert("0 10 * * *")  # must not raise
+        assert sched.objects.update_or_create.called  # base mirror write still ran
         assert "next_run_at" not in self._defaults(sched)
 
 

--- a/backend/scheduler/tests/test_pg_periodic_schedule_mirror.py
+++ b/backend/scheduler/tests/test_pg_periodic_schedule_mirror.py
@@ -9,7 +9,11 @@ path — without a test database.
 """
 
 from contextlib import nullcontext
+from datetime import datetime
+from datetime import timezone as dt_timezone
 from unittest.mock import MagicMock, patch
+
+from croniter import croniter
 
 from scheduler import tasks
 from scheduler.helper import SchedulerHelper
@@ -27,6 +31,7 @@ class _DoesNotExist(Exception):
 class TestUpsertMirror:
     def test_upserts_with_given_fields(self):
         with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            sched.objects.filter.return_value.values.return_value.first.return_value = None
             tasks.mirror_periodic_schedule_upsert(
                 pipeline_id=_PIPELINE_ID,
                 organization_id=_ORG,
@@ -46,6 +51,7 @@ class TestUpsertMirror:
 
     def test_disabled_pipeline_mirrors_enabled_false(self):
         with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            sched.objects.filter.return_value.values.return_value.first.return_value = None
             tasks.mirror_periodic_schedule_upsert(
                 pipeline_id=_PIPELINE_ID,
                 organization_id=_ORG,
@@ -58,6 +64,7 @@ class TestUpsertMirror:
 
     def test_failure_is_swallowed(self):
         with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            sched.objects.filter.return_value.values.return_value.first.return_value = None
             sched.objects.update_or_create.side_effect = RuntimeError("db down")
             # Must not raise.
             tasks.mirror_periodic_schedule_upsert(
@@ -68,6 +75,82 @@ class TestUpsertMirror:
                 cron_string="0 9 * * *",
                 enabled=True,
             )
+
+
+class TestUpsertNextRunRecompute:
+    """UN-3690 — a cron EDIT must retarget ``next_run_at`` (Beat parity), so the
+    new time takes effect this cycle instead of the pipeline firing once more at
+    the stale old-cron time. Only for an already-baselined row: a fresh row and a
+    Beat→PG hand-over keep ``next_run_at`` NULL for the scheduler's no-burst
+    baseline.
+    """
+
+    _OLD = datetime(2026, 1, 1, 9, 0, tzinfo=dt_timezone.utc)
+
+    @staticmethod
+    def _mock_existing(sched, *, cron_string, next_run_at):
+        sched.objects.filter.return_value.values.return_value.first.return_value = (
+            {"cron_string": cron_string, "next_run_at": next_run_at}
+            if cron_string is not None
+            else None
+        )
+
+    @staticmethod
+    def _upsert(cron):
+        tasks.mirror_periodic_schedule_upsert(
+            pipeline_id=_PIPELINE_ID,
+            organization_id=_ORG,
+            workflow_id=_WORKFLOW_ID,
+            pipeline_name=_REAL_NAME,
+            cron_string=cron,
+            enabled=True,
+        )
+
+    @staticmethod
+    def _defaults(sched):
+        return sched.objects.update_or_create.call_args.kwargs["defaults"]
+
+    def test_cron_change_on_baselined_row_retargets_next_run_at(self):
+        now = datetime(2026, 1, 1, 8, 0, tzinfo=dt_timezone.utc)
+        with (
+            patch("scheduler.tasks.PgPeriodicSchedule") as sched,
+            patch("scheduler.tasks.timezone.now", return_value=now),
+        ):
+            self._mock_existing(sched, cron_string="0 9 * * *", next_run_at=self._OLD)
+            self._upsert("0 10 * * *")  # edited to a new time
+        # recomputed from the NEW cron + now (not the stale 09:00)
+        assert self._defaults(sched)["next_run_at"] == croniter(
+            "0 10 * * *", now
+        ).get_next(datetime)
+
+    def test_unchanged_cron_leaves_next_run_at_untouched(self):
+        with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            self._mock_existing(sched, cron_string="0 9 * * *", next_run_at=self._OLD)
+            self._upsert("0 9 * * *")  # same cron (e.g. a rename)
+        assert "next_run_at" not in self._defaults(sched)
+
+    def test_null_next_run_at_left_for_baseline(self):
+        # Not-yet-baselined row (fresh mirror / Beat→PG hand-over) → keep NULL so
+        # the scheduler baseline records the first next-time (no double-retarget).
+        with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            self._mock_existing(sched, cron_string="0 9 * * *", next_run_at=None)
+            self._upsert("0 10 * * *")
+        assert "next_run_at" not in self._defaults(sched)
+
+    def test_new_row_does_not_set_next_run_at(self):
+        with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            self._mock_existing(sched, cron_string=None, next_run_at=None)  # → None
+            self._upsert("0 10 * * *")
+        assert "next_run_at" not in self._defaults(sched)
+
+    def test_invalid_cron_leaves_stale_next_run_at_but_still_upserts(self):
+        # An unparseable cron must not block the mirror write; next_run_at is left
+        # as-is (the scheduler quiesces a bad cron on its own tick).
+        with patch("scheduler.tasks.PgPeriodicSchedule") as sched:
+            self._mock_existing(sched, cron_string="0 9 * * *", next_run_at=self._OLD)
+            self._upsert("not a cron")
+        assert sched.objects.update_or_create.called
+        assert "next_run_at" not in self._defaults(sched)
 
 
 class TestHelperWiringSourcesRealName:


### PR DESCRIPTION
## UN-3690 — PG scheduler: recompute `next_run_at` on cron edit (Beat parity)

### Problem
Editing a `pg_owned` pipeline's schedule time didn't take effect until one stale cycle — the pipeline fired once more at the **old** cron's `next_run_at`, ignoring the new time.

Confirmed on integration via GCP logs (pipeline `438ac6d8`): baselined to `04:00` off the original `0 * * * *`; edits to `12`/`52`/`58` were ignored; it fired at the **stale** `04:00`, and only then recomputed the next one off the new cron.

### Root cause
`mirror_periodic_schedule_upsert` upserts `cron_string` but **never touches `next_run_at`** — which the PG scheduler fires on. Celery Beat has no such staleness: it recomputes due-ness live from the crontab each tick, so an edit takes effect within one beat interval. So this is a **PG-only, flag-gated (`pg_owned`) Beat-parity regression** — not present on staging/prod (still Beat).

### Fix
When the cron **changes** on an **already-baselined** row (`next_run_at IS NOT NULL`), retarget `next_run_at` to the new cron's next match. Deliberately left untouched (NULL) for:
- a **brand-new** row — the scheduler's no-burst baseline is correct (a new schedule fires at its next match);
- a **Beat→PG hand-over** — ownership nulls it.

The `next_run_at IS NOT NULL` guard means the branch only ever fires for a row the PG scheduler has already baselined — i.e. an actively PG-owned schedule — so **Celery-only rows are never touched**. Still best-effort (swallowed on error) and never touches the Beat `PeriodicTask`/`CrontabSchedule`.

### Testing
- **5 new mirror unit tests**: retarget-on-change, no-touch-when-cron-unchanged, NULL-left-for-baseline, new-row-no-set, invalid-cron-still-upserts. Existing mirror suite green (17 total).
- **Real-DB dev-test** (sqlite in-memory, hard-guarded off the real DB): exercised the actual function end-to-end (real ORM + croniter + model) — all 5 scenarios pass, including the Celery-untouched (`NULL` stays `NULL`) property.

### Live confirm after deploy
Edit a `pg_owned` pipeline's cron → `pg_periodic_schedule.next_run_at` reflects the new cron's next match immediately, and it fires at the intended minute (no stale cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
