### PR TITLE
UN-3797 [MISC] Add a browser-based frontend layout test tier

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -25,16 +25,18 @@ jobs:
   # skipped via `if:` reports conclusion `skipped`, which passes. Two scopes:
   # `relevant` gates unit/integration; `e2e_relevant` gates e2e and skips only
   # docs — the e2e image build is the sole CI check that compiles the frontend,
-  # and docker/** changes must be e2e-tested.
+  # and docker/** changes must be e2e-tested. `frontend` gates the JS tiers,
+  # which are the mirror image of `relevant`: only frontend/** matters to them.
   changes:
     runs-on: ubuntu-latest
     outputs:
       # Filtering is a PR-time saving only. On workflow_dispatch there is no
       # base to diff, so paths-filter resolves against the default branch and a
       # manual run on main diffs main against itself — every filter false, every
-      # tier skipped, gate green with nothing run. Force both true off-PR.
+      # tier skipped, gate green with nothing run. Force all true off-PR.
       relevant: ${{ github.event_name != 'pull_request' || steps.filter.outputs.relevant == 'true' }}
       e2e_relevant: ${{ github.event_name != 'pull_request' || steps.filter.outputs.e2e_relevant == 'true' }}
+      frontend: ${{ github.event_name != 'pull_request' || steps.filter.outputs.frontend == 'true' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -54,6 +56,8 @@ jobs:
               - "!docker/**"
               - "!frontend/**"
               - "!docs/**"
+            frontend:
+              - "frontend/**"
             e2e_relevant:
               - "!docs/**"
 
@@ -122,6 +126,78 @@ jobs:
         with:
           name: reports-${{ matrix.tier }}
           path: reports/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # Frontend tiers. Runs alongside the python tiers, not after them: nothing is
+  # shared, and the whole job is minutes against e2e's tens of minutes.
+  #
+  # Two vitest projects, one job:
+  #   unit   — happy-dom. Fast, but every rect measures 0, so it cannot see
+  #            layout at all.
+  #   layout — real Chromium. Asserts the geometric contracts of list rows
+  #            (columns line up, nothing spills onto the action icons, nothing
+  #            overflows) at the widths the CSS claims to support. These are
+  #            the regressions that reach staging because a CSS diff looks
+  #            innocent in review.
+  frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        # --ignore-scripts matches the frontend image build. Playwright's
+        # postinstall browser download is one of the scripts it skips; the
+        # dedicated step below does that explicitly and cacheably instead.
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Keyed on the lockfile: the browser build is pinned by the playwright
+      # version in it, so a bump invalidates the cache and re-downloads.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Chromium
+        # The locally installed binary, not `bunx playwright`: that would fetch
+        # whatever version the registry serves, while this is the one pinned in
+        # bun.lock and matched to @vitest/browser.
+        # --with-deps installs the shared libraries headless Chromium needs;
+        # they live outside the cached browser dir, so this runs either way.
+        run: ./node_modules/.bin/playwright install chromium --with-deps
+
+      - name: Run unit tests
+        run: bun run test:unit
+
+      - name: Run layout tests
+        run: bun run test:layout
+
+      - name: Upload layout failure screenshots
+        # Written by vitest's browser mode on failure — a red layout assertion
+        # is far quicker to read as a picture than as coordinates.
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: frontend-layout-screenshots
+          path: frontend/src/**/__screenshots__/**
           if-no-files-found: ignore
           retention-days: 14
 
@@ -238,7 +314,10 @@ jobs:
           retention-days: 14
 
   report:
-    needs: [changes, test, e2e]
+    # `frontend` is in `needs` for the gate below only: it emits no junit, so
+    # it contributes nothing to the combined report or the baseline. Without it
+    # a red layout assertion would leave the branch-protection check green.
+    needs: [changes, test, e2e, frontend]
     # `always()` so a red tier still posts a report. Any tier may skip on
     # irrelevant paths; the fail step below distinguishes a legitimate skip
     # from a real tier failure.
@@ -339,7 +418,9 @@ jobs:
           changes_result="${{ needs.changes.result }}"
           test_result="${{ needs.test.result }}"
           e2e_result="${{ needs.e2e.result }}"
+          frontend_result="${{ needs.frontend.result }}"
           # A broken filter job skips both tiers, which would read as pass.
           [ "$changes_result" = "success" ] || exit 1
           [ "$test_result" = "success" ] || [ "$test_result" = "skipped" ] || exit 1
           [ "$e2e_result" = "success" ] || [ "$e2e_result" = "skipped" ] || exit 1
+          [ "$frontend_result" = "success" ] || [ "$frontend_result" = "skipped" ] || exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -717,3 +717,6 @@ AGENTS.md
 # Unstract test rig
 reports/
 .test-selection
+
+# Vitest browser-mode failure screenshots (written on a red layout assertion)
+frontend/src/**/__screenshots__/

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -62,9 +62,11 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
         "@vitejs/plugin-react": "^4.4.0",
+        "@vitest/browser": "3.2.6",
         "baseline-browser-mapping": "^2.9.19",
         "happy-dom": "^20.10.2",
         "jsdom": "^27.0.1",
+        "playwright": "^1.61.1",
         "vite": "^7.3.5",
         "vite-plugin-svgr": "^4.5.0",
         "vitest": "^3.2.6",
@@ -297,6 +299,8 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
 
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
     "@posthog/core": ["@posthog/core@1.15.0", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-n2/Yy0+qc8xhmlcOFiYqTcGHBZuuaQjVolfFXk7yTCynzdMe8Fx1zYvPPUrbdQK5tWwXyilkzybpqhK6I7aV4Q=="],
 
     "@posthog/types": ["@posthog/types@1.336.1", "", {}, "sha512-KSGst/a/HK7GhfLSbwAy35HtU3KjDqjLtq3+PoDlGfbz9SbO0owjc6jo6hAHnMz67QTSvrn/r0xgimDO4NQ+rA=="],
@@ -489,7 +493,7 @@
 
     "@svgr/plugin-jsx": ["@svgr/plugin-jsx@8.1.0", "", { "dependencies": { "@babel/core": "^7.21.3", "@svgr/babel-preset": "8.1.0", "@svgr/hast-util-to-babel-ast": "8.0.0", "svg-parser": "^2.0.4" }, "peerDependencies": { "@svgr/core": "*" } }, "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA=="],
 
-    "@testing-library/dom": ["@testing-library/dom@8.20.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.1.3", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "pretty-format": "^27.0.2" } }, "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g=="],
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@5.17.0", "", { "dependencies": { "@adobe/css-tools": "^4.0.1", "@babel/runtime": "^7.9.2", "@types/testing-library__jest-dom": "^5.9.1", "aria-query": "^5.0.0", "chalk": "^3.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.5.6", "lodash": "^4.17.15", "redent": "^3.0.0" } }, "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg=="],
 
@@ -580,6 +584,8 @@
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@vitest/browser": ["@vitest/browser@3.2.6", "", { "dependencies": { "@testing-library/dom": "^10.4.0", "@testing-library/user-event": "^14.6.1", "@vitest/mocker": "3.2.6", "@vitest/utils": "3.2.6", "magic-string": "^0.30.17", "sirv": "^3.0.1", "tinyrainbow": "^2.0.0", "ws": "^8.18.2" }, "peerDependencies": { "playwright": "*", "vitest": "3.2.6", "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0" }, "optionalPeers": ["playwright", "webdriverio"] }, "sha512-CNjSynGBtAVOMTfQITv6Bc8da4/XTU1izorocbDStjUsynXcgx2FHVssh+10a8bKd/BxoqDdQtuSbYHfk302Wg=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.6", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.6", "@vitest/utils": "3.2.6", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ=="],
 
@@ -833,7 +839,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -875,7 +881,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1211,6 +1217,8 @@
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nan": ["nan@2.25.0", "", {}, "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g=="],
@@ -1270,6 +1278,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1487,6 +1499,8 @@
 
     "simple-get": ["simple-get@3.1.1", "", { "dependencies": { "decompress-response": "^4.2.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA=="],
 
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
     "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
@@ -1564,6 +1578,8 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toggle-selection": ["toggle-selection@1.0.6", "", {}, "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
@@ -1711,15 +1727,17 @@
 
     "@rjsf/antd/rc-picker": ["rc-picker@2.7.6", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "^2.2.1", "date-fns": "2.x", "dayjs": "1.x", "moment": "^2.24.0", "rc-trigger": "^5.0.4", "rc-util": "^5.37.0", "shallowequal": "^1.1.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-H9if/BUJUZBOhPfWcPeT15JUI3/ntrG9muzERrXDkSoWmDj4yzmBvumozpxYrHwjcKnjyDGAke68d+whWwvhHA=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "@svgr/hast-util-to-babel-ast/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
-    "@testing-library/dom/aria-query": ["aria-query@5.1.3", "", { "dependencies": { "deep-equal": "^2.0.5" } }, "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ=="],
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
-    "@testing-library/dom/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+    "@testing-library/react/@testing-library/dom": ["@testing-library/dom@8.20.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.1.3", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "pretty-format": "^27.0.2" } }, "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g=="],
 
     "@types/jest/pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
 
-    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+    "@vitest/browser/@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
@@ -1785,6 +1803,8 @@
 
     "refractor/prismjs": ["prismjs@1.27.0", "", {}, "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1795,11 +1815,17 @@
 
     "unified/is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "@mapbox/node-pre-gyp/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "@react-awesome-query-builder/ui/react-redux/@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.3", "", {}, "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="],
 
     "@rjsf/antd/rc-picker/date-fns": ["date-fns@2.30.0", "", { "dependencies": { "@babel/runtime": "^7.21.0" } }, "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw=="],
+
+    "@testing-library/react/@testing-library/dom/aria-query": ["aria-query@5.1.3", "", { "dependencies": { "deep-equal": "^2.0.5" } }, "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ=="],
+
+    "@testing-library/react/@testing-library/dom/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@types/jest/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,10 @@
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:layout": "vitest run --project layout",
+    "test:watch": "vitest",
     "lint": "biome lint src/",
     "lint:fix": "biome lint --write src/",
     "format": "biome format src/",
@@ -87,9 +90,11 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",
     "@vitejs/plugin-react": "^4.4.0",
+    "@vitest/browser": "3.2.6",
     "baseline-browser-mapping": "^2.9.19",
     "happy-dom": "^20.10.2",
     "jsdom": "^27.0.1",
+    "playwright": "^1.61.1",
     "vite": "^7.3.5",
     "vite-plugin-svgr": "^4.5.0",
     "vitest": "^3.2.6"

--- a/frontend/src/components/widgets/list-view/ListView.layout.test.jsx
+++ b/frontend/src/components/widgets/list-view/ListView.layout.test.jsx
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { useSessionStore } from "../../../store/session-store";
+import {
+  expectAlignedX,
+  expectContained,
+  expectNoHorizontalOverflow,
+  expectNoHorizontalOverlap,
+  expectTruncated,
+} from "../../../test-utils/layout/assertions";
+import {
+  mountAtWidth,
+  queryAll,
+  rowsOf,
+} from "../../../test-utils/layout/mount";
+import { ListView } from "./ListView";
+
+// The list row is a table drawn with flexbox: four columns that must line up
+// across rows even though every row lays itself out independently. These tests
+// hold that contract. Two shipped regressions motivated them — an owner column
+// that sized itself to its own text and so started at a different x on every
+// row, and pinned columns inside a shrinkable wrapper that spilled out of it
+// and printed over the action icons. Neither is visible in a CSS diff.
+
+const SESSION_EMAIL = "me@example.com";
+
+// The widths .list-view-wrapper itself declares support for (min 800, max
+// 1400) plus the midpoint. Keep in step with ListView.css if that range moves.
+const WIDTHS = [800, 1100, 1400];
+
+// Owner labels of wildly different lengths are the whole point: a column that
+// sizes to content only misaligns when its content differs row to row.
+// Long enough that no plausible width cap could ever fit it: the truncation
+// case must fail because truncation broke, never because someone widened a
+// column.
+const LONG_EMAIL = `a-really-long-service-account-name-${"x".repeat(300)}@example.com`;
+
+const ITEMS = [
+  {
+    id: "1",
+    tool_name: "S3",
+    description: "Short one",
+    created_by_email: SESSION_EMAIL,
+    created_at: "2026-01-02T03:04:05Z",
+    modified_at: "2026-07-20T03:04:05Z",
+  },
+  {
+    id: "2",
+    tool_name:
+      "A deliberately long project name that has to ellipsize somewhere",
+    description:
+      "A long description that runs past the width cap and gets clipped with a tooltip",
+    created_by_email: LONG_EMAIL,
+    created_at: "2025-03-02T03:04:05Z",
+    modified_at: "2025-04-02T03:04:05Z",
+  },
+  {
+    // No description: the left column collapses to a single line, so the row
+    // is shorter than its neighbours. Column alignment must not care.
+    id: "3",
+    tool_name: "KYC extractor",
+    created_by_email: "someone.else@example.com",
+    created_at: "2026-06-02T03:04:05Z",
+    modified_at: "2026-07-21T03:04:05Z",
+  },
+  {
+    // Membership model: renders "Me +2" rather than an address.
+    id: "4",
+    tool_name: "Co-owned invoice parser",
+    description: "Owned with two other people",
+    co_owners_count: 3,
+    is_owner: true,
+    created_at: "2026-07-01T03:04:05Z",
+    modified_at: "2026-07-22T03:04:05Z",
+  },
+];
+
+// Handlers only need to exist: their presence decides which columns and
+// controls ListView renders, and nothing here clicks anything.
+const noop = () => undefined;
+
+// Adapters and Prompt Studio: owner + updated, share and co-owner enabled.
+const fullConfig = {
+  listOfTools: ITEMS,
+  handleEdit: noop,
+  handleDelete: noop,
+  handleShare: noop,
+  handleCoOwner: noop,
+  titleProp: "tool_name",
+  descriptionProp: "description",
+  idProp: "id",
+  showOwner: true,
+  showModified: true,
+  type: "Tool",
+};
+
+// Connectors and Workflows: owner only, no updated column, no co-owner button
+// (so the badge renders as a div rather than a button).
+const ownerOnlyConfig = {
+  ...fullConfig,
+  handleShare: undefined,
+  handleCoOwner: undefined,
+  showModified: false,
+  centered: true,
+};
+
+const mountList = (props, width) => {
+  useSessionStore.setState({ sessionDetails: { email: SESSION_EMAIL } });
+  return mountAtWidth(<ListView {...props} />, width);
+};
+
+describe("ListView row layout", () => {
+  it("renders the owner column as a straight column, whatever the owner is called", async () => {
+    const { wrapper } = await mountList(fullConfig, 1100);
+
+    const owners = queryAll(wrapper, ".adapters-list-profile-container");
+    expect(owners).toHaveLength(ITEMS.length);
+    // Guard the fixture itself: if every row rendered the same label, the
+    // alignment assertion below would pass for the wrong reason.
+    const labels = queryAll(wrapper, ".shared-username").map((el) =>
+      el.textContent.trim(),
+    );
+    expect(new Set(labels).size).toBeGreaterThan(1);
+
+    expectAlignedX(owners, "owner column");
+  });
+
+  it("renders the updated column as a straight column, whatever the timestamps are", async () => {
+    const { wrapper } = await mountList(fullConfig, 1100);
+
+    const updated = queryAll(wrapper, ".list-view-modified-container");
+    expect(updated).toHaveLength(ITEMS.length);
+    const labels = queryAll(wrapper, ".list-view-modified-text").map((el) =>
+      el.textContent.trim(),
+    );
+    expect(new Set(labels).size).toBeGreaterThan(1);
+
+    expectAlignedX(updated, "updated column");
+  });
+
+  it.each(
+    WIDTHS,
+  )("keeps the metadata columns inside their box and clear of the actions at %ipx", async (width) => {
+    const { wrapper } = await mountList(fullConfig, width);
+
+    for (const row of rowsOf(wrapper)) {
+      const meta = row.querySelector(".list-view-meta");
+      const actions = row.querySelector(".action-button-container");
+
+      for (const column of meta.children) {
+        expectContained(column, meta, `meta column at ${width}px`);
+      }
+      expectNoHorizontalOverlap(
+        meta,
+        actions,
+        `metadata vs row actions at ${width}px`,
+      );
+      // The columns are what a user sees collide, so assert on them too:
+      // a contained-but-overlapping child would still print over the icons.
+      for (const column of meta.children) {
+        expectNoHorizontalOverlap(
+          column,
+          actions,
+          `metadata column vs row actions at ${width}px`,
+        );
+      }
+    }
+  });
+
+  it.each(WIDTHS)("never overflows the row at %ipx", async (width) => {
+    const { wrapper } = await mountList(fullConfig, width);
+
+    // Rows only: each row is its own clipping context (`overflow: hidden`), so
+    // asserting on the wrapper could never fail no matter how badly a row
+    // overflowed.
+    for (const row of rowsOf(wrapper)) {
+      expectNoHorizontalOverflow(row, `row at ${width}px`);
+    }
+  });
+
+  it("keeps the columns straight when rows carry icons", async () => {
+    // The adapter pages render an <Image> beside the title, which settles
+    // after mount; the left column absorbs it, so the meta columns must not
+    // move. This is the branch those pages actually use.
+    const { wrapper } = await mountList(
+      {
+        ...fullConfig,
+        iconProp: "icon",
+        listOfTools: ITEMS.map((item) => ({
+          ...item,
+          icon: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='38' height='38'%3E%3C/svg%3E",
+        })),
+      },
+      1100,
+    );
+
+    expectAlignedX(
+      queryAll(wrapper, ".adapters-list-profile-container"),
+      "owner column with row icons",
+    );
+    expectAlignedX(
+      queryAll(wrapper, ".list-view-modified-container"),
+      "updated column with row icons",
+    );
+  });
+
+  it("absorbs an over-long owner address by truncating it, not by moving the column", async () => {
+    const { wrapper } = await mountList(fullConfig, 800);
+
+    const longLabel = queryAll(wrapper, ".shared-username").find((el) =>
+      el.textContent.includes("a-really-long-service-account-name"),
+    );
+    expectTruncated(longLabel, "over-long owner address");
+    expectAlignedX(
+      queryAll(wrapper, ".adapters-list-profile-container"),
+      "owner column at the narrowest supported width",
+    );
+  });
+
+  describe("owner-only pages", () => {
+    it.each(
+      WIDTHS,
+    )("stay aligned, contained and overflow-free at %ipx", async (width) => {
+      const { wrapper } = await mountList(ownerOnlyConfig, width);
+
+      expect(queryAll(wrapper, ".list-view-modified-container")).toHaveLength(
+        0,
+      );
+
+      expectAlignedX(
+        queryAll(wrapper, ".adapters-list-profile-container"),
+        `owner column, owner-only page at ${width}px`,
+      );
+
+      for (const row of rowsOf(wrapper)) {
+        const meta = row.querySelector(".list-view-meta");
+        const actions = row.querySelector(".action-button-container");
+        for (const column of meta.children) {
+          expectContained(column, meta, `meta column at ${width}px`);
+        }
+        expectNoHorizontalOverlap(
+          meta,
+          actions,
+          `metadata vs row actions at ${width}px`,
+        );
+        expectNoHorizontalOverflow(row, `row at ${width}px`);
+      }
+    });
+  });
+});

--- a/frontend/src/test-utils/layout/assertions.js
+++ b/frontend/src/test-utils/layout/assertions.js
@@ -1,0 +1,75 @@
+import { expect } from "vitest";
+
+// Subpixel rounding only. Anything a real layout bug produces is orders of
+// magnitude larger (the column drift that motivated these helpers was 181px),
+// so a tight epsilon costs nothing and keeps the assertions meaningful.
+export const EPSILON = 1.5;
+
+const box = (el) => el.getBoundingClientRect();
+
+const describeAll = (elements, pick) =>
+  elements
+    .map((el, i) => `  [${i}] ${Math.round(pick(box(el)))}px  ${text(el)}`)
+    .join("\n");
+
+const text = (el) => {
+  const raw = (el.textContent || "").trim().replace(/\s+/g, " ");
+  return raw.length > 40 ? `${raw.slice(0, 40)}…` : raw;
+};
+
+/**
+ * Every element starts at the same x — i.e. they read as a column.
+ *
+ * This is the assertion that survives redesigns: it says nothing about where
+ * the column is, only that it is straight. Padding, fonts and design tokens
+ * can all change without touching it; only a column that sizes itself to its
+ * own content breaks it.
+ */
+export const expectAlignedX = (elements, label) => {
+  expect(elements.length, `${label}: nothing to align`).toBeGreaterThan(1);
+  const xs = elements.map((el) => box(el).x);
+  const spread = Math.max(...xs) - Math.min(...xs);
+  expect(
+    spread,
+    `${label}: expected one straight column, got ${spread.toFixed(1)}px of drift\n${describeAll(elements, (b) => b.x)}`,
+  ).toBeLessThanOrEqual(EPSILON);
+};
+
+/** `child` stays inside `parent` horizontally. */
+export const expectContained = (child, parent, label) => {
+  const c = box(child);
+  const p = box(parent);
+  const overflow = Math.max(p.left - c.left, c.right - p.right);
+  expect(
+    overflow,
+    `${label}: child escapes its container by ${overflow.toFixed(1)}px — a rigid child inside a shrinkable box spills instead of shrinking with it\n  child  ${Math.round(c.left)}→${Math.round(c.right)}  ${text(child)}\n  parent ${Math.round(p.left)}→${Math.round(p.right)}`,
+  ).toBeLessThanOrEqual(EPSILON);
+};
+
+/** `leftEl` ends before `rightEl` begins — they never sit on top of each other. */
+export const expectNoHorizontalOverlap = (leftEl, rightEl, label) => {
+  const a = box(leftEl);
+  const b = box(rightEl);
+  const overlap = a.right - b.left;
+  expect(
+    overlap,
+    `${label}: elements overlap by ${overlap.toFixed(1)}px\n  ${Math.round(a.left)}→${Math.round(a.right)}  ${text(leftEl)}\n  ${Math.round(b.left)}→${Math.round(b.right)}  ${text(rightEl)}`,
+  ).toBeLessThanOrEqual(EPSILON);
+};
+
+/** Content fits the element instead of forcing it wider. */
+export const expectNoHorizontalOverflow = (el, label) => {
+  const overflow = el.scrollWidth - el.clientWidth;
+  expect(
+    overflow,
+    `${label}: content is ${overflow}px wider than its box\n  ${text(el)}`,
+  ).toBeLessThanOrEqual(1);
+};
+
+/** Truncation engaged — the layout absorbed the content, not the reverse. */
+export const expectTruncated = (el, label) => {
+  expect(
+    el.scrollWidth,
+    `${label}: expected the text to be clipped and tooltip-backed, but it fits — the fixture no longer exercises overflow\n  ${text(el)}`,
+  ).toBeGreaterThan(el.clientWidth);
+};

--- a/frontend/src/test-utils/layout/mount.jsx
+++ b/frontend/src/test-utils/layout/mount.jsx
@@ -1,0 +1,81 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { expect, onTestFinished } from "vitest";
+
+const settle = async () => {
+  // Fonts change text metrics and antd injects its CSS-in-JS on mount; both
+  // must be done before anything is measured.
+  await document.fonts.ready;
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+};
+
+/**
+ * Mount `ui` with the list rendered at `width` px and wait for layout to settle.
+ *
+ * Returns the wrapper element plus the usual RTL result.
+ */
+export const mountAtWidth = async (ui, width) => {
+  const host = document.createElement("div");
+  host.style.width = `${width}px`;
+  document.body.appendChild(host);
+  // Testing Library unmounts the React tree but leaves the container behind,
+  // and every test in a file shares one browser page — so without this the
+  // body accumulates a dead host per mount, alongside the portals antd hangs
+  // off it.
+  onTestFinished(() => host.remove());
+
+  const result = render(<MemoryRouter>{ui}</MemoryRouter>, {
+    container: host,
+  });
+  await settle();
+
+  const wrapper = host.querySelector(".list-view-wrapper");
+  expect(wrapper, "list did not render").not.toBeNull();
+
+  // ListView sizes itself as a percentage of an ancestor that also carries
+  // padding, so the host width needed for a given list width can't be computed
+  // up front. Converge on it instead — measure, correct proportionally, repeat.
+  // Deriving it beats hard-coding the percentage: a design tweak there changes
+  // nothing this suite asserts and must not turn every case red.
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const measured = wrapper.getBoundingClientRect().width;
+    if (Math.abs(measured - width) <= 0.5) {
+      break;
+    }
+    const hostWidth = Number.parseFloat(host.style.width);
+    host.style.width = `${hostWidth + (width - measured) * (hostWidth / measured)}px`;
+    await settle();
+  }
+
+  // The width is also clamped (min/max on the wrapper). Without this guard a
+  // clamp would silently collapse three "different" widths into three runs of
+  // the same one, and the suite would look broader than it is.
+  const actual = wrapper.getBoundingClientRect().width;
+  expect(
+    Math.abs(actual - width),
+    `asked for a ${width}px list but got ${actual.toFixed(0)}px — the width is being clamped, so this case is not testing what it claims`,
+  ).toBeLessThanOrEqual(1.5);
+
+  return { ...result, wrapper, host };
+};
+
+/**
+ * The rows of a rendered list.
+ *
+ * Asserts there are some: `.ant-list-item` is antd's class, not ours, so a
+ * major bump could rename it — and every per-row assertion in a suite like
+ * this one lives inside `for (const row of rowsOf(...))`. Silence there would
+ * read as green.
+ */
+export const rowsOf = (wrapper) => {
+  const rows = [...wrapper.querySelectorAll(".ant-list-item")];
+  expect(
+    rows.length,
+    "no list rows found — the row selector no longer matches, so every per-row assertion would pass vacuously",
+  ).toBeGreaterThan(0);
+  return rows;
+};
+
+export const queryAll = (wrapper, selector) => [
+  ...wrapper.querySelectorAll(selector),
+];

--- a/frontend/src/test-utils/layout/setup.js
+++ b/frontend/src/test-utils/layout/setup.js
@@ -1,0 +1,12 @@
+import "@testing-library/jest-dom";
+
+// Layout is measured, so nothing may still be moving when we measure it.
+// antd animates list items, tooltips and buttons on mount.
+const style = document.createElement("style");
+style.textContent = `*, *::before, *::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}`;
+document.head.appendChild(style);

--- a/frontend/vite-plugins/optional-plugin-imports.js
+++ b/frontend/vite-plugins/optional-plugin-imports.js
@@ -1,0 +1,83 @@
+import fs from "fs";
+import path from "path";
+
+const EMPTY_MODULE_ID = "\0optional-plugin-empty";
+const EMPTY_ASSET_MODULE_ID = "\0optional-plugin-empty-asset";
+
+const ASSET_EXTENSIONS = new Set([
+  ".svg",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".ico",
+  ".bmp",
+  ".tiff",
+]);
+
+// Rollup plugin that resolves missing optional plugin imports to an empty
+// module instead of failing the build.  This lets the existing
+// `try { await import("./plugins/...") } catch {}` pattern work at build
+// time: Rollup will bundle an empty module for any plugin path that does
+// not exist on disk, and the catch block handles the rest at runtime.
+//
+// Asset imports (images, SVGs, etc.) are resolved to a module that exports
+// an empty string as default, so static `import logo from "..."` statements
+// don't break the build.
+export function optionalPluginImports() {
+  return {
+    name: "optional-plugin-imports",
+    resolveId(source, importer) {
+      if (!importer) {
+        return null;
+      }
+
+      // Only handle relative imports
+      if (!source.startsWith(".")) {
+        return null;
+      }
+
+      // Strip query strings and hashes (e.g. "./logo.svg?react" → "./logo.svg")
+      // so path.extname and fs.existsSync work correctly.
+      const sourcePath = source.split("?")[0].split("#")[0];
+      const resolved = path.resolve(path.dirname(importer), sourcePath);
+
+      // Only handle imports that resolve within a plugins directory.
+      // This covers both cross-plugin imports (e.g. "../plugins/foo")
+      // and intra-plugin sibling imports (e.g. "./TrialMessage" from
+      // within plugins/login-form/).
+      if (!resolved.includes("/plugins/")) {
+        return null;
+      }
+
+      // Check common extensions
+      const extensions = ["", ".js", ".jsx", ".ts", ".tsx"];
+      const exists = extensions.some(
+        (ext) =>
+          fs.existsSync(resolved + ext) ||
+          fs.existsSync(path.join(resolved, "index" + (ext || ".js"))),
+      );
+
+      if (!exists) {
+        // Asset files need a default export so static imports work.
+        const ext = path.extname(sourcePath).toLowerCase();
+        if (ASSET_EXTENSIONS.has(ext)) {
+          return EMPTY_ASSET_MODULE_ID;
+        }
+        return EMPTY_MODULE_ID;
+      }
+
+      return null;
+    },
+    load(id) {
+      if (id === EMPTY_MODULE_ID) {
+        return "throw new Error('Optional plugin not available');";
+      }
+      if (id === EMPTY_ASSET_MODULE_ID) {
+        return "export default '';";
+      }
+      return null;
+    },
+  };
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,83 +1,9 @@
-import react from "@vitejs/plugin-react";
-import fs from "fs";
 import path from "path";
+import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 import svgr from "vite-plugin-svgr";
 
-const EMPTY_MODULE_ID = "\0optional-plugin-empty";
-const EMPTY_ASSET_MODULE_ID = "\0optional-plugin-empty-asset";
-
-const ASSET_EXTENSIONS = new Set([
-  ".svg",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".gif",
-  ".webp",
-  ".ico",
-  ".bmp",
-  ".tiff",
-]);
-
-// Rollup plugin that resolves missing optional plugin imports to an empty
-// module instead of failing the build.  This lets the existing
-// `try { await import("./plugins/...") } catch {}` pattern work at build
-// time: Rollup will bundle an empty module for any plugin path that does
-// not exist on disk, and the catch block handles the rest at runtime.
-//
-// Asset imports (images, SVGs, etc.) are resolved to a module that exports
-// an empty string as default, so static `import logo from "..."` statements
-// don't break the build.
-function optionalPluginImports() {
-  return {
-    name: "optional-plugin-imports",
-    resolveId(source, importer) {
-      if (!importer) return null;
-
-      // Only handle relative imports
-      if (!source.startsWith(".")) return null;
-
-      // Strip query strings and hashes (e.g. "./logo.svg?react" → "./logo.svg")
-      // so path.extname and fs.existsSync work correctly.
-      const sourcePath = source.split("?")[0].split("#")[0];
-      const resolved = path.resolve(path.dirname(importer), sourcePath);
-
-      // Only handle imports that resolve within a plugins directory.
-      // This covers both cross-plugin imports (e.g. "../plugins/foo")
-      // and intra-plugin sibling imports (e.g. "./TrialMessage" from
-      // within plugins/login-form/).
-      if (!resolved.includes("/plugins/")) return null;
-
-      // Check common extensions
-      const extensions = ["", ".js", ".jsx", ".ts", ".tsx"];
-      const exists = extensions.some(
-        (ext) =>
-          fs.existsSync(resolved + ext) ||
-          fs.existsSync(path.join(resolved, "index" + (ext || ".js"))),
-      );
-
-      if (!exists) {
-        // Asset files need a default export so static imports work.
-        const ext = path.extname(sourcePath).toLowerCase();
-        if (ASSET_EXTENSIONS.has(ext)) {
-          return EMPTY_ASSET_MODULE_ID;
-        }
-        return EMPTY_MODULE_ID;
-      }
-
-      return null;
-    },
-    load(id) {
-      if (id === EMPTY_MODULE_ID) {
-        return "throw new Error('Optional plugin not available');";
-      }
-      if (id === EMPTY_ASSET_MODULE_ID) {
-        return "export default '';";
-      }
-      return null;
-    },
-  };
-}
+import { optionalPluginImports } from "./vite-plugins/optional-plugin-imports";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {

--- a/frontend/vitest.config.mjs
+++ b/frontend/vitest.config.mjs
@@ -1,8 +1,23 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
+import { optionalPluginImports } from "./vite-plugins/optional-plugin-imports";
+
+// Two projects, because they need different environments:
+//   unit   — happy-dom, fast, but no layout engine (every rect measures 0)
+//   layout — real Chromium via playwright, the only place geometry is real
+// `bun run test` runs both; `test:unit` / `test:layout` run one.
 export default defineConfig({
   plugins: [
+    // src/plugins/** is cloud content: gitignored, absent from OSS checkouts
+    // and from CI. Vite resolves those imports at transform time and fails the
+    // module outright, so tests need the same treatment the production build
+    // gives them — the very same plugin, not a lookalike. It makes a missing
+    // plugin *throw* on import, which is the signal the runtime fallbacks in
+    // pluginRegistry and friends match on; stubbing it to an empty module
+    // instead would make every one of those fallbacks silently take the wrong
+    // branch under test.
+    optionalPluginImports(),
     react({
       include: "**/*.{jsx,js}",
     }),
@@ -12,8 +27,43 @@ export default defineConfig({
     include: /src\/.*\.jsx?$/,
   },
   test: {
-    globals: true,
-    environment: "happy-dom",
-    setupFiles: "./src/setupTests.js",
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          globals: true,
+          environment: "happy-dom",
+          setupFiles: "./src/setupTests.js",
+          include: ["src/**/*.test.{js,jsx}"],
+          // Layout specs need a browser; they are the other project.
+          exclude: ["src/**/*.layout.test.{js,jsx}"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "layout",
+          globals: true,
+          include: ["src/**/*.layout.test.{js,jsx}"],
+          setupFiles: "./src/test-utils/layout/setup.js",
+          browser: {
+            enabled: true,
+            provider: "playwright",
+            headless: true,
+            screenshotFailures: true,
+            instances: [
+              {
+                browser: "chromium",
+                // Fixed so a runner's default window size can never change
+                // what is measured. Cases size the list themselves; this only
+                // has to be wider than the widest case.
+                viewport: { width: 1600, height: 900 },
+              },
+            ],
+          },
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
> **No longer stacked.** #2193 is merged, so this branch has been rebased onto `main`
> and now carries the test commit alone. The suite is green against `main` as it stands.

## What

Adds a second vitest project that runs the UI in real Chromium and asserts the
*geometric* contracts of the shared `ListView` row: that its columns line up
across rows, that the metadata cluster stays inside its own box and clear of the
action icons, that rows never overflow, and that an over-long owner label
truncates instead of displacing the layout.

Also wires the frontend tests into `ci-test.yaml` as a `frontend` job. This is
the first time any vitest test runs in CI — the existing ones have only ever run
on dev machines.

## Why

Two CSS regressions reached staging in the last week and were both caught by
human QA rather than by CI:

1. Row columns were switched from fixed widths to flex. The row's left column
   grows to absorb slack, so the metadata cluster is anchored on the row's right
   edge — which means a content-sized owner column starts at a different x on
   every row. Measured drift between a row owned by "Me" and one owned by a long
   email address: 181–222px.
2. The follow-up pinned those columns to fixed widths but left their wrapper
   shrinkable. A shrinkable box with rigid children lets the children spill out
   of it and print on top of the action icons: +26px at 1440, +66px at 1024.

Neither is visible when reading the CSS diff, and neither is catchable by the
existing test setup — `vitest.config.mjs` runs on happy-dom, which has no layout
engine, so every `getBoundingClientRect()` returns zeros. No amount of unit
testing in that environment can see either bug.

## How

`vitest.config.mjs` now defines two projects:

- **unit** — happy-dom, the existing tests, unchanged.
- **layout** — real Chromium via `@vitest/browser` + `playwright`, running only
  `*.layout.test.jsx`.

`src/test-utils/layout/` holds component-agnostic helpers: `expectAlignedX`,
`expectContained`, `expectNoHorizontalOverlap`, `expectNoHorizontalOverflow`,
`expectTruncated`, and a `mountAtWidth` harness that renders a component at a
requested width and waits for fonts and antd's runtime styles to settle.

Every assertion is **relational, never absolute**. Nothing asserts a pixel
position, a padding, a gap, or a CSS property value — a redesign that moves the
columns keeps passing, and only a column that stops *being* a column fails. This
is deliberate: absolute-pixel layout tests get deleted within a month of the
first innocuous design tweak.

The production build's `optionalPluginImports` plugin moved to
`frontend/vite-plugins/` so `vitest.config.mjs` can reuse it. Tests need the
same treatment the build gives absent cloud plugins — importantly, it makes a
missing plugin *throw*, which is the signal `pluginRegistry` and ~30 other
runtime fallbacks match on. A lookalike stub that resolved to an empty module
instead would silently push every one of those fallbacks down the wrong branch.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No product code changes — the diff is tests, test config, CI, and one
build-config extraction.

The extraction is the only line of risk: `optionalPluginImports` moved out of
`vite.config.js` into `vite-plugins/optional-plugin-imports.js` and is imported
back. The function body is byte-identical apart from added braces on three
single-line returns. `npx vite build` was run before and after and succeeds.

CI risk is one new job. It is gated on `frontend/**`, so non-frontend PRs skip
it (skip reads as pass, per the existing filter convention), and it runs in
parallel with the python tiers — no added wall-clock on a PR that also runs e2e.

## Database Migrations

None.

## Env Config

None.

## Relevant Docs

None.

## Related Issues or PRs

#2193 (merged) is the CSS fix these tests hold in place, UN-3741. Follows #2182.
Tracked under UN-3797, a sub-task of UN-3635 alongside the python rig work.

## Dependencies Versions

Two new frontend devDependencies: `@vitest/browser@3.2.6` (matches the pinned
vitest) and `playwright@^1.61.1`. CI caches `~/.cache/ms-playwright` and installs
only Chromium.

`bun.lock` is regenerated. `@vitest/browser` is pinned exactly rather than with
a caret: its peer dependency on vitest is an exact version, so a caret would
resolve to 3.2.7 against the repo's vitest 3.2.6 and warn on every install.

## Notes on Testing

The suite was validated against three states of the CSS it protects, to prove it
fails for the right reason rather than merely passing:

| CSS state | Result |
|---|---|
| pre-#2193 `main` (drift bug live) | 7 fail — *"expected one straight column, got 180.5px of drift"* |
| pre-#2193 `main` + first fix commit (columns pinned, wrapper still shrinkable) | 1 fail — *"child escapes its container by 89.7px"* at 800px |
| `main` today (#2193 merged) | 13 pass |

Each bug is caught by the assertion aimed at it, and neither masks the other.

Harness fidelity was checked against a deployed build in a dev namespace: at a
900px list the harness reproduces `owner 240px / updated 170px / meta 430px /
24px clearance to the actions` — the same numbers measured live in the browser
on the running app.

Runtime: 29 tests (16 existing unit + 13 layout) in ~3s locally. The CI job is
~2–4 minutes, dominated by dependency install and the Chromium fetch on a cold
cache.

Widths tested are 800 / 1100 / 1400 — the min and max `.list-view-wrapper`
itself declares, plus the midpoint. The harness asserts it actually achieved the
requested width, so a clamp can't silently collapse three cases into one.

### What this does not cover

- Colors, font weights, icon swaps, spacing — anything non-geometric.
- Page composition: components are mounted in a harness, not inside the app
  shell, so a page-level stylesheet override or a sidebar squeezing the content
  area is still QA's to catch.
- `src/plugins/**` (gitignored cloud content, absent in CI) and non-Chromium
  browsers.
- Any component other than `ListView`. The helpers are reusable; add a
  `*.layout.test.jsx` beside a component when it earns one.

## Screenshots

Failure output is the interesting artifact here — an assertion reports the
measured drift and the offending rows, and vitest writes a screenshot of the
failing render, uploaded as a CI artifact:

```
AssertionError: owner column: expected one straight column, got 180.5px of drift
  [0] 1180px  Owned By:Me
  [1] 1000px  Owned By:a-really-long-service-account-n…
  [2] 1015px  Owned By:someone.else@example.com
  [3] 1160px  Owned By:Me +2
```

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

