### PR TITLE
[MISC] Preserve view function identity in platform-service auth middleware

### DIFF
--- a/platform-service/src/unstract/platform_service/controller/platform.py
+++ b/platform-service/src/unstract/platform_service/controller/platform.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import uuid
 from datetime import datetime
@@ -33,6 +34,9 @@ def get_token_from_auth_header(request: Request) -> Any:
 
 
 def authentication_middleware(func: Any) -> Any:
+    # Flask names endpoints after the view's __name__; without wraps every
+    # decorated route registers as "wrapper" and collides.
+    @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         token = get_token_from_auth_header(request)
         # Check if bearer token exists and validate it
@@ -111,7 +115,7 @@ def validate_bearer_token(token: str | None) -> bool:
         return False
 
 
-@platform_bp.route("/page-usage", methods=["POST"], endpoint="page_usage")
+@platform_bp.route("/page-usage", methods=["POST"])
 @authentication_middleware
 def page_usage() -> Any:
     """Usage endpoint."""
@@ -262,11 +266,7 @@ def usage() -> Any:
         return make_response(result, 500)
 
 
-@platform_bp.route(
-    "/platform_details",
-    methods=["GET"],
-    endpoint="platform_details",
-)
+@platform_bp.route("/platform_details", methods=["GET"])
 @authentication_middleware
 def platform_details() -> Any:
     """Fetch details associated with the platform. This uses the authenticated
@@ -288,7 +288,7 @@ def platform_details() -> Any:
     return result, 200
 
 
-@platform_bp.route("/cache", methods=["POST", "GET", "DELETE"], endpoint="cache")
+@platform_bp.route("/cache", methods=["POST", "GET", "DELETE"])
 @authentication_middleware
 def cache() -> Any:
     """Cache endpoint.
@@ -348,11 +348,7 @@ def cache() -> Any:
     return "OK", 200
 
 
-@platform_bp.route(
-    "/adapter_instance",
-    methods=["GET"],
-    endpoint="adapter_instance",
-)
+@platform_bp.route("/adapter_instance", methods=["GET"])
 @authentication_middleware
 def adapter_instance() -> Any:
     """Fetch Adapter instance.
@@ -399,11 +395,7 @@ def adapter_instance() -> Any:
         raise APIError(message=msg)
 
 
-@platform_bp.route(
-    "/custom_tool_instance",
-    methods=["GET"],
-    endpoint="custom_tool_instance",
-)
+@platform_bp.route("/custom_tool_instance", methods=["GET"])
 @authentication_middleware
 def custom_tool_instance() -> Any:
     """Fetching exported custom tool instance.
@@ -438,11 +430,7 @@ def custom_tool_instance() -> Any:
         raise APIError(message=msg) from e
 
 
