### PR TITLE
UN-3636 [FIX] Two OSS test fixes blocking the cloud rig integration tier

### DIFF
--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_postgres.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_postgres.py
@@ -1,7 +1,6 @@
 import os
 from unittest.mock import Mock, patch
 
-import pytest
 from django.test import TestCase
 from unstract.connectors.databases.postgresql import PostgreSQL
 from workflow_manager.endpoint_v2.constants import DestinationKey
@@ -193,14 +192,6 @@ class TestDestinationConnectorPostgreSQL(TestCase):
             f"✅ Successfully inserted test data into PostgreSQL table: {self.test_table_name}"
         )
 
-    @pytest.mark.xfail(
-        reason=(
-            "get_sql_values_for_query serializes data=None as the literal "
-            "string 'None', which is invalid JSON for the jsonb data column "
-            "(PR #2115 review). Remove this marker once None maps to SQL NULL."
-        ),
-        strict=True,
-    )
     def test_insert_into_db_with_error_postgresql(self) -> None:
         """Test insertion with error parameter into real PostgreSQL database."""
         mock_workflow = self.create_mock_workflow()

--- a/backend/workflow_manager/execution/tests/test_execution_serializer.py
+++ b/backend/workflow_manager/execution/tests/test_execution_serializer.py
@@ -6,35 +6,18 @@ every non-successful file in a finished failure run has to land in ``failed`` �
 including files that never got a ``file_execution`` row. COMPLETED and live
 (PENDING/EXECUTING) runs keep the exact row-count behaviour.
 
-DB-free and app-registry-free: the heavy ``WorkflowExecution`` model is stubbed
-in ``sys.modules`` before importing the serializer (mirrors
-``usage_v2/tests/test_helper.py`` / ``pg_queue/tests/test_producer.py``), so no
-``django.setup()`` / live DB is needed — the methods under test are pure. The
-real ``ExecutionStatus`` enum (no Django) is kept for its ``is_failure`` logic.
+The methods under test are pure — they read counts off the passed object — so a
+MagicMock stands in for WorkflowExecution and no DB is touched. The suite runs
+under pytest-django (app registry loaded), so the serializer imports directly.
 """
 
 from __future__ import annotations
 
 import logging
-import os
-import sys
-import types
 from unittest.mock import MagicMock
 
-# Force (not setdefault): a dev shell that already exports DJANGO_SETTINGS_MODULE
-# (backend.settings.dev / .cloud) would otherwise redirect collection to a module
-# that may not exist here. DRF reads settings lazily; no django.setup() is run.
-os.environ["DJANGO_SETTINGS_MODULE"] = "backend.settings.test"
-
-# Stub the model module so importing the serializer needs no app registry / DB.
-_models_stub = types.ModuleType("workflow_manager.workflow_v2.models")
-_models_stub.WorkflowExecution = type("WorkflowExecution", (), {})
-sys.modules["workflow_manager.workflow_v2.models"] = _models_stub
-
-from workflow_manager.execution.serializer.execution import (  # noqa: E402
-    ExecutionSerializer,
-)
-from workflow_manager.workflow_v2.enums import ExecutionStatus  # noqa: E402
+from workflow_manager.execution.serializer.execution import ExecutionSerializer
+from workflow_manager.workflow_v2.enums import ExecutionStatus
 
 _LOGGER = "workflow_manager.execution.serializer.execution"
 _ids = iter(range(1, 100_000))

--- a/unstract/connectors/src/unstract/connectors/databases/unstract_db.py
+++ b/unstract/connectors/src/unstract/connectors/databases/unstract_db.py
@@ -356,6 +356,10 @@ class UnstractDB(UnstractConnector, ABC):
                     sql_values[column] = json.dumps(fallback_value)
             elif isinstance(value, Enum):
                 sql_values[column] = value.value
+            elif value is None:
+                # Bind as SQL NULL; f"{None}" would write the literal "None",
+                # invalid for a jsonb column (e.g. data on an errored record).
+                sql_values[column] = None
             else:
                 sql_values[column] = f"{value}"
 


### PR DESCRIPTION
Two OSS test issues that block the cloud test-rig integration tier (which consumes OSS `main`). Independent commits — splittable if preferred.

## 1. Leaked `sys.modules` stub (`test_execution_serializer`)

The test stubbed `workflow_manager.workflow_v2.models` in `sys.modules` at import time and never restored it. Under pytest-xdist a worker process is shared across many tests, so the fake `WorkflowExecution` (no real `Workflow`) shadowed the real module for **every later test on that worker** → `cannot import name 'Workflow'` via the URLconf. Latent until the rig ran real multi-worker parallelism, then deterministic (~30 failures/run).

**Fix:** delete the stub — the suite runs under `pytest-django` (app registry loaded), so the real serializer imports directly. Deleted rather than restored-in-`finally` so the footgun can't be copy-pasted; it was the only `sys.modules`-mutating test in the backend.

## 2. `None` DB value serialized as the string `"None"` (`get_sql_values_for_query`)

Fell through to `f"{value}"` for `None`, writing the literal `"None"` — invalid JSON for a `jsonb` column (e.g. `data` on an errored record). `test_insert_into_db_with_error_postgresql` was marked `xfail(strict)` for exactly this; the bug is env-fragile (reproduces on some Postgres builds, XPASSes on others), which the cloud rig surfaced as a hard `XPASS(strict)` failure.

**Fix:** bind `None` as SQL NULL (deterministic across environments); drop the obsolete strict xfail + unused `pytest` import.

## Verification
- serializer test, unit tier: **9 passed**
- full integration tier, `-n auto` (real rig config), ×2: **0 `Workflow` import errors, 708 passed**
- `get_sql_values_for_query({"data": None, ...})` → `data` is SQL `NULL`, other values unchanged
- cloud rig integration tier now **712 passed** (was 30 failed / 461 errors), lone remaining failure was this XPASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)