### PR TITLE
UN-3753 [GATED-FEAT] Route webhook notifications through PG-queue transport (flag-gated)

### DIFF
--- a/backend/notification_v2/internal_api_views.py
+++ b/backend/notification_v2/internal_api_views.py
@@ -515,19 +515,32 @@ def _reclaim_stale_sending() -> int:
     return int(reclaimed)
 
 
-def _org_identifier(org_pk: Any) -> str | None:
+def _org_identifier(org_pk: int) -> str | None:
     """Resolve the string ``Organization.organization_id`` from the buffer's org pk.
 
     ``resolve_transport`` keys its Flipt decision on the org's string identifier,
     but the buffer stores/uses the Organization pk. One indexed pk lookup per
-    dispatch group (post-commit) — negligible before the webhook HTTP call it
-    precedes. ``None`` (org deleted) fails closed to Celery in resolve_transport.
+    dispatch group (post-commit) — negligible relative to the downstream webhook
+    dispatch.
+
+    Data-anomaly guard: ``NotificationBuffer.organization`` is
+    ``on_delete=CASCADE``, so a live buffer row with a missing org is unreachable
+    in normal operation. A ``None`` here therefore signals a dangling FK — we log
+    it (the only org-traceable breadcrumb; resolve_transport's own warning is keyed
+    on the random dispatch uuid) and fail closed to Celery in resolve_transport.
     """