-@platform_bp.route(
-    "/agentic_tool_instance",
-    methods=["GET"],
-    endpoint="agentic_tool_instance",
-)
+@platform_bp.route("/agentic_tool_instance", methods=["GET"])
 @authentication_middleware
 def agentic_tool_instance() -> Any:
     """Fetching exported agentic tool instance.
@@ -479,11 +467,7 @@ def agentic_tool_instance() -> Any:
         raise APIError(message=msg) from e
 
 
-@platform_bp.route(
-    "/llm_profile_instance",
-    methods=["GET"],
-    endpoint="llm_profile_instance",
-)
+@platform_bp.route("/llm_profile_instance", methods=["GET"])
 @authentication_middleware
 def llm_profile_instance() -> Any:
     """Fetching llm profile instance."""

--- a/platform-service/tests/conftest.py
+++ b/platform-service/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# platform_service.env validates required settings at import time.
+os.environ.setdefault("REDIS_HOST", "localhost")
+os.environ.setdefault("ENCRYPTION_KEY", "test-key")
+os.environ.setdefault("DB_SCHEMA", "unstract")

--- a/platform-service/tests/test_auth_middleware.py
+++ b/platform-service/tests/test_auth_middleware.py
@@ -1,0 +1,58 @@
+"""Tests for bearer token validation used by `authentication_middleware`."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+from flask import Flask
+from unstract.platform_service.controller import platform
+
+
+@pytest.fixture
+def app_ctx() -> Iterator[None]:
+    """`validate_bearer_token` logs via `flask.current_app`."""
+    with Flask(__name__).app_context():
+        yield
+
+
+def _mock_safe_cursor(monkeypatch: pytest.MonkeyPatch, result_row: Any) -> None:
+    class _Cursor:
+        def fetchone(self) -> Any:
+            return result_row
+
+    @contextmanager
+    def _safe_cursor(query: str, params: tuple = ()) -> Iterator[_Cursor]:
+        yield _Cursor()
+
+    monkeypatch.setattr(platform, "safe_cursor", _safe_cursor)
+
+
+def test_valid_active_token(app_ctx: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_safe_cursor(monkeypatch, ("id", "test-token", True))
+    assert platform.validate_bearer_token("test-token") is True
+
+
+def test_rejects_missing_token(app_ctx: None) -> None:
+    assert platform.validate_bearer_token(None) is False
+
+
+def test_rejects_unknown_token(app_ctx: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_safe_cursor(monkeypatch, None)
+    assert platform.validate_bearer_token("test-token") is False
+
+
+def test_rejects_inactive_token(app_ctx: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_safe_cursor(monkeypatch, ("id", "test-token", False))
+    assert platform.validate_bearer_token("test-token") is False
+
+
+def test_db_error_denies_access(app_ctx: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auth must fail closed when the token lookup blows up."""
+
+    # Raising on call suffices: `safe_cursor(...)` is invoked inside the try.
+    def _boom(query: str, params: tuple = ()) -> Any:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(platform, "safe_cursor", _boom)
+    assert platform.validate_bearer_token("test-token") is False

--- a/platform-service/tests/test_route_endpoints.py
+++ b/platform-service/tests/test_route_endpoints.py
@@ -1,0 +1,18 @@
+"""Guards that `authentication_middleware` stays transparent to Flask.
+
+Without `functools.wraps` every decorated route registers as "wrapper", so the
+second such route raises at import time.
+"""
+
+from flask import Flask
+from unstract.platform_service.controller.platform import platform_bp
+
+
+def test_routes_register_under_their_function_names() -> None:
+    # NOSONAR — app is never served; bearer-token routes carry no CSRF surface.
+    app = Flask(__name__)  # NOSONAR
+    app.register_blueprint(platform_bp)
+
+    endpoints = {rule.endpoint for rule in app.url_map.iter_rules()}
+    assert "platform.wrapper" not in endpoints
+    assert "platform.usage" in endpoints


### PR DESCRIPTION
## What

Adds `functools.wraps` to `authentication_middleware` in `platform-service`, and drops the six now-redundant `endpoint="..."` kwargs it was forcing onto `@platform_bp.route(...)`.

Follow-up to the discussion on #1964. That PR fixed a decorator-**order** bug in `prompt-service` (auth stacked *above* `route`, so auth never ran). **That bug does not exist in `platform-service`** — all its routes already have `@route` on top. But a sibling defect in the same middleware does.

## Why

`authentication_middleware` returned a bare closure:

```python
def authentication_middleware(func):
    def wrapper(*args, **kwargs):
        ...
    return wrapper          # __name__ == "wrapper" for every route
```

Flask derives an endpoint name from the view function's `__name__`. So every authenticated view registered as `wrapper`. Consequences:

- Six routes carried an `endpoint="..."` kwarg whose only purpose was to dodge the resulting collision — each value already identical to its function name.
- `/usage` was the one authenticated route *without* that kwarg, so it registered as endpoint `platform.wrapper`. It worked only because it was the last one left defaulting.
- **Adding any new authenticated route without `endpoint=` fails at import** with `AssertionError: View function mapping is overwriting an existing endpoint function: platform.wrapper`. A landmine, not a live bug.
- Handler docstrings and signatures were lost on every view.

Reproduced on `main` before the fix:

```
platform.page_usage       /page-usage
platform.platform_details /platform_details
...
platform.wrapper          /usage        <-- here
```

`x2text-service`'s equivalent middleware already patches this by hand (`wrapper.__name__ = func.__name__`, `app/authentication_middleware.py:19`). This brings `platform-service` in line, using the stdlib decorator rather than a manual assignment.

## How

| File | Change |
|------|--------|
| `controller/platform.py` | `@functools.wraps(func)` on the middleware's `wrapper`; drop 6 redundant `endpoint=` kwargs |
| `tests/test_route_endpoints.py` | new — one test guarding endpoint naming |
| `tests/test_auth_middleware.py` | restored, hermetic (see below) |
| `tests/conftest.py` | new — sets the env vars `platform_service.env` demands at import |

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No.

**URL paths and methods are byte-identical** before and after — verified by dumping `app.url_map` on both sides. Only Flask's *internal* endpoint registry key changes, and only for one route: `platform.wrapper` → `platform.usage`.

An endpoint name is what `url_for()` and `app.view_functions[...]` look up. It is not the URL.

- There are **zero** references to `url_for`, `view_functions`, or `url_map` anywhere in the repo (venvs excluded). Nothing resolves a route by endpoint name.
- The external caller of `/usage` is `unstract/sdk1/src/unstract/sdk1/audit.py:128` — `url = f"{base_url}/usage"`, a plain HTTP path. Backend and workers reach platform-service over HTTP by path, never by endpoint name.
- The `v1/usage/` hits in `backend/` and `workers/` are Django's own REST APIs, a different service — unrelated to this Flask route.

Auth enforcement itself is unchanged: these routes were already correctly ordered and already authenticated.

## Database Migrations

N/A

## Env Config

N/A

## Relevant Docs

N/A

## Related Issues or PRs

Follow-up to #1964 (which targets `prompt-service`). Rebased on top of #2115 / #2151.

## Dependencies Versions

N/A

## Notes on Testing

Runs as the rig's existing `unit-platform-service` group (`tests/groups.yaml`) — no new group needed:

```
$ uv run python -m tests.rig run unit-platform-service
15 passed in 2.68s
```

**`test_route_endpoints.py`** — a single test that registers the real `platform_bp` and asserts no endpoint is named `platform.wrapper`. Verified as a real regression test: with `@functools.wraps` removed it fails with exactly the collision this PR prevents —

```
AssertionError: View function mapping is overwriting an existing endpoint function: platform.wrapper
```

**`test_auth_middleware.py`** — #2115 deleted this file because it imported `unstract.platform_service.main` (removed) and `get_account_from_bearer_token` (removed), and made live Postgres calls. That deletion was correct, and it left the whole `platform-service` suite uncollectable until then. This PR restores it as a hermetic test of `validate_bearer_token` against a mocked cursor: accepts a valid active token; rejects missing, unknown, and inactive tokens; and **fails closed when the token lookup raises**. No live DB, no removed imports.

Five auth cases + one route case. I deliberately did *not* test `validate_bearer_token`'s `platform_key != token` branch: the query is `WHERE key = %s` with `params=(token,)`, so that branch is unreachable defensive code and a test for it would be manufacturing coverage.

## Sonar

The initial push failed the quality gate with three issues, all in the new test files:

- **S1763 (bug, `Reliability C`)** — valid. A `yield` after `raise` in the DB-error mock was genuinely unreachable; the `@contextmanager` was unnecessary since `safe_cursor(...)` is invoked inside the function's own `try`. Fixed properly rather than suppressed.
- **S4502 ×2 (vulnerability, `Security D`)** — false positive. It flags `Flask(__name__)` as "CSRF protection disabled". The app is constructed in a unit test, never served, and exists only so `url_map` materialises; platform-service authenticates with bearer tokens and serves no cookie- or form-backed routes, so CSRF does not apply. Suppressed with `# NOSONAR` plus justification, matching the existing convention in `backend/utils/tests/test_cors_origin.py`.

Quality gate now passes with 0 open issues.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gUmgQQ7xV73qn6kcB7mXG
