### PR TITLE
UN-3707 [FIX] Cover Claude 5 family in deprecated sampling-param strip

### DIFF
--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -18,11 +18,15 @@ from unstract.sdk1.adapters.enums import AdapterTypes
 logger = logging.getLogger(__name__)
 
 # Anthropic models that have deprecated sampling parameters (`temperature`,
-# `top_p`, `top_k`). The patterns are regex-searched against the model id
-# after lowercasing and normalizing `.` / `_` to `-`. The match is anchored at
-# the trailing edge so that unrelated future ids (`claude-opus-4-70`,
-# `claude-opus-4-75`, `claude-opus-4-7verbose`) do not match. A single entry
-# covers every encoding of the id we have observed:
+# `top_p`, `top_k`) — sending any of them yields a 400. Anthropic began this
+# with Claude Opus 4.7 and continued it across the Claude 5 family (Opus 4.8,
+# Sonnet 5, Fable 5, Mythos 5); adjacent older families (Opus 4.6, Sonnet 4.6,
+# and earlier) still ACCEPT these params and must NOT be listed here.
+# The patterns are regex-searched against the model id after lowercasing and
+# normalizing `.` / `_` to `-`. Each match is anchored at the trailing edge so
+# that unrelated ids (`claude-opus-4-70`, `claude-sonnet-50`,
+# `claude-sonnet-5verbose`) do not match. One entry per model covers every
+# encoding of that id we have observed (shown here for `claude-opus-4-7`):
 #   - Native Anthropic              `claude-opus-4-7`, `anthropic/claude-opus-4-7`
 #   - Bedrock foundation model      `anthropic.claude-opus-4-7-<date>-v1:0`
 #   - Bedrock cross-region profile  `us.anthropic.claude-opus-4-7-...`,
@@ -44,6 +48,10 @@ logger = logging.getLogger(__name__)
 # See https://docs.claude.com/en/about-claude/models/whats-new-claude-4-7
 _SAMPLING_DEPRECATED_MODEL_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"claude-opus-4-7(?=$|[-:@/]|v\d)"),
+    re.compile(r"claude-opus-4-8(?=$|[-:@/]|v\d)"),
+    re.compile(r"claude-sonnet-5(?=$|[-:@/]|v\d)"),
+    re.compile(r"claude-fable-5(?=$|[-:@/]|v\d)"),
+    re.compile(r"claude-mythos-5(?=$|[-:@/]|v\d)"),
 )
 _DEPRECATED_SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
 # Fields whose value can carry a model id. `model` is universal; `model_id` is

--- a/unstract/sdk1/tests/test_sampling_strip.py
+++ b/unstract/sdk1/tests/test_sampling_strip.py
@@ -1,8 +1,11 @@
-"""Tests for Claude Opus 4.7 sampling-parameter strip.
+"""Tests for the Anthropic sampling-parameter strip.
+
+Covers Claude Opus 4.7 and the Claude 5 family (Opus 4.8, Sonnet 5, Fable 5,
+Mythos 5) — every model that rejects `temperature`/`top_p`/`top_k` with a 400.
 
 Pins the detection regex and the four-adapter wiring against the failure
 modes that surfaced in PR #1934 review:
-- prefix collisions (`claude-opus-4-70`, `-75`, `4-7verbose`)
+- prefix collisions (`claude-opus-4-70`, `-75`, `4-7verbose`, `claude-sonnet-50`)
 - Bedrock Application Inference Profile ARN fallback via `model_id`
 - mutate-and-return regression (input dict must be preserved)
 - silent skip with sampling params present must emit a debug breadcrumb
@@ -68,6 +71,44 @@ def test_has_deprecated_sampling_params_positive(model: str) -> None:
     assert _has_deprecated_sampling_params(model)
 
 
