### PR TITLE
UN-3636 [FIX] Stop re-running cross-tier deps in every tier leg

### DIFF
--- a/tests/rig/selection.py
+++ b/tests/rig/selection.py
@@ -7,6 +7,10 @@ Resolution order (de-duped, then dep-expanded, then topo-sorted by the manifest)
 The literal ``all`` expands to every group in the manifest. When the result is
 empty, callers should treat that as "do nothing" rather than silently running
 everything — the CLI surfaces a clear error.
+
+With ``--tier``, dep expansion never reaches outside that tier: each tier runs as
+its own CI leg, so a cross-tier ``depends_on`` would otherwise re-run the same
+group in every leg that transitively depends on it.
 """
 
 from __future__ import annotations
@@ -66,7 +70,18 @@ def resolve(
     if changed_only:
         selected.update(_groups_for_changed_paths(manifest, base=changed_base))
 
-    return manifest.expand(sorted(selected)) if selected else []
+    if not selected:
+        return []
+
+    requested = sorted(selected)
+    expanded = manifest.expand(requested)
+    if tier is not None:
+        # A tier run never pulls in another tier's groups. Tiers run as separate
+        # legs, so a cross-tier `depends_on` would re-run the same group once per
+        # leg; the owning tier's leg covers it. Explicitly requested groups stay.
+        keep = set(requested)
+        expanded = [n for n in expanded if n in keep or manifest.get(n).tier == tier]
+    return expanded
 
 
 def _groups_for_changed_paths(manifest: GroupManifest, *, base: str) -> set[str]:

--- a/tests/rig/tests/test_selection.py
+++ b/tests/rig/tests/test_selection.py
@@ -76,3 +76,51 @@ def test_tier_only_selects_that_tier_and_deps(tmp_path: Path) -> None:
     manifest = load_groups(_manifest(tmp_path))
     ordered = resolve(manifest, positional=[], tier="unit")
     assert set(ordered) == {"unit-a", "unit-b"}
+
+
+def _cross_tier_manifest(tmp_path: Path) -> Path:
+    p = tmp_path / "groups.yaml"
+    p.write_text(
+        """
+        version: 1
+        groups:
+          unit-a:
+            tier: unit
+            paths: [x]
+            optional: true
+          e2e-smoke:
+            tier: e2e
+            paths: [x]
+            requires_platform: true
+            optional: true
+          e2e-cross:
+            tier: e2e
+            paths: [x]
+            requires_platform: true
+            depends_on: [e2e-smoke, unit-a]
+            optional: true
+        """
+    )
+    return p
+
+
+def test_tier_run_does_not_pull_in_other_tiers(tmp_path: Path) -> None:
+    """Each tier is its own CI leg; a cross-tier dep must not re-run there."""
+    manifest = load_groups(_cross_tier_manifest(tmp_path))
+    ordered = resolve(manifest, positional=[], tier="e2e")
+    assert set(ordered) == {"e2e-smoke", "e2e-cross"}
+    # Intra-tier ordering still holds.
+    assert ordered.index("e2e-smoke") < ordered.index("e2e-cross")
+
+
+def test_explicitly_named_group_survives_tier_filter(tmp_path: Path) -> None:
+    """The filter only drops dep-expanded groups, never an explicit request."""
+    manifest = load_groups(_cross_tier_manifest(tmp_path))
+    ordered = resolve(manifest, positional=["unit-a"], tier="e2e")
+    assert set(ordered) == {"unit-a", "e2e-smoke", "e2e-cross"}
+
+
+def test_cross_tier_dep_still_expands_without_tier_filter(tmp_path: Path) -> None:
+    manifest = load_groups(_cross_tier_manifest(tmp_path))
+    ordered = resolve(manifest, positional=["e2e-cross"])
+    assert set(ordered) == {"unit-a", "e2e-smoke", "e2e-cross"}


### PR DESCRIPTION
## What

Bound the rig's `depends_on` expansion to the requested tier when `--tier` is passed.

## Why

`integration-workflow-execution` and `e2e-smoke` both declare `depends_on: [unit-sdk1, unit-workers]`. Because `--tier` expanded deps transitively with no tier bound, those two unit groups ran **three times per CI run** — once in the unit leg, again in the integration leg, again in the e2e leg.

Measured on run `29891886572` (main):

| group | unit leg | integration leg | e2e leg |
|---|---:|---:|---:|
| `unit-sdk1` | 21s | 27s | 27s |
| `unit-workers` | 37s | 51s | 51s |

≈136s of duplicate execution per run. On the cloud CI runner (`custom-k8s-runner`, ~2 xdist workers) the same duplication costs **~350s**.

## Changes

- `tests/rig/selection.py`: with `--tier`, drop dep-expanded groups outside that tier. Explicitly named groups are never dropped.
- `tests/rig/tests/test_selection.py`: +3 tests — cross-tier dep not pulled in, explicit request survives the filter, expansion unchanged without a tier filter.

## Safety

- Intra-tier deps still expand and topo-order (`e2e-smoke` → `e2e-login`).
- Gating is unaffected: `blocked_by` intersects with groups that failed *in the same run*, so a dep that wasn't run simply doesn't gate — and its own tier leg gates it.
- `tests.rig validate` OK — 18 groups, 16 critical paths. Full rig suite: 74 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnLaN45ShBbcCXWZkqCThz