### PR TITLE
[MISC] Fail rig groups that inherit an unrelated pytest config; skip order-dependent connector tests

### DIFF
--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_bigquery.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_bigquery.py
@@ -1,14 +1,19 @@
 import json
 import os
+import unittest
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from unstract.connectors.databases.bigquery import BigQuery
 from workflow_manager.endpoint_v2.constants import DestinationKey
 from workflow_manager.endpoint_v2.destination import DestinationConnector
 
-from unstract.connectors.databases.bigquery import BigQuery
 
-
+@unittest.skip(
+    "Order-dependent: shares a fixed table across tests with no working "
+    "teardown, so results depend on execution order. Fix isolation before "
+    "enabling, otherwise this fails once real credentials are provided."
+)
 class TestDestinationConnectorBigQuery(TestCase):
     """Integration test for insert_into_db method with real BigQuery connector."""
 
@@ -65,9 +70,7 @@ class TestDestinationConnectorBigQuery(TestCase):
 
     def verify_table_columns(self, table_name: str) -> None:
         """Verify that all expected columns exist in the table with correct types."""
-        table_info = self.bigquery_connector.get_information_schema(
-            table_name=table_name
-        )
+        table_info = self.bigquery_connector.get_information_schema(table_name=table_name)
 
         print(f"🔍 Actual table structure for '{table_name}': {table_info}")
 

--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_mariadb.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_mariadb.py
@@ -1,14 +1,19 @@
 import json
 import os
+import unittest
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from unstract.connectors.databases.mariadb import MariaDB
 from workflow_manager.endpoint_v2.constants import DestinationKey
 from workflow_manager.endpoint_v2.destination import DestinationConnector
 
-from unstract.connectors.databases.mariadb import MariaDB
 
-
+@unittest.skip(
+    "Order-dependent: shares a fixed table across tests with no working "
+    "teardown, so results depend on execution order. Fix isolation before "
+    "enabling, otherwise this fails once real credentials are provided."
+)
 class TestDestinationConnectorMariaDB(TestCase):
     """Integration test for insert_into_db method with real MariaDB connector."""
 
@@ -71,9 +76,7 @@ class TestDestinationConnectorMariaDB(TestCase):
 
     def verify_table_columns(self, table_name: str) -> None:
         """Verify that all expected columns exist in the table with correct types."""
-        table_info = self.mariadb_connector.get_information_schema(
-            table_name=table_name
-        )
+        table_info = self.mariadb_connector.get_information_schema(table_name=table_name)
 
         print(f"🔍 Actual table structure for '{table_name}': {table_info}")
 
@@ -347,9 +350,7 @@ class TestDestinationConnectorMariaDB(TestCase):
 
             self.assertIsNotNone(data, "Expected data column to contain inserted data")
 
-            self.assertIsNotNone(
-                metadata, "Expected metadata column to contain metadata"
-            )
+            self.assertIsNotNone(metadata, "Expected metadata column to contain metadata")
 
             cursor.close()
             print("✅ All column data values verified successfully")
@@ -371,7 +372,7 @@ class TestDestinationConnectorMariaDB(TestCase):
             )
             # Add the required columns for the test
             create_table_query += (
-                "file_path LONGTEXT, " "execution_id LONGTEXT, " "data LONGTEXT)"
+                "file_path LONGTEXT, execution_id LONGTEXT, data LONGTEXT)"
             )
 
             cursor.execute(create_table_query)

--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_mssql.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_mssql.py
@@ -1,13 +1,18 @@
 import os
+import unittest
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from unstract.connectors.databases.mssql import MSSQL
 from workflow_manager.endpoint_v2.constants import DestinationKey
 from workflow_manager.endpoint_v2.destination import DestinationConnector
 
-from unstract.connectors.databases.mssql import MSSQL
 
-
+@unittest.skip(
+    "Order-dependent: shares a fixed table across tests with no working "
+    "teardown, so results depend on execution order. Fix isolation before "
+    "enabling, otherwise this fails once real credentials are provided."
+)
 class TestDestinationConnectorMSSQL(TestCase):
     """Integration test for insert_into_db method with real MSSQL connector."""
 

--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_mysql.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_mysql.py
@@ -1,14 +1,19 @@
 import json
 import os
+import unittest
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from unstract.connectors.databases.mysql import MySQL
 from workflow_manager.endpoint_v2.constants import DestinationKey
 from workflow_manager.endpoint_v2.destination import DestinationConnector
 
-from unstract.connectors.databases.mysql import MySQL
 
-
+@unittest.skip(
+    "Order-dependent: shares a fixed table across tests with no working "
+    "teardown, so results depend on execution order. Fix isolation before "
+    "enabling, otherwise this fails once real credentials are provided."
+)
 class TestDestinationConnectorMySQL(TestCase):
     """Integration test for insert_into_db method with real MySQL connector."""
 
@@ -344,9 +349,7 @@ class TestDestinationConnectorMySQL(TestCase):
 
             self.assertIsNotNone(data, "Expected data column to contain inserted data")
 
-            self.assertIsNotNone(
-                metadata, "Expected metadata column to contain metadata"
-            )
+            self.assertIsNotNone(metadata, "Expected metadata column to contain metadata")
 
             cursor.close()
             print("✅ All column data values verified successfully")
@@ -368,7 +371,7 @@ class TestDestinationConnectorMySQL(TestCase):
             )
             # Add the required columns for the test
             create_table_query += (
-                "file_path LONGTEXT, " "execution_id LONGTEXT, " "data LONGTEXT)"
+                "file_path LONGTEXT, execution_id LONGTEXT, data LONGTEXT)"
             )
 
             cursor.execute(create_table_query)

--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_oracle.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_oracle.py
@@ -1,13 +1,18 @@
 import os
+import unittest
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from unstract.connectors.databases.oracle_db import OracleDB
 from workflow_manager.endpoint_v2.constants import DestinationKey
 from workflow_manager.endpoint_v2.destination import DestinationConnector
 
-from unstract.connectors.databases.oracle_db import OracleDB
 
-
+@unittest.skip(
+    "Order-dependent: shares a fixed table across tests with no working "
+    "teardown, so results depend on execution order. Fix isolation before "
+    "enabling, otherwise this fails once real credentials are provided."
+)
 class TestDestinationConnectorOracle(TestCase):
     """Integration test for insert_into_db method with real Oracle DB connector."""
 

--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_postgres.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_postgres.py
@@ -30,9 +30,12 @@ class TestDestinationConnectorPostgreSQL(TestCase):
             "processing_time": 1.5,
         }
         self.input_file_path = "/path/to/test/file.pdf"
-        # Lowercase: the connector quotes the name on CREATE (case-preserved) but
-        # lowercases it when reading information_schema back.
-        self.test_table_name = "output_3"
+        # Per-worker table so parallel xdist workers don't write to one shared
+        # table — a cross-worker row would otherwise win `ORDER BY created_at
+        # DESC LIMIT 1`. Lowercase: the connector quotes the name on CREATE
+        # (case-preserved) but lowercases it when reading information_schema back.
+        worker = os.getenv("PYTEST_XDIST_WORKER", "")
+        self.test_table_name = f"output_3_{worker}" if worker else "output_3"
 
         # Create real PostgreSQL connector instance
         self.postgres_connector = PostgreSQL(settings=self.postgres_config)

--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_redshift.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_redshift.py
@@ -1,13 +1,18 @@
 import os
+import unittest
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from unstract.connectors.databases.redshift import Redshift
 from workflow_manager.endpoint_v2.constants import DestinationKey
 from workflow_manager.endpoint_v2.destination import DestinationConnector
 
-from unstract.connectors.databases.redshift import Redshift
 
-
+@unittest.skip(
+    "Order-dependent: shares a fixed table across tests with no working "
+    "teardown, so results depend on execution order. Fix isolation before "
+    "enabling, otherwise this fails once real credentials are provided."
+)
 class TestDestinationConnectorRedshift(TestCase):
     """Integration test for insert_into_db method with real Redshift connector."""
 
@@ -72,9 +77,7 @@ class TestDestinationConnectorRedshift(TestCase):
 
     def verify_table_columns(self, table_name: str) -> None:
         """Verify that the table has expected columns with correct data types."""
-        table_info = self.redshift_connector.get_information_schema(
-            table_name=table_name
-        )
+        table_info = self.redshift_connector.get_information_schema(table_name=table_name)
 
         print(f"🔍 Actual table structure for '{table_name}': {table_info}")
 

--- a/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_snowflake.py
+++ b/backend/workflow_manager/endpoint_v2/tests/destination-connectors/test_destination_connector_snowflake.py
@@ -1,13 +1,18 @@
 import os
+import unittest
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
+from unstract.connectors.databases.snowflake import SnowflakeDB
 from workflow_manager.endpoint_v2.constants import DestinationKey
 from workflow_manager.endpoint_v2.destination import DestinationConnector
 
