### PR TITLE
UN-3636 [FIX] Pin the built-in auth service in the last-admin guard tests

### DIFF
--- a/backend/account_v2/tests.py
+++ b/backend/account_v2/tests.py
@@ -7,6 +7,7 @@ An organization must never lose its only admin via a role change. The guard
 
 import secrets
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.test import TestCase
 from tenant_account_v2.models import OrganizationMember
@@ -31,6 +32,15 @@ class LastAdminGuardTests(TestCase):
             name="org-a", display_name="Org A", organization_id="org-a"
         )
         UserContext.set_organization_identifier(self.org.organization_id)
+        # Pin the built-in auth service: role vocabulary is plugin-defined, so
+        # UserRole below is only meaningful while no auth plugin is installed.
+        registry = patch(
+            "account_v2.authentication_controller."
+            "AuthenticationPluginRegistry.is_plugin_available",
+            return_value=False,
+        )
+        registry.start()
+        self.addCleanup(registry.stop)
         self.controller = AuthenticationController()
         self.admin = _make_member(self.org, "admin@example.com", UserRole.ADMIN.value)
 


### PR DESCRIPTION
## What

`LastAdminGuardTests` (`backend/account_v2/tests.py`) silently depends on which authentication plugins happen to be present in the tree. This pins it to the built-in auth service so it tests what it claims to test.

Test-only change. The guard (`_ensure_not_last_admin_demotion`) and every other line of product code are untouched.

## Why

`AuthenticationController.__init__` resolves its auth service through `AuthenticationPluginRegistry`:

```python
if AuthenticationPluginRegistry.is_plugin_available():
    self.auth_service = AuthenticationPluginRegistry.get_plugin()
else:
    self.auth_service = AuthenticationService()
```

The tests build members with `account_v2.enums.UserRole` values (`ADMIN = "admin"`), and the guard decides who counts as an admin via `is_admin_by_role()` — which defers to whatever service got resolved. **Role vocabulary is plugin-defined.** An installed plugin can use entirely different role strings, in which case `is_admin_by_role("admin")` returns `False`, the guard finds zero admins to protect, and the three demotion assertions stop holding.

Two of them fail a second way: `add_user_role` / `remove_user_role` are handed a bare `SimpleNamespace(user=…)`, which any plugin that reads `request.session` cannot use.

Nobody noticed because the OSS tree has no auth plugin, so the registry always misses and the built-in service is always what runs. The tests have been passing for the right result via an unstated assumption.

## The fix

Force the registry lookup to miss in `setUp`, so the controller builds `AuthenticationService` and the `UserRole` values the tests assert on are the ones actually in play.

## Verification

`tox -e rig -- run integration-backend --paths account_v2/tests.py`, both trees:

| Tree | Before | After |
|---|---|---|
| OSS (no auth plugin) | 5 passed | **5 passed** |
| OSS + auth plugin | 2 passed, 3 failed | **5 passed** |

Unchanged where it already worked; correct where it did not. The failures it fixes are `AttributeError: 'types.SimpleNamespace' object has no attribute 'session'` (×2) and `AssertionError: Forbidden not raised` (×1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152fauJmYK3YhwtG1xtT4F9