### PR TITLE
UN-3735 [FIX] destination DB status — write enum .value, not the enum repr

### DIFF
--- a/backend/workflow_manager/endpoint_v2/database_utils.py
+++ b/backend/workflow_manager/endpoint_v2/database_utils.py
@@ -160,8 +160,13 @@ class DatabaseUtils:
         if error and has_error_col:
             values[TableColumns.ERROR_MESSAGE] = error
         if has_status_col:
+            # Use `.value` so the destination column stores the plain string
+            # ("SUCCESS"/"ERROR"), not the enum repr ("FileProcessingStatus.SUCCESS")
+            # that stringifying the member produces.
             values[TableColumns.STATUS] = (
-                FileProcessingStatus.ERROR if error else FileProcessingStatus.SUCCESS
+                FileProcessingStatus.ERROR.value
+                if error
+                else FileProcessingStatus.SUCCESS.value
             )
         if column_mode == ColumnModes.WRITE_JSON_TO_A_SINGLE_COLUMN:
             v2_col_name = f"{single_column_name}_v2"

--- a/backend/workflow_manager/endpoint_v2/tests/test_database_utils/test_status_value.py
+++ b/backend/workflow_manager/endpoint_v2/tests/test_database_utils/test_status_value.py
@@ -1,0 +1,37 @@
+"""Regression test for UN-3735.
+
+The destination `status` column must be written as the plain string
+"SUCCESS"/"ERROR", never the enum repr "FileProcessingStatus.SUCCESS".
+
+The backend ``FileProcessingStatus`` is a plain ``Enum``, so a stringified member
+renders as "FileProcessingStatus.SUCCESS"; the assertions check ``str(value)`` —
+what the DB driver persists. No DB access needed, so ``SimpleTestCase``.
+"""
+
+from django.test import SimpleTestCase
+
+from workflow_manager.endpoint_v2.constants import TableColumns
+from workflow_manager.endpoint_v2.database_utils import DatabaseUtils
+
+
+class DestinationStatusValueTests(SimpleTestCase):
+    def _status_for(self, error: str | None) -> object:
+        values = DatabaseUtils.get_columns_and_values(
+            column_mode_str="WRITE_JSON_TO_A_SINGLE_COLUMN",
+            data={"k": "v"},
+            file_path="f",
+            execution_id="e",
+            table_info={
+                "status": "STRING",
+                "error_message": "STRING",
+                "data": "STRING",
+            },
+            error=error,
+        )
+        return values[TableColumns.STATUS]
+
+    def test_status_success_is_plain_string(self) -> None:
+        self.assertEqual(str(self._status_for(None)), "SUCCESS")
+
+    def test_status_error_is_plain_string(self) -> None:
+        self.assertEqual(str(self._status_for("boom")), "ERROR")

--- a/workers/shared/infrastructure/database/utils.py
+++ b/workers/shared/infrastructure/database/utils.py
@@ -308,10 +308,14 @@ class WorkerDatabaseUtils:
         if error and has_error_col:
             values[TableColumns.ERROR_MESSAGE] = error
 
-        # Add status based on error presence
+        # Add status based on error presence. Use `.value` so the destination
+        # column stores the plain string ("SUCCESS"/"ERROR"), not the enum repr
+        # ("FileProcessingStatus.SUCCESS") that stringifying the member produces.
         if has_status_col:
             values[TableColumns.STATUS] = (
-                FileProcessingStatus.ERROR if error else FileProcessingStatus.SUCCESS
+                FileProcessingStatus.ERROR.value
+                if error
+                else FileProcessingStatus.SUCCESS.value
             )
 
     @staticmethod

--- a/workers/tests/test_destination_status_value.py
+++ b/workers/tests/test_destination_status_value.py
@@ -1,0 +1,35 @@
+"""Regression test for UN-3735.
+
+The destination `status` column must be written as the plain string
+"SUCCESS"/"ERROR", never the enum repr "FileProcessingStatus.SUCCESS".
+
+Subtlety: ``FileProcessingStatus`` is a ``(str, Enum)``, so the *member* already
+compares equal to its value ("SUCCESS"). The bug only shows when the value is
+**stringified** on the way into the DB insert (``str(member)`` →
+"FileProcessingStatus.SUCCESS"). So these tests assert on ``str(value)`` — what
+the DB driver actually persists — not on ``==``.
+"""
+
+from shared.enums.status_enums import FileProcessingStatus
+from shared.infrastructure.database.utils import TableColumns, WorkerDatabaseUtils
+
+
+def test_processing_status_success_is_plain_string() -> None:
+    values: dict = {}
+    WorkerDatabaseUtils._add_processing_columns(
+        values, table_info=None, metadata=None, error=None
+    )
+    assert str(values[TableColumns.STATUS]) == "SUCCESS"
+    assert values[TableColumns.STATUS] == FileProcessingStatus.SUCCESS.value
+    # It must be a plain str, not the enum member (which stringifies to the repr).
+    assert not isinstance(values[TableColumns.STATUS], FileProcessingStatus)
+
+
+def test_processing_status_error_is_plain_string() -> None:
+    values: dict = {}
+    WorkerDatabaseUtils._add_processing_columns(
+        values, table_info={"status": "STRING"}, metadata=None, error="boom"
+    )
+    assert str(values[TableColumns.STATUS]) == "ERROR"
+    assert values[TableColumns.STATUS] == FileProcessingStatus.ERROR.value
+    assert not isinstance(values[TableColumns.STATUS], FileProcessingStatus)


### PR DESCRIPTION
## What
Database destination writes (BigQuery, PostgreSQL, etc.) were storing the `status` column as the enum member repr — `FileProcessingStatus.SUCCESS` / `FileProcessingStatus.ERROR` — instead of the plain string `SUCCESS` / `ERROR`.

## Why
Both destination-write sites assigned the enum *member* rather than its `.value`. When the member is stringified into the DB insert it renders as `FileProcessingStatus.SUCCESS`, so any downstream query, dashboard, or automation filtering on `status = 'SUCCESS'` silently matches nothing. Independent of execution transport; affects both write paths.

## How
Use `.value` at both destination-write sites:
- `workers/shared/infrastructure/database/utils.py`
- `backend/workflow_manager/endpoint_v2/database_utils.py`

## Testing
Regression tests at both sites assert on `str(value)` — the workers enum is a `(str, Enum)` whose member compares `== "SUCCESS"` even with the bug, so only stringification (what the DB driver does) reveals it.
- `workers/tests/test_destination_status_value.py` — 2 passed locally.
- `backend/workflow_manager/endpoint_v2/tests/test_database_utils/test_status_value.py` — `SimpleTestCase`, runs in CI.

Ticket: UN-3735

🤖 Generated with [Claude Code](https://claude.com/claude-code)