### PR TITLE
UN-3794 [MISC] Remove x2text-service from the stack

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -206,8 +206,6 @@ jobs:
             tool-sidecar.cache-to=type=gha,mode=max,scope=tool-sidecar
             platform-service.cache-from=type=gha,scope=platform-service
             platform-service.cache-to=type=gha,mode=max,scope=platform-service
-            x2text-service.cache-from=type=gha,scope=x2text-service
-            x2text-service.cache-to=type=gha,mode=max,scope=x2text-service
             tool-classifier.cache-from=type=gha,scope=tool-classifier
             tool-classifier.cache-to=type=gha,mode=max,scope=tool-classifier
             tool-text_extractor.cache-from=type=gha,scope=tool-text_extractor

--- a/.github/workflows/production-build.yaml
+++ b/.github/workflows/production-build.yaml
@@ -103,7 +103,6 @@ jobs:
             platform-service,
             runner,
             worker-unified,
-            x2text-service,
           ]
 
     steps:
@@ -315,7 +314,7 @@ jobs:
             echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY
 
             # Define services in order
-            for service in backend frontend platform-service runner worker-unified x2text-service; do
+            for service in backend frontend platform-service runner worker-unified; do
               if [ -f "build-status/${service}.json" ]; then
                 STATUS=$(jq -r '.status' "build-status/${service}.json")
                 if [ "$STATUS" = "success" ]; then

--- a/docker/docker-compose.build.yaml
+++ b/docker/docker-compose.build.yaml
@@ -25,11 +25,6 @@ services:
     build:
       dockerfile: docker/dockerfiles/platform.Dockerfile
       context: ..
-  x2text-service:
-    image: unstract/x2text-service:${VERSION}
-    build:
-      dockerfile: docker/dockerfiles/x2text.Dockerfile
-      context: ..
   tool-classifier:
     image: unstract/tool-classifier:${VERSION}
     build:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
       - minio
       - minio-bootstrap
       - platform-service
-      - x2text-service
     volumes:
       - prompt_studio_data:/app/prompt-studio-data
       - ./workflow_data:/data
@@ -157,19 +156,6 @@ services:
       - ../platform-service/.env
     depends_on:
       - redis
-      - db
-    labels:
-      - traefik.enable=false
-
-  x2text-service:
-    image: unstract/x2text-service:${VERSION}
-    container_name: unstract-x2text-service
-    restart: unless-stopped
-    ports:
-      - "3004:3004"
-    env_file:
-      - ../x2text-service/.env
-    depends_on:
       - db
     labels:
       - traefik.enable=false

--- a/docker/sample.compose.override.yaml
+++ b/docker/sample.compose.override.yaml
@@ -139,16 +139,6 @@ services:
           path: ../platform-service/uv.lock
 
   #########################################################################################################
-  # X2Text Service
-  x2text-service:
-    image: unstract/x2text-service:${VERSION}
-    profiles:
-      - optional
-    build:
-      dockerfile: docker/dockerfiles/x2text.Dockerfile
-      context: ..
-
-  #########################################################################################################
   # Tool Sidecar
   tool-sidecar:
     image: unstract/tool-sidecar:${VERSION}

--- a/tests/rig/runtime.py
+++ b/tests/rig/runtime.py
@@ -298,7 +298,6 @@ def health_targets(endpoints: PlatformEndpoints) -> list[tuple[str, str]]:
     return [
         ("backend", endpoints.backend_url.rstrip("/") + "/health"),
         ("platform-service", endpoints.platform_service_url.rstrip("/") + "/health"),
-        ("x2text-service", endpoints.x2text_url.rstrip("/") + "/api/v1/x2text/health"),
     ]
 
 