+# Claude 5 family — the deprecation continued from Opus 4.7 to Opus 4.8,
+# Sonnet 5, Fable 5, and Mythos 5. Sonnet 5 on Azure AI Foundry is the
+# reported case that motivated adding these entries.
+CLAUDE_5_POSITIVES: list[str] = [
+    # Opus 4.8
+    "claude-opus-4-8",
+    "anthropic/claude-opus-4-8",
+    "anthropic.claude-opus-4-8-20260101-v1:0",
+    "us.anthropic.claude-opus-4-8-20260101-v1:0",
+    "vertex_ai/claude-opus-4-8@20260101",
+    "azure_ai/claude-opus-4-8",
+    "claude-opus-4-8v1",
+    # Sonnet 5 (reported: Azure AI Foundry)
+    "claude-sonnet-5",
+    "anthropic/claude-sonnet-5",
+    "anthropic.claude-sonnet-5",
+    "us.anthropic.claude-sonnet-5-20260101-v1:0",
+    "vertex_ai/claude-sonnet-5",
+    "azure_ai/claude-sonnet-5",
+    "azure_ai/my-claude-sonnet-5-deployment",
+    "claude.sonnet.5",
+    "claude_sonnet_5",
+    "claude-sonnet-5v1",
+    # Fable 5
+    "claude-fable-5",
+    "anthropic/claude-fable-5",
+    "azure_ai/claude-fable-5",
+    # Mythos 5
+    "claude-mythos-5",
+    "vertex_ai/claude-mythos-5",
+]
+
+
+@pytest.mark.parametrize("model", CLAUDE_5_POSITIVES)
+def test_has_deprecated_sampling_params_claude5_positive(model: str) -> None:
+    assert _has_deprecated_sampling_params(model)
+
+
 # ── detection: negatives ────────────────────────────────────────────────────
 
 NEGATIVES: list[str | None] = [
@@ -92,6 +133,17 @@ NEGATIVES: list[str | None] = [
     "claude-opus-4-7verbose",
     "claude-opus-4-7vnext",
     "claude-opus-4-7variant",
+    "claude-sonnet-5verbose",
+    # Claude 5 prefix collisions — trailing digit is not a boundary.
+    "claude-opus-4-80",
+    "claude-sonnet-50",
+    "claude-fable-50",
+    "claude-mythos-50",
+    # Adjacent Claude families that still accept sampling params.
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-6",
+    "claude-fable-4",
     # Opaque Bedrock Application Inference Profile ARN — model id is not
     # recoverable from the string. Strip-detection is expected to skip;
     # callers must keep the standard id in `model` or `model_id`.
@@ -273,6 +325,31 @@ def test_validate_strips_temperature_for_opus_4_7(
 
 def test_vertex_validate_strips_temperature_for_opus_4_7() -> None:
     result = VertexAILLMParameters.validate(_vertex_metadata("claude-opus-4-7@20260101"))
+    for param in _DEPRECATED_SAMPLING_PARAMS:
+        assert param not in result, f"vertex: {param} should be stripped"
+
+
+@pytest.mark.parametrize(
+    "name,cls,extra",
+    ADAPTER_CASES,
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_validate_strips_temperature_for_sonnet_5(
+    name: str, cls: type, extra: dict[str, Any]
+) -> None:
+    """Reported case: Claude Sonnet 5 on Azure AI Foundry (and its peers)."""
+    model = {
+        "anthropic": "claude-sonnet-5",
+        "bedrock": "anthropic.claude-sonnet-5",
+        "azure_ai_foundry": "claude-sonnet-5",
+    }[name]
+    result = cls.validate({"model": model, "temperature": 0.5, **extra})
+    for param in _DEPRECATED_SAMPLING_PARAMS:
+        assert param not in result, f"{name}: {param} should be stripped"
+
+
+def test_vertex_validate_strips_temperature_for_sonnet_5() -> None:
+    result = VertexAILLMParameters.validate(_vertex_metadata("claude-sonnet-5"))
     for param in _DEPRECATED_SAMPLING_PARAMS:
         assert param not in result, f"vertex: {param} should be stripped"
 


### PR DESCRIPTION
## What

- Extend the shared `_SAMPLING_DEPRECATED_MODEL_PATTERNS` tuple in `unstract/sdk1/.../adapters/base1.py` from 1 entry to 5, so the proactive sampling-param strip also fires for the Claude 5 family: `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`, `claude-mythos-5` (in addition to the existing `claude-opus-4-7`).
- Because all four Claude-capable adapters (Anthropic, AWS Bedrock, Vertex AI, Azure AI Foundry) call `_strip_deprecated_sampling_params`, which reads this one tuple, the single change fixes every adapter at once — no per-adapter edits.

## Why

- Configuring **Claude Sonnet 5** against an **Azure AI Foundry** environment fails at adapter-test time (reported by a customer):
  ```
  Error testing 'Claude Sonnet 5'. Error from LLM adapter 'azure_ai': Azure_aiException -
  {"type":"error","error":{"type":"invalid_request_error","message":"temperature is deprecated for this model."}}
  ```
- Anthropic deprecated `temperature` / `top_p` / `top_k` starting with Claude Opus 4.7 and continued the deprecation across the entire Claude 5 family — sending any of them returns a 400.
- The strip mechanism was already wired into the `azure_ai` adapter, but the shared detection regex only matched `claude-opus-4-7`. So Sonnet 5 / Opus 4.8 / Fable 5 slipped through and the Pydantic-default `temperature=0.1` reached the provider, producing the 400.

## How

- `adapters/base1.py`: add four `re.compile(...)` entries to `_SAMPLING_DEPRECATED_MODEL_PATTERNS`, each using the existing trailing-edge anchor `(?=$|[-:@/]|v\d)` so provider encodings (native, `anthropic/…`, Bedrock `anthropic.…-<date>-v1:0` and cross-region/ARN forms, Vertex `…@<date>`, Azure `azure_ai/…` deployment names, and dot/underscore variants) all match while prefix collisions (`claude-sonnet-50`, `claude-sonnet-5verbose`) do not. Comment block generalized to the Claude 5 family.
- `tests/test_sampling_strip.py`: added 22 positive cases across the four new models and their encodings; new negative cases locking the anchor against collisions and adjacent families (`claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-opus-4-80`, etc.); and adapter-wiring tests asserting Sonnet 5 is stripped on all four adapters (mirrors the existing Opus 4.7 coverage).
- Models that still **accept** sampling params (Opus 4.6, Sonnet 4.6, Opus 4.5/4.1/4.0, Sonnet 4.5/4.0, Haiku 4.5) are intentionally excluded, verified against the current Anthropic model reference.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. The change only **adds** models to a deny-list regex that removes deprecated sampling params before the request reaches the provider. It cannot affect any model that previously worked. The excluded older families (Opus 4.6 / Sonnet 4.6 and earlier) still keep `temperature` intact — explicitly pinned by `test_validate_retains_temperature_for_opus_4_6` and negative-detection tests. No adapter interfaces, request shapes, or public APIs changed.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- Anthropic model reference — sampling parameters (`temperature`/`top_p`/`top_k`) removed on Opus 4.7+ and the Claude 5 family: https://docs.claude.com/en/about-claude/models/whats-new-claude-4-7

## Related Issues or PRs

- UN-3707
- Builds on the existing four-adapter strip introduced in PR #1934.

## Dependencies Versions

- None.

## Notes on Testing

- `pytest unstract/sdk1/tests/test_sampling_strip.py` → **93 passed**. The 22 new Claude 5 positives fail against the pre-change opus-4-7-only regex, confirming they exercise the new code.
- All added lines are within the repo's 90-col limit.

## Known limitation (follow-up)

- The proactive-regex approach cannot detect an Azure AI Foundry deployment whose **name does not embed the model id** (e.g. a deployment literally named `my-deploy`). It also needs a new tuple entry each time Anthropic deprecates sampling on a future model. A durable follow-up is a reactive strip-and-retry that parses the "<param> is deprecated" 400 and retries — out of scope here.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
