### PR TITLE
UN-3718 [FIX] reaper recovery — add missing InternalAPIClient.recover_stuck_pg_executions delegator

### DIFF
--- a/workers/shared/api/internal_client.py
+++ b/workers/shared/api/internal_client.py
@@ -628,6 +628,19 @@ class InternalAPIClient(CachedAPIClientMixin):
             cascade_terminal_files=cascade_terminal_files,
         )
 
+    def recover_stuck_pg_executions(
+        self,
+        stuck_seconds: int | None = None,
+        limit: int | None = None,
+    ) -> APIResponse:
+        """Reaper safety-net: finalize PG executions stranded non-terminal after all
+        their files completed. Org-agnostic (the endpoint scans across orgs, scoped
+        to PG rows by ``queue_message_id``). Delegates to the execution client.
+        """
+        return self.execution_client.recover_stuck_pg_executions(
+            stuck_seconds=stuck_seconds, limit=limit
+        )
+
     def create_workflow_execution(self, execution_data: dict[str, Any]) -> dict[str, Any]:
         """Create workflow execution."""
         return self.execution_client.create_workflow_execution(execution_data)

--- a/workers/tests/test_pg_finalization_fixes.py
+++ b/workers/tests/test_pg_finalization_fixes.py
@@ -186,6 +186,30 @@ class TestStuckRecoverySweepGating:
         api.recover_stuck_pg_executions.assert_called_once_with(stuck_seconds=9000)
 
 
+class TestFacadeExposesRecovery:
+    """The reaper calls recover_stuck_pg_executions on the InternalAPIClient FACADE
+    (what _get_api_client() returns), which must delegate to its ExecutionAPIClient.
+    The mock-based gating test above CANNOT catch a missing delegator (a MagicMock
+    has every attribute) — this pins the real facade wiring, which once shipped an
+    AttributeError to prod because the delegator was never added."""
+
+    def test_facade_delegates_to_execution_client(self):
+        from shared.api.internal_client import InternalAPIClient
+
+        # __new__ (not __init__) → no network/env setup; inject a mock sub-client.
+        client = InternalAPIClient.__new__(InternalAPIClient)
+        client.execution_client = MagicMock()
+        sentinel = object()
+        client.execution_client.recover_stuck_pg_executions.return_value = sentinel
+
+        result = client.recover_stuck_pg_executions(stuck_seconds=600, limit=50)
+
+        client.execution_client.recover_stuck_pg_executions.assert_called_once_with(
+            stuck_seconds=600, limit=50
+        )
+        assert result is sentinel
+
+
 class TestReaperConstructorWiring:
     """__init__ sources _stuck_recovery_enabled from the helper (not a hardcoded
     literal) — pins the wiring so a stray `= True` can't slip through."""

--- a/workers/tests/test_pg_finalization_fixes.py
+++ b/workers/tests/test_pg_finalization_fixes.py
@@ -190,8 +190,9 @@ class TestFacadeExposesRecovery:
     """The reaper calls recover_stuck_pg_executions on the InternalAPIClient FACADE
     (what _get_api_client() returns), which must delegate to its ExecutionAPIClient.
     The mock-based gating test above CANNOT catch a missing delegator (a MagicMock
-    has every attribute) — this pins the real facade wiring, which once shipped an
-    AttributeError to prod because the delegator was never added."""
+    has every attribute) — this pins the real facade wiring; the delegator was
+    missing (added in UN-3718), a real AttributeError the MagicMock-based test can't
+    surface."""
 
     def test_facade_delegates_to_execution_client(self):
         from shared.api.internal_client import InternalAPIClient
@@ -208,6 +209,20 @@ class TestFacadeExposesRecovery:
             stuck_seconds=600, limit=50
         )
         assert result is sentinel
+
+    def test_facade_forwards_defaults(self):
+        # The only production caller (reaper) passes just stuck_seconds and relies on
+        # limit defaulting to None — exercise that forwarding path too.
+        from shared.api.internal_client import InternalAPIClient
+
+        client = InternalAPIClient.__new__(InternalAPIClient)
+        client.execution_client = MagicMock()
+
+        client.recover_stuck_pg_executions(stuck_seconds=600)
+
+        client.execution_client.recover_stuck_pg_executions.assert_called_once_with(
+            stuck_seconds=600, limit=None
+        )
 
 
 class TestReaperConstructorWiring:


### PR DESCRIPTION
## What
Add the missing `recover_stuck_pg_executions` delegator to the `InternalAPIClient` facade.

## Why
The reaper's recovery sweep calls `self._get_api_client().recover_stuck_pg_executions(...)`, where `_get_api_client()` returns an **`InternalAPIClient`**. That facade delegates every method to its `ExecutionAPIClient` via an explicit per-method wrapper — but #2172 added `recover_stuck_pg_executions` only to `ExecutionAPIClient` and **never added the facade delegator**. So the sweep threw on every cycle:

```
AttributeError: 'InternalAPIClient' object has no attribute 'recover_stuck_pg_executions'
  File "queue_backend/pg_queue/reaper.py", line 1224, in _maybe_recover_stuck_executions
```

Observed live on `snapshot.964`: the reaper is on the new image, is the leader, and sweeps every 5 min, but the recovery call died before any HTTP request (backend endpoint never hit), so a backlog of 787 EXECUTING+NULL executions was not draining.

## Why the tests missed it
`TestStuckRecoverySweepGating` mocked `_get_api_client()` — a `MagicMock` has every attribute, so the missing real delegator was invisible.

## How
- 13-line delegator on `InternalAPIClient` → forwards to `self.execution_client.recover_stuck_pg_executions(...)`.
- `TestFacadeExposesRecovery` exercises the **real** facade (constructed via `__new__`, mock sub-client) and asserts it delegates — this fails without the fix.

## Tests
19 worker tests pass.

## Deploy
Code bug → merge → rebuild snapshot → redeploy. The fixed reaper then drains the 787 automatically (~100/sweep × 5-min cadence ≈ 40 min; all are past the 2.5h window).

UN-3718 — follow-up to #2172 / #2174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