--- a/tests/rig/tests/test_x2text_decommissioned.py
+++ b/tests/rig/tests/test_x2text_decommissioned.py
@@ -1,0 +1,40 @@
+"""x2text-service is decommissioned and must not be shipped or built.
+
+The service was a bare HTTP proxy in front of unstructured.io, used only by
+the ``unstructured_community`` and ``unstructured_enterprise`` adapters. Both
+are sunset and nothing else routes through it, so it is no longer deployed —
+which only holds if it is gone from every file that would stand it up.
+
+The directory, its Dockerfile and the two adapters are a separate cleanup:
+removing those strands configured ``AdapterInstance`` rows, which makes it a
+migration decision rather than a packaging one.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Files that would deploy, build or publish the service.
+SHIPPING_FILES = [
+    "docker/docker-compose.yaml",
+    "docker/docker-compose.build.yaml",
+    "docker/sample.compose.override.yaml",
+    ".github/workflows/production-build.yaml",
+    ".github/workflows/ci-test.yaml",
+]
+
+
+@pytest.mark.parametrize("relative_path", SHIPPING_FILES)
+def test_service_is_not_shipped(relative_path):
+    path = REPO_ROOT / relative_path
+    assert path.exists(), f"{relative_path} moved — update this list"
+    assert "x2text-service" not in path.read_text(), (
+        f"{relative_path} still stands up or publishes x2text-service"
+    )
+
+
+def test_port_3004_is_not_published():
+    compose = (REPO_ROOT / "docker/docker-compose.yaml").read_text()
+    assert "3004" not in compose


### PR DESCRIPTION
## What

Stops shipping `x2text-service`: removed from `docker-compose.yaml`, the build and override compose files, the CI build matrix and cache config, and the e2e readiness check. Adds a test that fails if it comes back.

## Why

`x2text-service` is a thin HTTP proxy in front of unstructured.io. Only two adapters route through it — `unstructured_community` and `unstructured_enterprise` (via `UnstructuredHelper.make_request`). LLMWhisperer, llama_parse and no_op do not touch it. Both adapters are sunset, so this is a container we build, publish, run and health-check for nothing.

## How

- Dropped the service block and its `3004:3004` publish from `docker/docker-compose.yaml`, plus the backend's `depends_on` entry.
- Dropped the build entries from `docker/docker-compose.build.yaml` and `docker/sample.compose.override.yaml`.
- Dropped it from the `production-build.yaml` build matrix and its summary loop, and from the `ci-test.yaml` build cache config.
- Dropped the readiness probe from `tests/rig/runtime.py`, so e2e no longer waits on a service that is not started.

Left in place deliberately:

- **`X2TEXT_HOST` / `X2TEXT_PORT` stay in the sample envs.** `ToolsUtils.__init__` reads both with `raise_exception=True` on *every* workflow execution, not only for the two sunset adapters. Removing them breaks all execution, not just the paths being retired.
- **`x2text-service/`, its Dockerfile and the two adapters stay.** Deleting them strands configured `AdapterInstance` rows of those types, which makes it a migration decision rather than a packaging one. Worth a separate ticket owned by whoever sequences the sunset.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

Yes, narrowly and by design: any deployment still using an `unstructured_community` or `unstructured_enterprise` adapter loses text extraction through it, because nothing will be listening on 3004. That is the intent — both adapters are sunset. No other extraction path is affected; LLMWhisperer and the rest never used the service.

Two operational notes:

- Existing installs keep the container until it is explicitly removed — `docker compose up` does not delete a service that is gone from the file without `--remove-orphans`. Redeploys need to drop the container and unpublish 3004 rather than assume the file change did it.
- `UNSTRACT_X2TEXT_URL` is still threaded through the rig config; it is now unused by the readiness check. Left alone to avoid churning `tests/rig/tests/test_runtime.py` in this PR.

## Database Migrations

None.

## Env Config

No removals. `X2TEXT_HOST` / `X2TEXT_PORT` intentionally retained — see above.

## Relevant Docs

`docs/local-dev-setup-executor-migration.md` still lists the service on port 3004 and describes it as needed for text extraction. Not updated here to keep this PR to packaging; worth a follow-up.

## Related Issues or PRs

UN-3794

## Dependencies Versions

Unchanged.

## Notes on Testing

- `tests/rig/tests/test_x2text_decommissioned.py` asserts the service name is absent from every file that would deploy, build or publish it, and that 3004 is no longer published. Confirmed to fail against `main` before this change, so a partial revert fails rather than quietly reintroducing the container.
- `docker compose config` validates clean across the merged compose files, with no `x2text` or `3004` in the rendered output.

Manual check worth doing before merge: bring the stack up and confirm no `unstract-x2text-service` container, the backend healthy without the `depends_on`, port 3004 refused, and one non-unstructured extraction path (LLMWhisperer) still working end to end.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