-    return (
+    org_string_id = (
         Organization.objects.filter(pk=org_pk)
         .values_list("organization_id", flat=True)
         .first()
     )
+    if org_string_id is None:
+        logger.warning(
+            "metric=notification_org_identifier_missing_total org_pk=%s "
+            "(dangling FK; notification routing falls back to Celery)",
+            org_pk,
+        )
+    return org_string_id
 
 
 def _send_clubbed(
@@ -578,7 +591,7 @@ def _send_clubbed(
                 "organization_id": org_id,
             },
             queue="notifications",
-            organization_id=_org_identifier(org_id),
+            org_string_id=_org_identifier(org_id),
         )
         logger.info(
             "metric=notification_batch_dispatched_total platform=%s result=success "
@@ -588,7 +601,31 @@ def _send_clubbed(
             webhook_url_hash(url),
             len(buffer_ids),
         )
+    except (ValueError, TypeError):
+        # PERMANENT dispatch errors — enqueue_task validation (priority range /
+        # reply_key+callback exclusivity) or payload serialization — fail
+        # identically every flush tick. Dead-letter now (distinct metric) instead
+        # of reverting to PENDING and re-rendering + re-dispatching + emitting a
+        # broker_failure traceback until the attempt cap. Guard on SENDING so a row
+        # the worker already resolved isn't clobbered.
+        logger.exception(
+            "metric=notification_batch_dispatched_total platform=%s "
+            "result=dispatch_error org_id=%s webhook_url_hash=%s rows=%d",
+            platform,
+            org_id,
+            webhook_url_hash(url),
+            len(buffer_ids),
+        )
+        NotificationBuffer.objects.filter(
+            id__in=buffer_ids,
+            status=BufferStatus.SENDING.value,
+        ).update(status=BufferStatus.DEAD_LETTER.value)
     except Exception:
+        # TRANSIENT transport/broker failure — revert to PENDING (outside the
+        # committed txn) so the next flush tick retries; refund the SENDING-claim
+        # attempt since nothing was queued or sent. Guard on SENDING so a row the
+        # worker already marked terminal (broker raised post-delivery) isn't
+        # resurrected into a duplicate.
         logger.exception(
             "metric=notification_batch_dispatched_total platform=%s "
             "result=broker_failure org_id=%s webhook_url_hash=%s rows=%d",
@@ -597,10 +634,6 @@ def _send_clubbed(
             webhook_url_hash(url),
             len(buffer_ids),
         )
-        # Revert to PENDING (outside the committed txn) so a transient broker
-        # outage retries next tick; refund the SENDING-claim attempt since nothing
-        # was queued or sent. Guard on SENDING so a row the worker already marked
-        # terminal (broker raised post-delivery) isn't resurrected into a duplicate.
         NotificationBuffer.objects.filter(
             id__in=buffer_ids,
             status=BufferStatus.SENDING.value,

--- a/backend/notification_v2/internal_api_views.py
+++ b/backend/notification_v2/internal_api_views.py
@@ -38,7 +38,10 @@ from notification_v2.helper import (
     webhook_url_hash,
 )
 from notification_v2.models import Notification, NotificationBuffer
-from notification_v2.notification_dispatch import dispatch_webhook_notification
+from notification_v2.notification_dispatch import (
+    PermanentDispatchError,
+    dispatch_webhook_notification,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -601,13 +604,16 @@ def _send_clubbed(
             webhook_url_hash(url),
             len(buffer_ids),
         )
-    except (ValueError, TypeError):
-        # PERMANENT dispatch errors — enqueue_task validation (priority range /
-        # reply_key+callback exclusivity) or payload serialization — fail
+    except PermanentDispatchError:
+        # PG-ONLY permanent failure — enqueue_task validation (priority range /
+        # reply_key+callback exclusivity) or payload serialization — fails
         # identically every flush tick. Dead-letter now (distinct metric) instead
         # of reverting to PENDING and re-rendering + re-dispatching + emitting a
-        # broker_failure traceback until the attempt cap. Guard on SENDING so a row
-        # the worker already resolved isn't clobbered.
+        # broker_failure traceback until the attempt cap. The Celery path never
+        # raises this, so the flag-off flow is unchanged: a Celery send_task failure
+        # is an ordinary Exception handled by the transient branch below, exactly as
+        # before UN-3753. Guard on SENDING so a row the worker already resolved
+        # isn't clobbered.
         logger.exception(
             "metric=notification_batch_dispatched_total platform=%s "
             "result=dispatch_error org_id=%s webhook_url_hash=%s rows=%d",

--- a/backend/notification_v2/internal_api_views.py
+++ b/backend/notification_v2/internal_api_views.py
@@ -14,6 +14,7 @@ import logging
 from datetime import timedelta
 from typing import Any, cast
 
+from account_v2.models import Organization
 from api_v2.models import APIDeployment
 from django.conf import settings
 from django.db import transaction
@@ -37,6 +38,7 @@ from notification_v2.helper import (
     webhook_url_hash,
 )
 from notification_v2.models import Notification, NotificationBuffer
+from notification_v2.notification_dispatch import dispatch_webhook_notification
 
 logger = logging.getLogger(__name__)
 
@@ -513,6 +515,21 @@ def _reclaim_stale_sending() -> int:
     return int(reclaimed)
 
 
+def _org_identifier(org_pk: Any) -> str | None:
+    """Resolve the string ``Organization.organization_id`` from the buffer's org pk.
+
+    ``resolve_transport`` keys its Flipt decision on the org's string identifier,
+    but the buffer stores/uses the Organization pk. One indexed pk lookup per
+    dispatch group (post-commit) — negligible before the webhook HTTP call it
+    precedes. ``None`` (org deleted) fails closed to Celery in resolve_transport.
+    """
+    return (
+        Organization.objects.filter(pk=org_pk)
+        .values_list("organization_id", flat=True)
+        .first()
+    )
+
+
 def _send_clubbed(
     *,
     url: str,
@@ -540,8 +557,12 @@ def _send_clubbed(
     ``buffer_row_ids`` + ``organization_id`` to the worker so it can mark them.
     """
     try:
-        celery_app.send_task(
-            "send_webhook_notification",
+        # Flag-gated transport (UN-3753): PG queue when pg_queue_enabled for this
+        # org, else Celery (byte-identical to the prior send_task). resolve_transport
+        # keys on the org STRING id, but the buffer/worker contract below uses the
+        # org pk — hence _org_identifier(org_id) for routing, org_id in kwargs.
+        dispatch_webhook_notification(
+            celery_app=celery_app,
             args=[url, body, headers, settings.NOTIFICATION_TIMEOUT],
             kwargs={
                 "max_retries": max_retries,
@@ -557,6 +578,7 @@ def _send_clubbed(
                 "organization_id": org_id,
             },
             queue="notifications",
+            organization_id=_org_identifier(org_id),
         )
         logger.info(
             "metric=notification_batch_dispatched_total platform=%s result=success "

--- a/backend/notification_v2/notification_dispatch.py
+++ b/backend/notification_v2/notification_dispatch.py
@@ -1,0 +1,95 @@
+"""Transport-routed dispatch for buffered webhook notifications (UN-3753).
+
+Routes the ``send_webhook_notification`` task through the same
+:func:`resolve_transport` flag as the execution path: the PG queue when
+``pg_queue_enabled`` for this org, else Celery. **Fail-closed** — with the gate
+off (the production default) it resolves to Celery, behaving exactly like the
+prior unconditional ``celery_app.send_task`` (zero regression). On PG the task
+is drained by the PG notification consumer on the ``notifications`` queue.
+
+The same ``args``/``kwargs``/``queue`` are forwarded on both paths; on PG they're
+JSON-normalized by ``enqueue_task`` (UUIDs/datetimes → str), so the consumer sees
+the same payload the Celery worker would.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from pg_queue.producer import enqueue_task
+from workflow_manager.workflow_v2.transport import resolve_transport
+
+from unstract.core.data_models import is_pg_transport
+
+logger = logging.getLogger(__name__)
+
+# The fired task name — mirrors the Celery task registered by the notification
+# worker; kept as a local constant so the backend doesn't import the workers pkg.
+WEBHOOK_NOTIFICATION_TASK = "send_webhook_notification"
+
+
+def dispatch_webhook_notification(
+    *,
+    celery_app: Any,
+    args: list[Any],
+    kwargs: dict[str, Any],
+    queue: str,
+    organization_id: str | None,
+) -> str:
+    """Dispatch ``send_webhook_notification`` on the resolved transport.
+
+    ``args``/``kwargs``/``queue`` are forwarded unchanged on both paths, so the
+    flag-off (Celery) path is byte-identical to the legacy ``send_task`` call.
+
+    Args:
+        celery_app: Injected Celery app (the backend's ``celery_service.app``);
+            passed in rather than imported so this seam stays trivially testable.
+        args: Positional task args, forwarded verbatim.
+        kwargs: Keyword task args, forwarded verbatim. For the buffered path this
+            carries ``organization_id`` = the buffer's org **pk** (the worker's
+            buffer-mark contract) — distinct from the ``organization_id`` param
+            below, which is the string identifier used only for flag routing.
+        queue: Target queue name, forwarded verbatim.
+        organization_id: The org's **string** identifier
+            (``Organization.organization_id``), used solely for the Flipt
+            transport decision. ``None`` (or empty) fails closed to Celery.
+
+    Returns:
+        A task id string — the Celery ``AsyncResult`` id on the Celery path, or
+        the minted PG task id on the PG path (usable by callers that surface it
+        in an API response).
+    """
+    # A buffered notification is a single fire-and-forget task with no natural
+    # sticky entity, so mint a fresh id to drive Flipt's percentage bucketing and
+    # to serve as the PG task id.
+    dispatch_id = str(uuid.uuid4())
+    transport = resolve_transport(
+        execution_id=dispatch_id,
+        organization_id=organization_id or None,
+    )
+    # Use the shared is_pg_transport() — the single source for "what counts as PG
+    # transport" — rather than opening a second comparison site.
+    if is_pg_transport(transport):
+        enqueue_task(
+            task_name=WEBHOOK_NOTIFICATION_TASK,
+            queue=queue,
+            args=args,
+            kwargs=kwargs,
+            org_id=organization_id or "",
+            task_id=dispatch_id,
+        )
+        logger.info(
+            "Webhook notification enqueued on PG '%s' queue (task_id=%s)",
+            queue,
+            dispatch_id,
+        )
+        return dispatch_id
+    result = celery_app.send_task(
+        WEBHOOK_NOTIFICATION_TASK,
+        args=args,
+        kwargs=kwargs,
+        queue=queue,
+    )
+    return result.id

--- a/backend/notification_v2/notification_dispatch.py
+++ b/backend/notification_v2/notification_dispatch.py
@@ -36,7 +36,7 @@ def dispatch_webhook_notification(
     args: list[Any],
     kwargs: dict[str, Any],
     queue: str,
-    organization_id: str | None,
+    org_string_id: str | None,
 ) -> str:
     """Dispatch ``send_webhook_notification`` on the resolved transport.
 
@@ -49,25 +49,28 @@ def dispatch_webhook_notification(
         args: Positional task args, forwarded verbatim.
         kwargs: Keyword task args, forwarded verbatim. For the buffered path this
             carries ``organization_id`` = the buffer's org **pk** (the worker's
-            buffer-mark contract) — distinct from the ``organization_id`` param
-            below, which is the string identifier used only for flag routing.
+            buffer-mark contract) — deliberately a DIFFERENT identifier from the
+            ``org_string_id`` param below (the two must not be conflated).
         queue: Target queue name, forwarded verbatim.
-        organization_id: The org's **string** identifier
+        org_string_id: The org's **string** identifier
             (``Organization.organization_id``), used solely for the Flipt
-            transport decision. ``None`` (or empty) fails closed to Celery.
+            transport decision — NOT the org pk carried in ``kwargs``. ``None`` (or
+            empty) fails closed to Celery.
 
     Returns:
         A task id string — the Celery ``AsyncResult`` id on the Celery path, or
-        the minted PG task id on the PG path (usable by callers that surface it
-        in an API response).
+        the minted PG task id on the PG path. Returned for symmetry / any future
+        caller; the sole current caller (fire-and-forget) discards it.
     """
     # A buffered notification is a single fire-and-forget task with no natural
     # sticky entity, so mint a fresh id to drive Flipt's percentage bucketing and
     # to serve as the PG task id.
     dispatch_id = str(uuid.uuid4())
+    # resolve_transport already normalizes falsy input to Celery, so pass the id
+    # straight through (no `or None` needed).
     transport = resolve_transport(
         execution_id=dispatch_id,
-        organization_id=organization_id or None,
+        organization_id=org_string_id,
     )
     # Use the shared is_pg_transport() — the single source for "what counts as PG
     # transport" — rather than opening a second comparison site.
@@ -77,7 +80,9 @@ def dispatch_webhook_notification(
             queue=queue,
             args=args,
             kwargs=kwargs,
-            org_id=organization_id or "",
+            # enqueue_task's org_id is str-typed — coerce None→"" (unlike the
+            # routing arg above, this `or ""` is load-bearing).
+            org_id=org_string_id or "",
             task_id=dispatch_id,
         )
         logger.info(

--- a/backend/notification_v2/notification_dispatch.py
+++ b/backend/notification_v2/notification_dispatch.py
@@ -30,6 +30,18 @@ logger = logging.getLogger(__name__)
 WEBHOOK_NOTIFICATION_TASK = "send_webhook_notification"
 
 
+class PermanentDispatchError(Exception):
+    """A dispatch failure that would fail identically on every retry.
+
+    Raised ONLY on the PG path, when ``enqueue_task`` rejects the message for a
+    permanent reason (priority range / reply_key+callback exclusivity validation,
+    or a payload that can't be JSON-serialized). The Celery path never raises it,
+    so a caller can dead-letter on this exception without altering the flag-off
+    (Celery) error flow — a Celery ``send_task`` failure stays an ordinary
+    ``Exception`` the caller's transient handler owns, exactly as before.
+    """
+
+
 def dispatch_webhook_notification(
     *,
     celery_app: Any,
@@ -75,16 +87,23 @@ def dispatch_webhook_notification(
     # Use the shared is_pg_transport() — the single source for "what counts as PG
     # transport" — rather than opening a second comparison site.
     if is_pg_transport(transport):
-        enqueue_task(
-            task_name=WEBHOOK_NOTIFICATION_TASK,
-            queue=queue,
-            args=args,
-            kwargs=kwargs,
-            # enqueue_task's org_id is str-typed — coerce None→"" (unlike the
-            # routing arg above, this `or ""` is load-bearing).
-            org_id=org_string_id or "",
-            task_id=dispatch_id,
-        )
+        try:
+            enqueue_task(
+                task_name=WEBHOOK_NOTIFICATION_TASK,
+                queue=queue,
+                args=args,
+                kwargs=kwargs,
+                # enqueue_task's org_id is str-typed — coerce None→"" (unlike the
+                # routing arg above, this `or ""` is load-bearing).
+                org_id=org_string_id or "",
+                task_id=dispatch_id,
+            )
+        except (ValueError, TypeError) as exc:
+            # PG-only permanent failure (enqueue_task validation / JSON encode):
+            # re-raise as PermanentDispatchError so the caller dead-letters it.
+            # A transient PG error (DB down) is NOT wrapped — it propagates as an
+            # ordinary Exception into the caller's retry (revert-to-PENDING) path.
+            raise PermanentDispatchError(str(exc)) from exc
         logger.info(
             "Webhook notification enqueued on PG '%s' queue (task_id=%s)",
             queue,

--- a/backend/notification_v2/tests/test_notification_dispatch.py
+++ b/backend/notification_v2/tests/test_notification_dispatch.py
@@ -69,8 +69,8 @@ class TestDispatchWebhookNotification:
         assert result is celery.send_task.return_value.id
 
     def test_pg_enqueue_failure_propagates_with_no_celery_fallback(self):
-        # No silent Celery fallback on PG failure — the caller (_send_clubbed)
-        # reverts the buffer rows to PENDING for a clean retry next tick.
+        # No silent Celery fallback on a TRANSIENT PG failure — it propagates raw
+        # (not wrapped), so the caller (_send_clubbed) reverts rows to PENDING.
         celery = MagicMock()
         with (
             patch.object(nd, "resolve_transport", return_value="pg_queue"),
@@ -79,6 +79,20 @@ class TestDispatchWebhookNotification:
             with pytest.raises(RuntimeError, match="pg down"):
                 _dispatch(celery)
         celery.send_task.assert_not_called()
+
+    def test_pg_permanent_enqueue_error_is_wrapped(self):
+        # A PERMANENT enqueue error (ValueError/TypeError: validation / JSON encode)
+        # is re-raised as PermanentDispatchError so the caller dead-letters it —
+        # raised ONLY on the PG path, so the Celery flow is never affected.
+        celery = MagicMock()
+        for exc in (ValueError("priority out of range"), TypeError("not serializable")):
+            with (
+                patch.object(nd, "resolve_transport", return_value="pg_queue"),
+                patch.object(nd, "enqueue_task", side_effect=exc),
+            ):
+                with pytest.raises(nd.PermanentDispatchError):
+                    _dispatch(celery)
+            celery.send_task.assert_not_called()
 
     def test_none_org_fails_closed_to_celery(self):
         # A missing org string (org deleted) must not route to PG — resolve_transport

--- a/backend/notification_v2/tests/test_notification_dispatch.py
+++ b/backend/notification_v2/tests/test_notification_dispatch.py
@@ -1,0 +1,122 @@
+"""Unit tests for the buffered-webhook transport routing (UN-3753).
+
+``resolve_transport`` + ``enqueue_task`` are patched on the module, so no Flipt /
+DB is needed — these pin the routing contract: PG when the flag resolves PG,
+Celery otherwise (fail-closed), with byte-identical args/kwargs/queue on both
+paths.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import notification_v2.notification_dispatch as nd
+
+_ARGS = ["https://hook.test", {"text": "hi"}, {"Content-Type": "application/json"}, 30]
+_KWARGS = {
+    "max_retries": 3,
+    "retry_delay": 10,
+    "platform": "SLACK",
+    "raise_on_final_failure": True,
+    "buffer_row_ids": ["b1", "b2"],
+    "organization_id": 7,  # the org pk (worker's buffer-mark contract)
+}
+_QUEUE = "notifications"
+
+
+def _dispatch(celery_app, organization_id="org_x"):
+    return nd.dispatch_webhook_notification(
+        celery_app=celery_app,
+        args=_ARGS,
+        kwargs=_KWARGS,
+        queue=_QUEUE,
+        organization_id=organization_id,
+    )
+
+
+class TestDispatchWebhookNotification:
+    def test_routes_to_pg_when_flag_resolves_pg(self):
+        celery = MagicMock()
+        with (
+            patch.object(nd, "resolve_transport", return_value="pg_queue"),
+            patch.object(nd, "enqueue_task", return_value=42) as enqueue,
+        ):
+            task_id = _dispatch(celery)
+        enqueue.assert_called_once()
+        kwargs = enqueue.call_args.kwargs
+        assert kwargs["task_name"] == "send_webhook_notification"
+        assert kwargs["queue"] == _QUEUE
+        assert kwargs["args"] == _ARGS
+        assert kwargs["kwargs"] == _KWARGS
+        assert kwargs["org_id"] == "org_x"
+        # The minted PG task id is returned and threaded into the enqueue row.
+        assert kwargs["task_id"] == task_id
+        celery.send_task.assert_not_called()
+
+    def test_routes_to_celery_when_flag_resolves_celery(self):
+        celery = MagicMock()
+        with (
+            patch.object(nd, "resolve_transport", return_value="celery"),
+            patch.object(nd, "enqueue_task") as enqueue,
+        ):
+            result = _dispatch(celery)
+        celery.send_task.assert_called_once_with(
+            "send_webhook_notification", args=_ARGS, kwargs=_KWARGS, queue=_QUEUE
+        )
+        enqueue.assert_not_called()
+        assert result is celery.send_task.return_value.id
+
+    def test_pg_enqueue_failure_propagates_with_no_celery_fallback(self):
+        # No silent Celery fallback on PG failure — the caller (_send_clubbed)
+        # reverts the buffer rows to PENDING for a clean retry next tick.
+        celery = MagicMock()
+        with (
+            patch.object(nd, "resolve_transport", return_value="pg_queue"),
+            patch.object(nd, "enqueue_task", side_effect=RuntimeError("pg down")),
+        ):
+            with pytest.raises(RuntimeError, match="pg down"):
+                _dispatch(celery)
+        celery.send_task.assert_not_called()
+
+    def test_none_org_fails_closed_to_celery(self):
+        # A missing org string (org deleted) must not route to PG — resolve_transport
+        # fails closed, and we pass organization_id=None straight through to it.
+        celery = MagicMock()
+        with (
+            patch.object(nd, "resolve_transport", return_value="celery") as resolve,
+            patch.object(nd, "enqueue_task") as enqueue,
+        ):
+            _dispatch(celery, organization_id=None)
+        assert resolve.call_args.kwargs["organization_id"] is None
+        celery.send_task.assert_called_once()
+        enqueue.assert_not_called()
+
+    def test_resolve_transport_buckets_by_minted_dispatch_id(self):
+        # Fire-and-forget: entity_id is a freshly minted uuid (str), and it equals
+        # the PG task_id so the row and the Flipt bucket agree.
+        celery = MagicMock()
+        with (
+            patch.object(nd, "resolve_transport", return_value="pg_queue") as resolve,
+            patch.object(nd, "enqueue_task", return_value=1) as enqueue,
+        ):
+            task_id = _dispatch(celery)
+        assert resolve.call_args.kwargs["execution_id"] == task_id
+        assert enqueue.call_args.kwargs["task_id"] == task_id
+
+    def test_args_and_kwargs_identical_on_both_paths(self):
+        # The consumer must behave the same regardless of transport.
+        celery = MagicMock()
+        with patch.object(nd, "resolve_transport", return_value="celery"):
+            _dispatch(celery)
+        celery_call = celery.send_task.call_args.kwargs
+        celery2 = MagicMock()
+        with (
+            patch.object(nd, "resolve_transport", return_value="pg_queue"),
+            patch.object(nd, "enqueue_task", return_value=1) as enqueue,
+        ):
+            _dispatch(celery2)
+        assert enqueue.call_args.kwargs["args"] == celery_call["args"]
+        assert enqueue.call_args.kwargs["kwargs"] == celery_call["kwargs"]
+        assert enqueue.call_args.kwargs["queue"] == celery_call["queue"]

--- a/backend/notification_v2/tests/test_notification_dispatch.py
+++ b/backend/notification_v2/tests/test_notification_dispatch.py
@@ -26,13 +26,13 @@ _KWARGS = {
 _QUEUE = "notifications"
 
 
-def _dispatch(celery_app, organization_id="org_x"):
+def _dispatch(celery_app, org_string_id="org_x"):
     return nd.dispatch_webhook_notification(
         celery_app=celery_app,
         args=_ARGS,
         kwargs=_KWARGS,
         queue=_QUEUE,
-        organization_id=organization_id,
+        org_string_id=org_string_id,
     )
 
 
@@ -88,7 +88,7 @@ class TestDispatchWebhookNotification:
             patch.object(nd, "resolve_transport", return_value="celery") as resolve,
             patch.object(nd, "enqueue_task") as enqueue,
         ):
-            _dispatch(celery, organization_id=None)
+            _dispatch(celery, org_string_id=None)
         assert resolve.call_args.kwargs["organization_id"] is None
         celery.send_task.assert_called_once()
         enqueue.assert_not_called()

--- a/backend/notification_v2/tests/test_send_clubbed.py
+++ b/backend/notification_v2/tests/test_send_clubbed.py
@@ -7,8 +7,10 @@ the two highest-risk regressions at the buffer-flush call site:
    the org **pk** stays in the worker kwargs (swapping them passes every seam test
    yet mis-routes every org to Celery and strands the mark endpoint);
 2. failure recovery — a transient/broker error refunds and reverts SENDING rows to
-   PENDING, while a permanent (ValueError/TypeError) enqueue error dead-letters
-   instead of retrying forever.
+   PENDING, while a permanent PG enqueue error (surfaced as ``PermanentDispatchError``,
+   raised only on the PG path) dead-letters instead of retrying forever. A Celery
+   send_task failure is an ordinary ``Exception`` → the PENDING path, so flag-off is
+   byte-identical.
 
 Mock-based (no broker/DB): patch the module's collaborators.
 """
@@ -70,13 +72,16 @@ class TestSendClubbedFailureRecovery:
         assert ukw["status"] == BufferStatus.PENDING.value
         assert ukw["dispatched_at"] is None
 
-    def test_permanent_error_dead_letters(self):
+    def test_permanent_pg_error_dead_letters(self):
+        # The PG path surfaces a permanent enqueue failure as PermanentDispatchError;
+        # only that dead-letters. (A raw ValueError from the Celery path can't occur,
+        # and would fall through to the transient PENDING branch, unchanged.)
         with (
             patch.object(views, "_org_identifier", return_value="o"),
             patch.object(
                 views,
                 "dispatch_webhook_notification",
-                side_effect=ValueError("priority out of range"),
+                side_effect=views.PermanentDispatchError("priority out of range"),
             ),
             patch.object(views, "NotificationBuffer") as buf,
         ):

--- a/backend/notification_v2/tests/test_send_clubbed.py
+++ b/backend/notification_v2/tests/test_send_clubbed.py
@@ -1,0 +1,107 @@
+"""Call-site tests for ``_send_clubbed`` / ``_org_identifier`` (UN-3753).
+
+The seam's own routing is covered by ``test_notification_dispatch``; these lock
+the two highest-risk regressions at the buffer-flush call site:
+
+1. the two-org-identifier contract — the org **string** id routes the flag, while
+   the org **pk** stays in the worker kwargs (swapping them passes every seam test
+   yet mis-routes every org to Celery and strands the mark endpoint);
+2. failure recovery — a transient/broker error refunds and reverts SENDING rows to
+   PENDING, while a permanent (ValueError/TypeError) enqueue error dead-letters
+   instead of retrying forever.
+
+Mock-based (no broker/DB): patch the module's collaborators.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from notification_v2 import internal_api_views as views
+from notification_v2.enums import BufferStatus
+
+
+def _send(**overrides):
+    kw = {
+        "url": "https://hook.test",
+        "body": {"text": "x"},
+        "headers": {"Content-Type": "application/json"},
+        "platform": "SLACK",
+        "max_retries": 3,
+        "buffer_ids": ["b1"],
+        "org_id": 7,
+    }
+    kw.update(overrides)
+    views._send_clubbed(**kw)
+
+
+class TestSendClubbedOrgContract:
+    def test_routes_string_id_and_keeps_pk_in_kwargs(self):
+        with (
+            patch.object(views, "_org_identifier", return_value="org-str-id") as ident,
+            patch.object(views, "dispatch_webhook_notification") as seam,
+        ):
+            _send(org_id=7)
+        ident.assert_called_once_with(7)
+        call = seam.call_args.kwargs
+        # Routing uses the STRING id; the worker buffer-mark contract keeps the PK.
+        assert call["org_string_id"] == "org-str-id"
+        assert call["kwargs"]["organization_id"] == 7
+        assert call["queue"] == "notifications"
+
+
+class TestSendClubbedFailureRecovery:
+    def test_transient_failure_reverts_sending_rows_to_pending(self):
+        with (
+            patch.object(views, "_org_identifier", return_value="o"),
+            patch.object(
+                views,
+                "dispatch_webhook_notification",
+                side_effect=RuntimeError("broker down"),
+            ),
+            patch.object(views, "NotificationBuffer") as buf,
+        ):
+            _send(buffer_ids=["b1", "b2"])
+        # Guarded on SENDING, reverted to PENDING (attempt refunded).
+        fkw = buf.objects.filter.call_args.kwargs
+        assert fkw["status"] == BufferStatus.SENDING.value
+        assert set(fkw["id__in"]) == {"b1", "b2"}
+        ukw = buf.objects.filter.return_value.update.call_args.kwargs
+        assert ukw["status"] == BufferStatus.PENDING.value
+        assert ukw["dispatched_at"] is None
+
+    def test_permanent_error_dead_letters(self):
+        with (
+            patch.object(views, "_org_identifier", return_value="o"),
+            patch.object(
+                views,
+                "dispatch_webhook_notification",
+                side_effect=ValueError("priority out of range"),
+            ),
+            patch.object(views, "NotificationBuffer") as buf,
+        ):
+            _send()
+        # Permanent error → terminal DEAD_LETTER, no PENDING revert / refund.
+        ukw = buf.objects.filter.return_value.update.call_args.kwargs
+        assert ukw == {"status": BufferStatus.DEAD_LETTER.value}
+
+
+class TestOrgIdentifier:
+    def test_returns_string_id(self):
+        with patch.object(views, "Organization") as org:
+            chain = org.objects.filter.return_value.values_list.return_value
+            chain.first.return_value = "org-uuid"
+            assert views._org_identifier(7) == "org-uuid"
+        org.objects.filter.assert_called_once_with(pk=7)
+
+    def test_missing_org_returns_none_and_warns(self):
+        with (
+            patch.object(views, "Organization") as org,
+            patch.object(views.logger, "warning") as warn,
+        ):
+            chain = org.objects.filter.return_value.values_list.return_value
+            chain.first.return_value = None
+            assert views._org_identifier(7) is None
+        # A dangling FK is logged (org-traceable) rather than swallowed.
+        warn.assert_called_once()
+        assert "org_pk" in warn.call_args.args[0]


### PR DESCRIPTION
## What

- Adds `notification_v2/notification_dispatch.py` — a flag-gated transport seam for the buffered-webhook dispatch, mirroring `pipeline_dispatch.py`.
- Routes `_send_clubbed` (the notification buffer-flush path) through the seam: PG queue when `pg_queue_enabled` is on for the org, else the prior `celery_app.send_task` (byte-identical).
- `_org_identifier()` resolves the buffer's org **pk** → the string `organization_id` that `resolve_transport` needs for its Flipt decision (the org pk stays in the task kwargs — the worker's buffer-mark contract).
- 6 unit tests (`test_notification_dispatch.py`) pinning both routes + fail-closed behavior.

## Why

- Part of migrating the notification worker off Celery onto the PG queue (UN-3753, under the PG-queue epic UN-3445), so Celery can eventually be decommissioned.
- Universal pattern: flag-gate the enqueue point; flag OFF keeps Celery byte-unchanged, flag ON enqueues onto PG (drained by the PG notification consumer).

## How

- `resolve_transport(execution_id, organization_id)` decides the transport; `is_pg_transport()` is the single "counts as PG" check.
- PG path: `enqueue_task(task_name="send_webhook_notification", queue="notifications", …)` — the exact args/kwargs the Celery call used, JSON-normalized by the producer.
- Celery path: unchanged `send_task` with identical args/kwargs/queue.
- Scope: only site 1 (`_send_clubbed`, the production flush path) is migrated. The `WebhookSend` / `WebhookBatch` internal endpoints stay on Celery — they use a `countdown` stagger the PG queue has no delayed-visibility for (a follow-up).

## Can this PR break any existing features?

- No. With `pg_queue_enabled` OFF (the default) `resolve_transport` fails closed to Celery and the seam calls the same `send_task` as before — byte-identical. The PG branch only runs when the flag is explicitly enabled for an org. Dev-tested on a live stack: flag-off produced 0 PG rows (Celery taken); an enqueued task was drained by the PG notification consumer and delivered end-to-end.

## Database Migrations

- None.

## Env Config

- None (uses the existing `pg_queue_enabled` Flipt flag).

## Notes on Testing

- `pytest notification_v2/tests/test_notification_dispatch.py` — 6 tests pass; `pipeline_dispatch` regression suite green.
- Live dev-test: flag-off Celery parity (0 PG rows); PG round-trip enqueue → `pg_queue_consumer` (WORKER_TYPE=notification) → webhook delivered (200) → row acked.

## Related Issues or PRs

- UN-3753 (sub-task of UN-3445). Cloud counterpart: `workerPgNotification` chart (batched into the aux-workers cloud PR). Depends on the epic branch merging first, then rebased to main.
