### PR TITLE
UN-3699 [FIX] Fix runner DockerException with requests>=2.32 by bumping docker-py to 7.1.0

### DIFF
--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = { text = "MIT" }
 
 dependencies = [
-    "docker==6.1.3",
+    "docker==7.1.0",
     "flask~=3.1.3",
     "python-dotenv>=1.2.2",
     "redis~=5.2.1",

--- a/runner/uv.lock
+++ b/runner/uv.lock
@@ -146,18 +146,16 @@ wheels = [
 
 [[package]]
 name = "docker"
-version = "6.1.3"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "urllib3" },
-    { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/73/f7c9a14e88e769f38cb7fb45aa88dfd795faa8e18aea11bababf6e068d5e/docker-6.1.3.tar.gz", hash = "sha256:aa6d17830045ba5ef0168d5eaa34d37beeb113948c413affe1d5991fc11f9a20", size = 259301, upload-time = "2023-06-01T14:24:49.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/be/3032490fa33b36ddc8c4b1da3252c6f974e7133f1a50de00c6b85cca203a/docker-6.1.3-py3-none-any.whl", hash = "sha256:aecd2277b8bf8e506e484f6ab7aec39abe0038e29fa4a6d3ba86c3fe01844ed9", size = 148096, upload-time = "2023-06-01T14:24:47.769Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -910,7 +908,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "docker", specifier = "==6.1.3" },
+    { name = "docker", specifier = "==7.1.0" },
     { name = "flask", specifier = "~=3.1.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "redis", specifier = "~=5.2.1" },
@@ -952,15 +950,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Bump the runner's `docker` (docker-py) pin from `6.1.3` to `7.1.0` and regenerate `runner/uv.lock`.

## Why

- Any `runner` image rebuilt from current `main` on the Docker container-client path crashes at `DockerClient.from_env()` with:
  `docker.errors.DockerException: Error while fetching server API version: Not supported URL scheme http+docker`
- Root cause: docker-py `6.1.3` is incompatible with `requests>=2.32`. A dependabot bump raised the transitive `requests` to `2.33.0` (hard-pinned `==2.33.0` by `unstract-core`; also required `>=2.33.0` by `workers` / `x2text-service`). docker-py's `UnixHTTPAdapter` only overrides the old `get_connection`; requests 2.32+ walks `get_connection_with_tls_context`, so the internal `http+docker://` socket URL reaches urllib3 → `URLSchemeUnknown` → `InvalidURL`.
- Only surfaces on a Docker-socket runner rebuilt from source: cloud/k8s uses the Kubernetes container client and never calls `from_env()`; other devs run older published runner images baked with `requests<2.32`. It is a latent bug on `main` for anyone who rebuilds runner.
- Lowering `requests` is unsatisfiable (other services require `>=2.33.0`), so the fix bumps the stale consumer instead.

## How

- `runner/pyproject.toml`: `docker==6.1.3` → `docker==7.1.0`.
- `runner/uv.lock`: regenerated — docker updated; `websocket-client` drops out (it is now an optional docker extra and the runner uses no websocket features).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

- Low risk. The runner uses only stable high-level docker APIs (`containers.run` / `containers.get`, `images.get`, `api.pull`, `container.logs(follow=True)`), all unchanged in docker-py 7.x. It uses no `exec_run` / `attach` / websocket features, so dropping `websocket-client` is safe. The Kubernetes container-client path is untouched.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- docker-py 7.1.0 release notes (adds `requests>=2.32` compatibility).

## Related Issues or PRs

- UN-3699

## Dependencies Versions

- `docker` (docker-py): `6.1.3` → `7.1.0`

## Notes on Testing

- Verified `docker 7.1.0 + requests 2.33.0` → `DockerClient.from_env().ping() == True` against a real Docker socket; the runner boots and spawns tool containers again.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
