### PR TITLE
UN-3693 [FIX] PG — Prompt Studio task_status resolves from pg_task_result (consumer-writes)

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/tests/test_task_status.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/tests/test_task_status.py
@@ -1,0 +1,104 @@
+"""UN-3693: PromptStudioCoreView.task_status — flag-gated.
+
+Gate on the per-org ``pg_queue_enabled`` flag (the same the executor dispatch uses):
+flag ON → read ``pg_task_result`` (completed / failed / none→processing); flag OFF
+(default) → Celery ``AsyncResult`` unchanged, and the PG table is never queried on
+the hot poll path. ``check_feature_flag_status`` already fails closed to ``False`` on
+any Flipt error, so "flag off / Flipt down" is one path. A transient PG DB error
+degrades to "processing", not a bare 500.
+
+NOTE: run via a Django-bootstrapped harness (no pytest-django in this repo yet — the
+CI-gating of these view tests is tracked in UN-3692). Verified locally green.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from prompt_studio.prompt_studio_core_v2.views import PromptStudioCoreView
+
+_VIEWS = "prompt_studio.prompt_studio_core_v2.views"
+_TID = "task-abc"
+
+
+def _view():
+    view = PromptStudioCoreView()
+    view.get_object = MagicMock()  # bypass permission/object lookup
+    return view
+
+
+def _flag(enabled):
+    return patch(f"{_VIEWS}.check_feature_flag_status", return_value=enabled)
+
+
+def _org():
+    return patch(f"{_VIEWS}.UserSessionUtils.get_organization_id", return_value="org1")
+
+
+def _stub_pg(pg_row=None, *, error=None):
+    """Patch pg_task_result read: .filter().values().first() → pg_row, or raise."""
+    m = MagicMock()
+    if error is not None:
+        m.objects.filter.side_effect = error
+    else:
+        m.objects.filter.return_value.values.return_value.first.return_value = pg_row
+    return patch("pg_queue.models.PgTaskResult", m), m
+
+
+def _async(ready, successful=True, result=""):
+    ar = MagicMock()
+    ar.return_value.ready.return_value = ready
+    ar.return_value.successful.return_value = successful
+    ar.return_value.result = result
+    return ar
+
+
+class TestTaskStatusFlagOn:
+    def test_pg_completed(self):
+        p_pg, _ = _stub_pg({"status": "completed", "error": ""})
+        with _org(), _flag(True), p_pg:
+            resp = _view().task_status(MagicMock(), task_id=_TID)
+        assert resp.data == {"task_id": _TID, "status": "completed"}
+
+    def test_pg_failed(self):
+        p_pg, _ = _stub_pg({"status": "failed", "error": "extraction blew up"})
+        with _org(), _flag(True), p_pg:
+            resp = _view().task_status(MagicMock(), task_id=_TID)
+        assert resp.data["status"] == "failed"
+        assert resp.data["error"] == "extraction blew up"
+        assert resp.status_code == 500
+
+    def test_no_pg_row_is_processing(self):
+        p_pg, _ = _stub_pg(None)  # PG task not done yet — no "pending" row
+        with _org(), _flag(True), p_pg:
+            resp = _view().task_status(MagicMock(), task_id=_TID)
+        assert resp.data == {"task_id": _TID, "status": "processing"}
+
+    def test_pg_db_error_degrades_to_processing(self):
+        # A transient PG read error must not 500; degrade to "processing".
+        p_pg, _ = _stub_pg(error=RuntimeError("db blip"))
+        with _org(), _flag(True), p_pg:
+            resp = _view().task_status(MagicMock(), task_id=_TID)
+        assert resp.data == {"task_id": _TID, "status": "processing"}
+
+
+class TestTaskStatusFlagOff:
+    def test_celery_completed_never_queries_pg(self):
+        # flag off (also the Flipt-error fail-closed path): Celery + PG untouched.
+        p_pg, pg = _stub_pg({"status": "completed"})  # would resolve, if queried
+        with _org(), _flag(False), p_pg, patch(f"{_VIEWS}.AsyncResult", _async(ready=True)):
+            resp = _view().task_status(MagicMock(), task_id=_TID)
+        assert resp.data == {"task_id": _TID, "status": "completed"}
+        pg.objects.filter.assert_not_called()  # default path never touches PG
+
+    def test_celery_failed(self):
+        with _org(), _flag(False), patch(
+            f"{_VIEWS}.AsyncResult", _async(ready=True, successful=False, result="celery boom")
+        ):
+            resp = _view().task_status(MagicMock(), task_id=_TID)
+        assert resp.data["status"] == "failed"
+        assert "celery boom" in resp.data["error"]
+        assert resp.status_code == 500
+
+    def test_pending(self):
+        with _org(), _flag(False), patch(f"{_VIEWS}.AsyncResult", _async(ready=False)):
+            resp = _view().task_status(MagicMock(), task_id=_TID)
+        assert resp.data == {"task_id": _TID, "status": "processing"}

--- a/backend/prompt_studio/prompt_studio_core_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/views.py
@@ -19,6 +19,7 @@ from file_management.constants import FileInformationKey as FileKey
 from file_management.exceptions import FileNotFound
 from permissions.permission import IsOwner, IsOwnerOrSharedUserOrSharedToOrg
 from permissions.resource_share_views import ResourceShareManagementMixin
+from pg_queue.flags import PG_QUEUE_FLAG_KEY
 from pipeline_v2.models import Pipeline
 from plugins import get_plugin
 from rest_framework import status, viewsets
@@ -81,6 +82,8 @@ from prompt_studio.prompt_studio_registry_v2.serializers import (
 from prompt_studio.prompt_studio_v2.constants import ToolStudioPromptErrors
 from prompt_studio.prompt_studio_v2.models import ToolStudioPrompt
 from prompt_studio.prompt_studio_v2.serializers import ToolStudioPromptSerializer
+from unstract.core.data_models import PgTaskStatus
+from unstract.flags.feature_flag import check_feature_flag_status
 from unstract.sdk1.utils.common import Utils as CommonUtils
 
 from .models import CustomTool
@@ -872,6 +875,51 @@ class PromptStudioCoreView(ResourceShareManagementMixin, viewsets.ModelViewSet):
         """
         # Verify the user has access to this tool (triggers permission check)
         self.get_object()
