### PR TITLE
UN-3798 [FIX] Skip broken file-path task load for PG pluggable workers

### DIFF
--- a/workers/shared/enums/worker_enums_base.py
+++ b/workers/shared/enums/worker_enums_base.py
@@ -58,13 +58,22 @@ class WorkerType(str, Enum):
         if self.is_pluggable():
             return f"pluggable_worker.{self.value}.tasks"
 
-        # Map to actual directory structure
+        return f"{self.to_directory()}.tasks"
+
+    def to_directory(self) -> str:
+        """Return the on-disk directory name for this (non-pluggable) worker.
+
+        Single source of truth for the naming-convention mapping: enum values use
+        underscores (Python module names), but a few on-disk dirs use hyphens
+        (e.g. ``api-deployment``). ``to_import_path`` builds on this, and the
+        file-path task loader in ``worker.py`` reads it directly rather than
+        slicing the import path.
+        """
         directory_mapping = {
             "api_deployment": "api-deployment",
             # All others use same name for directory and module
         }
-        directory = directory_mapping.get(self.value, self.value)
-        return f"{directory}.tasks"
+        return directory_mapping.get(self.value, self.value)
 
     def is_pluggable(self) -> bool:
         """Check if this worker type is a pluggable worker.

--- a/workers/tests/test_worker_enums_directory.py
+++ b/workers/tests/test_worker_enums_directory.py
@@ -1,0 +1,30 @@
+"""WorkerType.to_directory() — the single source for the on-disk dir mapping (UN-3798).
+
+worker.py's file-path task loader reads to_directory() directly instead of slicing
+to_import_path(); these pin the hyphen/underscore mapping and that to_import_path
+is built on top of it, so the two can't drift.
+"""
+
+from celery import Celery
+from shared.enums.worker_enums_base import WorkerType
+
+# The workers autouse conftest fixture finalizes celery's default_app around every
+# test; this pure-enum test builds no Celery app of its own, so establish one.
+Celery("test-worker-enums").set_default()
+
+
+def test_to_directory_maps_underscored_value_to_hyphenated_dir():
+    # The one worker whose on-disk dir differs from its enum value.
+    assert WorkerType.API_DEPLOYMENT.value == "api_deployment"
+    assert WorkerType.API_DEPLOYMENT.to_directory() == "api-deployment"
+
+
+def test_to_directory_passthrough_when_dir_equals_value():
+    assert WorkerType.GENERAL.to_directory() == "general"
+
+
+def test_to_import_path_is_built_on_to_directory():
+    # to_import_path must derive from to_directory (not a separate mapping), so the
+    # directory naming lives in exactly one place.
+    wt = WorkerType.API_DEPLOYMENT
+    assert wt.to_import_path() == f"{wt.to_directory()}.tasks"

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -444,36 +444,50 @@ logger.info("✅ Worker infrastructure initialized successfully")
 # Determine worker path dynamically based on worker type
 base_dir = os.path.dirname(os.path.abspath(__file__))
 if worker_type.is_pluggable():
-    # Pluggable workers live inside workers/pluggable_worker/{worker_name}
-    worker_directory = os.path.join("pluggable_worker", worker_type.value)
-    worker_path = os.path.join(base_dir, worker_directory)
+    # Pluggable workers' tasks are ALREADY registered by this point:
+    # build_celery_app() above verifies the plugin via
+    # WorkerBuilder._verify_pluggable_worker_exists, which does
+    # `importlib.import_module("pluggable_worker.{type}.worker")` — a proper
+    # PACKAGE import that runs the plugin's own `from . import tasks`, resolving
+    # its relative imports (`from .clients import ...`) and registering the tasks
+    # on this same app. The generic file-path load below loads tasks.py under a
+    # bare "tasks" spec (no parent package), which BREAKS those relative imports
+    # ("attempted relative import with no known parent package"), so it MUST be
+    # skipped for pluggable workers — otherwise every cloud PG pluggable worker
+    # crashes on startup.
+    logger.info(
+        f"✅ Pluggable worker {worker_type.value} tasks already registered via "
+        "WorkerBuilder (package import); skipping file-path task load"
+    )
 else:
-    # Enum values use underscores (Python module names); a few on-disk dirs
-    # still use hyphens (e.g. api-deployment). Derive the directory from the
+    # Non-pluggable (top-level) workers register tasks via a file-path load of
+    # their tasks.py — they use absolute imports, with their dir on sys.path.
+    # Enum values use underscores (Python module names); a few on-disk dirs still
+    # use hyphens (e.g. api-deployment). Derive the directory from the
     # authoritative import-path map on WorkerType instead of a blind replace.
     worker_directory = worker_type.to_import_path().rsplit(".", 1)[0]
     worker_path = os.path.join(base_dir, worker_directory)
 
-# Add worker directory to path for task imports
-if os.path.exists(worker_path):
-    sys.path.append(worker_path)
-    logger.info(f"✅ Added {worker_directory} to Python path for task imports")
+    # Add worker directory to path for task imports
+    if os.path.exists(worker_path):
+        sys.path.append(worker_path)
+        logger.info(f"✅ Added {worker_directory} to Python path for task imports")
 
-    # Import tasks module to register tasks
-    tasks_file = os.path.join(worker_path, "tasks.py")
-    if os.path.exists(tasks_file):
-        logger.info(f"📋 Loading tasks from: {tasks_file}")
-        # Import the tasks module to register tasks with the app
-        import importlib.util
+        # Import tasks module to register tasks
+        tasks_file = os.path.join(worker_path, "tasks.py")
+        if os.path.exists(tasks_file):
+            logger.info(f"📋 Loading tasks from: {tasks_file}")
+            # Import the tasks module to register tasks with the app
+            import importlib.util
 
-        spec = importlib.util.spec_from_file_location("tasks", tasks_file)
-        tasks_module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(tasks_module)
-        logger.info(f"✅ Tasks loaded successfully from {worker_directory}")
+            spec = importlib.util.spec_from_file_location("tasks", tasks_file)
+            tasks_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(tasks_module)
+            logger.info(f"✅ Tasks loaded successfully from {worker_directory}")
+        else:
+            logger.warning(f"⚠️ No tasks.py found at: {tasks_file}")
     else:
-        logger.warning(f"⚠️ No tasks.py found at: {tasks_file}")
-else:
-    logger.error(f"❌ Worker directory not found: {worker_path}")
+        logger.error(f"❌ Worker directory not found: {worker_path}")
 
 # Log successful configuration
 logger.info(f"✅ Successfully loaded {worker_type} worker using WorkerBuilder")

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -5,6 +5,7 @@ This module serves as the main entry point for all Celery workers.
 It uses WorkerBuilder to ensure proper configuration including chord retry settings.
 """
 