-from unstract.connectors.databases.snowflake import SnowflakeDB
 
-
+@unittest.skip(
+    "Order-dependent: shares a fixed table across tests with no working "
+    "teardown, so results depend on execution order. Fix isolation before "
+    "enabling, otherwise this fails once real credentials are provided."
+)
 class TestDestinationConnectorSnowflake(TestCase):
     """Integration test for insert_into_db method with real Snowflake connector."""
 
@@ -162,9 +167,7 @@ class TestDestinationConnectorSnowflake(TestCase):
         endpoint = Mock()
         endpoint.connector_instance = mock_connector_instance
         endpoint.configuration = {
-            DestinationKey.TABLE: self.test_table_name.split(".")[
-                -1
-            ],  # Just table name
+            DestinationKey.TABLE: self.test_table_name.split(".")[-1],  # Just table name
             DestinationKey.INCLUDE_AGENT: True,
             DestinationKey.INCLUDE_TIMESTAMP: True,
             DestinationKey.AGENT_NAME: "Unstract/DBWriter",

--- a/tests/README.md
+++ b/tests/README.md
@@ -107,6 +107,7 @@ Optional knobs (see `groups.yaml` for examples):
 | `install_editable` | Runs `uv pip install -e .` in the workdir. |
 | `pip_install` | Explicit deps to install before pytest. |
 | `requires_services` | Infra needed (`postgres`, `redis`, `minio`, ...). |
+| `migrate` | `{workdir, apps, env}` — runs `manage.py migrate` against the provisioned Postgres before the group, for tests that read tables another service's ORM owns. |
 | `requires_platform` | Set true for e2e — rig brings the full platform up. |
 | `depends_on` | Other groups that must run first. |
 | `critical` | Marks the group as covering a critical path. |

--- a/tests/README.md
+++ b/tests/README.md
@@ -107,7 +107,7 @@ Optional knobs (see `groups.yaml` for examples):
 | `install_editable` | Runs `uv pip install -e .` in the workdir. |
 | `pip_install` | Explicit deps to install before pytest. |
 | `requires_services` | Infra needed (`postgres`, `redis`, `minio`, ...). |
-| `migrate` | `{workdir, apps, env}` — runs `manage.py migrate` against the provisioned Postgres before the group, for tests that read tables another service's ORM owns. |
+| `postgres_migrate` (under `defaults`, applied once per run — not a per-group key) | `{workdir, apps, env}` — runs `manage.py migrate` against the provisioned Postgres before any group runs, for tests that read tables another service's ORM owns. |
 | `requires_platform` | Set true for e2e — rig brings the full platform up. |
 | `depends_on` | Other groups that must run first. |
 | `critical` | Marks the group as covering a critical path. |

--- a/tests/groups.yaml
+++ b/tests/groups.yaml
@@ -14,6 +14,39 @@ defaults:
   parallel: true
   runner: pytest
 
+  # Django settings shared by both backend test groups and by the schema step
+  # below, so migrations apply under the same configuration the tests read.
+  backend_test_env: &backend_test_env
+    DJANGO_SETTINGS_MODULE: backend.settings.test
+    # Tenancy is row-level, not schema-per-tenant; tests run in public.
+    DB_SCHEMA: public
+    # Resolved at import with no default; supply test-safe values.
+    DJANGO_SECRET_KEY: test-secret-key-not-for-production
+    # All-zero Fernet key: valid format, obviously a placeholder.
+    ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    CELERY_BROKER_BASE_URL: redis://localhost:6379
+    CELERY_BROKER_USER: guest
+    CELERY_BROKER_PASS: guest
+    INDEXING_FLAG_TTL: "3600"
+    ENABLE_LOG_HISTORY: "False"
+    STRUCTURE_TOOL_IMAGE_URL: docker:test
+    STRUCTURE_TOOL_IMAGE_NAME: test-structure-tool
+    STRUCTURE_TOOL_IMAGE_TAG: test
+    SYSTEM_ADMIN_USERNAME: admin
+    SYSTEM_ADMIN_PASSWORD: admin
+    SYSTEM_ADMIN_EMAIL: admin@example.com
+    # Only used to build paths at init; never written in these tests.
+    WORKFLOW_EXECUTION_DIR_PREFIX: /tmp/unstract-workflow-exec
+
+  # The pg_queue tables the workers' integration tests read are Django-managed
+  # models owned by the backend, so the provisioned database gets its schema
+  # from the real migration rather than DDL duplicated in a fixture. Applied
+  # once when the rig provisions Postgres, before any group runs.
+  postgres_migrate:
+    workdir: backend
+    apps: [pg_queue]
+    env: *backend_test_env
+
 groups:
   # ── Unit tier: pure pytest, no external services ───────────────────────────
   unit-rig:
@@ -52,24 +85,6 @@ groups:
     uv_sync_group: test
     coverage_source: shared
 
-  integration-workers:
-    tier: integration
-    workdir: workers
-    paths: [tests, shared/tests]
-    # Real-Postgres tests: barrier-decrement races, reaper, batch dedup, leader
-    # election, result backend. `conftest.py` marks these `integration` (any
-    # test using a real-connection fixture). They skip when Postgres is
-    # unreachable or the pg_queue schema isn't migrated.
-    markers: "integration"
-    uv_sync_group: test
-    coverage_source: shared
-    requires_services: [postgres]
-    # Optional until CI provisions a *migrated* database and sets
-    # REQUIRE_PG_TESTS=1 — that env flips the graceful skips into hard failures
-    # (see conftest `_skip_or_fail_no_pg`) so the lane can't pass having run
-    # nothing. Until then it runs-and-skips against a bare Postgres.
-    optional: true
-
   unit-backend:
     tier: unit
     workdir: backend
@@ -78,28 +93,7 @@ groups:
     paths: ["."]
     markers: "not integration"
     uv_sync_group: test
-    # Shared with integration-backend so both halves use identical settings.
-    env: &backend_test_env
-      DJANGO_SETTINGS_MODULE: backend.settings.test
-      # Tenancy is row-level, not schema-per-tenant; tests run in public.
-      DB_SCHEMA: public
-      # Resolved at import with no default; supply test-safe values.
-      DJANGO_SECRET_KEY: test-secret-key-not-for-production
-      # All-zero Fernet key: valid format, obviously a placeholder.
-      ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-      CELERY_BROKER_BASE_URL: redis://localhost:6379
-      CELERY_BROKER_USER: guest
-      CELERY_BROKER_PASS: guest
-      INDEXING_FLAG_TTL: "3600"
-      ENABLE_LOG_HISTORY: "False"
-      STRUCTURE_TOOL_IMAGE_URL: docker:test
-      STRUCTURE_TOOL_IMAGE_NAME: test-structure-tool
-      STRUCTURE_TOOL_IMAGE_TAG: test
-      SYSTEM_ADMIN_USERNAME: admin
-      SYSTEM_ADMIN_PASSWORD: admin
-      SYSTEM_ADMIN_EMAIL: admin@example.com
-      # Only used to build paths at init; never written in these tests.
-      WORKFLOW_EXECUTION_DIR_PREFIX: /tmp/unstract-workflow-exec
+    env: *backend_test_env
     coverage_source: .
 
   unit-connectors:
@@ -133,6 +127,23 @@ groups:
     env: *backend_test_env
     requires_services: [postgres, redis, minio]
     coverage_source: .
+
+  integration-workers:
+    tier: integration
+    workdir: workers
+    paths: [tests, shared/tests]
+    # Real-Postgres tests: barrier-decrement races, reaper, batch dedup, leader
+    # election, result backend. `conftest.py` marks these `integration` (any
+    # test using a real-connection fixture) and connects over TEST_DB_*, which
+    # the rig points at the provisioned container.
+    markers: "integration"
+    uv_sync_group: test
+    coverage_source: shared
+    requires_services: [postgres]
+    # Optional until REQUIRE_PG_TESTS=1 flips the fixtures' graceful skips into
+    # hard failures (see conftest `_skip_or_fail_no_pg`) so the lane can't pass
+    # having run nothing.
+    optional: true
 
   integration-connectors:
     tier: integration

--- a/tests/groups.yaml
+++ b/tests/groups.yaml
@@ -14,15 +14,14 @@ defaults:
   parallel: true
   runner: pytest
 
-  # Django settings shared by both backend test groups and by the schema step
-  # below, so migrations apply under the same configuration the tests read.
+  # Shared so migrations run under the same settings the tests read.
   backend_test_env: &backend_test_env
     DJANGO_SETTINGS_MODULE: backend.settings.test
-    # Tenancy is row-level, not schema-per-tenant; tests run in public.
+    # Tenancy is row-level, not schema-per-tenant.
     DB_SCHEMA: public
-    # Resolved at import with no default; supply test-safe values.
+    # Resolved at import with no default.
     DJANGO_SECRET_KEY: test-secret-key-not-for-production
-    # All-zero Fernet key: valid format, obviously a placeholder.
+    # All-zero Fernet key: valid format, obvious placeholder.
     ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
     CELERY_BROKER_BASE_URL: redis://localhost:6379
     CELERY_BROKER_USER: guest
@@ -35,13 +34,11 @@ defaults:
     SYSTEM_ADMIN_USERNAME: admin
     SYSTEM_ADMIN_PASSWORD: admin
     SYSTEM_ADMIN_EMAIL: admin@example.com
-    # Only used to build paths at init; never written in these tests.
+    # Only used to build paths at init.
     WORKFLOW_EXECUTION_DIR_PREFIX: /tmp/unstract-workflow-exec
 
-  # The pg_queue tables the workers' integration tests read are Django-managed
-  # models owned by the backend, so the provisioned database gets its schema
-  # from the real migration rather than DDL duplicated in a fixture. Applied
-  # once when the rig provisions Postgres, before any group runs.
+  # Provisioned DB gets its schema from the real migration, not fixture DDL,
+  # since the tables are Django-managed models owned by the backend.
   postgres_migrate:
     workdir: backend
     apps: [pg_queue]
@@ -132,17 +129,14 @@ groups:
     tier: integration
     workdir: workers
     paths: [tests, shared/tests]
-    # Real-Postgres tests: barrier-decrement races, reaper, batch dedup, leader
-    # election, result backend. `conftest.py` marks these `integration` (any
-    # test using a real-connection fixture) and connects over TEST_DB_*, which
-    # the rig points at the provisioned container.
+    # Real-Postgres tests, auto-marked `integration` by conftest and connecting
+    # over TEST_DB_*, which the rig points at the provisioned container.
     markers: "integration"
     uv_sync_group: test
     coverage_source: shared
     requires_services: [postgres]
-    # Optional until REQUIRE_PG_TESTS=1 flips the fixtures' graceful skips into
-    # hard failures (see conftest `_skip_or_fail_no_pg`) so the lane can't pass
-    # having run nothing.
+    # Optional until REQUIRE_PG_TESTS=1 turns the fixtures' graceful skips into
+    # hard failures, so the lane can't pass having run nothing.
     optional: true
 
   integration-connectors:

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -30,6 +30,7 @@ from tests.rig.groups import (
     REPO_ROOT,
     TIERS,
     GroupDefinition,
+    MigrateSpec,
     load_groups,
 )
 from tests.rig.reporting import (
@@ -63,6 +64,11 @@ _PYTEST_PLUGIN_DIR = REPO_ROOT / "tests" / "rig" / "pytest_plugin"
 
 # saxutils.escape leaves quotes alone, which is wrong inside an attribute.
 _XML_ATTR_ESCAPES = {'"': "&quot;"}
+
+# Cap the pre-group `manage.py migrate`. It runs outside the group's own
+# timeout budget, so without this a wedged connection hangs the job to the CI
+# ceiling.
+_MIGRATE_TIMEOUT_SECONDS = 300
 
 
 @lru_cache(maxsize=1)
@@ -456,14 +462,31 @@ def cmd_run(args: argparse.Namespace) -> int:
             endpoints = runtime.up()
         elif needs_services and not args.dry_run:
             # Infra-only: testcontainers Postgres/Redis/etc., no platform
-            # services. ponytail: up() starts the full infra set even if a run
-            # only needs Postgres; trim to the requested services if startup
-            # cost ever matters.
+            # services. up() starts the full infra set even if a run only needs
+            # Postgres; trim to the requested services if startup cost matters.
             runtime = TestcontainersRuntime()
             print(
                 f"[rig] bringing infra up via runtime={runtime.name} (requires_services)"
             )
             endpoints = runtime.up()
+
+        # Schema for the database the rig just provisioned. Guarded on
+        # `postgres_url` so it only fires for a rig-owned container: under the
+        # compose runtime the platform's own backend migrates on startup, and
+        # migrating its database from here would be both redundant and wrong.
+        if endpoints is not None and manifest.postgres_migrate is not None:
+            postgres_url = endpoints.infra.postgres_url
+            if postgres_url:
+                migrate_exit = _run_migrations(
+                    manifest.postgres_migrate, postgres_url=postgres_url
+                )
+                if migrate_exit != 0:
+                    # Every DB-backed test would skip on a missing table, which
+                    # reads as "nothing to run" rather than a broken database.
+                    raise RuntimeError(
+                        f"migrations failed against the provisioned database "
+                        f"(exit {migrate_exit}); aborting before any group runs"
+                    )
 
         # Groups run in topo order, so a dependency's result is always known by
         # the time its dependents come up. A red dep means the precondition it
@@ -730,7 +753,17 @@ def _inject_infra_env(
         return
     infra = endpoints.infra
     if "postgres" in group.requires_services and infra.postgres_url:
-        env.update(_db_env_from_postgres_url(infra.postgres_url))
+        db_env = _db_env_from_postgres_url(infra.postgres_url)
+        env.update(db_env)
+        # A rig-provisioned Postgres is bare — `public` is the only schema it
+        # has. Groups needing another one declare DB_SCHEMA themselves.
+        env.setdefault("DB_SCHEMA", "public")
+        db_env["DB_SCHEMA"] = env["DB_SCHEMA"]
+        # The workers' real-Postgres fixtures read TEST_DB_* so that a developer
+        # run keeps pointing at their own compose database. Mirror the
+        # provisioned values onto that prefix, or those tests silently connect
+        # to the dev-compose defaults instead of the container the rig started.
+        env.update({f"TEST_{key}": value for key, value in db_env.items()})
     if "minio" in group.requires_services and infra.minio_endpoint:
         # http: this is a local, throwaway testcontainers MinIO with no TLS.
         env.setdefault(
@@ -840,27 +873,12 @@ def _execute_group(
     if group.runner == "hurl":
         cmd = _hurl_command(group, workdir)
         exit_code = _spawn(cmd, env=env, cwd=workdir, timeout=timeout)
-        # Match the exit.txt write's defensive handling: a read-only reports
-        # dir or full disk shouldn't abort the whole run and orphan completed
-        # groups before the summary renders.
-        try:
-            _write_synthetic_junit(junit, group.name, exit_code)
-        except OSError as err:
-            print(
-                f"[rig] could not write synthetic junit for {group.name}: {err}",
-                file=sys.stderr,
-            )
+        _write_synthetic_junit_safe(junit, group.name, exit_code)
     elif (isolation_error := _config_isolation_error(group, workdir)) is not None:
         print(isolation_error, file=sys.stderr)
         # 4 is pytest's usage-error code, so this gates like any hard failure.
         exit_code = 4
-        try:
-            _write_synthetic_junit(junit, group.name, exit_code)
-        except OSError as err:
-            print(
-                f"[rig] could not write synthetic junit for {group.name}: {err}",
-                file=sys.stderr,
-            )
+        _write_synthetic_junit_safe(junit, group.name, exit_code)
     else:
         cmd = _pytest_command(
             group,
@@ -928,6 +946,45 @@ def _prepare_group_env(group: GroupDefinition, *, env: dict[str, str]) -> None:
     # NOTE: rig pytest plugins (pytest-timeout, pytest-md-report, etc.) are
     # injected via `uv run --with ...` in _pytest_command, not installed here.
     # That avoids losing them on the next `uv run` (which re-syncs the venv).
+
+
+def _run_migrations(spec: MigrateSpec, *, postgres_url: str) -> int:
+    """Apply Django migrations to the rig-provisioned database.
+
+    Runs once, right after the container is up and before any group, because the
+    schema is a property of the database rather than of a group. Only the
+    migrating project's own Django settings are layered over the connection env
+    — a group's environment is irrelevant here and may not even exist yet.
+    """
+    env = {
+        **os.environ,
+        **_db_env_from_postgres_url(postgres_url),
+        # A rig-provisioned Postgres is bare; `public` is the only schema it has.
+        "DB_SCHEMA": "public",
+        **spec.env,
+    }
+    workdir = spec.absolute_workdir()
+    base = ["uv", "run", "python"] if shutil.which("uv") else [sys.executable]
+    cmd = [*base, "manage.py", "migrate", *spec.apps, "--noinput"]
+    print(
+        f"[rig] migrating provisioned database via {spec.workdir}: "
+        f"{' '.join(spec.apps) or 'all apps'}"
+    )
+    return _spawn(cmd, env=env, cwd=workdir, timeout=_MIGRATE_TIMEOUT_SECONDS)
+
+
+def _write_synthetic_junit_safe(path: Path, group_name: str, exit_code: int) -> None:
+    """Mirror the exit.txt write's defensive handling: a read-only reports dir
+    or full disk shouldn't abort the whole run and orphan completed groups
+    before the summary renders.
+    """
+    try:
+        _write_synthetic_junit(path, group_name, exit_code)
+    except OSError as err:
+        print(
+            f"[rig] could not write synthetic junit for {group_name}: {err}",
+            file=sys.stderr,
+        )
 
 
 def _pytest_base_cmd(group: GroupDefinition, workdir: Path) -> list[str]:
@@ -1074,7 +1131,8 @@ def _hurl_command(group: GroupDefinition, workdir: Path) -> list[str]:
 
 
 def _write_synthetic_junit(path: Path, group_name: str, exit_code: int) -> None:
-    """Synthesise a JUnit XML for hurl runs.
+    """Synthesise a JUnit XML for a group pytest never wrote one for (hurl runs,
+    or a group whose pre-run migration failed).
 
     Exit 5 ("no tests collected") must produce failures=0; otherwise an empty
     hurl group would show ⚪ via :class:`GroupResult` while also being counted

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -850,6 +850,17 @@ def _execute_group(
                 f"[rig] could not write synthetic junit for {group.name}: {err}",
                 file=sys.stderr,
             )
+    elif (isolation_error := _config_isolation_error(group, workdir)) is not None:
+        print(isolation_error, file=sys.stderr)
+        # 4 is pytest's usage-error code, so this gates like any hard failure.
+        exit_code = 4
+        try:
+            _write_synthetic_junit(junit, group.name, exit_code)
+        except OSError as err:
+            print(
+                f"[rig] could not write synthetic junit for {group.name}: {err}",
+                file=sys.stderr,
+            )
     else:
         cmd = _pytest_command(
             group,
@@ -931,6 +942,62 @@ def _pytest_base_cmd(group: GroupDefinition, workdir: Path) -> list[str]:
     if group.install_editable:
         with_args += ["--with-editable", str(workdir)]
     return ["uv", "run", *with_args, "pytest"]
+
+
+# Order matters: pytest picks the first of these it finds walking upward.
+_PYTEST_CONFIG_FILES = (
+    ("pytest.ini", None),
+    (".pytest.ini", None),
+    ("pyproject.toml", "[tool.pytest.ini_options]"),
+    ("tox.ini", "[pytest]"),
+    ("setup.cfg", "[tool:pytest]"),
+)
+
+
+def _resolve_pytest_configfile(workdir: Path) -> Path | None:
+    """Find the config file pytest would adopt when invoked from `workdir`.
+
+    Mirrors pytest's upward search. `pytest.ini` counts even when empty; the
+    shared files only count when they carry a pytest section.
+    """
+    for directory in [workdir, *workdir.parents]:
+        for name, required_section in _PYTEST_CONFIG_FILES:
+            candidate = directory / name
+            if not candidate.is_file():
+                continue
+            if required_section is None:
+                return candidate
+            try:
+                if required_section in candidate.read_text(encoding="utf-8"):
+                    return candidate
+            except OSError:
+                continue
+        if directory == REPO_ROOT:
+            break
+    return None
+
+
+def _config_isolation_error(group: GroupDefinition, workdir: Path) -> str | None:
+    """Reject a group that would silently inherit an unrelated project's config.
+
+    `cd workdir && pytest` does not pin config to workdir — pytest walks up. A
+    nested project without its own config therefore adopts its parent's
+    `addopts` (coverage targets, --strict-config), which fails in ways that
+    have nothing to do with the group's tests. Inheriting the repo-root config
+    is the normal monorepo case and stays allowed; inheriting some *other*
+    project's config never is.
+    """
+    configfile = _resolve_pytest_configfile(workdir)
+    if configfile is None or configfile.parent in (workdir, REPO_ROOT):
+        return None
+    return (
+        f"[rig] group '{group.name}' would run under {configfile}, which belongs "
+        f"to neither its workdir ({workdir}) nor the repo root.\n"
+        f"[rig] pytest resolves config by walking up from the workdir, so this "
+        f"group inherits that project's addopts.\n"
+        f"[rig] fix: add a [tool.pytest.ini_options] section to "
+        f"{workdir / 'pyproject.toml'}."
+    )
 
 
 def _pytest_command(

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -65,9 +65,8 @@ _PYTEST_PLUGIN_DIR = REPO_ROOT / "tests" / "rig" / "pytest_plugin"
 # saxutils.escape leaves quotes alone, which is wrong inside an attribute.
 _XML_ATTR_ESCAPES = {'"': "&quot;"}
 
-# Cap the pre-group `manage.py migrate`. It runs outside the group's own
-# timeout budget, so without this a wedged connection hangs the job to the CI
-# ceiling.
+# Runs outside any group's timeout budget, so a wedged connection would
+# otherwise hang the job to the CI ceiling.
 _MIGRATE_TIMEOUT_SECONDS = 300
 
 
@@ -461,19 +460,15 @@ def cmd_run(args: argparse.Namespace) -> int:
             # in the finally, cleaning up any partial stack.
             endpoints = runtime.up()
         elif needs_services and not args.dry_run:
-            # Infra-only: testcontainers Postgres/Redis/etc., no platform
-            # services. up() starts the full infra set even if a run only needs
-            # Postgres; trim to the requested services if startup cost matters.
+            # Infra-only: testcontainers Postgres/Redis/etc., no platform.
             runtime = TestcontainersRuntime()
             print(
                 f"[rig] bringing infra up via runtime={runtime.name} (requires_services)"
             )
             endpoints = runtime.up()
 
-        # Schema for the database the rig just provisioned. Guarded on
-        # `postgres_url` so it only fires for a rig-owned container: under the
-        # compose runtime the platform's own backend migrates on startup, and
-        # migrating its database from here would be both redundant and wrong.
+        # Guarded on `postgres_url` so it only fires for a rig-owned container:
+        # under compose the platform migrates its own database on startup.
         if endpoints is not None and manifest.postgres_migrate is not None:
             postgres_url = endpoints.infra.postgres_url
             if postgres_url:
@@ -755,14 +750,12 @@ def _inject_infra_env(
     if "postgres" in group.requires_services and infra.postgres_url:
         db_env = _db_env_from_postgres_url(infra.postgres_url)
         env.update(db_env)
-        # A rig-provisioned Postgres is bare — `public` is the only schema it
-        # has. Groups needing another one declare DB_SCHEMA themselves.
+        # A bare Postgres only has `public`; groups needing another declare it.
         env.setdefault("DB_SCHEMA", "public")
         db_env["DB_SCHEMA"] = env["DB_SCHEMA"]
-        # The workers' real-Postgres fixtures read TEST_DB_* so that a developer
-        # run keeps pointing at their own compose database. Mirror the
-        # provisioned values onto that prefix, or those tests silently connect
-        # to the dev-compose defaults instead of the container the rig started.
+        # Fixtures read TEST_DB_* so a developer run keeps pointing at their own
+        # compose DB. Mirror onto that prefix or those tests connect to the
+        # dev-compose defaults instead of the provisioned container.
         env.update({f"TEST_{key}": value for key, value in db_env.items()})
     if "minio" in group.requires_services and infra.minio_endpoint:
         # http: this is a local, throwaway testcontainers MinIO with no TLS.

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -301,6 +301,17 @@ def cmd_validate(_args: argparse.Namespace) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
     errors = cp.validate_registry_against_manifest(registry, manifest)
+    # Config-isolation is filesystem-dependent, so it lives here rather than in
+    # the pure loader — but running it at validate time catches a misconfigured
+    # group in review instead of mid-run, after infra/dep bring-up.
+    for name in manifest.names():
+        group = manifest.get(name)
+        # Optional groups may be placeholders whose paths don't exist yet.
+        if group.optional:
+            continue
+        isolation_error = _config_isolation_error(group, group.absolute_workdir())
+        if isolation_error is not None:
+            errors.append(isolation_error)
     for err in errors:
         print(f"ERROR: {err}", file=sys.stderr)
     if errors:
@@ -764,8 +775,10 @@ def _inject_infra_env(
         db_env["DB_SCHEMA"] = env["DB_SCHEMA"]
         # Fixtures read TEST_DB_* so a developer run keeps pointing at their own
         # compose DB. Mirror onto that prefix or those tests connect to the
-        # dev-compose defaults instead of the provisioned container.
-        env.update({f"TEST_{key}": value for key, value in db_env.items()})
+        # dev-compose defaults instead of the provisioned container. setdefault so
+        # a group can still override with its own TEST_DB_* escape hatch.
+        for key, value in db_env.items():
+            env.setdefault(f"TEST_{key}", value)
     if "minio" in group.requires_services and infra.minio_endpoint:
         # http: this is a local, throwaway testcontainers MinIO with no TLS.
         env.setdefault(
@@ -960,10 +973,15 @@ def _run_migrations(spec: MigrateSpec, *, postgres_url: str) -> int:
     """
     env = {
         **os.environ,
-        **_db_env_from_postgres_url(postgres_url),
-        # A rig-provisioned Postgres is bare; `public` is the only schema it has.
-        "DB_SCHEMA": "public",
+        # spec.env carries Django settings (e.g. schema); the provisioned
+        # connection is layered on top so a stray DB_HOST/DB_NAME in spec.env
+        # can't silently redirect migrations away from the container the groups
+        # then test against.
         **spec.env,
+        **_db_env_from_postgres_url(postgres_url),
+        # A rig-provisioned Postgres is bare; `public` is the only schema it has,
+        # unless the spec deliberately migrates into another.
+        "DB_SCHEMA": spec.env.get("DB_SCHEMA", "public"),
     }
     workdir = spec.absolute_workdir()
     base = ["uv", "run", "python"] if shutil.which("uv") else [sys.executable]
@@ -1027,10 +1045,13 @@ def _resolve_pytest_configfile(workdir: Path) -> Path | None:
             if required_section is None:
                 return candidate
             try:
-                if required_section in candidate.read_text(encoding="utf-8"):
-                    return candidate
+                lines = candidate.read_text(encoding="utf-8").splitlines()
             except OSError:
                 continue
+            # Match the section header on its own line, as the TOML/INI parsers
+            # do — a commented-out or docstring mention is not a real config.
+            if any(line.strip() == required_section for line in lines):
+                return candidate
         if directory == REPO_ROOT:
             break
     return None
@@ -1039,23 +1060,34 @@ def _resolve_pytest_configfile(workdir: Path) -> Path | None:
 def _config_isolation_error(group: GroupDefinition, workdir: Path) -> str | None:
     """Reject a group that would silently inherit an unrelated project's config.
 
-    `cd workdir && pytest` does not pin config to workdir — pytest walks up. A
-    nested project without its own config therefore adopts its parent's
-    `addopts` (coverage targets, --strict-config), which fails in ways that
-    have nothing to do with the group's tests. Inheriting the repo-root config
-    is the normal monorepo case and stays allowed; inheriting some *other*
-    project's config never is.
+    `cd workdir && pytest <paths>` does not pin config to workdir — pytest walks
+    up from the common ancestor of its path args. A nested project without its
+    own config therefore adopts its parent's `addopts` (coverage targets,
+    --strict-config), which fails in ways that have nothing to do with the
+    group's tests. Inheriting the repo-root config is the normal monorepo case
+    and stays allowed; inheriting some *other* project's config never is.
     """
-    configfile = _resolve_pytest_configfile(workdir)
+    # Match pytest: ini discovery starts at the common ancestor of the path args
+    # (the rig always passes paths), not the workdir — they differ whenever paths
+    # reach into a subdirectory that is itself a nested project.
+    paths = [str(workdir / p) for p in group.paths]
+    start = Path(os.path.commonpath(paths)) if paths else workdir
+    configfile = _resolve_pytest_configfile(start)
     if configfile is None or configfile.parent in (workdir, REPO_ROOT):
         return None
+    # An empty pytest.ini is the lightest fix for a workdir with no pyproject.
+    fix_target = (
+        workdir / "pyproject.toml"
+        if (workdir / "pyproject.toml").is_file()
+        else workdir / "pytest.ini"
+    )
     return (
         f"[rig] group '{group.name}' would run under {configfile}, which belongs "
         f"to neither its workdir ({workdir}) nor the repo root.\n"
-        f"[rig] pytest resolves config by walking up from the workdir, so this "
-        f"group inherits that project's addopts.\n"
-        f"[rig] fix: add a [tool.pytest.ini_options] section to "
-        f"{workdir / 'pyproject.toml'}."
+        f"[rig] pytest resolves config by walking up from the tests' common "
+        f"ancestor, so this group inherits that project's addopts.\n"
+        f"[rig] fix: give the group its own pytest config, e.g. add a "
+        f"[tool.pytest.ini_options] section to or create {fix_target}."
     )
 
 
@@ -1134,7 +1166,7 @@ def _hurl_command(group: GroupDefinition, workdir: Path) -> list[str]:
 
 def _write_synthetic_junit(path: Path, group_name: str, exit_code: int) -> None:
     """Synthesise a JUnit XML for a group pytest never wrote one for (hurl runs,
-    or a group whose pre-run migration failed).
+    or a group rejected by the config-isolation guardrail).
 
     Exit 5 ("no tests collected") must produce failures=0; otherwise an empty
     hurl group would show ⚪ via :class:`GroupResult` while also being counted

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -467,9 +467,18 @@ def cmd_run(args: argparse.Namespace) -> int:
             )
             endpoints = runtime.up()
 
-        # Guarded on `postgres_url` so it only fires for a rig-owned container:
-        # under compose the platform migrates its own database on startup.
-        if endpoints is not None and manifest.postgres_migrate is not None:
+        # Guarded on `postgres_url` so it only fires for a rig-owned container
+        # (under compose the platform migrates its own database on startup), and
+        # on a runnable group actually needing Postgres, since `up()` provisions
+        # the full infra set even for a run that only wants another service.
+        needs_postgres = any(
+            "postgres" in manifest.get(n).requires_services for n in runnable
+        )
+        if (
+            endpoints is not None
+            and manifest.postgres_migrate is not None
+            and needs_postgres
+        ):
             postgres_url = endpoints.infra.postgres_url
             if postgres_url:
                 migrate_exit = _run_migrations(

--- a/tests/rig/groups.py
+++ b/tests/rig/groups.py
@@ -33,6 +33,29 @@ EXTRA_MANIFESTS_ENV = "UNSTRACT_RIG_EXTRA_MANIFESTS"
 
 
 @dataclass(frozen=True)
+class MigrateSpec:
+    """A ``manage.py migrate`` run against the rig-provisioned database.
+
+    Schema belongs to the database, not to any one group, so this is declared
+    once per manifest and applied when the rig provisions Postgres. Applying the
+    real migrations (rather than hand-written DDL in a fixture) keeps the
+    throwaway schema identical to the one the models generate, so tests that
+    assert on constraints stay meaningful.
+    """
+
+    workdir: str
+    apps: tuple[str, ...] = ()
+    env: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.env, MappingProxyType):
+            object.__setattr__(self, "env", MappingProxyType(dict(self.env)))
+
+    def absolute_workdir(self) -> Path:
+        return (REPO_ROOT / self.workdir).resolve()
+
+
+@dataclass(frozen=True)
 class GroupDefinition:
     name: str
     tier: Tier
@@ -71,6 +94,9 @@ class GroupDefinition:
 @dataclass(frozen=True)
 class GroupManifest:
     groups: dict[str, GroupDefinition]
+    # Applied once, when the rig provisions Postgres — see `postgres_migrate`
+    # in the manifest defaults.
+    postgres_migrate: MigrateSpec | None = None
 
     def get(self, name: str) -> GroupDefinition:
         if name not in self.groups:
@@ -142,7 +168,10 @@ def load_groups(path: Path | None = None) -> GroupManifest:
     _validate_paths(groups)
     smoke_gate = defaults.get("platform_gate_group", "e2e-smoke")
     _validate_platform_groups_depend_on_gate(groups, gate=smoke_gate)
-    return GroupManifest(groups=groups)
+    return GroupManifest(
+        groups=groups,
+        postgres_migrate=_build_postgres_migrate(defaults.get("postgres_migrate")),
+    )
 
 
 def _extra_manifest_paths() -> list[Path]:
@@ -240,6 +269,32 @@ def _build_group(
         parallel=bool(spec.get("parallel", defaults.get("parallel", True))),
         optional=bool(spec.get("optional", False)),
     )
+
+
+def _build_postgres_migrate(spec: Any) -> MigrateSpec | None:
+    """Parse and validate ``defaults.postgres_migrate``.
+
+    A bad spec is a silent no-show at runtime — every DB-backed test skips on a
+    missing table — so both the shape and the ``manage.py`` are checked at load.
+    """
+    if spec is None:
+        return None
+    if not isinstance(spec, dict) or not spec.get("workdir"):
+        raise ValueError(
+            f"`defaults.postgres_migrate` must be a mapping with a `workdir` "
+            f"(got {spec!r})"
+        )
+    migrate = MigrateSpec(
+        workdir=spec["workdir"],
+        apps=tuple(spec.get("apps") or ()),
+        env=dict(spec.get("env") or {}),
+    )
+    manage_py = migrate.absolute_workdir() / "manage.py"
+    if not manage_py.is_file():
+        raise ValueError(
+            f"`defaults.postgres_migrate.workdir` has no manage.py: {manage_py}"
+        )
+    return migrate
 
 
 def _validate_no_cycles(groups: dict[str, GroupDefinition]) -> None:

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -785,3 +785,79 @@ def test_failed_gate_blocks_dependents_and_cascades(tmp_path: Path, monkeypatch)
     # The blocked groups persisted a junit so CI's `rig report` can render them.
     assert (reports_dir / "e2e-mid" / "junit.xml").exists()
     assert (reports_dir / "e2e-leaf" / "junit.xml").exists()
+
+
+def _make_group(name: str, workdir: str):
+    from tests.rig.groups import GroupDefinition
+
+    return GroupDefinition(name=name, tier="unit", workdir=workdir, paths=["tests"])
+
+
+def _pytest_section(path: Path) -> None:
+    path.write_text('[tool.pytest.ini_options]\ntestpaths = ["tests"]\n')
+
+
+def test_resolve_configfile_skips_pyproject_without_pytest_section(
+    tmp_path: Path,
+) -> None:
+    """A pyproject without the pytest table is not a config file to pytest."""
+    from tests.rig import cli
+
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "root"\n')
+    child = tmp_path / "child"
+    child.mkdir()
+    (child / "pyproject.toml").write_text('[project]\nname = "child"\n')
+
+    assert cli._resolve_pytest_configfile(child) is None
+
+
+def test_resolve_configfile_finds_nearest_ancestor(tmp_path: Path) -> None:
+    from tests.rig import cli
+
+    _pytest_section(tmp_path / "pyproject.toml")
+    child = tmp_path / "child"
+    child.mkdir()
+
+    assert cli._resolve_pytest_configfile(child) == tmp_path / "pyproject.toml"
+
+
+def test_config_isolation_allows_own_config(tmp_path: Path, monkeypatch) -> None:
+    from tests.rig import cli
+
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    workdir = tmp_path / "pkg"
+    workdir.mkdir()
+    _pytest_section(workdir / "pyproject.toml")
+
+    assert cli._config_isolation_error(_make_group("g", "pkg"), workdir) is None
+
+
+def test_config_isolation_allows_repo_root_config(tmp_path: Path, monkeypatch) -> None:
+    """Inheriting the monorepo-wide config is the normal case, not a defect."""
+    from tests.rig import cli
+
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    _pytest_section(tmp_path / "pyproject.toml")
+    workdir = tmp_path / "pkg"
+    workdir.mkdir()
+
+    assert cli._config_isolation_error(_make_group("g", "pkg"), workdir) is None
+
+
+def test_config_isolation_rejects_sibling_project_config(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A nested project inheriting its parent project's config is the bug."""
+    from tests.rig import cli
+
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    parent = tmp_path / "workers"
+    nested = parent / "plugins" / "agentic_table"
+    nested.mkdir(parents=True)
+    _pytest_section(parent / "pyproject.toml")
+
+    error = cli._config_isolation_error(_make_group("unit-nested", "x"), nested)
+
+    assert error is not None
+    assert "unit-nested" in error
+    assert str(parent / "pyproject.toml") in error

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -669,6 +669,57 @@ def test_db_env_from_postgres_url_maps_discrete_vars() -> None:
     }
 
 
+def test_inject_infra_env_mirrors_postgres_onto_test_db_prefix() -> None:
+    """The workers' real-Postgres fixtures connect via ``TEST_DB_*`` (so a
+    developer run keeps hitting their own compose DB). Without the mirror they
+    fall back to the dev-compose defaults and every such test skips on connect
+    while the provisioned container sits idle.
+    """
+    import tests.rig.cli as cli_mod
+    from tests.rig.groups import GroupDefinition
+    from tests.rig.runtime import InfraEndpoints, PlatformEndpoints
+
+    endpoints = PlatformEndpoints.from_env(
+        infra=InfraEndpoints(
+            postgres_url="postgresql+psycopg2://tcuser:tcpass@127.0.0.1:49231/testdb"
+        )
+    )
+    group = GroupDefinition(
+        name="g", tier="integration", paths=("tests",), requires_services=("postgres",)
+    )
+    env: dict[str, str] = {}
+    cli_mod._inject_infra_env(env, group, endpoints)
+    assert env["TEST_DB_HOST"] == "127.0.0.1"
+    assert env["TEST_DB_PORT"] == "49231"
+    assert env["TEST_DB_NAME"] == "testdb"
+    assert env["TEST_DB_USER"] == "tcuser"
+    assert env["TEST_DB_PASSWORD"] == "tcpass"  # NOSONAR - test placeholder
+    # The queue's search_path and the schema migrations land in must agree, and
+    # a provisioned Postgres only has `public`.
+    assert env["DB_SCHEMA"] == "public"
+    assert env["TEST_DB_SCHEMA"] == "public"
+
+
+def test_inject_infra_env_keeps_group_declared_schema() -> None:
+    """A group that declares its own DB_SCHEMA keeps it — on both prefixes."""
+    import tests.rig.cli as cli_mod
+    from tests.rig.groups import GroupDefinition
+    from tests.rig.runtime import InfraEndpoints, PlatformEndpoints
+
+    endpoints = PlatformEndpoints.from_env(
+        infra=InfraEndpoints(
+            postgres_url="postgresql+psycopg2://u:p@127.0.0.1:5432/db"  # NOSONAR
+        )
+    )
+    group = GroupDefinition(
+        name="g", tier="integration", paths=("tests",), requires_services=("postgres",)
+    )
+    env = {"DB_SCHEMA": "unstract"}
+    cli_mod._inject_infra_env(env, group, endpoints)
+    assert env["DB_SCHEMA"] == "unstract"
+    assert env["TEST_DB_SCHEMA"] == "unstract"
+
+
 def test_inject_infra_env_wires_provisioned_redis() -> None:
     """A group declaring `requires_services: [redis]` must get REDIS_HOST/PORT +
     the Celery broker URL rewritten to the provisioned endpoint — otherwise

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -849,11 +849,12 @@ def _pytest_section(path: Path) -> None:
 
 
 def test_resolve_configfile_skips_pyproject_without_pytest_section(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A pyproject without the pytest table is not a config file to pytest."""
     from tests.rig import cli
 
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
     (tmp_path / "pyproject.toml").write_text('[project]\nname = "root"\n')
     child = tmp_path / "child"
     child.mkdir()

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -913,3 +913,45 @@ def test_config_isolation_rejects_sibling_project_config(
     assert error is not None
     assert "unit-nested" in error
     assert str(parent / "pyproject.toml") in error
+
+
+def test_config_isolation_catches_intermediate_nested_project(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Paths reaching into a nested project pick up that project's config, even
+    when the workdir has its own — pytest starts discovery at the paths' common
+    ancestor, so resolving from the workdir alone would miss it.
+    """
+    from tests.rig import cli
+    from tests.rig.groups import GroupDefinition
+
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    workdir = tmp_path / "workers"
+    nested = workdir / "plugins" / "agentic_table"
+    (nested / "tests").mkdir(parents=True)
+    _pytest_section(workdir / "pyproject.toml")  # workdir's own config
+    _pytest_section(nested / "pyproject.toml")  # the nested project shadows it
+
+    group = GroupDefinition(
+        name="unit-agentic",
+        tier="unit",
+        workdir="workers",
+        paths=["plugins/agentic_table/tests"],
+    )
+    error = cli._config_isolation_error(group, workdir)
+
+    assert error is not None
+    assert str(nested / "pyproject.toml") in error
+
+
+def test_resolve_configfile_ignores_commented_section(tmp_path: Path) -> None:
+    """A commented-out section header is not a real pytest config."""
+    from tests.rig import cli
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "root"\n# [tool.pytest.ini_options] disabled\n'
+    )
+    child = tmp_path / "child"
+    child.mkdir()
+
+    assert cli._resolve_pytest_configfile(child) is None

--- a/tests/rig/tests/test_groups.py
+++ b/tests/rig/tests/test_groups.py
@@ -383,3 +383,85 @@ def test_extra_manifest_missing_path_names_env_var(
     monkeypatch.setenv("UNSTRACT_RIG_EXTRA_MANIFESTS", str(tmp_path / "nope.yaml"))
     with pytest.raises(ValueError, match="UNSTRACT_RIG_EXTRA_MANIFESTS"):
         load_groups()
+
+
+def test_postgres_migrate_spec_parsed(tmp_path: Path) -> None:
+    manifest = _write_manifest(
+        tmp_path,
+        """
+        version: 1
+        defaults:
+          postgres_migrate:
+            workdir: backend
+            apps: [pg_queue]
+            env:
+              DB_SCHEMA: public
+        groups:
+          a:
+            tier: integration
+            paths: [x]
+            optional: true
+            requires_services: [postgres]
+        """,
+    )
+    spec = load_groups(manifest).postgres_migrate
+    assert spec is not None
+    assert spec.apps == ("pg_queue",)
+    assert spec.env["DB_SCHEMA"] == "public"
+    assert spec.absolute_workdir().name == "backend"
+
+
+def test_postgres_migrate_absent_by_default(tmp_path: Path) -> None:
+    manifest = _write_manifest(
+        tmp_path,
+        """
+        version: 1
+        groups:
+          a:
+            tier: integration
+            paths: [x]
+            optional: true
+        """,
+    )
+    assert load_groups(manifest).postgres_migrate is None
+
+
+def test_postgres_migrate_workdir_must_hold_manage_py(tmp_path: Path) -> None:
+    """A bad workdir would otherwise surface only after infra is up, as every
+    DB-backed test skipping on a missing table."""
+    manifest = _write_manifest(
+        tmp_path,
+        """
+        version: 1
+        defaults:
+          postgres_migrate:
+            workdir: workers
+        groups:
+          a:
+            tier: integration
+            paths: [x]
+            optional: true
+            requires_services: [postgres]
+        """,
+    )
+    with pytest.raises(ValueError, match="manage.py"):
+        load_groups(manifest)
+
+
+def test_postgres_migrate_requires_workdir(tmp_path: Path) -> None:
+    manifest = _write_manifest(
+        tmp_path,
+        """
+        version: 1
+        defaults:
+          postgres_migrate:
+            apps: [pg_queue]
+        groups:
+          a:
+            tier: integration
+            paths: [x]
+            optional: true
+        """,
+    )
+    with pytest.raises(ValueError, match="workdir"):
+        load_groups(manifest)

--- a/tests/rig/tests/test_groups.py
+++ b/tests/rig/tests/test_groups.py
@@ -444,7 +444,7 @@ def test_postgres_migrate_workdir_must_hold_manage_py(tmp_path: Path) -> None:
             requires_services: [postgres]
         """,
     )
-    with pytest.raises(ValueError, match="manage.py"):
+    with pytest.raises(ValueError, match=r"manage\.py"):
         load_groups(manifest)
 
 

--- a/unstract/connectors/tests/filesystems/test_sharepoint_fs.py
+++ b/unstract/connectors/tests/filesystems/test_sharepoint_fs.py
@@ -241,6 +241,11 @@ class TestSharePointFSUnit(unittest.TestCase):
 class TestSharePointFSIntegration(unittest.TestCase):
     """Integration tests for SharePointFS (require real credentials)."""
 
+    @unittest.skip(
+        "Order-dependent: writes to a fixed remote path with no cleanup, and "
+        "the read test consumes what the write test left behind. Fix isolation "
+        "before enabling, otherwise this fails once real credentials are provided."
+    )
     @unittest.skipUnless(
         os.environ.get("SHAREPOINT_CLIENT_SECRET"),
         "Integration test requires SHAREPOINT_* environment variables",
@@ -286,6 +291,11 @@ class TestSharePointFSIntegration(unittest.TestCase):
         except Exception as e:
             self.fail(f"Failed to write file: {e}")
 
+    @unittest.skip(
+        "Order-dependent: writes to a fixed remote path with no cleanup, and "
+        "the read test consumes what the write test left behind. Fix isolation "
+        "before enabling, otherwise this fails once real credentials are provided."
+    )
     @unittest.skipUnless(
         os.environ.get("SHAREPOINT_CLIENT_SECRET"),
         "Integration test requires SHAREPOINT_* environment variables",

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import psycopg2
 import pytest
 from dotenv import load_dotenv
+from psycopg2 import sql
 
 _env_test = Path(__file__).resolve().parent.parent / ".env.test"
 load_dotenv(_env_test)
@@ -245,15 +246,34 @@ def _pg_worker_schema():
         conn = integration_pg_conn()
         try:
             with conn.cursor() as cur:
-                cur.execute(f"SELECT to_regclass('{base}.pg_barrier_state')")
+                cur.execute(
+                    sql.SQL("SELECT to_regclass({})").format(
+                        sql.Literal(f"{base}.pg_barrier_state")
+                    )
+                )
                 if cur.fetchone()[0] is not None:
                     reachable = True
                     if schema != base:
-                        cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+                        # Drop first: IF NOT EXISTS would keep a stale clone from
+                        # a prior run whose table definitions have since changed.
+                        cur.execute(
+                            sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(
+                                sql.Identifier(schema)
+                            )
+                        )
+                        cur.execute(
+                            sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema))
+                        )
                         for table in QUEUE_TABLES:
                             cur.execute(
-                                f'CREATE TABLE IF NOT EXISTS "{schema}".{table} '
-                                f"(LIKE {base}.{table} INCLUDING ALL)"
+                                sql.SQL(
+                                    "CREATE TABLE {}.{} (LIKE {}.{} INCLUDING ALL)"
+                                ).format(
+                                    sql.Identifier(schema),
+                                    sql.Identifier(table),
+                                    sql.Identifier(base),
+                                    sql.Identifier(table),
+                                )
                             )
             conn.commit()
         finally:
@@ -286,7 +306,11 @@ def _pg_worker_schema_env(request, _restore_os_environ, _pg_worker_schema):
         try:
             with conn.cursor() as cur:
                 for table in QUEUE_TABLES:
-                    cur.execute(f'TRUNCATE "{schema}".{table}')
+                    cur.execute(
+                        sql.SQL("TRUNCATE {}.{}").format(
+                            sql.Identifier(schema), sql.Identifier(table)
+                        )
+                    )
             conn.commit()
         finally:
             conn.close()

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -249,10 +249,10 @@ def _pg_worker_schema():
 
 
 @pytest.fixture(autouse=True)
-def _pg_worker_schema_env(_pg_worker_schema):
+def _pg_worker_schema_env(_restore_os_environ, _pg_worker_schema):
     """Point the queue's schema at this worker's, and clear it before each test.
 
-    Defined after ``_restore_os_environ`` so the schema survives that fixture's
+    Depends on ``_restore_os_environ`` so the schema survives that fixture's
     per-test reset. Both prefixes are set: ``DB_SCHEMA`` for the code under test
     (``qualified()`` / the production connection) and ``TEST_DB_SCHEMA`` for the
     fixtures' own connections.

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -200,6 +200,80 @@ def pg_client(pg_conn):
     return PgQueueClient(conn=pg_conn)
 
 
+# --- Per-worker Postgres isolation (real-DB integration lane) ---
+#
+# This is the only suite that opens a *raw* psycopg2 connection, so it bypasses
+# pytest-django's per-worker test database. Under xdist every worker would share
+# one physical table, and the reaper/sweeper paths scan *all* rows — so a whole-
+# table assertion in one worker sees another worker's rows. Give each worker its
+# own schema (the raw-connection equivalent of Django's per-worker database) and
+# truncate between tests, since a raw connection carries committed rows to the
+# next test with no rollback.
+
+
+def _worker_pg_schema() -> str:
+    worker = os.getenv("PYTEST_XDIST_WORKER", "")
+    return f"test_{worker}" if worker else "public"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _pg_worker_schema():
+    """Clone the pg_queue tables into a per-worker schema, once per worker.
+
+    Cloned from ``public`` (which the rig migrates before any group runs) via
+    ``LIKE ... INCLUDING ALL`` — the tables have no cross-table foreign keys, so
+    the clone carries every check/not-null/default/index. No-op when running
+    serially (``public``) or when Postgres is unreachable/unmigrated (the tests
+    skip anyway).
+    """
+    from queue_backend.pg_queue.schema import QUEUE_TABLES
+
+    schema = _worker_pg_schema()
+    if schema != "public":
+        with contextlib.suppress(psycopg2.OperationalError):
+            conn = integration_pg_conn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT to_regclass('public.pg_barrier_state')")
+                    if cur.fetchone()[0] is not None:
+                        cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+                        for table in QUEUE_TABLES:
+                            cur.execute(
+                                f'CREATE TABLE IF NOT EXISTS "{schema}".{table} '
+                                f"(LIKE public.{table} INCLUDING ALL)"
+                            )
+                conn.commit()
+            finally:
+                conn.close()
+    yield schema
+
+
+@pytest.fixture(autouse=True)
+def _pg_worker_schema_env(_pg_worker_schema):
+    """Point the queue's schema at this worker's, and clear it before each test.
+
+    Defined after ``_restore_os_environ`` so the schema survives that fixture's
+    per-test reset. Both prefixes are set: ``DB_SCHEMA`` for the code under test
+    (``qualified()`` / the production connection) and ``TEST_DB_SCHEMA`` for the
+    fixtures' own connections.
+    """
+    from queue_backend.pg_queue.schema import QUEUE_TABLES
+
+    schema = _pg_worker_schema
+    os.environ["DB_SCHEMA"] = schema
+    os.environ["TEST_DB_SCHEMA"] = schema
+    with contextlib.suppress(psycopg2.Error):
+        conn = integration_pg_conn()
+        try:
+            with conn.cursor() as cur:
+                for table in QUEUE_TABLES:
+                    cur.execute(f'TRUNCATE "{schema}".{table}')
+            conn.commit()
+        finally:
+            conn.close()
+    yield
+
+
 # --- Test-isolation fixtures (deterministic single-process runs) ---
 #
 # The workers suite carries several process-global registries/singletons that

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -211,55 +211,74 @@ def pg_client(pg_conn):
 # next test with no rollback.
 
 
+def _base_pg_schema() -> str:
+    """Schema the pg_queue tables actually live in for this run.
+
+    CI injects ``TEST_DB_SCHEMA``/``DB_SCHEMA=public`` and migrates there; a
+    developer running ``pytest -m integration`` against their compose DB has
+    neither set, where ``backend migrate`` puts the tables in ``unstract``.
+    """
+    return os.getenv("TEST_DB_SCHEMA") or os.getenv("DB_SCHEMA") or "unstract"
+
+
 def _worker_pg_schema() -> str:
     worker = os.getenv("PYTEST_XDIST_WORKER", "")
-    return f"test_{worker}" if worker else "public"
+    return f"test_{worker}" if worker else _base_pg_schema()
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _pg_worker_schema():
     """Clone the pg_queue tables into a per-worker schema, once per worker.
 
-    Cloned from ``public`` (which the rig migrates before any group runs) via
+    Cloned from the base schema (where the migration ran) via
     ``LIKE ... INCLUDING ALL`` — the tables have no cross-table foreign keys, so
-    the clone carries every check/not-null/default/index. No-op when running
-    serially (``public``) or when Postgres is unreachable/unmigrated (the tests
-    skip anyway).
+    the clone carries every check/not-null/default/index. Yields the schema when
+    Postgres is reachable and migrated, else ``None`` so per-test fixtures can
+    short-circuit instead of retrying a dead connection on every test.
     """
     from queue_backend.pg_queue.schema import QUEUE_TABLES
 
+    base = _base_pg_schema()
     schema = _worker_pg_schema()
-    if schema != "public":
-        with contextlib.suppress(psycopg2.OperationalError):
-            conn = integration_pg_conn()
-            try:
-                with conn.cursor() as cur:
-                    cur.execute("SELECT to_regclass('public.pg_barrier_state')")
-                    if cur.fetchone()[0] is not None:
+    reachable = False
+    with contextlib.suppress(psycopg2.OperationalError):
+        conn = integration_pg_conn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT to_regclass('{base}.pg_barrier_state')")
+                if cur.fetchone()[0] is not None:
+                    reachable = True
+                    if schema != base:
                         cur.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
                         for table in QUEUE_TABLES:
                             cur.execute(
                                 f'CREATE TABLE IF NOT EXISTS "{schema}".{table} '
-                                f"(LIKE public.{table} INCLUDING ALL)"
+                                f"(LIKE {base}.{table} INCLUDING ALL)"
                             )
-                conn.commit()
-            finally:
-                conn.close()
-    yield schema
+            conn.commit()
+        finally:
+            conn.close()
+    yield schema if reachable else None
 
 
 @pytest.fixture(autouse=True)
-def _pg_worker_schema_env(_restore_os_environ, _pg_worker_schema):
+def _pg_worker_schema_env(request, _restore_os_environ, _pg_worker_schema):
     """Point the queue's schema at this worker's, and clear it before each test.
 
-    Depends on ``_restore_os_environ`` so the schema survives that fixture's
-    per-test reset. Both prefixes are set: ``DB_SCHEMA`` for the code under test
-    (``qualified()`` / the production connection) and ``TEST_DB_SCHEMA`` for the
-    fixtures' own connections.
+    Only real-Postgres tests (auto-marked ``integration``) reach the connection;
+    the DB-free unit lane and any run where Postgres is unreachable skip the body
+    entirely, so unit tests neither open a connection nor have their schema env
+    mutated. Depends on ``_restore_os_environ`` so the schema survives that
+    fixture's per-test reset. Both prefixes are set: ``DB_SCHEMA`` for the code
+    under test and ``TEST_DB_SCHEMA`` for the fixtures' own connections.
     """
     from queue_backend.pg_queue.schema import QUEUE_TABLES
 
     schema = _pg_worker_schema
+    if schema is None or request.node.get_closest_marker("integration") is None:
+        yield
+        return
+
     os.environ["DB_SCHEMA"] = schema
     os.environ["TEST_DB_SCHEMA"] = schema
     with contextlib.suppress(psycopg2.Error):

--- a/workers/tests/test_pg_barrier.py
+++ b/workers/tests/test_pg_barrier.py
@@ -833,9 +833,9 @@ class TestPgBarrierEnqueue:
             cur.execute(
                 "INSERT INTO pg_barrier_state "
                 "(execution_id, organization_id, remaining, results, "
-                " created_at, expires_at) "
+                " created_at, expires_at, last_progress_at) "
                 "VALUES ('exec-R', '', 1, '[1,2]'::jsonb, now(), "
-                "        now() + interval '1h')"
+                "        now() + interval '1h', now())"
             )
         task, _ = _mock_header_task()
         PgBarrier().enqueue(
@@ -874,9 +874,9 @@ class TestPgBarrierEnqueue:
             cur.execute(
                 "INSERT INTO pg_barrier_state "
                 "(execution_id, organization_id, remaining, results, "
-                " created_at, expires_at) "
+                " created_at, expires_at, last_progress_at) "
                 "VALUES ('exec-REORG', 'old-org', 1, '[]'::jsonb, now(), "
-                "        now() + interval '1h')"
+                "        now() + interval '1h', now())"
             )
         PgBarrier().enqueue(
             [_mock_header_task()[0]],
@@ -908,8 +908,8 @@ def _seed(conn, execution_id, remaining, *, results="[]"):
         cur.execute(
             "INSERT INTO pg_barrier_state "
             "(execution_id, organization_id, remaining, results, "
-            " created_at, expires_at) "
-            "VALUES (%s, '', %s, %s::jsonb, now(), now() + interval '1h')",
+            " created_at, expires_at, last_progress_at) "
+            "VALUES (%s, '', %s, %s::jsonb, now(), now() + interval '1h', now())",
             (execution_id, remaining, results),
         )
 
@@ -1265,8 +1265,8 @@ class TestDbConstraint:
                 cur.execute(
                     "INSERT INTO pg_barrier_state "
                     "(execution_id, organization_id, remaining, results, "
-                    " created_at, expires_at) "
-                    "VALUES ('bad', '', 1, '[]'::jsonb, now(), now())"  # expires==created
+                    " created_at, expires_at, last_progress_at) "
+                    "VALUES ('bad', '', 1, '[]'::jsonb, now(), now(), now())"  # expires==created
                 )
 
 


### PR DESCRIPTION
## Why

Two related test-rig defects surfaced while wiring cloud CI onto the rig.

**1. A group can silently inherit another project's pytest config.**
The rig runs `cd <workdir> && pytest <paths>` and never pins the config file. pytest resolves config by walking *up* from the workdir, so a group whose workdir is a nested project without its own config adopts its parent's `addopts` — coverage targets, `--strict-config` — and fails for reasons that have nothing to do with its tests. Observed symptom: `ERROR: Unknown config option: asyncio_mode` followed by `no tests ran`, and a tier exit 4.

`--rootdir` does **not** fix this (verified empirically — it moves rootdir but leaves ini-file discovery alone). Only an own config section, or `-c`, does.

This matters beyond the one case: `workers/plugins/` holds 11 nested projects, each a future instance of the same trap.

**2. Several connector tests are order-dependent and dormant.**
They share a fixed table (or remote path) across test methods with no working teardown — several `tearDown` bodies are a bare `pass` with the drops commented out. They are inert only because their credentials aren't provisioned, so the breakage would appear as a surprise the moment someone adds them.

## What

- `_resolve_pytest_configfile()` mirrors pytest's upward search; `_config_isolation_error()` fails a group up front when the resolved config belongs to neither its workdir nor the repo root, with a message naming the offending file and the fix.
  - Inheriting the **repo-root** config stays allowed — that's the normal monorepo case, and `unit-core` / `unit-platform-service` rely on it today.
- Explicit `@unittest.skip` with the reason stated on the 7 dormant connector test classes and the 2 SharePoint tests, so enabling credentials becomes a deliberate step.
  - The **postgres** variant is deliberately untouched: it runs today and is being fixed rather than skipped.

## Verification

- Guardrail checked against all **18** existing pytest groups — none rejected.
- Rig self-tests: **86 passed, 1 skipped** (5 new tests cover own-config, root-config, and nested-sibling-config cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnLaN45ShBbcCXWZkqCThz