+
+        # Gate on the same per-org ``pg_queue_enabled`` flag the executor dispatch
+        # uses (``resolve_pg_transport`` — bucketed per org): flag ON → the task rode
+        # PG, which records its terminal state in ``pg_task_result`` (the eager PG
+        # executor never writes a Celery result backend, so ``AsyncResult`` alone
+        # would poll "processing" forever — UN-3693); flag OFF (default) → Celery,
+        # unchanged, and PG is not touched. ``entity_id``/``context`` match
+        # ``resolve_pg_transport`` so the per-org bucket agrees with the dispatch.
+        # No wrapper: ``check_feature_flag_status`` already fails closed to ``False``
+        # (its own try/except + warning) on any Flipt error → reads as "off" → Celery.
+        org_id = str(UserSessionUtils.get_organization_id(request) or "")
+        pg_enabled = check_feature_flag_status(
+            flag_key=PG_QUEUE_FLAG_KEY,
+            entity_id=org_id or "default",
+            context={"organization_id": org_id},
+        )
+        if pg_enabled:
+            from pg_queue.models import PgTaskResult
+
+            try:
+                row = (
+                    PgTaskResult.objects.filter(task_id=task_id)
+                    .values("status", "error")
+                    .first()
+                )
+            except Exception:
+                # A transient DB blip degrades to "processing" (a poll retries) rather
+                # than a bare 500 that a status-code-keyed client would misread as a
+                # terminal task failure.
+                logger.exception(
+                    "task_status: pg_task_result read failed for %s; treating as "
+                    "pending",
+                    task_id,
+                )
+                row = None
+            # No row → not finished yet (there is no "pending" row). Status compared
+            # against PgTaskStatus (the writer's source of truth), not a bare literal.
+            if row is None:
+                return Response({"task_id": task_id, "status": "processing"})
+            if row["status"] == PgTaskStatus.COMPLETED.value:
+                return Response({"task_id": task_id, "status": "completed"})
+            return Response(
+                {"task_id": task_id, "status": "failed", "error": row["error"] or ""},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
         result = AsyncResult(task_id, app=celery_app)
         if not result.ready():

--- a/workers/queue_backend/pg_queue/consumer.py
+++ b/workers/queue_backend/pg_queue/consumer.py
@@ -70,6 +70,15 @@ _DEFAULT_POISON_REPARK_VT_SECONDS = 300
 # last net) after this many extra reads past max_attempts, so a permanently
 # unmarkable pipeline message can't re-park forever.
 _DEFAULT_POISON_REPARK_BUDGET = 5
+# Retention for the pg_task_result rows the REST task_status poll reads (UN-3693).
+# 24h (Celery's default result_expires) — the 1h default would expire a completed
+# task's row while a late poll (a browser resumed from sleep, an API client checking
+# back) is still querying it. Completed rows are status-only (no payload); FAILED rows
+# carry the executor error text, which can embed document content (cf. the _forget_sql
+# note in result_backend.py / UN-3683) — accepted at this horizon because that same
+# text is already shown to the owner via the WebSocket event + the task_status
+# response, and the row is TTL'd.
+_TASK_STATUS_RETENTION_SECONDS = 86400
 # Liveness: a poll loop that hasn't cycled in this many seconds is reported
 # unhealthy. The heartbeat is stamped at the top of each poll_once and frozen
 # during task execution, so this threshold doubles as an UPPER BOUND on a single
@@ -434,6 +443,56 @@ class PgQueueConsumer:
             self._result_backend = PgResultBackend()
         self._result_backend.store_result(reply_key, result=result, error=error)
 
+    def _record_task_status(
+        self, payload: TaskPayload, *, error: str | None, executor_result: object
+    ) -> None:
+        """Record a ``dispatch_with_callback`` task's terminal status in
+        ``pg_task_result`` so the REST ``PromptStudio.task_status`` poll resolves
+        under the PG transport (UN-3693) — the eager PG executor never writes a Celery
+        result backend under the dispatch id, so ``AsyncResult`` alone would poll
+        "processing" forever.
+
+        Keyed by the dispatch ``task_id``; ``completed`` unless the run raised
+        (``error`` set) or the executor reported an application failure
+        (``executor_result["success"]`` false). Status-only + PII-free (no payload
+        stored) + TTL'd. Best-effort — never raises, so it can't wedge the ack.
+        """
+        task_id = payload.get("task_id")
+        if not task_id:
+            return
+        executor_failed = isinstance(executor_result, dict) and not executor_result.get(
+            "success", True
+        )
+        try:
+            with PgResultBackend() as rb:
+                if error is not None or executor_failed:
+                    msg = (
+                        error
+                        or (
+                            executor_result.get("error")
+                            if isinstance(executor_result, dict)
+                            else None
+                        )
+                        or "Task failed"
+                    )
+                    rb.store_result(
+                        task_id,
+                        error=msg,
+                        retention_seconds=_TASK_STATUS_RETENTION_SECONDS,
+                    )
+                else:
+                    rb.store_result(
+                        task_id,
+                        result={},  # status-only → completed (PII-free)
+                        retention_seconds=_TASK_STATUS_RETENTION_SECONDS,
+                    )
+        except Exception:
+            logger.exception(
+                "PG-queue consumer: could not record pg_task_result status for task "
+                "%s — the REST task_status poll may report 'processing'",
+                task_id,
+            )
+
     def _chain_continuation(
         self,
         spec: ContinuationSpec,
@@ -467,6 +526,18 @@ class PgQueueConsumer:
         its user-facing WebSocket event — is lost, logged loud with the run/task/org
         so the stranded session is correlatable).
         """
+        # Record the terminal status for the REST PromptStudio.task_status poll
+        # (UN-3693) before the enqueue, so it resolves under PG even if the callback
+        # enqueue below fails. This self-chain is the single terminal choke point for
+        # both success (``error`` None) and failure (``error`` set) of a callback
+        # dispatch. The recorded status reflects the EXECUTOR outcome, not callback
+        # delivery: on a rare on_success-enqueue-failure ``_fail_dispatch`` re-enters
+        # here with on_error, but ``store_result`` is first-write-wins (ON CONFLICT DO
+        # NOTHING) so the "completed" already written stands — a REST poll then reads
+        # "completed" (the executor did succeed) even though the callback's socket
+        # event / bookkeeping was lost. Accepted (the browser also relies on that
+        # socket event, so this window is REST-poll-only and rare).
+        self._record_task_status(payload, error=error, executor_result=prepend)
         try:
             queue = spec["queue"]
             kwargs = dict(spec.get("kwargs") or {})

--- a/workers/tests/test_pg_queue_consumer.py
+++ b/workers/tests/test_pg_queue_consumer.py
@@ -978,3 +978,80 @@ class TestSelfChain:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestRecordTaskStatus:
+    """UN-3693: a dispatch_with_callback task's terminal status is recorded in
+    pg_task_result so the REST PromptStudio.task_status poll resolves under PG.
+    completed unless the run raised (error) or the executor reported success=False
+    (completed rows are status-only; failed rows carry the executor error text). TTL'd
+    + best-effort — never wedges the ack."""
+
+    _RB = "queue_backend.pg_queue.consumer.PgResultBackend"
+    _RET = 86400
+
+    @staticmethod
+    def _consumer(client=None):
+        return PgQueueConsumer(["q"], client=client or MagicMock())
+
+    @staticmethod
+    def _entered_rb(patched):  # object bound by `with PgResultBackend() as rb:`
+        return patched.return_value.__enter__.return_value
+
+    def test_success_records_completed(self):
+        with patch(self._RB) as RB:
+            self._consumer()._record_task_status(
+                {"task_id": "tid"}, error=None, executor_result={"success": True, "data": {}}
+            )
+        self._entered_rb(RB).store_result.assert_called_once_with(
+            "tid", result={}, retention_seconds=self._RET
+        )
+
+    def test_executor_reported_failure_records_failed(self):
+        with patch(self._RB) as RB:
+            self._consumer()._record_task_status(
+                {"task_id": "tid"}, error=None,
+                executor_result={"success": False, "error": "boom"},
+            )
+        self._entered_rb(RB).store_result.assert_called_once_with(
+            "tid", error="boom", retention_seconds=self._RET
+        )
+
+    def test_run_raised_records_failed(self):
+        with patch(self._RB) as RB:
+            self._consumer()._record_task_status(
+                {"task_id": "tid"}, error="RuntimeError: kaboom", executor_result="tid"
+            )
+        self._entered_rb(RB).store_result.assert_called_once_with(
+            "tid", error="RuntimeError: kaboom", retention_seconds=self._RET
+        )
+
+    def test_no_task_id_is_noop(self):
+        with patch(self._RB) as RB:
+            self._consumer()._record_task_status(
+                {}, error=None, executor_result={"success": True}
+            )
+        RB.assert_not_called()
+
+    def test_backend_error_is_swallowed(self):
+        with patch(self._RB) as RB:
+            RB.side_effect = RuntimeError("pg down")
+            self._consumer()._record_task_status(
+                {"task_id": "tid"}, error=None, executor_result={"success": True}
+            )  # must not raise
+
+    def test_chain_continuation_records_status_even_if_enqueue_fails(self):
+        # Single-site wiring: status is recorded before the enqueue, so a REST poll
+        # resolves even when the callback continuation is lost.
+        client = MagicMock()
+        client.send.side_effect = RuntimeError("enqueue down")
+        with patch(self._RB) as RB:
+            ok = self._consumer(client)._chain_continuation(
+                {"task_name": "cb.done", "queue": "ide_callback", "kwargs": {}},
+                prepend={"success": True},
+                payload={"task_id": "tid", "args": [{}]},
+            )
+        assert ok is False
+        self._entered_rb(RB).store_result.assert_called_once_with(
+            "tid", result={}, retention_seconds=self._RET
+        )

--- a/workers/tests/test_pg_result_backend.py
+++ b/workers/tests/test_pg_result_backend.py
@@ -66,6 +66,17 @@ class TestStoreGet:
         assert row["error"] == "boom"
         assert row["result"] is None
 
+    def test_store_empty_dict_result_is_completed(self, result_backend):
+        # UN-3693: ide-callback status-only writes pass result={} (a non-None empty
+        # dict). store_result must record COMPLETED (its `result is not None` check),
+        # not FAILED — an `if result:` regression would flip every successful PG
+        # prompt to failed with the REST task_status poll reading "failed".
+        k = _key()
+        result_backend.store_result(k, result={})
+        row = result_backend.get_result(k)
+        assert row["status"] == STATUS_COMPLETED
+        assert row["result"] == {}
+
     def test_absent_returns_none(self, result_backend):
         assert result_backend.get_result(_key()) is None
 


### PR DESCRIPTION
## UN-3693 — Prompt Studio `task_status` resolves from `pg_task_result` (consumer-writes, flag-gated)

### Problem
Under `pg_queue_enabled`, Prompt Studio's `dispatch_with_callback` tasks never register a Celery task, so the REST `task_status` endpoint (`AsyncResult` → `celery_taskmeta`) reported **`"processing"` forever** even though the work succeeded — hanging every REST-polling client. The flag-ON regression suite died at `createEtlProject` setup → **0 tests** (flag-OFF ran 208/17/23). Browser UI unaffected (Socket.IO event).

### Fix — PG-native, gated by the same per-org `pg_queue_enabled` flag the dispatch uses
- **Write (one site):** the PG consumer records the terminal status in **`pg_task_result`** from `_chain_continuation` — the single choke point for both success (`error=None`, executor result) and failure (`error` set) of a callback dispatch — keyed by the dispatch `task_id`. `completed` unless the run raised or the executor reported `success=False`; written **before** the enqueue (resolves even if the callback is lost); TTL 24h; best-effort (never wedges the ack). PG-only by construction.
- **Read (`task_status`):** flag **ON** → read `pg_task_result` (completed/failed/none→processing; DB-read guarded → a blip degrades to "processing", not a bare 500); flag **OFF** (default) → Celery `AsyncResult` **unchanged**, PG never queried.

**Clean table separation:** PG tasks live entirely in `pg_task_result`; Celery tasks entirely in `celery_taskmeta`; neither bleeds into the other. **No change to the Celery flow** (flag-off is the original `AsyncResult` code; `ide_callback` untouched).

_Note:_ completed rows are status-only (PII-free); failed rows carry the executor error text (already shown to the owner via the socket event + `task_status` response), TTL'd.

### Testing
Consumer: completed / executor-failed / run-raised / no-id / swallow / records-even-if-enqueue-fails. Backend flag-gate: on completed/failed/pending/DB-blip; off Celery + PG-untouched assertion. DB-gated `store_result(result={}) → completed` guard.

### Deploy
Touches backend + workers → next snapshot rebuilds both; then the flag-ON regression suite should clear `createEtlProject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