+import importlib.util
 import logging
 import os
 import sys
@@ -440,54 +441,69 @@ logger.info("🏗️ Initializing worker infrastructure (singleton pattern)...")
 initialize_worker_infrastructure()
 logger.info("✅ Worker infrastructure initialized successfully")
 
-# Import tasks from the worker-specific directory
-# Determine worker path dynamically based on worker type
-base_dir = os.path.dirname(os.path.abspath(__file__))
-if worker_type.is_pluggable():
-    # Pluggable workers' tasks are ALREADY registered by this point:
-    # build_celery_app() above verifies the plugin via
-    # WorkerBuilder._verify_pluggable_worker_exists, which does
-    # `importlib.import_module("pluggable_worker.{type}.worker")` — a proper
-    # PACKAGE import that runs the plugin's own `from . import tasks`, resolving
-    # its relative imports (`from .clients import ...`) and registering the tasks
-    # on this same app. The generic file-path load below loads tasks.py under a
-    # bare "tasks" spec (no parent package), which BREAKS those relative imports
-    # ("attempted relative import with no known parent package"), so it MUST be
-    # skipped for pluggable workers — otherwise every cloud PG pluggable worker
-    # crashes on startup.
-    logger.info(
-        f"✅ Pluggable worker {worker_type.value} tasks already registered via "
-        "WorkerBuilder (package import); skipping file-path task load"
-    )
-else:
-    # Non-pluggable (top-level) workers register tasks via a file-path load of
-    # their tasks.py — they use absolute imports, with their dir on sys.path.
-    # Enum values use underscores (Python module names); a few on-disk dirs still
-    # use hyphens (e.g. api-deployment). Derive the directory from the
-    # authoritative import-path map on WorkerType instead of a blind replace.
-    worker_directory = worker_type.to_import_path().rsplit(".", 1)[0]
+
+def load_worker_tasks(worker_type: WorkerType) -> None:
+    """Register the worker type's Celery tasks.
+
+    Pluggable workers are already registered by this point: ``build_celery_app()``
+    above verified the plugin via ``WorkerBuilder._verify_pluggable_worker_exists``,
+    which does ``importlib.import_module("pluggable_worker.<type>.worker")`` — a
+    proper PACKAGE import that runs the plugin's own task-registration code (e.g.
+    ``from . import tasks``, which may use relative imports such as
+    ``from .clients import ...``). Celery binds those tasks to the worker's app
+    when it finalizes, so they are registered by this point. The generic file-path
+    load below is therefore SKIPPED for pluggable workers — it loads ``tasks.py``
+    under a bare ``"tasks"`` spec with no parent package, which breaks any relative
+    imports in the plugin's ``tasks.py`` ("attempted relative import with no known
+    parent package").
+
+    Non-pluggable (top-level) workers use absolute imports; their ``tasks.py`` is
+    loaded by file path with the worker directory on ``sys.path``.
+    """
+    if worker_type.is_pluggable():
+        logger.info(
+            f"✅ Pluggable worker {worker_type.value} tasks already registered via "
+            "WorkerBuilder (package import); skipping file-path task load"
+        )
+        return
+
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    worker_directory = worker_type.to_directory()
     worker_path = os.path.join(base_dir, worker_directory)
-
-    # Add worker directory to path for task imports
-    if os.path.exists(worker_path):
-        sys.path.append(worker_path)
-        logger.info(f"✅ Added {worker_directory} to Python path for task imports")
-
-        # Import tasks module to register tasks
-        tasks_file = os.path.join(worker_path, "tasks.py")
-        if os.path.exists(tasks_file):
-            logger.info(f"📋 Loading tasks from: {tasks_file}")
-            # Import the tasks module to register tasks with the app
-            import importlib.util
-
-            spec = importlib.util.spec_from_file_location("tasks", tasks_file)
-            tasks_module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(tasks_module)
-            logger.info(f"✅ Tasks loaded successfully from {worker_directory}")
-        else:
-            logger.warning(f"⚠️ No tasks.py found at: {tasks_file}")
-    else:
+    if not os.path.exists(worker_path):
         logger.error(f"❌ Worker directory not found: {worker_path}")
+        return
+
+    sys.path.append(worker_path)
+    logger.info(f"✅ Added {worker_directory} to Python path for task imports")
+
+    tasks_file = os.path.join(worker_path, "tasks.py")
+    if not os.path.exists(tasks_file):
+        logger.warning(f"⚠️ No tasks.py found at: {tasks_file}")
+        return
+
+    logger.info(f"📋 Loading tasks from: {tasks_file}")
+    spec = importlib.util.spec_from_file_location("tasks", tasks_file)
+    tasks_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(tasks_module)
+    logger.info(f"✅ Tasks loaded successfully from {worker_directory}")
+
+
+load_worker_tasks(worker_type)
+
+# A worker that boots with no registered tasks starts but silently processes
+# nothing (Celery does not error on an empty registry). Surface that misconfig —
+# as a WARNING, not a hard failure: pluggable tasks bind on app finalize
+# (@shared_task / connect_on_app_finalize), which can be after this point, so a
+# raise here would false-positive on a correctly-configured pluggable worker.
+_registered_tasks = [name for name in app.tasks if not name.startswith("celery.")]
+if not _registered_tasks:
+    logger.warning(
+        f"⚠️ No non-celery tasks registered yet for worker '{worker_type.value}' "
+        f"(pluggable={worker_type.is_pluggable()}). If this persists past app "
+        "finalize the worker will start but process nothing — check the "
+        "worker/plugin task registration."
+    )
 
 # Log successful configuration
 logger.info(f"✅ Successfully loaded {worker_type} worker using WorkerBuilder")


### PR DESCRIPTION
## What
- For pluggable `WORKER_TYPE`s, the top-level `workers/worker.py` no longer loads the plugin's `tasks.py` by file path under a bare `"tasks"` module name. Their tasks are already registered by `WorkerBuilder.build_celery_app()`; the file-path load is skipped.
- Non-pluggable (top-level) workers keep the existing file-path load, unchanged.

## Why
- The file-path load used `spec_from_file_location("tasks", ...)` — a bare name with **no parent package** — so every plugin `tasks.py` relative import (`from .clients import ...`) failed with `ImportError: attempted relative import with no known parent package`, crash-looping the worker on startup under `python -m pg_queue_consumer`.
- This blocks **every** cloud PG pluggable worker (bulk-download UN-3752, agentic-callback UN-3754, agentic_studio UN-3779). It was never caught because these workers are disabled in all base values and no test had started one via the PG consumer.
- The Celery path is unaffected: Celery pluggable workers run via `celery -A pluggable_worker.{type}.worker` (a proper dotted package import), which resolves relative imports and never touches this loader. The `is_pluggable()` file-path branch never actually ran successfully.

## How
- `build_celery_app()` (called just above the loader) verifies a pluggable type via `_verify_pluggable_worker_exists` → `importlib.import_module("pluggable_worker.{type}.worker")` — a package import that runs the plugin's `from . import tasks` and registers the tasks on this same app. So the file-path load is redundant + broken; skip it for pluggable workers.

## Can this PR break any existing features?
- No. The Celery path and non-pluggable file-path path are untouched (non-pluggable load simply moved into the `else` branch). Removes a code path that never ran successfully. PG and Celery register identical tasks (both via `build_celery_app`).

## Database Migrations
- None.

## Env Config
- None.

## Notes on Testing
- Validated on a running dev stack via `python -m pg_queue_consumer`: `agentic_callback` and `agentic_studio` now start clean (`tasks already registered … skipping file-path task load` → `ready for Celery`); `general` (non-pluggable) loads unchanged via the file-path path.
- No unit test: `worker.py` is module-level startup code and this repo has no pluggable-worker fixture; the runtime worker-start is the validation.

## Related Issues or PRs
- Prerequisite for UN-3752, UN-3754, UN-3779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)