### PR TITLE
UN-2646 [FEAT] OSS half of the VLM image-answer feature (path contract, loader, vision policy, bridge)

### DIFF
--- a/backend/adapter_processor_v2/image_output_gating.py
+++ b/backend/adapter_processor_v2/image_output_gating.py
@@ -94,4 +94,14 @@ def validate_image_output_allowed(
         return
     if adapter_id is not None and not adapter_id.startswith(LLMWHISPERER_ADAPTER_PREFIX):
         return
-    raise ValidationError(IMAGE_OUTPUT_REQUIRES_CLOUD)
+    logger.warning(
+        "Rejecting image output mode without the consumer plugin "
+        "(adapter_id=%s, output_mode=%s)",
+        adapter_id,
+        adapter_metadata.get(ImageOutputConstants.OUTPUT_MODE),
+    )
+    # Dict detail, not a bare string: this is raised from inside
+    # ``to_internal_value``, where DRF folds the detail into its per-field
+    # error mapping — a bare string there crashes error collection with a
+    # 500 instead of surfacing a clean 400.
+    raise ValidationError({"adapter_metadata": [IMAGE_OUTPUT_REQUIRES_CLOUD]})

--- a/backend/api_v2/serializers.py
+++ b/backend/api_v2/serializers.py
@@ -8,6 +8,9 @@ from django.apps import apps
 from django.core.validators import RegexValidator
 from pipeline_v2.models import Pipeline
 from prompt_studio.prompt_profile_manager_v2.models import ProfileManager
+from prompt_studio.vlm_utils import (
+    validate_workflow_for_deployment as validate_workflow_vlm_for_deployment,
+)
 from rest_framework import serializers
 from rest_framework.serializers import (
     BooleanField,
@@ -148,6 +151,11 @@ class APIDeploymentSerializer(IntegrityErrorMixin, AuditSerializer):
             raise ValidationError(
                 "Destination endpoint must have a connector configured for non-API and non-manual review connections before creating an API deployment."
             )
+
+        # Image-output-mode profiles need a vision-capable LLM at run time;
+        # block deployment creation on a definitive mismatch (cloud-only
+        # check — no-op in OSS, where image mode is gated off entirely).
+        validate_workflow_vlm_for_deployment(workflow)
 
         return workflow
 

--- a/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
@@ -4,6 +4,7 @@ from adapter_processor_v2.adapter_processor import AdapterProcessor
 
 from backend.serializers import AuditSerializer
 from prompt_studio.prompt_profile_manager_v2.constants import ProfileManagerKeys
+from prompt_studio.vlm_utils import get_profile_vision_warning
 
 from .models import ProfileManager
 
@@ -38,4 +39,9 @@ class ProfileManagerSerializer(AuditSerializer):
             rep[ProfileManagerKeys.X2TEXT] = AdapterProcessor.get_adapter_instance_by_id(
                 x2text
             )
+        # Non-blocking image-mode/vision-LLM mismatch warning (cloud-only;
+        # always None in OSS — key omitted).
+        vision_warning = get_profile_vision_warning(instance)
+        if vision_warning:
+            rep["vision_warning"] = vision_warning
         return rep

--- a/backend/prompt_studio/prompt_studio_core_v2/constants.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/constants.py
@@ -99,6 +99,12 @@ class ToolStudioPromptKeys:
     VARIABLE_MAP = "variable_map"
     RECORD = "record"
     FILE_PATH = "file_path"
+    # Extract-file path that never gets rewritten by summarize-as-source /
+    # smart-table overrides — the page-image reader keys on this.
+    EXTRACT_FILE_PATH = "extract_file_path"
+    # Per-prompt stamp of the x2text adapter's output mode (LLMWhisperer
+    # only), so the executor detects image mode without a platform call.
+    X2TEXT_OUTPUT_MODE = "x2text_output_mode"
     ENABLE_HIGHLIGHT = "enable_highlight"
     ENABLE_WORD_CONFIDENCE = "enable_word_confidence"
     REQUIRED = "required"

--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -445,6 +445,7 @@ class PromptStudioHelper:
         output[TSPKeys.SIMILARITY_TOP_K] = profile_manager.similarity_top_k
         output[TSPKeys.SECTION] = profile_manager.section
         output[TSPKeys.X2TEXT_ADAPTER] = x2text
+        PromptStudioHelper._stamp_x2text_output_mode(output, profile_manager)
 
         webhook_enabled = bool(prompt.enable_postprocessing_webhook)
         webhook_url = (prompt.postprocessing_webhook_url or "").strip()
@@ -822,6 +823,9 @@ class PromptStudioHelper:
             enable_highlight=tool.enable_highlight,
         )
 
+        # Captured before the summarize override: the page-image reader must
+        # key on the extract path even when answers run over the summary.
+        image_extract_path = extract_path
         is_summary = tool.summarize_as_source
         if is_summary:
             profile_manager.chunk_size = 0
@@ -868,6 +872,7 @@ class PromptStudioHelper:
         output[TSPKeys.SIMILARITY_TOP_K] = profile_manager.similarity_top_k
         output[TSPKeys.SECTION] = profile_manager.section
         output[TSPKeys.X2TEXT_ADAPTER] = x2text
+        PromptStudioHelper._stamp_x2text_output_mode(output, profile_manager)
 
         webhook_enabled = bool(prompt.enable_postprocessing_webhook)
         webhook_url = (prompt.postprocessing_webhook_url or "").strip()
@@ -929,6 +934,7 @@ class PromptStudioHelper:
             TSPKeys.FILE_NAME: doc_name,
             TSPKeys.FILE_HASH: file_hash,
             TSPKeys.FILE_PATH: extract_path,
+            TSPKeys.EXTRACT_FILE_PATH: image_extract_path,
             Common.LOG_EVENTS_ID: StateStore.get(Common.LOG_EVENTS_ID),
             TSPKeys.EXECUTION_SOURCE: ExecutionSource.IDE.value,
             TSPKeys.CUSTOM_DATA: tool.custom_data,
@@ -1046,6 +1052,9 @@ class PromptStudioHelper:
             enable_highlight=tool.enable_highlight,
         )
 
+        # Captured before the summarize override: the page-image reader must
+        # key on the extract path even when answers run over the summary.
+        image_extract_path = extract_path
         is_summary = tool.summarize_as_source
         if is_summary:
             profile_manager.chunk_size = 0
@@ -1123,6 +1132,7 @@ class PromptStudioHelper:
             TSPKeys.FILE_NAME: doc_name,
             TSPKeys.FILE_HASH: file_hash,
             TSPKeys.FILE_PATH: extract_path,
+            TSPKeys.EXTRACT_FILE_PATH: image_extract_path,
             Common.LOG_EVENTS_ID: StateStore.get(Common.LOG_EVENTS_ID),
             TSPKeys.EXECUTION_SOURCE: ExecutionSource.IDE.value,
             TSPKeys.CUSTOM_DATA: tool.custom_data,
@@ -1371,6 +1381,29 @@ class PromptStudioHelper:
             tool_id=tool_id
         ).order_by(TSPKeys.SEQUENCE_NUMBER)
         return prompt_instances
+
+    @staticmethod
+    def _stamp_x2text_output_mode(output: dict, profile_manager) -> None:
+        """Stamp the x2text output mode onto a per-prompt payload.
+
+        Lets the executor detect image mode from the payload instead of a
+        platform-service call. LLMWhisperer-only (the sole adapter with an
+        image output mode); best-effort — a metadata read failure leaves
+        the stamp absent and the executor falls back to live resolution.
+        """
+        x2text = getattr(profile_manager, "x2text", None)
+        if x2text is None:
+            return
+        try:
+            adapter_id = str(getattr(x2text, "adapter_id", "") or "")
+            if not adapter_id.startswith("llmwhisperer|"):
+                return
+            metadata = x2text.metadata or {}
+            output[TSPKeys.X2TEXT_OUTPUT_MODE] = metadata.get(
+                ImageOutputConstants.OUTPUT_MODE
+            )
+        except Exception:
+            logger.exception("Could not stamp x2text output mode; will resolve live")
 
     @staticmethod
     def _validate_image_output_pdf_only(
@@ -2050,6 +2083,7 @@ class PromptStudioHelper:
         output[TSPKeys.SIMILARITY_TOP_K] = profile_manager.similarity_top_k
         output[TSPKeys.SECTION] = profile_manager.section
         output[TSPKeys.X2TEXT_ADAPTER] = x2text
+        PromptStudioHelper._stamp_x2text_output_mode(output, profile_manager)
         # Webhook postprocessing settings
         webhook_enabled = bool(prompt.enable_postprocessing_webhook)
         webhook_url = (prompt.postprocessing_webhook_url or "").strip()

--- a/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/prompt_studio_helper.py
@@ -76,6 +76,7 @@ from prompt_studio.prompt_studio_output_manager_v2.output_manager_helper import 
     OutputManagerHelper,
 )
 from prompt_studio.prompt_studio_v2.models import ToolStudioPrompt
+from prompt_studio.vlm_utils import invalidate_vlm_answers_on_reextraction
 from unstract.core.pubsub_helper import LogPublisher
 from unstract.sdk1.adapters.x2text.constants import ImageOutputConstants
 from unstract.sdk1.constants import LogLevel
@@ -2575,6 +2576,15 @@ class PromptStudioHelper:
                 f"Failed to mark extraction success for document {document_id}. "
                 f"Extraction completed but status not saved."
             )
+
+        # A fresh (non-cache-hit) extraction rewrote any persisted page
+        # images — stored VLM answers for this document are stale.
+        # No-op in OSS (cloud-only hook).
+        invalidate_vlm_answers_on_reextraction(
+            document_id=str(document_id),
+            profile_manager=profile_manager,
+            extract_file_path=extract_file_path,
+        )
 
         return extracted_text
 

--- a/backend/prompt_studio/tests/test_vlm_utils.py
+++ b/backend/prompt_studio/tests/test_vlm_utils.py
@@ -1,0 +1,74 @@
+"""Tests for the OSS vlm_utils bridge (no-op without the cloud package).
+
+Mirrors the lookup_utils bridge contract: every helper degrades safely
+in OSS, delegates when the cloud hooks module is present, and the
+non-critical hooks (warning, invalidation) never let a cloud-side
+failure break the OSS operation they ride on.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from prompt_studio import vlm_utils
+
+
+class TestOssNoOps:
+    def test_cloud_package_absent_in_oss(self) -> None:
+        assert vlm_utils.VLM_IMAGE_ANSWER_AVAILABLE is False
+
+    def test_vision_warning_is_none(self) -> None:
+        assert vlm_utils.get_profile_vision_warning(SimpleNamespace()) is None
+
+    def test_deployment_validation_is_noop(self) -> None:
+        vlm_utils.validate_workflow_for_deployment(SimpleNamespace())  # no raise
+
+    def test_invalidation_is_noop(self) -> None:
+        vlm_utils.invalidate_vlm_answers_on_reextraction(
+            document_id="d1",
+            profile_manager=SimpleNamespace(),
+            extract_file_path="/x/extract/doc.txt",
+        )  # no raise
+
+
+@pytest.fixture
+def cloud_hooks(monkeypatch: MonkeyPatch) -> MagicMock:
+    hooks = MagicMock()
+    monkeypatch.setattr(vlm_utils, "_hooks", hooks)
+    monkeypatch.setattr(vlm_utils, "VLM_IMAGE_ANSWER_AVAILABLE", True)
+    return hooks
+
+
+class TestCloudDelegation:
+    def test_vision_warning_delegates(self, cloud_hooks: MagicMock) -> None:
+        cloud_hooks.get_profile_vision_warning.return_value = "warn!"
+        assert vlm_utils.get_profile_vision_warning(SimpleNamespace()) == "warn!"
+
+    def test_vision_warning_failure_swallowed(self, cloud_hooks: MagicMock) -> None:
+        # A warning must never break profile save/read.
+        cloud_hooks.get_profile_vision_warning.side_effect = RuntimeError("x")
+        assert vlm_utils.get_profile_vision_warning(SimpleNamespace()) is None
+
+    def test_deployment_validation_propagates(self, cloud_hooks: MagicMock) -> None:
+        # Deploy-time rejection is a hard gate — errors must propagate.
+        cloud_hooks.validate_workflow_for_deployment.side_effect = ValueError("no")
+        with pytest.raises(ValueError):
+            vlm_utils.validate_workflow_for_deployment(SimpleNamespace())
+
+    def test_invalidation_delegates_and_swallows_failure(
+        self, cloud_hooks: MagicMock
+    ) -> None:
+        profile = SimpleNamespace()
+        vlm_utils.invalidate_vlm_answers_on_reextraction(
+            document_id="d1", profile_manager=profile, extract_file_path="/e.txt"
+        )
+        cloud_hooks.invalidate_vlm_answers_on_reextraction.assert_called_once_with(
+            document_id="d1", profile_manager=profile, extract_file_path="/e.txt"
+        )
+        # Invalidation failure must not fail the extraction it rides on.
+        cloud_hooks.invalidate_vlm_answers_on_reextraction.side_effect = RuntimeError
+        vlm_utils.invalidate_vlm_answers_on_reextraction(
+            document_id="d1", profile_manager=profile, extract_file_path="/e.txt"
+        )  # no raise

--- a/backend/prompt_studio/vlm_utils.py
+++ b/backend/prompt_studio/vlm_utils.py
@@ -21,6 +21,21 @@ try:
 except ImportError:
     _hooks = None
     VLM_IMAGE_ANSWER_AVAILABLE = False
+    # Distinguish "running OSS" (package absent — expected, silent) from
+    # "cloud hooks are broken" (package present but backend_hooks failed
+    # to import): in the latter case the adapter gating still enables
+    # image output mode while these hooks quietly stop existing.
+    try:
+        import plugins.vlm_image_answer  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        logger.warning(
+            "plugins.vlm_image_answer is present but backend_hooks failed "
+            "to import — VLM profile warnings, deploy-time validation and "
+            "re-extraction invalidation are disabled while image output "
+            "mode remains enabled"
+        )
 
 
 def get_profile_vision_warning(profile_manager: Any) -> str | None:

--- a/backend/prompt_studio/vlm_utils.py
+++ b/backend/prompt_studio/vlm_utils.py
@@ -1,0 +1,71 @@
+"""Bridge helpers for the cloud-only VLM image-answer feature. No-ops in OSS.
+
+Image output mode is answered by a vision LLM through the cloud-only
+``vlm-image-answer`` plugin. The backend touch points below (profile-save
+vision warning, deploy-time validation, answer-cache invalidation on
+re-extraction) delegate to ``plugins.vlm_image_answer.backend_hooks`` when
+that cloud package is present and degrade to no-ops when it is not — OSS
+additionally hides the image output mode entirely via
+``adapter_processor_v2.image_output_gating``.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    from plugins.vlm_image_answer import backend_hooks as _hooks
+
+    VLM_IMAGE_ANSWER_AVAILABLE = True
+except ImportError:
+    _hooks = None
+    VLM_IMAGE_ANSWER_AVAILABLE = False
+
+
+def get_profile_vision_warning(profile_manager: Any) -> str | None:
+    """Non-blocking warning when an image-mode profile's LLM lacks vision.
+
+    Returns a human-readable warning string, or None (always None in OSS).
+    Never raises — a warning must not break profile save/read.
+    """
+    if not VLM_IMAGE_ANSWER_AVAILABLE:
+        return None
+    try:
+        return _hooks.get_profile_vision_warning(profile_manager)
+    except Exception:
+        logger.exception("VLM vision warning check failed; skipping warning")
+        return None
+
+
+def validate_workflow_for_deployment(workflow: Any) -> None:
+    """Deploy-time guard: reject deployments that cannot serve image mode.
+
+    The cloud hook raises ``rest_framework.serializers.ValidationError``
+    for a definitive misconfiguration (e.g. image-mode profile with a
+    known non-vision LLM); OSS is a no-op (image mode is gated off).
+    """
+    if not VLM_IMAGE_ANSWER_AVAILABLE:
+        return
+    _hooks.validate_workflow_for_deployment(workflow)
+
+
+def invalidate_vlm_answers_on_reextraction(
+    document_id: str, profile_manager: Any, extract_file_path: str
+) -> None:
+    """Invalidate stored VLM answers after a re-extraction rewrote pages/.
+
+    Called from the extraction choke point right after a successful
+    (non-cache-hit) extraction. Never raises — invalidation failure must
+    not fail the extraction itself; the cloud hook logs and degrades.
+    """
+    if not VLM_IMAGE_ANSWER_AVAILABLE:
+        return
+    try:
+        _hooks.invalidate_vlm_answers_on_reextraction(
+            document_id=document_id,
+            profile_manager=profile_manager,
+            extract_file_path=extract_file_path,
+        )
+    except Exception:
+        logger.exception("VLM answer invalidation failed after re-extraction")

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
@@ -360,6 +360,16 @@ function AddLlmProfile({
           type: "success",
           content: "Saved successfully",
         });
+        // Backend-computed advisory (e.g. image output mode selected with
+        // an LLM that may not support vision). Absent in OSS responses.
+        if (data?.vision_warning) {
+          setAlertDetails({
+            type: "warning",
+            title: "Check LLM compatibility",
+            content: data.vision_warning,
+            duration: 10,
+          });
+        }
 
         if (newLlmProfiles?.length === 1) {
           // Set the first LLM profile as default

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
@@ -356,18 +356,21 @@ function AddLlmProfile({
           llmProfiles: newLlmProfiles,
         };
         updateCustomTool(updatedState);
-        setAlertDetails({
-          type: "success",
-          content: "Saved successfully",
-        });
-        // Backend-computed advisory (e.g. image output mode selected with
-        // an LLM that may not support vision). Absent in OSS responses.
+        // Single alert: the store holds one alertDetails object, so two
+        // synchronous calls would batch and only the last would render.
+        // vision_warning is a backend-computed advisory (image output
+        // mode with an LLM that may not support vision); absent in OSS.
         if (data?.vision_warning) {
           setAlertDetails({
             type: "warning",
-            title: "Check LLM compatibility",
+            title: "Saved — check LLM compatibility",
             content: data.vision_warning,
             duration: 10,
+          });
+        } else {
+          setAlertDetails({
+            type: "success",
+            content: "Saved successfully",
           });
         }
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/constants.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/constants.py
@@ -39,14 +39,13 @@ class ImageOutputConstants:
     # The adapter (writer) persists one PNG per page under a ``pages``
     # subfolder as ``page_NNN.png`` (zero-padded to PAGE_NUMBER_PADDING
     # digits; four or more digits appear naturally past page 999). Readers
-    # discover pages with PAGE_GLOB_PATTERN and MUST order them by the
-    # integer captured by PAGE_NUMBER_REGEX — never lexicographically,
-    # which silently misorders once page numbers outgrow the padding.
+    # list the directory and MUST order pages by the integer captured by
+    # PAGE_NUMBER_REGEX — never lexicographically, which silently
+    # misorders once page numbers outgrow the padding.
     PAGES_SUBFOLDER = "pages"
     PAGE_IMAGE_PREFIX = "page_"
     PAGE_IMAGE_EXTENSION = ".png"
     PAGE_NUMBER_PADDING = 3
-    PAGE_GLOB_PATTERN = "page_*.png"
     # First capture group is the numeric page index (as a string, possibly
     # zero-padded) — cast to int before sorting.
     PAGE_NUMBER_REGEX = r"page_(\d+)\.png"

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/constants.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/constants.py
@@ -35,7 +35,43 @@ class ImageOutputConstants:
         "Please provide a PDF file or select a text output mode."
     )
 
+    # --- Page image storage layout (writer/reader contract) ---
+    # The adapter (writer) persists one PNG per page under a ``pages``
+    # subfolder as ``page_NNN.png`` (zero-padded to PAGE_NUMBER_PADDING
+    # digits; four or more digits appear naturally past page 999). Readers
+    # discover pages with PAGE_GLOB_PATTERN and MUST order them by the
+    # integer captured by PAGE_NUMBER_REGEX — never lexicographically,
+    # which silently misorders once page numbers outgrow the padding.
+    PAGES_SUBFOLDER = "pages"
+    PAGE_IMAGE_PREFIX = "page_"
+    PAGE_IMAGE_EXTENSION = ".png"
+    PAGE_NUMBER_PADDING = 3
+    PAGE_GLOB_PATTERN = "page_*.png"
+    # First capture group is the numeric page index (as a string, possibly
+    # zero-padded) — cast to int before sorting.
+    PAGE_NUMBER_REGEX = r"page_(\d+)\.png"
+
     @staticmethod
     def is_pdf(file_name: str) -> bool:
         """Return True when ``file_name`` is a PDF (case-insensitive suffix)."""
         return Path(file_name).suffix.lower() == ImageOutputConstants.PDF_EXTENSION
+
+
+def build_page_store_dir(output_file_path: str | None, input_file_path: str) -> str:
+    """Per-document folder for page images: ``{extract_dir}/{stem}/pages``.
+
+    The single canonical derivation shared by the adapter (writer) and any
+    page-image reader, so both sides agree on the location without metadata
+    persistence or a manifest sidecar. Keyed on the document ``stem`` (the
+    same discriminator the extract ``.txt`` files alongside use), not the
+    per-run whisper_hash. This is collision-safe against concurrent documents
+    in the same project, is reconstructible from ``output_file_path`` alone,
+    and — being stable across runs — makes a re-extraction overwrite its own
+    pages instead of orphaning a fresh tree in FileStorage on every run.
+
+    Pure and deterministic: no I/O, no lookups.
+    """
+    reference = output_file_path or input_file_path
+    base_dir = str(Path(reference).parent) if reference else "."
+    stem = Path(reference).stem if reference else "document"
+    return str(Path(base_dir) / stem / ImageOutputConstants.PAGES_SUBFOLDER)

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/constants.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/constants.py
@@ -51,10 +51,20 @@ class ImageOutputConstants:
     # zero-padded) — cast to int before sorting.
     PAGE_NUMBER_REGEX = r"page_(\d+)\.png"
 
+    # Leading bytes of every PDF file — the content-based check for inputs
+    # whose storage name carries no extension (workflow executions store the
+    # source file under an extension-less name like ``SOURCE``).
+    PDF_MAGIC_BYTES = b"%PDF-"
+
     @staticmethod
     def is_pdf(file_name: str) -> bool:
         """Return True when ``file_name`` is a PDF (case-insensitive suffix)."""
         return Path(file_name).suffix.lower() == ImageOutputConstants.PDF_EXTENSION
+
+    @staticmethod
+    def is_pdf_bytes(header: bytes) -> bool:
+        """Return True when ``header`` starts with the PDF magic bytes."""
+        return bytes(header).startswith(ImageOutputConstants.PDF_MAGIC_BYTES)
 
 
 def build_page_store_dir(output_file_path: str | None, input_file_path: str) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/constants.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/constants.py
@@ -181,10 +181,19 @@ class ImageOutputConfig:
     FILE_NAME_PARAM = "file_name"
 
     # --- Per-page image naming / storage layout ---
-    PAGE_IMAGE_PREFIX = "page_"
-    PAGE_IMAGE_EXTENSION = ".png"
-    PAGE_NUMBER_PADDING = 3
-    PAGES_SUBFOLDER = "pages"
+    # Sourced from the shared x2text surface so the writer (this adapter)
+    # and any page-image reader agree on one storage contract.
+    PAGE_IMAGE_PREFIX = ImageOutputConstants.PAGE_IMAGE_PREFIX
+    PAGE_IMAGE_EXTENSION = ImageOutputConstants.PAGE_IMAGE_EXTENSION
+    PAGE_NUMBER_PADDING = ImageOutputConstants.PAGE_NUMBER_PADDING
+    PAGES_SUBFOLDER = ImageOutputConstants.PAGES_SUBFOLDER
+
+    # ZIP member names as sent by the LLMWhisperer service. Distinct from
+    # the storage contract above (ImageOutputConstants.PAGE_NUMBER_REGEX):
+    # this tolerates service-side naming variations (``page-1.png``) when
+    # ingesting the download; persisted files are always renamed to the
+    # strict ``page_NNN.png`` layout.
+    ZIP_PAGE_MEMBER_REGEX = r"page[_-]?(\d+)\.png$"
 
     # --- PDF-only validation (shared with the backend index-time guard) ---
     PDF_EXTENSION = ImageOutputConstants.PDF_EXTENSION

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/helper.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/helper.py
@@ -17,7 +17,12 @@ from unstract.llmwhisperer.client_v2 import (
 )
 from unstract.sdk1.adapters.exceptions import ExtractorError
 from unstract.sdk1.adapters.utils import AdapterUtils
-from unstract.sdk1.adapters.x2text.constants import X2TextConstants
+from unstract.sdk1.adapters.x2text.constants import (
+    X2TextConstants,
+)
+from unstract.sdk1.adapters.x2text.constants import (
+    build_page_store_dir as _shared_build_page_store_dir,
+)
 from unstract.sdk1.adapters.x2text.dto import PageImageReference
 from unstract.sdk1.adapters.x2text.llm_whisperer_v2.src.constants import (
     ImageOutputConfig,
@@ -441,7 +446,7 @@ class LLMWhispererHelper:
     # Matches service page files like `page_001.png` / `page-1.png`. The
     # captured digits are passed through int() (leading zeros stripped there),
     # so no separate `0*` prefix is needed — keeping the pattern linear.
-    _PAGE_IMAGE_RE = re.compile(r"page[_-]?(\d+)\.png$", re.IGNORECASE)
+    _PAGE_IMAGE_RE = re.compile(ImageOutputConfig.ZIP_PAGE_MEMBER_REGEX, re.IGNORECASE)
 
     @staticmethod
     def _safe_json(response: Response) -> dict[str, Any]:
@@ -718,21 +723,9 @@ class LLMWhispererHelper:
                 status_code=502,
             )
 
-    @staticmethod
-    def build_page_store_dir(output_file_path: str | None, input_file_path: str) -> str:
-        """Per-document folder for page images: ``{extract_dir}/{stem}/pages``.
-
-        Keyed on the document ``stem`` (the same discriminator the extract
-        ``.txt`` files alongside use), not the per-run whisper_hash. This is
-        collision-safe against concurrent documents in the same project, is
-        reconstructible from ``output_file_path`` alone, and — being stable
-        across runs — makes a re-extraction overwrite its own pages instead of
-        orphaning a fresh tree in FileStorage on every run.
-        """
-        reference = output_file_path or input_file_path
-        base_dir = str(Path(reference).parent) if reference else "."
-        stem = Path(reference).stem if reference else "document"
-        return str(Path(base_dir) / stem / ImageOutputConfig.PAGES_SUBFOLDER)
+    # Single canonical derivation of ``{extract_dir}/{stem}/pages`` shared
+    # by writer and reader alike (see unstract.sdk1.adapters.x2text.constants).
+    build_page_store_dir = staticmethod(_shared_build_page_store_dir)
 
     @staticmethod
     def _page_image_filename(page_number: int) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/llm_whisperer_v2.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/llm_whisperer_v2.py
@@ -5,7 +5,10 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from unstract.sdk1.adapters.exceptions import ExtractorError
-from unstract.sdk1.adapters.x2text.constants import X2TextConstants
+from unstract.sdk1.adapters.x2text.constants import (
+    ImageOutputConstants,
+    X2TextConstants,
+)
 from unstract.sdk1.adapters.x2text.dto import (
     TextExtractionMetadata,
     TextExtractionResult,
@@ -66,17 +69,31 @@ class LLMWhispererV2(X2TextAdapter):
         return True
 
     @staticmethod
-    def _validate_pdf_only(input_file_path: str) -> None:
+    def _validate_pdf_only(input_file_path: str, fs: FileStorage | None = None) -> None:
         """Enforce the PDF-only constraint for image output mode (v1).
+
+        Checks the filename extension first; when the storage name carries no
+        ``.pdf`` suffix, falls back to content sniffing — workflow executions
+        store the source file under an extension-less name (e.g. ``SOURCE``),
+        so an extension-only check would false-reject every deployment input.
+        Fail-closed: if the content cannot be verified either, reject.
 
         The message is sourced from ``ImageOutputConfig`` so it stays identical
         to the UI-layer validation surfaced in ``adapter_processor_v2``.
         """
-        if not ImageOutputConfig.is_pdf(input_file_path):
-            raise ExtractorError(
-                ImageOutputConfig.PDF_ONLY_ERROR,
-                status_code=400,
-            )
+        if ImageOutputConfig.is_pdf(input_file_path):
+            return
+        if fs is not None:
+            try:
+                header = fs.read(path=input_file_path, mode="rb", length=5)
+            except Exception:
+                header = b""
+            if ImageOutputConstants.is_pdf_bytes(header):
+                return
+        raise ExtractorError(
+            ImageOutputConfig.PDF_ONLY_ERROR,
+            status_code=400,
+        )
 
     def _process_image_mode(
         self,
@@ -98,7 +115,7 @@ class LLMWhispererV2(X2TextAdapter):
         ``tag`` is forwarded for service-side usage reporting.
         """
         logger.info("Image mode: processing %s in image output mode", input_file_path)
-        self._validate_pdf_only(input_file_path)
+        self._validate_pdf_only(input_file_path, fs=fs)
         whisper_hash, page_images = LLMWhispererHelper.get_page_images(
             config=self.config,
             input_file_path=input_file_path,

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
@@ -113,6 +113,17 @@ def discover_page_images(fs: FileStorage, page_store_dir: str) -> list[tuple[int
         PageImagesNotFoundError: directory missing or no page images in it.
         PageImageSetIncompleteError: duplicate or missing page numbers.
     """
+    # Object-store backends serve listings from fsspec's directory cache in
+    # long-lived worker processes; a page purged since the last listing would
+    # still "exist" here and only blow up at read time. Refresh the cache
+    # first so discovery reflects reality (no-op for backends without one).
+    invalidate = getattr(getattr(fs, "fs", None), "invalidate_cache", None)
+    if callable(invalidate):
+        try:
+            invalidate(page_store_dir)
+        except Exception:  # pragma: no cover - cache refresh is best-effort
+            logger.debug("Could not invalidate listing cache for %s", page_store_dir)
+
     try:
         entries = fs.ls(page_store_dir) if fs.exists(page_store_dir) else None
     except FileNotFoundError:
@@ -196,7 +207,21 @@ def load_page_images(
         )
     loaded = []
     for page_number, path in discovered:
-        data = fs.read(path=path, mode="rb")
+        try:
+            data = fs.read(path=path, mode="rb")
+        except FileNotFoundError as e:
+            # TOCTOU guard: the page vanished between discovery and read
+            # (purged concurrently, or discovery served a stale listing).
+            # Surface the typed incomplete-set error, never a raw IO error.
+            raise PageImageSetIncompleteError(
+                f"Page image {PurePosixPath(path).name} is missing from "
+                f"'{page_store_dir}' (it disappeared after discovery); the "
+                "page set is incomplete. Re-extract the document with cache "
+                "bypass to regenerate it (billed per page).",
+                page_store_dir=page_store_dir,
+                found_pages=[n for n, _ in discovered if n != page_number],
+                missing_pages=[page_number],
+            ) from e
         encoded = base64.b64encode(bytes(data)).decode("ascii")
         loaded.append(
             LoadedPageImage(page_number=page_number, path=path, base64_data=encoded)

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
@@ -216,9 +216,11 @@ def load_page_images(
     """Discover, cap-check, read, and base64-encode all page images.
 
     The page-count cap runs before any bytes are read so an oversized
-    document fails fast and cheap; the aggregate byte budget is enforced
-    while reading so an unusually large render cannot grow memory or the
-    provider request unbounded. ``None`` disables either limit.
+    document fails fast and cheap. The aggregate byte budget is enforced
+    twice: first from storage *metadata* before any read (so even a single
+    pathological object is never pulled into worker memory), then again
+    while reading as a belt-and-braces guard for backends without size
+    metadata and for stat/read races. ``None`` disables either limit.
 
     Raises:
         PageCapExceededError: more pages than ``page_cap`` allows.
@@ -236,6 +238,34 @@ def load_page_images(
             page_count=len(discovered),
             page_cap=page_cap,
         )
+
+    def _too_large(page_number: int, total_bytes: int) -> PageImageSetTooLargeError:
+        return PageImageSetTooLargeError(
+            f"Page images total more than "
+            f"{max_total_bytes // (1024 * 1024)}MB by page {page_number} "
+            f"of {len(discovered)} — too large to send to the LLM in "
+            "one request. Reduce the page range (e.g. via the adapter's "
+            "'pages to extract' setting).",
+            page_store_dir=page_store_dir,
+            total_bytes=total_bytes,
+            max_total_bytes=max_total_bytes,
+        )
+
+    # Pre-read budget check from storage metadata (e.g. an object HEAD):
+    # rejects before ANY image bytes enter worker memory. Duck-typed —
+    # backends without a size() API fall through to the read-time guard.
+    size_of = getattr(fs, "size", None)
+    if max_total_bytes is not None and callable(size_of):
+        stat_total = 0
+        for page_number, path in discovered:
+            try:
+                stat_total += int(size_of(path))
+            except Exception:
+                # Unknown size — rely on the read-time accounting below.
+                break
+            if stat_total > max_total_bytes:
+                raise _too_large(page_number, stat_total)
+
     loaded = []
     total_bytes = 0
     for page_number, path in discovered:
@@ -258,16 +288,7 @@ def load_page_images(
         if max_total_bytes is not None and total_bytes > max_total_bytes:
             # Stop before encoding/retaining more — the page cap bounds the
             # count, this bounds the payload.
-            raise PageImageSetTooLargeError(
-                f"Page images total more than "
-                f"{max_total_bytes // (1024 * 1024)}MB by page {page_number} "
-                f"of {len(discovered)} — too large to send to the LLM in "
-                "one request. Reduce the page range (e.g. via the adapter's "
-                "'pages to extract' setting).",
-                page_store_dir=page_store_dir,
-                total_bytes=total_bytes,
-                max_total_bytes=max_total_bytes,
-            )
+            raise _too_large(page_number, total_bytes)
         encoded = base64.b64encode(bytes(data)).decode("ascii")
         loaded.append(
             LoadedPageImage(page_number=page_number, path=path, base64_data=encoded)

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
@@ -10,7 +10,7 @@ base64-encodes them, and shapes multimodal content blocks for
 ``LLM.complete_vision``.
 
 All reads go through the FileStorage abstraction so the same code serves
-local disk and remote object storage. Discovery is glob-based on the
+local disk and remote object storage. Discovery lists the
 deterministic path — no manifest, no metadata transport.
 
 Failure modes are typed so callers can surface distinct, actionable errors:
@@ -123,6 +123,16 @@ class LoadedPageImage:
     base64_data: str
 
 
+def _not_found(page_store_dir: str) -> PageImagesNotFoundError:
+    return PageImagesNotFoundError(
+        f"No page images found at '{page_store_dir}'. The document has "
+        "not been extracted in image output mode (or its images were "
+        "removed). Re-extract the document with cache bypass to "
+        "regenerate them (re-extraction is billed per page).",
+        page_store_dir=page_store_dir,
+    )
+
+
 def discover_page_images(fs: FileStorage, page_store_dir: str) -> list[tuple[int, str]]:
     """Discover persisted page images, ordered by integer page number.
 
@@ -153,13 +163,7 @@ def discover_page_images(fs: FileStorage, page_store_dir: str) -> list[tuple[int
     except FileNotFoundError:
         entries = None
     if entries is None:
-        raise PageImagesNotFoundError(
-            f"No page images found at '{page_store_dir}'. The document has "
-            "not been extracted in image output mode (or its images were "
-            "removed). Re-extract the document with cache bypass to "
-            "regenerate them (re-extraction is billed per page).",
-            page_store_dir=page_store_dir,
-        )
+        raise _not_found(page_store_dir)
 
     pages: dict[int, str] = {}
     for entry in entries:
@@ -182,13 +186,7 @@ def discover_page_images(fs: FileStorage, page_store_dir: str) -> list[tuple[int
         pages[page_number] = str(entry)
 
     if not pages:
-        raise PageImagesNotFoundError(
-            f"No page images found at '{page_store_dir}'. The document has "
-            "not been extracted in image output mode (or its images were "
-            "removed). Re-extract the document with cache bypass to "
-            "regenerate them (re-extraction is billed per page).",
-            page_store_dir=page_store_dir,
-        )
+        raise _not_found(page_store_dir)
 
     found = sorted(pages)
     missing = sorted(set(range(1, found[-1] + 1)) - set(found))
@@ -217,10 +215,11 @@ def load_page_images(
 
     The page-count cap runs before any bytes are read so an oversized
     document fails fast and cheap. The aggregate byte budget is enforced
-    twice: first from storage *metadata* before any read (so even a single
-    pathological object is never pulled into worker memory), then again
-    while reading as a belt-and-braces guard for backends without size
-    metadata and for stat/read races. ``None`` disables either limit.
+    with **bounded reads**: each page is read with a length limit of the
+    remaining budget plus one byte, so no read — not even of a single
+    pathological object — can ever allocate more than the budget in
+    worker memory, regardless of the object's actual size or whether the
+    backend exposes size metadata. ``None`` disables either limit.
 
     Raises:
         PageCapExceededError: more pages than ``page_cap`` allows.
@@ -239,38 +238,17 @@ def load_page_images(
             page_cap=page_cap,
         )
 
-    def _too_large(page_number: int, total_bytes: int) -> PageImageSetTooLargeError:
-        return PageImageSetTooLargeError(
-            f"Page images total more than "
-            f"{max_total_bytes // (1024 * 1024)}MB by page {page_number} "
-            f"of {len(discovered)} — too large to send to the LLM in "
-            "one request. Reduce the page range (e.g. via the adapter's "
-            "'pages to extract' setting).",
-            page_store_dir=page_store_dir,
-            total_bytes=total_bytes,
-            max_total_bytes=max_total_bytes,
-        )
-
-    # Pre-read budget check from storage metadata (e.g. an object HEAD):
-    # rejects before ANY image bytes enter worker memory. Duck-typed —
-    # backends without a size() API fall through to the read-time guard.
-    size_of = getattr(fs, "size", None)
-    if max_total_bytes is not None and callable(size_of):
-        stat_total = 0
-        for page_number, path in discovered:
-            try:
-                stat_total += int(size_of(path))
-            except Exception:
-                # Unknown size — rely on the read-time accounting below.
-                break
-            if stat_total > max_total_bytes:
-                raise _too_large(page_number, stat_total)
-
     loaded = []
     total_bytes = 0
     for page_number, path in discovered:
+        read_kwargs: dict[str, int] = {}
+        if max_total_bytes is not None:
+            # Bounded read: never pull more than the remaining budget (+1
+            # byte to detect the overflow) into memory — the hard
+            # allocation ceiling for this loop is max_total_bytes + 1.
+            read_kwargs["length"] = max_total_bytes - total_bytes + 1
         try:
-            data = fs.read(path=path, mode="rb")
+            data = bytes(fs.read(path=path, mode="rb", **read_kwargs))
         except FileNotFoundError as e:
             # TOCTOU guard: the page vanished between discovery and read
             # (purged concurrently, or discovery served a stale listing).
@@ -288,8 +266,17 @@ def load_page_images(
         if max_total_bytes is not None and total_bytes > max_total_bytes:
             # Stop before encoding/retaining more — the page cap bounds the
             # count, this bounds the payload.
-            raise _too_large(page_number, total_bytes)
-        encoded = base64.b64encode(bytes(data)).decode("ascii")
+            raise PageImageSetTooLargeError(
+                f"Page images total more than "
+                f"{max_total_bytes // (1024 * 1024)}MB by page {page_number} "
+                f"of {len(discovered)} — too large to send to the LLM in "
+                "one request. Reduce the page range (e.g. via the adapter's "
+                "'pages to extract' setting).",
+                page_store_dir=page_store_dir,
+                total_bytes=total_bytes,
+                max_total_bytes=max_total_bytes,
+            )
+        encoded = base64.b64encode(data).decode("ascii")
         loaded.append(
             LoadedPageImage(page_number=page_number, path=path, base64_data=encoded)
         )

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
@@ -38,6 +38,13 @@ logger = logging.getLogger(__name__)
 # (platform-configured), this is only the fallback.
 DEFAULT_PAGE_CAP = 20
 
+# Aggregate raw-byte budget across all loaded pages. The page cap bounds the
+# COUNT of images, not their size — without a byte budget, unusually large
+# renders would grow worker memory and the provider request unbounded
+# (base64 adds ~33% on top). 50MB raw comfortably exceeds any normal
+# LLMWhisperer render while staying inside provider request limits.
+DEFAULT_MAX_TOTAL_BYTES = 50 * 1024 * 1024
+
 _PAGE_NAME_RE = re.compile(ImageOutputConstants.PAGE_NUMBER_REGEX)
 
 
@@ -88,6 +95,23 @@ class PageCapExceededError(PageImageLoadError):
         super().__init__(message, page_store_dir=page_store_dir)
         self.page_count = page_count
         self.page_cap = page_cap
+
+
+class PageImageSetTooLargeError(PageImageLoadError):
+    """The combined size of the page images exceeds the byte budget."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        page_store_dir: str,
+        total_bytes: int,
+        max_total_bytes: int,
+    ) -> None:
+        """Record the observed total and the budget that was exceeded."""
+        super().__init__(message, page_store_dir=page_store_dir)
+        self.total_bytes = total_bytes
+        self.max_total_bytes = max_total_bytes
 
 
 @dataclass(frozen=True)
@@ -183,15 +207,22 @@ def discover_page_images(fs: FileStorage, page_store_dir: str) -> list[tuple[int
 
 
 def load_page_images(
-    fs: FileStorage, page_store_dir: str, *, page_cap: int | None = DEFAULT_PAGE_CAP
+    fs: FileStorage,
+    page_store_dir: str,
+    *,
+    page_cap: int | None = DEFAULT_PAGE_CAP,
+    max_total_bytes: int | None = DEFAULT_MAX_TOTAL_BYTES,
 ) -> list[LoadedPageImage]:
     """Discover, cap-check, read, and base64-encode all page images.
 
-    The cap check runs before any bytes are read so an oversized document
-    fails fast and cheap. ``page_cap=None`` disables the cap.
+    The page-count cap runs before any bytes are read so an oversized
+    document fails fast and cheap; the aggregate byte budget is enforced
+    while reading so an unusually large render cannot grow memory or the
+    provider request unbounded. ``None`` disables either limit.
 
     Raises:
         PageCapExceededError: more pages than ``page_cap`` allows.
+        PageImageSetTooLargeError: pages total more than ``max_total_bytes``.
         (plus the discovery errors from ``discover_page_images``)
     """
     discovered = discover_page_images(fs, page_store_dir)
@@ -206,6 +237,7 @@ def load_page_images(
             page_cap=page_cap,
         )
     loaded = []
+    total_bytes = 0
     for page_number, path in discovered:
         try:
             data = fs.read(path=path, mode="rb")
@@ -222,6 +254,20 @@ def load_page_images(
                 found_pages=[n for n, _ in discovered if n != page_number],
                 missing_pages=[page_number],
             ) from e
+        total_bytes += len(data)
+        if max_total_bytes is not None and total_bytes > max_total_bytes:
+            # Stop before encoding/retaining more — the page cap bounds the
+            # count, this bounds the payload.
+            raise PageImageSetTooLargeError(
+                f"Page images total more than "
+                f"{max_total_bytes // (1024 * 1024)}MB by page {page_number} "
+                f"of {len(discovered)} — too large to send to the LLM in "
+                "one request. Reduce the page range (e.g. via the adapter's "
+                "'pages to extract' setting).",
+                page_store_dir=page_store_dir,
+                total_bytes=total_bytes,
+                max_total_bytes=max_total_bytes,
+            )
         encoded = base64.b64encode(bytes(data)).decode("ascii")
         loaded.append(
             LoadedPageImage(page_number=page_number, path=path, base64_data=encoded)

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/page_image_loader.py
@@ -1,0 +1,231 @@
+"""FileStorage-backed reader for persisted page images.
+
+Reader half of the page-image storage contract defined in
+``unstract.sdk1.adapters.x2text.constants``: the LLMWhisperer adapter
+(writer) persists one PNG per page as ``page_NNN.png`` under the directory
+returned by ``build_page_store_dir``; this module discovers those pages via
+the shared naming constants, orders them by their **integer** page index
+(never lexicographically — that misorders past the zero-padding width),
+base64-encodes them, and shapes multimodal content blocks for
+``LLM.complete_vision``.
+
+All reads go through the FileStorage abstraction so the same code serves
+local disk and remote object storage. Discovery is glob-based on the
+deterministic path — no manifest, no metadata transport.
+
+Failure modes are typed so callers can surface distinct, actionable errors:
+
+- ``PageImagesNotFoundError`` — directory missing/empty (never extracted in
+  image mode, or fully purged).
+- ``PageImageSetIncompleteError`` — pages exist but the 1..N set is broken
+  (post-write loss). Distinct from "not found" so remediation can differ.
+- ``PageCapExceededError`` — document larger than the page cap; callers
+  must fail explicitly rather than silently truncate.
+"""
+
+import base64
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from unstract.sdk1.adapters.x2text.constants import ImageOutputConstants
+from unstract.sdk1.file_storage import FileStorage
+
+logger = logging.getLogger(__name__)
+
+# Conservative default; effective value is supplied by the caller
+# (platform-configured), this is only the fallback.
+DEFAULT_PAGE_CAP = 20
+
+_PAGE_NAME_RE = re.compile(ImageOutputConstants.PAGE_NUMBER_REGEX)
+
+
+class PageImageLoadError(Exception):
+    """Base error for page-image discovery/loading failures."""
+
+    def __init__(self, message: str, *, page_store_dir: str) -> None:
+        """Store the offending pages directory alongside the message."""
+        super().__init__(message)
+        self.page_store_dir = page_store_dir
+
+
+class PageImagesNotFoundError(PageImageLoadError):
+    """The pages directory is missing or contains no page images.
+
+    Either the document was never extracted in image output mode, or the
+    persisted images were purged. Remediation: re-extract the document with
+    cache bypass (note: re-extraction re-submits to LLMWhisperer and is
+    billed per page — a plain re-run is an extraction cache hit and will
+    NOT regenerate images).
+    """
+
+
+class PageImageSetIncompleteError(PageImageLoadError):
+    """Pages exist but the contiguous 1..N set is broken (post-write loss)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        page_store_dir: str,
+        found_pages: list[int],
+        missing_pages: list[int],
+    ) -> None:
+        """Record which pages were found vs missing for remediation UIs."""
+        super().__init__(message, page_store_dir=page_store_dir)
+        self.found_pages = found_pages
+        self.missing_pages = missing_pages
+
+
+class PageCapExceededError(PageImageLoadError):
+    """The document has more pages than the configured cap allows."""
+
+    def __init__(
+        self, message: str, *, page_store_dir: str, page_count: int, page_cap: int
+    ) -> None:
+        """Record the observed page count and the cap that was exceeded."""
+        super().__init__(message, page_store_dir=page_store_dir)
+        self.page_count = page_count
+        self.page_cap = page_cap
+
+
+@dataclass(frozen=True)
+class LoadedPageImage:
+    """A page image read from FileStorage, base64-encoded for a VLM call."""
+
+    page_number: int
+    path: str
+    base64_data: str
+
+
+def discover_page_images(fs: FileStorage, page_store_dir: str) -> list[tuple[int, str]]:
+    """Discover persisted page images, ordered by integer page number.
+
+    Lists ``page_store_dir`` through FileStorage, keeps entries whose
+    basename matches the shared ``PAGE_NUMBER_REGEX`` (others are logged
+    and skipped), and validates the set is exactly 1..N.
+
+    Returns:
+        ``[(page_number, full_path), ...]`` sorted by page number.
+
+    Raises:
+        PageImagesNotFoundError: directory missing or no page images in it.
+        PageImageSetIncompleteError: duplicate or missing page numbers.
+    """
+    try:
+        entries = fs.ls(page_store_dir) if fs.exists(page_store_dir) else None
+    except FileNotFoundError:
+        entries = None
+    if entries is None:
+        raise PageImagesNotFoundError(
+            f"No page images found at '{page_store_dir}'. The document has "
+            "not been extracted in image output mode (or its images were "
+            "removed). Re-extract the document with cache bypass to "
+            "regenerate them (re-extraction is billed per page).",
+            page_store_dir=page_store_dir,
+        )
+
+    pages: dict[int, str] = {}
+    for entry in entries:
+        name = PurePosixPath(str(entry)).name
+        match = _PAGE_NAME_RE.fullmatch(name)
+        if not match:
+            logger.debug("Skipping non-page entry in %s: %s", page_store_dir, name)
+            continue
+        page_number = int(match.group(1))
+        if page_number in pages:
+            raise PageImageSetIncompleteError(
+                f"Duplicate page number {page_number} in '{page_store_dir}' "
+                f"({PurePosixPath(pages[page_number]).name} vs {name}); the "
+                "page set is corrupt. Re-extract the document with cache "
+                "bypass (billed per page).",
+                page_store_dir=page_store_dir,
+                found_pages=sorted(pages),
+                missing_pages=[],
+            )
+        pages[page_number] = str(entry)
+
+    if not pages:
+        raise PageImagesNotFoundError(
+            f"No page images found at '{page_store_dir}'. The document has "
+            "not been extracted in image output mode (or its images were "
+            "removed). Re-extract the document with cache bypass to "
+            "regenerate them (re-extraction is billed per page).",
+            page_store_dir=page_store_dir,
+        )
+
+    found = sorted(pages)
+    missing = sorted(set(range(1, found[-1] + 1)) - set(found))
+    if missing:
+        raise PageImageSetIncompleteError(
+            f"Only {len(found)} of {found[-1]} page images are present at "
+            f"'{page_store_dir}' (missing pages: {missing[:10]}"
+            f"{'…' if len(missing) > 10 else ''}). Re-extract the document "
+            "with cache bypass to regenerate them (billed per page).",
+            page_store_dir=page_store_dir,
+            found_pages=found,
+            missing_pages=missing,
+        )
+
+    return [(number, pages[number]) for number in found]
+
+
+def load_page_images(
+    fs: FileStorage, page_store_dir: str, *, page_cap: int | None = DEFAULT_PAGE_CAP
+) -> list[LoadedPageImage]:
+    """Discover, cap-check, read, and base64-encode all page images.
+
+    The cap check runs before any bytes are read so an oversized document
+    fails fast and cheap. ``page_cap=None`` disables the cap.
+
+    Raises:
+        PageCapExceededError: more pages than ``page_cap`` allows.
+        (plus the discovery errors from ``discover_page_images``)
+    """
+    discovered = discover_page_images(fs, page_store_dir)
+    if page_cap is not None and len(discovered) > page_cap:
+        raise PageCapExceededError(
+            f"Document exceeds {page_cap} pages for image output mode "
+            f"({len(discovered)} pages found). Reduce the page range (e.g. "
+            "via the adapter's 'pages to extract' setting) or raise the "
+            "configured page cap.",
+            page_store_dir=page_store_dir,
+            page_count=len(discovered),
+            page_cap=page_cap,
+        )
+    loaded = []
+    for page_number, path in discovered:
+        data = fs.read(path=path, mode="rb")
+        encoded = base64.b64encode(bytes(data)).decode("ascii")
+        loaded.append(
+            LoadedPageImage(page_number=page_number, path=path, base64_data=encoded)
+        )
+    return loaded
+
+
+def build_vision_message_content(
+    pages: list[LoadedPageImage], prompt_text: str
+) -> list[dict]:
+    """Shape multimodal content blocks for ``LLM.complete_vision``.
+
+    Layout: the prompt text first (task framing), then for each page — in
+    page order — a ``Page N`` text label immediately followed by that
+    page's image block. The explicit labels preserve reading order for the
+    model and enable page citations later at zero cost.
+
+    Returns the ``content`` list for a single user message; callers wrap it
+    as ``[{"role": "user", "content": content}]``.
+    """
+    content: list[dict] = [{"type": "text", "text": prompt_text}]
+    for page in pages:
+        content.append({"type": "text", "text": f"Page {page.page_number}"})
+        content.append(
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{page.base64_data}",
+                },
+            }
+        )
+    return content

--- a/unstract/sdk1/src/unstract/sdk1/utils/vision_capability.py
+++ b/unstract/sdk1/src/unstract/sdk1/utils/vision_capability.py
@@ -1,0 +1,103 @@
+"""Vision-capability detection and gating policy for LLM models.
+
+The image output mode sends page images to the profile's LLM via
+``complete_vision``; a non-vision model fails only at run time with an
+opaque provider error. This module classifies a model's vision support
+up front and applies the gating policy shared by config-time warnings
+and run-time guards.
+
+Classification uses LiteLLM's **local** ``model_cost`` registry only —
+never ``get_model_info`` — because ``get_model_info`` can make network
+calls for self-hosted providers (e.g. it queries the Ollama server), and
+``litellm.supports_vision`` alone returns ``False`` for both known
+non-vision models *and* unknown models, which would wrongly hard-block
+custom/self-hosted vision models (LiteLLM proxies, Ollama).
+
+Policy (locked): hard-block only on a **definitive** "known model, no
+vision support"; unknown/custom models are allowed with a warning — the
+provider's own runtime error remains the backstop.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+import litellm
+
+logger = logging.getLogger(__name__)
+
+
+class VisionSupport(Enum):
+    """Classification of a model's vision (image input) capability."""
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class VisionValidationResult:
+    """Outcome of applying the gating policy to a model."""
+
+    model: str
+    support: VisionSupport
+    allowed: bool
+    message: str | None
+
+
+def check_vision_support(model: str) -> VisionSupport:
+    """Classify ``model``'s vision capability from the local registry.
+
+    The registry is keyed both with and without provider prefixes
+    (``anthropic/claude-…`` vs ``claude-…``); a model found under either
+    form is "known". On known models the ``supports_vision`` flag is
+    authoritative — absence means no vision support. Models not in the
+    registry (self-hosted, proxies, brand-new releases) are UNKNOWN.
+    """
+    if not model:
+        return VisionSupport.UNKNOWN
+    registry = litellm.model_cost
+    entry = registry.get(model)
+    if entry is None and "/" in model:
+        entry = registry.get(model.split("/", 1)[-1])
+    if entry is None:
+        return VisionSupport.UNKNOWN
+    if entry.get("supports_vision"):
+        return VisionSupport.SUPPORTED
+    return VisionSupport.UNSUPPORTED
+
+
+def validate_vision_capability(model: str) -> VisionValidationResult:
+    """Apply the image-mode gating policy to ``model``.
+
+    Returns a result rather than raising so callers can map it to their
+    own error/warning surfaces (structured API errors, profile-save
+    warnings). ``allowed`` is False only for a definitive UNSUPPORTED.
+    """
+    support = check_vision_support(model)
+    if support is VisionSupport.SUPPORTED:
+        return VisionValidationResult(
+            model=model, support=support, allowed=True, message=None
+        )
+    if support is VisionSupport.UNKNOWN:
+        message = (
+            f"Model '{model}' is not in the capability registry, so its "
+            "image (vision) support cannot be verified. The run will "
+            "proceed; if the model does not accept image input, the "
+            "provider will reject the request."
+        )
+        logger.warning(message)
+        return VisionValidationResult(
+            model=model, support=support, allowed=True, message=message
+        )
+    return VisionValidationResult(
+        model=model,
+        support=support,
+        allowed=False,
+        message=(
+            f"Model '{model}' does not support image input. Image output "
+            "mode requires a vision-capable LLM — update this profile's "
+            "LLM to a vision model (e.g. a GPT-4o, Claude, or Gemini "
+            "vision model) and re-run."
+        ),
+    )

--- a/unstract/sdk1/tests/llmw_image_fixtures.py
+++ b/unstract/sdk1/tests/llmw_image_fixtures.py
@@ -112,7 +112,11 @@ class InMemoryFileStorage:
     def read(
         self, path: str, mode: str = "rb", encoding: str = "utf-8", **_: object
     ) -> bytes | str:
-        payload = self._files[str(path)]
+        try:
+            payload = self._files[str(path)]
+        except KeyError:
+            # Real backends (fsspec/local) raise FileNotFoundError.
+            raise FileNotFoundError(str(path)) from None
         return payload if "b" in mode else payload.decode(encoding)
 
     def exists(self, path: str) -> bool:

--- a/unstract/sdk1/tests/llmw_image_fixtures.py
+++ b/unstract/sdk1/tests/llmw_image_fixtures.py
@@ -117,7 +117,22 @@ class InMemoryFileStorage:
 
     def exists(self, path: str) -> bool:
         key = str(path)
-        return key in self._files or key in self._dirs
+        if key in self._files or key in self._dirs:
+            return True
+        # S3-like: a "directory" exists when any object lives under it.
+        prefix = key.rstrip("/") + "/"
+        return any(stored.startswith(prefix) for stored in self._files)
+
+    def ls(self, path: str) -> list[str]:
+        """Direct children of ``path`` (full paths), fsspec-style."""
+        from pathlib import PurePosixPath
+
+        parent = str(path).rstrip("/")
+        return sorted(
+            stored
+            for stored in self._files
+            if str(PurePosixPath(stored).parent) == parent
+        )
 
     @property
     def stored_paths(self) -> list[str]:

--- a/unstract/sdk1/tests/llmw_image_fixtures.py
+++ b/unstract/sdk1/tests/llmw_image_fixtures.py
@@ -110,13 +110,20 @@ class InMemoryFileStorage:
         return len(payload)
 
     def read(
-        self, path: str, mode: str = "rb", encoding: str = "utf-8", **_: object
+        self,
+        path: str,
+        mode: str = "rb",
+        encoding: str = "utf-8",
+        length: int = -1,
+        **_: object,
     ) -> bytes | str:
         try:
             payload = self._files[str(path)]
         except KeyError:
             # Real backends (fsspec/local) raise FileNotFoundError.
             raise FileNotFoundError(str(path)) from None
+        if length is not None and length >= 0:
+            payload = payload[:length]
         return payload if "b" in mode else payload.decode(encoding)
 
     def exists(self, path: str) -> bool:

--- a/unstract/sdk1/tests/llmw_image_fixtures.py
+++ b/unstract/sdk1/tests/llmw_image_fixtures.py
@@ -127,6 +127,13 @@ class InMemoryFileStorage:
         prefix = key.rstrip("/") + "/"
         return any(stored.startswith(prefix) for stored in self._files)
 
+    def size(self, path: str) -> int:
+        """Byte size from 'metadata' (fsspec info-style), like real backends."""
+        try:
+            return len(self._files[str(path)])
+        except KeyError:
+            raise FileNotFoundError(str(path)) from None
+
     def ls(self, path: str) -> list[str]:
         """Direct children of ``path`` (full paths), fsspec-style."""
         from pathlib import PurePosixPath

--- a/unstract/sdk1/tests/test_llmw_v2_process_image.py
+++ b/unstract/sdk1/tests/test_llmw_v2_process_image.py
@@ -165,3 +165,36 @@ class TestPdfOnlyValidation:
     def test_validate_pdf_only_rejects_other(self) -> None:
         with pytest.raises(ExtractorError, match="PDF input only"):
             LLMWhispererV2._validate_pdf_only("/tmp/doc.tiff")
+
+    def test_extensionless_pdf_accepted_via_content_sniff(self) -> None:
+        # Workflow executions store inputs under extension-less names
+        # (e.g. SOURCE); the guard must sniff the content, not just the
+        # storage filename, or every deployment input is false-rejected.
+        class _Fs:
+            def read(self, path: str, mode: str = "rb", **_: object) -> bytes:
+                return b"%PDF-1.7 rest-of-file"
+
+        LLMWhispererV2._validate_pdf_only("/exec/data/SOURCE", fs=_Fs())  # no raise
+
+    def test_extensionless_non_pdf_rejected_via_content_sniff(self) -> None:
+        class _Fs:
+            def read(self, path: str, mode: str = "rb", **_: object) -> bytes:
+                return b"PK\x03\x04zipfile"
+
+        with pytest.raises(ExtractorError, match="PDF input only"):
+            LLMWhispererV2._validate_pdf_only("/exec/data/SOURCE", fs=_Fs())
+
+    def test_extensionless_unreadable_rejected_fail_closed(self) -> None:
+        class _Fs:
+            def read(self, path: str, mode: str = "rb", **_: object) -> bytes:
+                raise OSError("storage down")
+
+        with pytest.raises(ExtractorError, match="PDF input only"):
+            LLMWhispererV2._validate_pdf_only("/exec/data/SOURCE", fs=_Fs())
+
+    def test_pdf_extension_skips_content_read(self) -> None:
+        class _Fs:
+            def read(self, path: str, mode: str = "rb", **_: object) -> bytes:
+                raise AssertionError("must not read when the extension is .pdf")
+
+        LLMWhispererV2._validate_pdf_only("/tmp/doc.pdf", fs=_Fs())  # no raise

--- a/unstract/sdk1/tests/test_page_image_loader.py
+++ b/unstract/sdk1/tests/test_page_image_loader.py
@@ -16,6 +16,7 @@ from unstract.sdk1.adapters.x2text.page_image_loader import (
     LoadedPageImage,
     PageCapExceededError,
     PageImageSetIncompleteError,
+    PageImageSetTooLargeError,
     PageImagesNotFoundError,
     build_vision_message_content,
     discover_page_images,
@@ -247,3 +248,31 @@ class TestStaleListingAndToctou:
         # The in-memory double has no .fs attribute — must not error.
         fs = _store({1: b"a"})
         assert [n for n, _ in discover_page_images(fs, _DIR)] == [1]
+
+
+class TestByteBudget:
+    """The page cap bounds count; the byte budget bounds payload size."""
+
+    def test_over_budget_raises_typed_error(self) -> None:
+        fs = _store({1: b"a" * 30, 2: b"b" * 30, 3: b"c" * 30})
+        with pytest.raises(PageImageSetTooLargeError) as excinfo:
+            load_page_images(fs, _DIR, max_total_bytes=50)
+        err = excinfo.value
+        assert err.total_bytes == 60  # stopped at page 2, not after all reads
+        assert err.max_total_bytes == 50
+        assert "pages to extract" in str(err)
+
+    def test_within_budget_loads(self) -> None:
+        fs = _store({1: b"a" * 10, 2: b"b" * 10})
+        assert len(load_page_images(fs, _DIR, max_total_bytes=25)) == 2
+
+    def test_none_disables_budget(self) -> None:
+        fs = _store({1: b"a" * 100})
+        assert len(load_page_images(fs, _DIR, max_total_bytes=None)) == 1
+
+    def test_default_budget_is_generous(self) -> None:
+        from unstract.sdk1.adapters.x2text.page_image_loader import (
+            DEFAULT_MAX_TOTAL_BYTES,
+        )
+
+        assert DEFAULT_MAX_TOTAL_BYTES == 50 * 1024 * 1024

--- a/unstract/sdk1/tests/test_page_image_loader.py
+++ b/unstract/sdk1/tests/test_page_image_loader.py
@@ -197,3 +197,53 @@ class TestLocalFileStorageBackend:
         with pytest.raises(PageImageSetIncompleteError) as excinfo:
             discover_page_images(fs, pages_dir)
         assert excinfo.value.missing_pages == [2]
+
+
+class TestStaleListingAndToctou:
+    """Regressions from live testing.
+
+    Object-store listing caches and read-time disappearance must surface
+    typed errors, never raw IO errors.
+    """
+
+    def test_read_time_file_not_found_maps_to_incomplete(self) -> None:
+        # Discovery sees 3 pages (e.g. a stale fsspec dircache), but page 2
+        # was purged — the read must raise the typed incomplete-set error.
+        fs = _store({1: b"a", 2: b"b", 3: b"c"})
+        del fs._files[f"{_DIR}/page_002.png"]
+
+        class StaleLsFs:
+            def exists(self, path: str) -> bool:
+                return True
+
+            def ls(self, path: str) -> list[str]:
+                return [f"{_DIR}/page_00{n}.png" for n in (1, 2, 3)]
+
+            def read(self, path: str, mode: str = "rb", **_: object) -> bytes:
+                return fs.read(path, mode)
+
+        with pytest.raises(PageImageSetIncompleteError) as excinfo:
+            load_page_images(StaleLsFs(), _DIR)
+        err = excinfo.value
+        assert err.missing_pages == [2]
+        assert err.found_pages == [1, 3]
+        assert "cache bypass" in str(err)
+
+    def test_discovery_invalidates_backend_listing_cache(self) -> None:
+        # When the FileStorage wraps an fsspec filesystem exposing
+        # invalidate_cache (s3fs etc.), discovery must refresh it first.
+        calls: list[str] = []
+
+        class Underlying:
+            def invalidate_cache(self, path: str) -> None:
+                calls.append(path)
+
+        fs = _store({1: b"a"})
+        fs.fs = Underlying()
+        discover_page_images(fs, _DIR)
+        assert calls == [_DIR]
+
+    def test_backends_without_listing_cache_are_fine(self) -> None:
+        # The in-memory double has no .fs attribute — must not error.
+        fs = _store({1: b"a"})
+        assert [n for n, _ in discover_page_images(fs, _DIR)] == [1]

--- a/unstract/sdk1/tests/test_page_image_loader.py
+++ b/unstract/sdk1/tests/test_page_image_loader.py
@@ -258,38 +258,44 @@ class TestByteBudget:
         with pytest.raises(PageImageSetTooLargeError) as excinfo:
             load_page_images(fs, _DIR, max_total_bytes=50)
         err = excinfo.value
-        assert err.total_bytes == 60  # stopped at page 2, not after all reads
+        # Bounded read: page 2 was read with length 21 (remaining + 1), so
+        # the recorded total is budget + 1, and page 3 was never touched.
+        assert err.total_bytes == 51
         assert err.max_total_bytes == 50
         assert "pages to extract" in str(err)
 
-    def test_budget_rejects_from_metadata_before_any_read(self) -> None:
-        # A single pathological object must never be pulled into memory:
-        # the budget is checked from storage size metadata BEFORE reads.
-        fs = _store({1: b"g" * 100})
-        reads: list[str] = []
+    def test_single_oversized_page_reads_are_bounded(self) -> None:
+        # A single pathological object must never be fully allocated: each
+        # read is capped at remaining-budget + 1 bytes regardless of the
+        # object's real size (no size metadata needed).
+        fs = _store({1: b"g" * (10 * 1024 * 1024)})  # 10MB object
+        lengths: list[object] = []
         original_read = fs.read
-        fs.read = lambda path, **kw: reads.append(path) or original_read(path, **kw)
+
+        def recording_read(path: str, **kw: object) -> bytes | str:
+            lengths.append(kw.get("length"))
+            return original_read(path, **kw)
+
+        fs.read = recording_read
         with pytest.raises(PageImageSetTooLargeError):
             load_page_images(fs, _DIR, max_total_bytes=50)
-        assert reads == []  # zero bytes entered memory
+        assert lengths == [51]  # only 51 bytes ever entered memory
 
-    def test_budget_enforced_at_read_time_without_size_metadata(self) -> None:
-        # Backends lacking a size() API still get the read-time guard.
-        fs = _store({1: b"a" * 30, 2: b"b" * 30})
+    def test_budget_never_over_allocates_across_pages(self) -> None:
+        # Aggregate guarantee: sum of bytes actually read stays <= budget+1.
+        fs = _store({1: b"a" * 30, 2: b"b" * 30, 3: b"c" * 30})
+        read_bytes: list[int] = []
+        original_read = fs.read
 
-        class NoSizeFs:
-            exists = fs.exists
-            ls = fs.ls
-            read = fs.read
+        def recording_read(path: str, **kw: object) -> bytes | str:
+            data = original_read(path, **kw)
+            read_bytes.append(len(data))
+            return data
 
-        with pytest.raises(PageImageSetTooLargeError):
-            load_page_images(NoSizeFs(), _DIR, max_total_bytes=50)
-
-    def test_unreadable_size_metadata_falls_back_to_read_guard(self) -> None:
-        fs = _store({1: b"a" * 30, 2: b"b" * 30})
-        fs.size = lambda path: (_ for _ in ()).throw(OSError("no stat"))
+        fs.read = recording_read
         with pytest.raises(PageImageSetTooLargeError):
             load_page_images(fs, _DIR, max_total_bytes=50)
+        assert sum(read_bytes) <= 51
 
     def test_within_budget_loads(self) -> None:
         fs = _store({1: b"a" * 10, 2: b"b" * 10})

--- a/unstract/sdk1/tests/test_page_image_loader.py
+++ b/unstract/sdk1/tests/test_page_image_loader.py
@@ -1,0 +1,199 @@
+"""Tests for the FileStorage-backed page-image loader (reader side).
+
+Covers discovery + natural ordering (incl. >999 pages), the page cap,
+base64 encoding and vision message-block construction, and the typed
+empty/partial/duplicate failure modes — across the in-memory S3-like
+double and the real local-filesystem FileStorage backend.
+"""
+
+import base64
+from pathlib import Path
+
+import pytest
+from llmw_image_fixtures import InMemoryFileStorage, minimal_png
+from unstract.sdk1.adapters.x2text.page_image_loader import (
+    DEFAULT_PAGE_CAP,
+    LoadedPageImage,
+    PageCapExceededError,
+    PageImageSetIncompleteError,
+    PageImagesNotFoundError,
+    build_vision_message_content,
+    discover_page_images,
+    load_page_images,
+)
+from unstract.sdk1.file_storage import FileStorage, FileStorageProvider
+
+_DIR = "/data/extract/doc/pages"
+
+
+def _store(
+    pages: dict[int, bytes], extra: dict[str, bytes] | None = None
+) -> InMemoryFileStorage:
+    fs = InMemoryFileStorage()
+    for number, data in pages.items():
+        fs.write(path=f"{_DIR}/page_{number:03d}.png", mode="wb", data=data)
+    for name, data in (extra or {}).items():
+        fs.write(path=f"{_DIR}/{name}", mode="wb", data=data)
+    return fs
+
+
+class TestDiscovery:
+    def test_orders_by_integer_page_number(self) -> None:
+        fs = _store({n: b"x" for n in (3, 1, 2)})
+        assert [n for n, _ in discover_page_images(fs, _DIR)] == [1, 2, 3]
+
+    def test_returns_full_paths(self) -> None:
+        fs = _store({1: b"x"})
+        assert discover_page_images(fs, _DIR) == [(1, f"{_DIR}/page_001.png")]
+
+    def test_natural_sort_beyond_999_pages(self) -> None:
+        # Lexicographic ordering would put page_1000 before page_999.
+        fs = InMemoryFileStorage()
+        for n in (999, 1000, 1, 1001):
+            fs.write(path=f"{_DIR}/page_{n:03d}.png", mode="wb", data=b"x")
+        # Fill 2..998 so the set is contiguous.
+        for n in range(2, 999):
+            fs.write(path=f"{_DIR}/page_{n:03d}.png", mode="wb", data=b"x")
+        numbers = [n for n, _ in discover_page_images(fs, _DIR)]
+        assert numbers == list(range(1, 1002))
+
+    def test_ignores_non_page_entries(self) -> None:
+        fs = _store({1: b"x", 2: b"y"}, extra={"thumbnail.png": b"t", "notes.txt": b"n"})
+        assert [n for n, _ in discover_page_images(fs, _DIR)] == [1, 2]
+
+
+class TestFailureModes:
+    def test_missing_directory_raises_not_found(self) -> None:
+        with pytest.raises(PageImagesNotFoundError) as excinfo:
+            discover_page_images(InMemoryFileStorage(), _DIR)
+        # Remediation must steer to cache-bypass re-extraction + billing note.
+        assert "cache bypass" in str(excinfo.value)
+        assert "billed per page" in str(excinfo.value)
+
+    def test_directory_with_only_foreign_files_raises_not_found(self) -> None:
+        fs = _store({}, extra={"thumbnail.png": b"t"})
+        with pytest.raises(PageImagesNotFoundError):
+            discover_page_images(fs, _DIR)
+
+    def test_partial_set_raises_incomplete_with_missing_pages(self) -> None:
+        fs = _store({1: b"a", 2: b"b", 4: b"d", 7: b"g"})
+        with pytest.raises(PageImageSetIncompleteError) as excinfo:
+            discover_page_images(fs, _DIR)
+        err = excinfo.value
+        assert err.found_pages == [1, 2, 4, 7]
+        assert err.missing_pages == [3, 5, 6]
+        assert "cache bypass" in str(err)
+
+    def test_empty_and_partial_are_distinct_types(self) -> None:
+        # Callers branch remediation copy on the exception type; neither may
+        # be a subclass of the other.
+        assert not issubclass(PageImagesNotFoundError, PageImageSetIncompleteError)
+        assert not issubclass(PageImageSetIncompleteError, PageImagesNotFoundError)
+
+    def test_duplicate_page_numbers_raise_incomplete(self) -> None:
+        fs = _store({1: b"a"})
+        # page_001.png and page_1.png parse to the same page number.
+        fs.write(path=f"{_DIR}/page_1.png", mode="wb", data=b"dup")
+        with pytest.raises(PageImageSetIncompleteError, match="Duplicate"):
+            discover_page_images(fs, _DIR)
+
+
+class TestPageCap:
+    def test_within_cap_loads(self) -> None:
+        fs = _store({1: b"a", 2: b"b"})
+        assert len(load_page_images(fs, _DIR, page_cap=2)) == 2
+
+    def test_over_cap_raises_with_clear_message(self) -> None:
+        fs = _store({n: b"x" for n in range(1, 6)})
+        with pytest.raises(PageCapExceededError) as excinfo:
+            load_page_images(fs, _DIR, page_cap=4)
+        err = excinfo.value
+        assert err.page_count == 5
+        assert err.page_cap == 4
+        assert "exceeds 4 pages" in str(err)
+
+    def test_cap_check_precedes_reads(self) -> None:
+        # Fail-fast: no image bytes are read for an oversized document.
+        fs = _store({n: b"x" for n in range(1, 6)})
+        reads: list[str] = []
+        original_read = fs.read
+        fs.read = lambda path, **kw: reads.append(path) or original_read(path, **kw)
+        with pytest.raises(PageCapExceededError):
+            load_page_images(fs, _DIR, page_cap=1)
+        assert reads == []
+
+    def test_none_disables_cap(self) -> None:
+        fs = _store({n: b"x" for n in range(1, DEFAULT_PAGE_CAP + 5)})
+        loaded = load_page_images(fs, _DIR, page_cap=None)
+        assert len(loaded) == DEFAULT_PAGE_CAP + 4
+
+
+class TestLoadingAndEncoding:
+    def test_base64_round_trip(self) -> None:
+        payload = minimal_png()
+        fs = _store({1: payload})
+        [loaded] = load_page_images(fs, _DIR)
+        assert isinstance(loaded, LoadedPageImage)
+        assert base64.b64decode(loaded.base64_data) == payload
+
+    def test_loaded_pages_keep_page_order(self) -> None:
+        fs = _store({2: b"two", 1: b"one", 3: b"three"})
+        loaded = load_page_images(fs, _DIR)
+        assert [p.page_number for p in loaded] == [1, 2, 3]
+        assert base64.b64decode(loaded[0].base64_data) == b"one"
+
+
+class TestVisionMessageContent:
+    def test_prompt_first_then_labelled_pages(self) -> None:
+        pages = [
+            LoadedPageImage(page_number=1, path="p1", base64_data="QQ=="),
+            LoadedPageImage(page_number=2, path="p2", base64_data="Qg=="),
+        ]
+        content = build_vision_message_content(pages, "What is the total?")
+        assert content[0] == {"type": "text", "text": "What is the total?"}
+        # "Page N" label immediately precedes each image, in page order.
+        assert content[1] == {"type": "text", "text": "Page 1"}
+        assert content[2]["type"] == "image_url"
+        assert content[2]["image_url"]["url"] == "data:image/png;base64,QQ=="
+        assert content[3] == {"type": "text", "text": "Page 2"}
+        assert content[4]["image_url"]["url"] == "data:image/png;base64,Qg=="
+        assert len(content) == 5
+
+    def test_no_pages_yields_prompt_only(self) -> None:
+        assert build_vision_message_content([], "q") == [{"type": "text", "text": "q"}]
+
+
+class TestLocalFileStorageBackend:
+    """UNS-809: the loader behaves identically on a real FileStorage backend."""
+
+    def _local_fs(self) -> FileStorage:
+        return FileStorage(provider=FileStorageProvider.LOCAL)
+
+    def test_discovery_and_load_on_local_backend(self, tmp_path: Path) -> None:
+        fs = self._local_fs()
+        pages_dir = str(tmp_path / "doc" / "pages")
+        fs.mkdir(pages_dir)
+        payloads = {1: b"one", 2: b"two", 10: b"ten"}
+        for n in range(1, 11):
+            fs.write(
+                path=f"{pages_dir}/page_{n:03d}.png",
+                mode="wb",
+                data=payloads.get(n, b"x"),
+            )
+        loaded = load_page_images(fs, pages_dir, page_cap=None)
+        assert [p.page_number for p in loaded] == list(range(1, 11))
+        assert base64.b64decode(loaded[9].base64_data) == b"ten"
+
+    def test_missing_dir_on_local_backend(self, tmp_path: Path) -> None:
+        with pytest.raises(PageImagesNotFoundError):
+            discover_page_images(self._local_fs(), str(tmp_path / "absent" / "pages"))
+
+    def test_partial_set_on_local_backend(self, tmp_path: Path) -> None:
+        fs = self._local_fs()
+        pages_dir = str(tmp_path / "doc" / "pages")
+        fs.mkdir(pages_dir)
+        for n in (1, 3):
+            fs.write(path=f"{pages_dir}/page_{n:03d}.png", mode="wb", data=b"x")
+        with pytest.raises(PageImageSetIncompleteError) as excinfo:
+            discover_page_images(fs, pages_dir)
+        assert excinfo.value.missing_pages == [2]

--- a/unstract/sdk1/tests/test_page_image_loader.py
+++ b/unstract/sdk1/tests/test_page_image_loader.py
@@ -262,6 +262,35 @@ class TestByteBudget:
         assert err.max_total_bytes == 50
         assert "pages to extract" in str(err)
 
+    def test_budget_rejects_from_metadata_before_any_read(self) -> None:
+        # A single pathological object must never be pulled into memory:
+        # the budget is checked from storage size metadata BEFORE reads.
+        fs = _store({1: b"g" * 100})
+        reads: list[str] = []
+        original_read = fs.read
+        fs.read = lambda path, **kw: reads.append(path) or original_read(path, **kw)
+        with pytest.raises(PageImageSetTooLargeError):
+            load_page_images(fs, _DIR, max_total_bytes=50)
+        assert reads == []  # zero bytes entered memory
+
+    def test_budget_enforced_at_read_time_without_size_metadata(self) -> None:
+        # Backends lacking a size() API still get the read-time guard.
+        fs = _store({1: b"a" * 30, 2: b"b" * 30})
+
+        class NoSizeFs:
+            exists = fs.exists
+            ls = fs.ls
+            read = fs.read
+
+        with pytest.raises(PageImageSetTooLargeError):
+            load_page_images(NoSizeFs(), _DIR, max_total_bytes=50)
+
+    def test_unreadable_size_metadata_falls_back_to_read_guard(self) -> None:
+        fs = _store({1: b"a" * 30, 2: b"b" * 30})
+        fs.size = lambda path: (_ for _ in ()).throw(OSError("no stat"))
+        with pytest.raises(PageImageSetTooLargeError):
+            load_page_images(fs, _DIR, max_total_bytes=50)
+
     def test_within_budget_loads(self) -> None:
         fs = _store({1: b"a" * 10, 2: b"b" * 10})
         assert len(load_page_images(fs, _DIR, max_total_bytes=25)) == 2

--- a/unstract/sdk1/tests/test_vision_capability.py
+++ b/unstract/sdk1/tests/test_vision_capability.py
@@ -1,0 +1,97 @@
+"""Tests for vision-capability detection and the image-mode gating policy.
+
+Registry lookups are exercised against a controlled fake of
+``litellm.model_cost`` so results don't drift with litellm releases; a
+couple of smoke tests hit the real registry for stable, long-lived models.
+"""
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from unstract.sdk1.utils import vision_capability as vc
+from unstract.sdk1.utils.vision_capability import (
+    VisionSupport,
+    check_vision_support,
+    validate_vision_capability,
+)
+
+_FAKE_REGISTRY = {
+    "vision-model": {"supports_vision": True},
+    "provider/prefixed-vision": {"supports_vision": True},
+    "text-only-model": {"litellm_provider": "x"},  # known, no vision flag
+    "explicit-no-vision": {"supports_vision": False},
+}
+
+
+@pytest.fixture
+def fake_registry(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(vc.litellm, "model_cost", _FAKE_REGISTRY)
+
+
+class TestCheckVisionSupport:
+    def test_known_vision_model(self, fake_registry: None) -> None:
+        assert check_vision_support("vision-model") is VisionSupport.SUPPORTED
+
+    def test_prefix_stripped_lookup(self, fake_registry: None) -> None:
+        # Registry keyed without the provider prefix still resolves.
+        assert check_vision_support("provider/prefixed-vision") is (
+            VisionSupport.SUPPORTED
+        )
+
+    def test_known_model_without_flag_is_unsupported(self, fake_registry: None) -> None:
+        # In the registry, absence of supports_vision on a KNOWN model is
+        # authoritative "no vision" (litellm omits the key rather than
+        # setting False).
+        assert check_vision_support("text-only-model") is VisionSupport.UNSUPPORTED
+
+    def test_explicit_false_is_unsupported(self, fake_registry: None) -> None:
+        assert check_vision_support("explicit-no-vision") is VisionSupport.UNSUPPORTED
+
+    def test_unregistered_model_is_unknown(self, fake_registry: None) -> None:
+        assert check_vision_support("ollama/llava") is VisionSupport.UNKNOWN
+
+    def test_empty_model_is_unknown(self, fake_registry: None) -> None:
+        assert check_vision_support("") is VisionSupport.UNKNOWN
+
+    def test_no_network_calls_ever(self, monkeypatch: MonkeyPatch) -> None:
+        # get_model_info can hit the network for self-hosted providers —
+        # classification must never call it.
+        monkeypatch.setattr(
+            vc.litellm,
+            "get_model_info",
+            lambda *a, **k: pytest.fail("get_model_info must not be called"),
+            raising=False,
+        )
+        check_vision_support("ollama/anything")
+        check_vision_support("gpt-4o")
+
+
+class TestPolicy:
+    def test_supported_allows_silently(self, fake_registry: None) -> None:
+        result = validate_vision_capability("vision-model")
+        assert result.allowed is True
+        assert result.message is None
+
+    def test_unknown_warns_and_allows(self, fake_registry: None) -> None:
+        result = validate_vision_capability("ollama/custom-vlm")
+        assert result.allowed is True
+        assert result.support is VisionSupport.UNKNOWN
+        assert result.message and "cannot be verified" in result.message
+
+    def test_unsupported_blocks_and_names_model(self, fake_registry: None) -> None:
+        result = validate_vision_capability("text-only-model")
+        assert result.allowed is False
+        assert "text-only-model" in result.message
+        assert "vision-capable" in result.message
+
+
+class TestRealRegistrySmoke:
+    """Long-stable models against the real litellm registry."""
+
+    def test_gpt_4o_supported(self) -> None:
+        assert check_vision_support("gpt-4o") is VisionSupport.SUPPORTED
+
+    def test_gpt_35_turbo_unsupported(self) -> None:
+        assert check_vision_support("gpt-3.5-turbo") is VisionSupport.UNSUPPORTED
+
+    def test_fabricated_model_unknown(self) -> None:
+        assert check_vision_support("no-such/model-xyz-123") is VisionSupport.UNKNOWN

--- a/unstract/sdk1/tests/test_x2text_shared_page_path.py
+++ b/unstract/sdk1/tests/test_x2text_shared_page_path.py
@@ -1,0 +1,144 @@
+"""Writer/reader path-agreement tests for the shared page-image contract.
+
+The adapter (writer) and any page-image reader must derive the
+``{extract_dir}/{stem}/pages`` directory through the single shared
+``build_page_store_dir`` helper, and discover/order pages via the shared
+naming constants. These tests pin that contract: pure functions and
+constants only — no I/O, no network, no adapter/consumer classes.
+"""
+
+import fnmatch
+import re
+
+import pytest
+from unstract.sdk1.adapters.x2text.constants import (
+    ImageOutputConstants,
+    build_page_store_dir,
+)
+
+# (output_file_path, input_file_path, expected) — expected derives from the
+# output path's stem when present (the extract-file discriminator).
+_PATH_CASES = [
+    pytest.param(
+        "/data/extract/doc.txt", "/in/doc.pdf", "/data/extract/doc/pages", id="flat"
+    ),
+    pytest.param(
+        "/a/b/c/d/extract/report.txt",
+        "/uploads/report.pdf",
+        "/a/b/c/d/extract/report/pages",
+        id="nested-output-dir",
+    ),
+    pytest.param(
+        "/data/report.v2.final.txt",
+        "/in/report.v2.final.pdf",
+        "/data/report.v2.final/pages",
+        id="stem-with-dots",
+    ),
+    pytest.param(
+        "/data/annual report (2026).txt",
+        "/in/annual report (2026).pdf",
+        "/data/annual report (2026)/pages",
+        id="stem-with-spaces-and-specials",
+    ),
+    pytest.param("/data/x.txt", "/in/x.pdf", "/data/x/pages", id="single-char-stem"),
+    pytest.param(
+        None, "/in/scan.pdf", "/in/scan/pages", id="no-output-path-falls-back-to-input"
+    ),
+]
+
+
+class TestBuildPageStoreDir:
+    @pytest.mark.parametrize(("output_path", "input_path", "expected"), _PATH_CASES)
+    def test_expected_path_and_determinism(
+        self, output_path: str | None, input_path: str, expected: str
+    ) -> None:
+        first = build_page_store_dir(output_path, input_path)
+        second = build_page_store_dir(output_path, input_path)
+        assert first == expected
+        assert first == second  # pure + deterministic
+
+    @pytest.mark.parametrize(("output_path", "input_path", "expected"), _PATH_CASES)
+    def test_path_ends_with_pages_subfolder(
+        self, output_path: str | None, input_path: str, expected: str
+    ) -> None:
+        result = build_page_store_dir(output_path, input_path)
+        assert result.split("/")[-1] == ImageOutputConstants.PAGES_SUBFOLDER
+
+    def test_writer_and_reader_share_one_implementation(self) -> None:
+        # The adapter exposes the helper as a staticmethod bound to the very
+        # same shared function — identity, not a reimplementation. Any reader
+        # importing from the shared surface therefore agrees byte-for-byte.
+        from unstract.sdk1.adapters.x2text.llm_whisperer_v2.src.helper import (
+            LLMWhispererHelper,
+        )
+
+        assert LLMWhispererHelper.build_page_store_dir is build_page_store_dir
+
+
+class TestPageNamingConstants:
+    def test_glob_pattern_value(self) -> None:
+        assert ImageOutputConstants.PAGE_GLOB_PATTERN == "page_*.png"
+
+    def test_glob_matches_writer_filenames(self) -> None:
+        for name in ("page_001.png", "page_042.png", "page_100.png", "page_1000.png"):
+            assert fnmatch.fnmatch(name, ImageOutputConstants.PAGE_GLOB_PATTERN)
+        assert not fnmatch.fnmatch(
+            "thumbnail.png", ImageOutputConstants.PAGE_GLOB_PATTERN
+        )
+
+    @pytest.mark.parametrize(
+        ("filename", "captured"),
+        [
+            ("page_001.png", "001"),
+            ("page_042.png", "042"),
+            ("page_100.png", "100"),
+            ("page_999.png", "999"),
+            # Past page 999 the writer naturally emits 4+ digits — the
+            # regex must keep matching (a 3-digit-only pattern would
+            # silently drop pages of very large documents).
+            ("page_1000.png", "1000"),
+        ],
+    )
+    def test_number_regex_captures_page_index(self, filename: str, captured: str) -> None:
+        match = re.search(ImageOutputConstants.PAGE_NUMBER_REGEX, filename)
+        assert match is not None
+        assert match.group(1) == captured
+
+    @pytest.mark.parametrize(
+        "filename", ["thumbnail.png", "page_abc.png", "page_.png", "page_001.jpg"]
+    )
+    def test_number_regex_rejects_non_page_files(self, filename: str) -> None:
+        assert re.fullmatch(ImageOutputConstants.PAGE_NUMBER_REGEX, filename) is None
+
+    def test_natural_sort_via_captured_int(self) -> None:
+        # The reason the regex exists: integer sort of the captured group
+        # orders pages correctly where lexicographic sort fails past the
+        # zero-padding width.
+        names = ["page_1000.png", "page_999.png", "page_010.png", "page_001.png"]
+        page_re = re.compile(ImageOutputConstants.PAGE_NUMBER_REGEX)
+        ordered = sorted(names, key=lambda n: int(page_re.search(n).group(1)))
+        assert ordered == [
+            "page_001.png",
+            "page_010.png",
+            "page_999.png",
+            "page_1000.png",
+        ]
+        # Lexicographic order puts page_1000 before page_999 — the misorder
+        # the integer sort exists to prevent.
+        assert sorted(names) != ordered
+
+
+class TestWriterFilenamesMatchReaderContract:
+    def test_writer_filename_matches_glob_and_regex(self) -> None:
+        # The writer's filename builder must produce names the reader-side
+        # glob + regex discover and parse — the two halves of the contract.
+        from unstract.sdk1.adapters.x2text.llm_whisperer_v2.src.helper import (
+            LLMWhispererHelper,
+        )
+
+        for page in (1, 42, 999, 1000):
+            name = LLMWhispererHelper._page_image_filename(page)
+            assert fnmatch.fnmatch(name, ImageOutputConstants.PAGE_GLOB_PATTERN)
+            match = re.fullmatch(ImageOutputConstants.PAGE_NUMBER_REGEX, name)
+            assert match is not None
+            assert int(match.group(1)) == page

--- a/unstract/sdk1/tests/test_x2text_shared_page_path.py
+++ b/unstract/sdk1/tests/test_x2text_shared_page_path.py
@@ -7,7 +7,6 @@ naming constants. These tests pin that contract: pure functions and
 constants only — no I/O, no network, no adapter/consumer classes.
 """
 
-import fnmatch
 import re
 
 import pytest
@@ -76,16 +75,6 @@ class TestBuildPageStoreDir:
 
 
 class TestPageNamingConstants:
-    def test_glob_pattern_value(self) -> None:
-        assert ImageOutputConstants.PAGE_GLOB_PATTERN == "page_*.png"
-
-    def test_glob_matches_writer_filenames(self) -> None:
-        for name in ("page_001.png", "page_042.png", "page_100.png", "page_1000.png"):
-            assert fnmatch.fnmatch(name, ImageOutputConstants.PAGE_GLOB_PATTERN)
-        assert not fnmatch.fnmatch(
-            "thumbnail.png", ImageOutputConstants.PAGE_GLOB_PATTERN
-        )
-
     @pytest.mark.parametrize(
         ("filename", "captured"),
         [
@@ -129,16 +118,15 @@ class TestPageNamingConstants:
 
 
 class TestWriterFilenamesMatchReaderContract:
-    def test_writer_filename_matches_glob_and_regex(self) -> None:
+    def test_writer_filename_matches_reader_regex(self) -> None:
         # The writer's filename builder must produce names the reader-side
-        # glob + regex discover and parse — the two halves of the contract.
+        # regex discovers and parses — the two halves of the contract.
         from unstract.sdk1.adapters.x2text.llm_whisperer_v2.src.helper import (
             LLMWhispererHelper,
         )
 
         for page in (1, 42, 999, 1000):
             name = LLMWhispererHelper._page_image_filename(page)
-            assert fnmatch.fnmatch(name, ImageOutputConstants.PAGE_GLOB_PATTERN)
             match = re.fullmatch(ImageOutputConstants.PAGE_NUMBER_REGEX, name)
             assert match is not None
             assert int(match.group(1)) == page

--- a/workers/executor/executors/constants.py
+++ b/workers/executor/executors/constants.py
@@ -20,6 +20,12 @@ class PromptServiceConstants:
     VECTOR_DB = "vector-db"
     EMBEDDING = "embedding"
     X2TEXT_ADAPTER = "x2text_adapter"
+    # Extract-file path that is never rewritten by summarize-as-source /
+    # smart-table overrides — the page-image reader keys on this.
+    EXTRACT_FILE_PATH = "extract_file_path"
+    # Per-prompt stamp of the x2text adapter's output mode (LLMWhisperer
+    # only); lets image-mode detection skip the platform-service call.
+    X2TEXT_OUTPUT_MODE = "x2text_output_mode"
     CHUNK_OVERLAP = "chunk-overlap"
     LLM = "llm"
     IS_ASSERT = "is_assert"

--- a/workers/executor/executors/exceptions.py
+++ b/workers/executor/executors/exceptions.py
@@ -82,3 +82,24 @@ class CustomDataError(LegacyExecutorError):
             f"Custom data error for variable '{variable_display}': {reason} {help_text}"
         )
         super().__init__(message=message)
+
+
+class VlmImageAnswerError(LegacyExecutorError):
+    """Raised when an image-mode prompt cannot be answered.
+
+    Image output mode requires the cloud-only "vlm-image-answer" plugin;
+    when it is missing, or the vision path fails in a way the user must
+    act on (non-vision LLM, missing images, page cap), the prompt must
+    fail loudly — never fall through to the text path, which would
+    silently answer against the one-line extraction summary.
+
+    ``error_code`` is a stable machine-readable identifier; it is also
+    prefixed onto the message so it survives the string-only error
+    propagation to Prompt Studio and API deployment responses.
+    """
+
+    code = 400
+
+    def __init__(self, message: str, error_code: str):
+        self.error_code = error_code
+        super().__init__(message=f"{error_code}: {message}")

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -26,6 +26,7 @@ from executor.executors.lookup_enrichment import (
     run_lookup_enrichment,
     run_webhook_postprocessing,
 )
+from executor.executors.vlm_image_answer import run_vlm_image_answer
 
 from unstract.sdk1.adapters.exceptions import AdapterError
 from unstract.sdk1.adapters.x2text.constants import X2TextConstants
@@ -1769,9 +1770,27 @@ class LegacyExecutor(BaseExecutor):
         records: list[dict[str, Any]] = []
         try:
             answer = "NA"
+            # Image output mode: the document has page images, not text —
+            # the answer comes from a vision LLM (cloud plugin) and RAG
+            # retrieval is skipped entirely. Returns None when the
+            # prompt's x2text adapter is not in image mode; raises rather
+            # than falling through when it is but cannot be served.
+            vlm_answer = run_vlm_image_answer(
+                output=output,
+                shim=shim,
+                llm=llm,
+                file_path=file_path,
+                execution_source=execution_source,
+                metadata=metadata,
+                metrics=metrics,
+                usage_kwargs=usage_kwargs,
+            )
             retrieval_strategy = output.get(PSKeys.RETRIEVAL_STRATEGY)
             valid_strategies = {s.value for s in RetrievalStrategy}
-            if retrieval_strategy in valid_strategies:
+            if vlm_answer is not None:
+                answer = vlm_answer
+                metadata[PSKeys.CONTEXT][prompt_name] = []
+            elif retrieval_strategy in valid_strategies:
                 if chunk_size > 0:
                     shim.stream_log(f"Retrieving context for: `{prompt_name}`")
                 logger.info(
@@ -2292,6 +2311,30 @@ class LegacyExecutor(BaseExecutor):
 
                 {"output": dict, "metadata": dict, "metrics": dict}
         """
+        from executor.executors.constants import PromptServiceConstants as PSKeys
+        from executor.executors.vlm_image_answer import raise_if_image_mode_unsupported
+
+        # Image output mode cannot run single-pass: one combined prompt over
+        # the "full text" would silently answer from the one-line extraction
+        # summary. (The answer_prompt fallback below re-checks per prompt;
+        # this covers the cloud single-pass plugin delegation too.)
+        params = context.executor_params
+        tool_settings = params.get(PSKeys.TOOL_SETTINGS) or {}
+        outputs = params.get(PSKeys.OUTPUTS) or [{}]
+        x2text_instance_id = tool_settings.get(PSKeys.X2TEXT_ADAPTER) or outputs[0].get(
+            PSKeys.X2TEXT_ADAPTER
+        )
+        if x2text_instance_id:
+            raise_if_image_mode_unsupported(
+                operation="Single-pass extraction",
+                adapter_instance_id=str(x2text_instance_id),
+                shim=self._build_shim(
+                    platform_api_key=params.get(PSKeys.PLATFORM_SERVICE_API_KEY, ""),
+                    component=self._log_component,
+                ),
+                execution_id=str(params.get(PSKeys.EXECUTION_ID, "")),
+            )
+
         try:
             from unstract.sdk1.execution.registry import ExecutorRegistry
 

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -2332,7 +2332,9 @@ class LegacyExecutor(BaseExecutor):
                     platform_api_key=params.get(PSKeys.PLATFORM_SERVICE_API_KEY, ""),
                     component=self._log_component,
                 ),
-                execution_id=str(params.get(PSKeys.EXECUTION_ID, "")),
+                scope_id=str(
+                    params.get(PSKeys.EXECUTION_ID) or params.get(PSKeys.RUN_ID) or ""
+                ),
             )
 
         try:

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -26,7 +26,10 @@ from executor.executors.lookup_enrichment import (
     run_lookup_enrichment,
     run_webhook_postprocessing,
 )
-from executor.executors.vlm_image_answer import run_vlm_image_answer
+from executor.executors.vlm_image_answer import (
+    detect_image_mode_config,
+    run_vlm_image_answer,
+)
 
 from unstract.sdk1.adapters.exceptions import AdapterError
 from unstract.sdk1.adapters.x2text.constants import X2TextConstants
@@ -1755,10 +1758,16 @@ class LegacyExecutor(BaseExecutor):
             )
 
         usage_kwargs = {"run_id": run_id, "execution_id": execution_id}
+        # Image output mode: detected up front (payload stamp fast-path,
+        # platform-service fallback) so retrieval adapters are never
+        # constructed for a prompt that answers from page images.
+        vlm_config = detect_image_mode_config(
+            output=output, shim=shim, usage_kwargs=usage_kwargs
+        )
         llm, embedding, vector_db = self._init_llm_and_retrieval(
             output=output,
             shim=shim,
-            chunk_size=chunk_size,
+            chunk_size=0 if vlm_config is not None else chunk_size,
             llm_cls=llm_cls,
             embedding_compat_cls=embedding_compat_cls,
             vector_db_cls=vector_db_cls,
@@ -1770,25 +1779,28 @@ class LegacyExecutor(BaseExecutor):
         records: list[dict[str, Any]] = []
         try:
             answer = "NA"
-            # Image output mode: the document has page images, not text —
-            # the answer comes from a vision LLM (cloud plugin) and RAG
-            # retrieval is skipped entirely. Returns None when the
-            # prompt's x2text adapter is not in image mode; raises rather
-            # than falling through when it is but cannot be served.
-            vlm_answer = run_vlm_image_answer(
-                output=output,
-                shim=shim,
-                llm=llm,
-                file_path=file_path,
-                execution_source=execution_source,
-                metadata=metadata,
-                metrics=metrics,
-                usage_kwargs=usage_kwargs,
-            )
             retrieval_strategy = output.get(PSKeys.RETRIEVAL_STRATEGY)
             valid_strategies = {s.value for s in RetrievalStrategy}
-            if vlm_answer is not None:
-                answer = vlm_answer
+            if vlm_config is not None:
+                # Image output mode: the document has page images, not
+                # text — the answer comes from a vision LLM (cloud
+                # plugin); RAG retrieval is skipped entirely. The pages
+                # directory keys on the never-rewritten extract path (the
+                # payload FILE_PATH may point at the summarize output or
+                # the original source for smart-table runs).
+                answer = run_vlm_image_answer(
+                    output=output,
+                    shim=shim,
+                    llm=llm,
+                    extract_file_path=(
+                        params.get(PSKeys.EXTRACT_FILE_PATH) or file_path
+                    ),
+                    execution_source=execution_source,
+                    metadata=metadata,
+                    metrics=metrics,
+                    x2text_config=vlm_config,
+                    usage_kwargs=usage_kwargs,
+                )
                 metadata[PSKeys.CONTEXT][prompt_name] = []
             elif retrieval_strategy in valid_strategies:
                 if chunk_size > 0:
@@ -1878,30 +1890,40 @@ class LegacyExecutor(BaseExecutor):
                 shim=shim,
             )
 
-            records.extend(
-                self._run_challenge_if_enabled(
-                    tool_settings=tool_settings,
+            if vlm_config is None:
+                records.extend(
+                    self._run_challenge_if_enabled(
+                        tool_settings=tool_settings,
+                        output=output,
+                        structured_output=structured_output,
+                        context_list=context_list,
+                        llm=llm,
+                        llm_cls=llm_cls,
+                        usage_kwargs=usage_kwargs,
+                        run_id=run_id,
+                        platform_api_key=platform_api_key,
+                        metadata=metadata,
+                        shim=shim,
+                        prompt_name=prompt_name,
+                    )
+                )
+                self._run_evaluation_if_enabled(
                     output=output,
-                    structured_output=structured_output,
                     context_list=context_list,
-                    llm=llm,
-                    llm_cls=llm_cls,
-                    usage_kwargs=usage_kwargs,
-                    run_id=run_id,
+                    structured_output=structured_output,
                     platform_api_key=platform_api_key,
-                    metadata=metadata,
                     shim=shim,
                     prompt_name=prompt_name,
                 )
-            )
-            self._run_evaluation_if_enabled(
-                output=output,
-                context_list=context_list,
-                structured_output=structured_output,
-                platform_api_key=platform_api_key,
-                shim=shim,
-                prompt_name=prompt_name,
-            )
+            else:
+                # Image mode has no retrieval context; challenge and
+                # evaluation verify an answer AGAINST context, so running
+                # them here would bill a doomed second LLM call. A
+                # vision-aware challenge is a later-phase decision.
+                shim.stream_log(
+                    f"Skipped challenge/evaluation for `{prompt_name}` "
+                    "(image output mode has no retrieval context)"
+                )
             shim.stream_log(f"Completed prompt: `{prompt_name}`")
 
             val = structured_output.get(prompt_name)

--- a/workers/executor/executors/legacy_executor.py
+++ b/workers/executor/executors/legacy_executor.py
@@ -1792,9 +1792,7 @@ class LegacyExecutor(BaseExecutor):
                     output=output,
                     shim=shim,
                     llm=llm,
-                    extract_file_path=(
-                        params.get(PSKeys.EXTRACT_FILE_PATH) or file_path
-                    ),
+                    extract_file_path=(params.get(PSKeys.EXTRACT_FILE_PATH) or file_path),
                     execution_source=execution_source,
                     metadata=metadata,
                     metrics=metrics,

--- a/workers/executor/executors/vlm_image_answer.py
+++ b/workers/executor/executors/vlm_image_answer.py
@@ -1,0 +1,201 @@
+"""Bridge for the cloud-only VLM image-answer plugin.
+
+Image output mode (an LLMWhisperer x2text adapter with
+``output_mode == "image"``) persists per-page PNGs instead of text, so
+answering a prompt against such a document means sending those images to a
+vision-capable LLM. That consumer ships only with Unstract Cloud, as the
+``vlm-image-answer`` executor plugin.
+
+This OSS bridge owns detection and dispatch (mirroring the
+``lookup_enrichment`` bridge, with the opposite error policy — lookups
+degrade gracefully, image mode must fail loudly):
+
+- Detects image mode from the profile's x2text adapter configuration. The
+  executor payload carries only the adapter *instance id* (no metadata),
+  so the config is resolved through the platform service once per
+  (execution, adapter) and cached.
+- When the plugin is installed, delegates the answer to it. RAG retrieval
+  is skipped by the caller — image mode has no text to retrieve.
+- When the plugin is absent, raises a structured error rather than letting
+  the prompt silently answer against the one-line extraction summary.
+"""
+
+import logging
+from collections import OrderedDict
+from typing import Any
+
+from executor.executors.constants import PromptServiceConstants as PSKeys
+from executor.executors.exceptions import VlmImageAnswerError
+from executor.executors.file_utils import FileUtils
+from executor.executors.plugins.loader import ExecutorPluginLoader
+
+from unstract.sdk1.adapters.x2text.constants import (
+    ImageOutputConstants,
+    build_page_store_dir,
+)
+from unstract.sdk1.adapters.x2text.page_image_loader import (
+    PageCapExceededError,
+    PageImageLoadError,
+    PageImageSetIncompleteError,
+    PageImagesNotFoundError,
+)
+from unstract.sdk1.platform import PlatformHelper
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "vlm-image-answer"
+
+# Stable machine-readable error codes (prefixed onto error messages so they
+# survive the string-only propagation to PS / deployment API responses).
+IMAGE_OUTPUT_REQUIRES_CLOUD = "IMAGE_OUTPUT_REQUIRES_CLOUD"
+IMAGE_OUTPUT_MISSING = "IMAGE_OUTPUT_MISSING"
+IMAGE_PAGE_CAP_EXCEEDED = "IMAGE_PAGE_CAP_EXCEEDED"
+IMAGE_OUTPUT_UNSUPPORTED_OPERATION = "IMAGE_OUTPUT_UNSUPPORTED_OPERATION"
+VISION_LLM_REQUIRED = "VISION_LLM_REQUIRED"
+
+_LLMWHISPERER_ADAPTER_PREFIX = "llmwhisperer|"
+
+# (execution_id, adapter_instance_id) -> resolved config dict | None.
+# Execution-scoped so adapter edits are picked up by the next run; bounded
+# so a long-lived worker never grows it unchecked.
+_MODE_CACHE: OrderedDict[tuple[str, str], dict[str, Any] | None] = OrderedDict()
+_MODE_CACHE_MAX = 256
+
+
+def _resolve_image_mode_config(
+    shim: Any, adapter_instance_id: str, execution_id: str
+) -> dict[str, Any] | None:
+    """Return the x2text adapter config when it is in image mode, else None.
+
+    Resolution goes through the platform service (the payload has no
+    adapter metadata); results are cached per (execution, adapter).
+    """
+    cache_key = (execution_id, adapter_instance_id)
+    if cache_key in _MODE_CACHE:
+        _MODE_CACHE.move_to_end(cache_key)
+        return _MODE_CACHE[cache_key]
+
+    config = PlatformHelper.get_adapter_config(shim, adapter_instance_id) or {}
+    adapter_id = str(config.get("adapter_id", ""))
+    adapter_metadata = config.get("adapter_metadata") or {}
+    is_image_mode = adapter_id.startswith(_LLMWHISPERER_ADAPTER_PREFIX) and (
+        adapter_metadata.get(ImageOutputConstants.OUTPUT_MODE)
+        == ImageOutputConstants.IMAGE_MODE
+    )
+
+    result = config if is_image_mode else None
+    _MODE_CACHE[cache_key] = result
+    while len(_MODE_CACHE) > _MODE_CACHE_MAX:
+        _MODE_CACHE.popitem(last=False)
+    return result
+
+
+def run_vlm_image_answer(
+    *,
+    output: dict[str, Any],
+    shim: Any,
+    llm: Any,
+    file_path: str,
+    execution_source: str,
+    metadata: dict[str, Any],
+    metrics: dict[str, Any],
+    usage_kwargs: dict[str, Any] | None = None,
+) -> str | None:
+    """Answer an image-mode prompt via the cloud plugin.
+
+    Returns:
+        The raw answer string when the prompt's x2text adapter is in image
+        mode (the caller assigns it in place of the RAG/completion answer,
+        so type conversion, lookups, webhooks etc. run unchanged), or
+        ``None`` when not in image mode (normal path continues).
+
+    Raises:
+        VlmImageAnswerError: image mode detected but the cloud plugin is
+            not installed, or the vision path failed in a way the user
+            must act on (missing images, page cap, non-vision LLM).
+    """
+    adapter_instance_id = str(output.get(PSKeys.X2TEXT_ADAPTER) or "")
+    if not adapter_instance_id:
+        return None
+
+    usage_kwargs = usage_kwargs or {}
+    execution_id = str(usage_kwargs.get("execution_id", ""))
+    x2text_config = _resolve_image_mode_config(shim, adapter_instance_id, execution_id)
+    if x2text_config is None:
+        return None
+
+    prompt_name = output.get(PSKeys.NAME, "")
+    plugin_cls = ExecutorPluginLoader.get(PLUGIN_NAME)
+    if plugin_cls is None:
+        raise VlmImageAnswerError(
+            "This document was extracted in image output mode, which is "
+            "answered by a vision LLM available only on Unstract Cloud. "
+            "Switch the profile's text extractor to a text output mode, "
+            "or run this on Unstract Cloud.",
+            error_code=IMAGE_OUTPUT_REQUIRES_CLOUD,
+        )
+
+    shim.stream_log(f"Answering `{prompt_name}` from page images via vision LLM")
+    fs = FileUtils.get_fs_instance(execution_source=execution_source)
+    page_store_dir = build_page_store_dir(file_path, file_path)
+
+    try:
+        outcome = plugin_cls.run_with_metrics(
+            output=output,
+            llm=llm,
+            fs=fs,
+            page_store_dir=page_store_dir,
+            x2text_config=x2text_config,
+            metadata=metadata,
+            shim=shim,
+            usage_kwargs=usage_kwargs,
+        )
+    except (PageImagesNotFoundError, PageImageSetIncompleteError) as e:
+        raise VlmImageAnswerError(str(e), error_code=IMAGE_OUTPUT_MISSING) from e
+    except PageCapExceededError as e:
+        raise VlmImageAnswerError(str(e), error_code=IMAGE_PAGE_CAP_EXCEEDED) from e
+    except PageImageLoadError as e:
+        raise VlmImageAnswerError(str(e), error_code=IMAGE_OUTPUT_MISSING) from e
+    except VlmImageAnswerError:
+        raise
+    except Exception as e:
+        # Plugin-defined hard failures carry a stable error_code attribute
+        # (e.g. VISION_LLM_REQUIRED). Anything else propagates untouched —
+        # never degrade to the text path.
+        plugin_code = getattr(e, "error_code", None)
+        if isinstance(plugin_code, str) and plugin_code:
+            raise VlmImageAnswerError(str(e), error_code=plugin_code) from e
+        raise
+
+    llm_metrics = outcome.get("llm_metrics") if isinstance(outcome, dict) else None
+    if llm_metrics:
+        metrics.setdefault(prompt_name, {})["vlm_image_answer"] = llm_metrics
+
+    answer = outcome["answer"] if isinstance(outcome, dict) else str(outcome)
+    shim.stream_log(f"Vision LLM answered `{prompt_name}`")
+    return answer
+
+
+def raise_if_image_mode_unsupported(
+    *,
+    operation: str,
+    adapter_instance_id: str | None,
+    shim: Any,
+    execution_id: str = "",
+) -> None:
+    """Guard operations that cannot run against image-mode documents.
+
+    Single-pass extraction (and any future full-text operation) would
+    silently run against the one-line extraction summary — reject it
+    explicitly instead.
+    """
+    if not adapter_instance_id:
+        return
+    config = _resolve_image_mode_config(shim, str(adapter_instance_id), execution_id)
+    if config is not None:
+        raise VlmImageAnswerError(
+            f"{operation} is not supported in image output mode. Run "
+            "prompts individually, or switch the profile's text extractor "
+            "to a text output mode.",
+            error_code=IMAGE_OUTPUT_UNSUPPORTED_OPERATION,
+        )

--- a/workers/executor/executors/vlm_image_answer.py
+++ b/workers/executor/executors/vlm_image_answer.py
@@ -37,6 +37,7 @@ from unstract.sdk1.adapters.x2text.page_image_loader import (
     PageCapExceededError,
     PageImageLoadError,
     PageImageSetIncompleteError,
+    PageImageSetTooLargeError,
     PageImagesNotFoundError,
 )
 from unstract.sdk1.platform import PlatformHelper
@@ -50,28 +51,34 @@ PLUGIN_NAME = "vlm-image-answer"
 IMAGE_OUTPUT_REQUIRES_CLOUD = "IMAGE_OUTPUT_REQUIRES_CLOUD"
 IMAGE_OUTPUT_MISSING = "IMAGE_OUTPUT_MISSING"
 IMAGE_PAGE_CAP_EXCEEDED = "IMAGE_PAGE_CAP_EXCEEDED"
+IMAGE_PAGES_TOO_LARGE = "IMAGE_PAGES_TOO_LARGE"
 IMAGE_OUTPUT_UNSUPPORTED_OPERATION = "IMAGE_OUTPUT_UNSUPPORTED_OPERATION"
 VISION_LLM_REQUIRED = "VISION_LLM_REQUIRED"
 
 _LLMWHISPERER_ADAPTER_PREFIX = "llmwhisperer|"
 
-# (execution_id, adapter_instance_id) -> resolved config dict | None.
-# Execution-scoped so adapter edits are picked up by the next run; bounded
-# so a long-lived worker never grows it unchecked.
+# (scope_id, adapter_instance_id) -> resolved config dict | None, where
+# scope_id is the execution id or (for IDE runs, which carry no execution
+# id) the run id. Run-scoped on purpose: the cache exists to deduplicate
+# the N per-prompt resolutions within ONE run — never to cache across
+# runs, where it would pin a stale output mode after an adapter edit.
+# Bounded so a long-lived worker never grows it unchecked.
 _MODE_CACHE: OrderedDict[tuple[str, str], dict[str, Any] | None] = OrderedDict()
 _MODE_CACHE_MAX = 256
 
 
 def _resolve_image_mode_config(
-    shim: Any, adapter_instance_id: str, execution_id: str
+    shim: Any, adapter_instance_id: str, scope_id: str
 ) -> dict[str, Any] | None:
     """Return the x2text adapter config when it is in image mode, else None.
 
     Resolution goes through the platform service (the payload has no
-    adapter metadata); results are cached per (execution, adapter).
+    adapter metadata); results are cached per (scope, adapter). With no
+    scope id at all, caching is skipped entirely — a shared ("", adapter)
+    entry would serve a stale mode to every later run on this worker.
     """
-    cache_key = (execution_id, adapter_instance_id)
-    if cache_key in _MODE_CACHE:
+    cache_key = (scope_id, adapter_instance_id)
+    if scope_id and cache_key in _MODE_CACHE:
         _MODE_CACHE.move_to_end(cache_key)
         return _MODE_CACHE[cache_key]
 
@@ -84,9 +91,10 @@ def _resolve_image_mode_config(
     )
 
     result = config if is_image_mode else None
-    _MODE_CACHE[cache_key] = result
-    while len(_MODE_CACHE) > _MODE_CACHE_MAX:
-        _MODE_CACHE.popitem(last=False)
+    if scope_id:
+        _MODE_CACHE[cache_key] = result
+        while len(_MODE_CACHE) > _MODE_CACHE_MAX:
+            _MODE_CACHE.popitem(last=False)
     return result
 
 
@@ -119,8 +127,10 @@ def run_vlm_image_answer(
         return None
 
     usage_kwargs = usage_kwargs or {}
-    execution_id = str(usage_kwargs.get("execution_id", ""))
-    x2text_config = _resolve_image_mode_config(shim, adapter_instance_id, execution_id)
+    # IDE payloads carry no execution_id — fall back to the run id so the
+    # cache stays scoped to one run (see _MODE_CACHE).
+    scope_id = str(usage_kwargs.get("execution_id") or usage_kwargs.get("run_id") or "")
+    x2text_config = _resolve_image_mode_config(shim, adapter_instance_id, scope_id)
     if x2text_config is None:
         return None
 
@@ -154,6 +164,8 @@ def run_vlm_image_answer(
         raise VlmImageAnswerError(str(e), error_code=IMAGE_OUTPUT_MISSING) from e
     except PageCapExceededError as e:
         raise VlmImageAnswerError(str(e), error_code=IMAGE_PAGE_CAP_EXCEEDED) from e
+    except PageImageSetTooLargeError as e:
+        raise VlmImageAnswerError(str(e), error_code=IMAGE_PAGES_TOO_LARGE) from e
     except PageImageLoadError as e:
         raise VlmImageAnswerError(str(e), error_code=IMAGE_OUTPUT_MISSING) from e
     except VlmImageAnswerError:
@@ -181,7 +193,7 @@ def raise_if_image_mode_unsupported(
     operation: str,
     adapter_instance_id: str | None,
     shim: Any,
-    execution_id: str = "",
+    scope_id: str = "",
 ) -> None:
     """Guard operations that cannot run against image-mode documents.
 
@@ -191,7 +203,7 @@ def raise_if_image_mode_unsupported(
     """
     if not adapter_instance_id:
         return
-    config = _resolve_image_mode_config(shim, str(adapter_instance_id), execution_id)
+    config = _resolve_image_mode_config(shim, str(adapter_instance_id), scope_id)
     if config is not None:
         raise VlmImageAnswerError(
             f"{operation} is not supported in image output mode. Run "

--- a/workers/executor/executors/vlm_image_answer.py
+++ b/workers/executor/executors/vlm_image_answer.py
@@ -98,42 +98,71 @@ def _resolve_image_mode_config(
     return result
 
 
-def run_vlm_image_answer(
+def detect_image_mode_config(
     *,
     output: dict[str, Any],
     shim: Any,
-    llm: Any,
-    file_path: str,
-    execution_source: str,
-    metadata: dict[str, Any],
-    metrics: dict[str, Any],
     usage_kwargs: dict[str, Any] | None = None,
-) -> str | None:
-    """Answer an image-mode prompt via the cloud plugin.
+) -> dict[str, Any] | None:
+    """Detect image mode for one prompt; None means normal text path.
 
-    Returns:
-        The raw answer string when the prompt's x2text adapter is in image
-        mode (the caller assigns it in place of the RAG/completion answer,
-        so type conversion, lookups, webhooks etc. run unchanged), or
-        ``None`` when not in image mode (normal path continues).
+    Fast path: the backend stamps the adapter's ``x2text_output_mode``
+    onto the per-prompt payload (it already holds the decrypted adapter
+    metadata), so text-mode prompts cost nothing here. The platform-
+    service resolution runs only as the fallback for payloads without
+    the stamp (e.g. API deployments, older payloads).
 
-    Raises:
-        VlmImageAnswerError: image mode detected but the cloud plugin is
-            not installed, or the vision path failed in a way the user
-            must act on (missing images, page cap, non-vision LLM).
+    Returns the resolved adapter config for the plugin, or ``{}`` when
+    image mode was determined from the stamp alone.
     """
     adapter_instance_id = str(output.get(PSKeys.X2TEXT_ADAPTER) or "")
     if not adapter_instance_id:
+        return None
+
+    if PSKeys.X2TEXT_OUTPUT_MODE in output:
+        stamped_mode = output.get(PSKeys.X2TEXT_OUTPUT_MODE)
+        if stamped_mode == ImageOutputConstants.IMAGE_MODE:
+            return {}
         return None
 
     usage_kwargs = usage_kwargs or {}
     # IDE payloads carry no execution_id — fall back to the run id so the
     # cache stays scoped to one run (see _MODE_CACHE).
     scope_id = str(usage_kwargs.get("execution_id") or usage_kwargs.get("run_id") or "")
-    x2text_config = _resolve_image_mode_config(shim, adapter_instance_id, scope_id)
-    if x2text_config is None:
-        return None
+    return _resolve_image_mode_config(shim, adapter_instance_id, scope_id)
 
+
+def run_vlm_image_answer(
+    *,
+    output: dict[str, Any],
+    shim: Any,
+    llm: Any,
+    extract_file_path: str,
+    execution_source: str,
+    metadata: dict[str, Any],
+    metrics: dict[str, Any],
+    x2text_config: dict[str, Any],
+    usage_kwargs: dict[str, Any] | None = None,
+) -> str:
+    """Answer an image-mode prompt via the cloud plugin.
+
+    The caller has already detected image mode via
+    ``detect_image_mode_config``. ``extract_file_path`` must be the
+    extract-file path (never the summarize/source rewrite of it) — the
+    pages directory is derived from it via the shared writer/reader
+    helper.
+
+    Returns:
+        The raw answer string (the caller assigns it in place of the
+        RAG/completion answer, so type conversion, lookups, webhooks
+        etc. run unchanged).
+
+    Raises:
+        VlmImageAnswerError: the cloud plugin is not installed, or the
+            vision path failed in a way the user must act on (missing
+            images, page cap, non-vision LLM).
+    """
+    usage_kwargs = usage_kwargs or {}
     prompt_name = output.get(PSKeys.NAME, "")
     plugin_cls = ExecutorPluginLoader.get(PLUGIN_NAME)
     if plugin_cls is None:
@@ -147,7 +176,7 @@ def run_vlm_image_answer(
 
     shim.stream_log(f"Answering `{prompt_name}` from page images via vision LLM")
     fs = FileUtils.get_fs_instance(execution_source=execution_source)
-    page_store_dir = build_page_store_dir(file_path, file_path)
+    page_store_dir = build_page_store_dir(extract_file_path, extract_file_path)
 
     try:
         outcome = plugin_cls.run_with_metrics(

--- a/workers/executor/tests/test_vlm_image_answer_bridge.py
+++ b/workers/executor/tests/test_vlm_image_answer_bridge.py
@@ -1,0 +1,233 @@
+"""Tests for the OSS vlm_image_answer bridge (detection + dispatch).
+
+The bridge must: detect image mode from the resolved x2text adapter
+config (never from payload metadata, which doesn't exist), raise a
+structured plugin-absent error instead of falling through to the text
+path, map sdk1 loader errors to stable error codes, and return None for
+non-image adapters so the normal path continues untouched.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from executor.executors.exceptions import VlmImageAnswerError  # noqa: E402
+from executor.executors.vlm_image_answer import (  # noqa: E402
+    _MODE_CACHE,
+    IMAGE_OUTPUT_MISSING,
+    IMAGE_OUTPUT_REQUIRES_CLOUD,
+    IMAGE_OUTPUT_UNSUPPORTED_OPERATION,
+    IMAGE_PAGE_CAP_EXCEEDED,
+    raise_if_image_mode_unsupported,
+    run_vlm_image_answer,
+)
+
+from unstract.sdk1.adapters.x2text.page_image_loader import (  # noqa: E402
+    PageCapExceededError,
+    PageImagesNotFoundError,
+)
+
+_IMAGE_CONFIG = {
+    "adapter_id": "llmwhisperer|0a1647f0-f65f-410d-843b-3d979c78350e",
+    "adapter_metadata": {"output_mode": "image", "url": "http://svc"},
+}
+_TEXT_CONFIG = {
+    "adapter_id": "llmwhisperer|0a1647f0-f65f-410d-843b-3d979c78350e",
+    "adapter_metadata": {"output_mode": "layout_preserving"},
+}
+_OTHER_ADAPTER_CONFIG = {
+    "adapter_id": "someocr|123",
+    "adapter_metadata": {"output_mode": "image"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _MODE_CACHE.clear()
+    yield
+    _MODE_CACHE.clear()
+
+
+def _call(output=None, plugin=None, adapter_config=_IMAGE_CONFIG, **overrides):
+    output = output or {"x2text_adapter": "uuid-1", "name": "p1", "promptx": "q?"}
+    kwargs = {
+        "output": output,
+        "shim": MagicMock(),
+        "llm": MagicMock(),
+        "file_path": "/data/extract/doc.txt",
+        "execution_source": "ide",
+        "metadata": {"context": {}},
+        "metrics": {},
+        "usage_kwargs": {"run_id": "r1", "execution_id": "e1"},
+    }
+    kwargs.update(overrides)
+    with (
+        patch(
+            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+            return_value=adapter_config,
+        ),
+        patch(
+            "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
+            return_value=plugin,
+        ),
+        patch(
+            "executor.executors.vlm_image_answer.FileUtils.get_fs_instance",
+            return_value=MagicMock(),
+        ),
+    ):
+        return run_vlm_image_answer(**kwargs)
+
+
+class TestDetection:
+    def test_non_image_mode_returns_none(self):
+        assert _call(adapter_config=_TEXT_CONFIG) is None
+
+    def test_non_llmwhisperer_adapter_returns_none(self):
+        # Another adapter with a coincidental output_mode key is not gated.
+        assert _call(adapter_config=_OTHER_ADAPTER_CONFIG) is None
+
+    def test_missing_adapter_id_returns_none_without_platform_call(self):
+        with patch(
+            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config"
+        ) as resolve:
+            result = run_vlm_image_answer(
+                output={"name": "p1"},
+                shim=MagicMock(),
+                llm=MagicMock(),
+                file_path="/f.txt",
+                execution_source="ide",
+                metadata={},
+                metrics={},
+            )
+        assert result is None
+        resolve.assert_not_called()
+
+    def test_resolution_cached_per_execution_and_adapter(self):
+        plugin = MagicMock()
+        plugin.run_with_metrics.return_value = {"answer": "a"}
+        with (
+            patch(
+                "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+                return_value=_IMAGE_CONFIG,
+            ) as resolve,
+            patch(
+                "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
+                return_value=plugin,
+            ),
+            patch(
+                "executor.executors.vlm_image_answer.FileUtils.get_fs_instance",
+                return_value=MagicMock(),
+            ),
+        ):
+            common = {
+                "shim": MagicMock(),
+                "llm": MagicMock(),
+                "file_path": "/data/extract/doc.txt",
+                "execution_source": "ide",
+                "metadata": {"context": {}},
+                "metrics": {},
+                "usage_kwargs": {"execution_id": "e1"},
+            }
+            for _ in range(3):  # three prompts, same adapter + execution
+                run_vlm_image_answer(
+                    output={"x2text_adapter": "uuid-1", "name": "p"}, **common
+                )
+        assert resolve.call_count == 1
+
+
+class TestPluginAbsent:
+    def test_raises_structured_error_never_falls_through(self):
+        with pytest.raises(VlmImageAnswerError) as excinfo:
+            _call(plugin=None)
+        assert excinfo.value.error_code == IMAGE_OUTPUT_REQUIRES_CLOUD
+        assert str(excinfo.value).startswith(IMAGE_OUTPUT_REQUIRES_CLOUD + ":")
+        assert "Unstract Cloud" in str(excinfo.value)
+
+
+class TestPluginDispatch:
+    def test_answer_and_page_store_dir_contract(self):
+        plugin = MagicMock()
+        plugin.run_with_metrics.return_value = {"answer": "42", "llm_metrics": {"t": 1}}
+        metrics = {}
+        answer = _call(plugin=plugin, metrics=metrics)
+        assert answer == "42"
+        call_kwargs = plugin.run_with_metrics.call_args.kwargs
+        # Deterministic path derived from the extract file path via the
+        # shared helper — the writer/reader agreement contract.
+        assert call_kwargs["page_store_dir"] == "/data/extract/doc/pages"
+        assert call_kwargs["x2text_config"] == _IMAGE_CONFIG
+        assert metrics["p1"]["vlm_image_answer"] == {"t": 1}
+
+    def test_loader_not_found_maps_to_image_output_missing(self):
+        plugin = MagicMock()
+        plugin.run_with_metrics.side_effect = PageImagesNotFoundError(
+            "no images", page_store_dir="/d/pages"
+        )
+        with pytest.raises(VlmImageAnswerError) as excinfo:
+            _call(plugin=plugin)
+        assert excinfo.value.error_code == IMAGE_OUTPUT_MISSING
+
+    def test_cap_error_maps_to_page_cap_code(self):
+        plugin = MagicMock()
+        plugin.run_with_metrics.side_effect = PageCapExceededError(
+            "too big", page_store_dir="/d/pages", page_count=50, page_cap=20
+        )
+        with pytest.raises(VlmImageAnswerError) as excinfo:
+            _call(plugin=plugin)
+        assert excinfo.value.error_code == IMAGE_PAGE_CAP_EXCEEDED
+
+    def test_plugin_error_code_attribute_is_wrapped(self):
+        class VisionError(Exception):
+            error_code = "VISION_LLM_REQUIRED"
+
+        plugin = MagicMock()
+        plugin.run_with_metrics.side_effect = VisionError("model X has no vision")
+        with pytest.raises(VlmImageAnswerError) as excinfo:
+            _call(plugin=plugin)
+        assert excinfo.value.error_code == "VISION_LLM_REQUIRED"
+        assert "model X has no vision" in str(excinfo.value)
+
+    def test_unexpected_plugin_error_propagates_unwrapped(self):
+        plugin = MagicMock()
+        plugin.run_with_metrics.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            _call(plugin=plugin)
+
+
+class TestUnsupportedOperationGuard:
+    def test_single_pass_rejected_for_image_mode(self):
+        with patch(
+            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+            return_value=_IMAGE_CONFIG,
+        ):
+            with pytest.raises(VlmImageAnswerError) as excinfo:
+                raise_if_image_mode_unsupported(
+                    operation="Single-pass extraction",
+                    adapter_instance_id="uuid-1",
+                    shim=MagicMock(),
+                    execution_id="e1",
+                )
+        assert excinfo.value.error_code == IMAGE_OUTPUT_UNSUPPORTED_OPERATION
+
+    def test_text_mode_passes(self):
+        with patch(
+            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+            return_value=_TEXT_CONFIG,
+        ):
+            raise_if_image_mode_unsupported(
+                operation="Single-pass extraction",
+                adapter_instance_id="uuid-1",
+                shim=MagicMock(),
+                execution_id="e1",
+            )  # no raise
+
+    def test_no_adapter_id_passes(self):
+        raise_if_image_mode_unsupported(
+            operation="Single-pass extraction",
+            adapter_instance_id=None,
+            shim=MagicMock(),
+        )  # no raise, no platform call

--- a/workers/executor/tests/test_vlm_image_answer_bridge.py
+++ b/workers/executor/tests/test_vlm_image_answer_bridge.py
@@ -22,12 +22,14 @@ from executor.executors.vlm_image_answer import (  # noqa: E402
     IMAGE_OUTPUT_REQUIRES_CLOUD,
     IMAGE_OUTPUT_UNSUPPORTED_OPERATION,
     IMAGE_PAGE_CAP_EXCEEDED,
+    IMAGE_PAGES_TOO_LARGE,
     raise_if_image_mode_unsupported,
     run_vlm_image_answer,
 )
 
 from unstract.sdk1.adapters.x2text.page_image_loader import (  # noqa: E402
     PageCapExceededError,
+    PageImageSetTooLargeError,
     PageImagesNotFoundError,
 )
 
@@ -138,6 +140,75 @@ class TestDetection:
                 )
         assert resolve.call_count == 1
 
+    def test_run_id_scopes_cache_when_execution_id_missing(self):
+        # IDE payloads carry no execution_id: two RUNS on the same adapter
+        # must each resolve fresh (an adapter edit between runs takes
+        # effect), while prompts within one run share the cached result.
+        plugin = MagicMock()
+        plugin.run_with_metrics.return_value = {"answer": "a"}
+        with (
+            patch(
+                "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+                return_value=_IMAGE_CONFIG,
+            ) as resolve,
+            patch(
+                "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
+                return_value=plugin,
+            ),
+            patch(
+                "executor.executors.vlm_image_answer.FileUtils.get_fs_instance",
+                return_value=MagicMock(),
+            ),
+        ):
+            common = {
+                "shim": MagicMock(),
+                "llm": MagicMock(),
+                "file_path": "/data/extract/doc.txt",
+                "execution_source": "ide",
+                "metadata": {"context": {}},
+                "metrics": {},
+            }
+            for run in ("run-1", "run-2"):
+                for _ in range(2):  # two prompts per run
+                    run_vlm_image_answer(
+                        output={"x2text_adapter": "uuid-1", "name": "p"},
+                        usage_kwargs={"run_id": run},
+                        **common,
+                    )
+        assert resolve.call_count == 2  # once per run, not once total
+
+    def test_no_scope_id_never_caches(self):
+        # With neither execution_id nor run_id, a shared ("", adapter)
+        # entry would pin a stale mode forever — caching must be skipped.
+        plugin = MagicMock()
+        plugin.run_with_metrics.return_value = {"answer": "a"}
+        with (
+            patch(
+                "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+                return_value=_IMAGE_CONFIG,
+            ) as resolve,
+            patch(
+                "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
+                return_value=plugin,
+            ),
+            patch(
+                "executor.executors.vlm_image_answer.FileUtils.get_fs_instance",
+                return_value=MagicMock(),
+            ),
+        ):
+            for _ in range(3):
+                run_vlm_image_answer(
+                    output={"x2text_adapter": "uuid-1", "name": "p"},
+                    shim=MagicMock(),
+                    llm=MagicMock(),
+                    file_path="/data/extract/doc.txt",
+                    execution_source="ide",
+                    metadata={"context": {}},
+                    metrics={},
+                    usage_kwargs={},
+                )
+        assert resolve.call_count == 3
+
 
 class TestPluginAbsent:
     def test_raises_structured_error_never_falls_through(self):
@@ -180,6 +251,18 @@ class TestPluginDispatch:
             _call(plugin=plugin)
         assert excinfo.value.error_code == IMAGE_PAGE_CAP_EXCEEDED
 
+    def test_too_large_error_maps_to_pages_too_large_code(self):
+        plugin = MagicMock()
+        plugin.run_with_metrics.side_effect = PageImageSetTooLargeError(
+            "too many bytes",
+            page_store_dir="/d/pages",
+            total_bytes=99,
+            max_total_bytes=10,
+        )
+        with pytest.raises(VlmImageAnswerError) as excinfo:
+            _call(plugin=plugin)
+        assert excinfo.value.error_code == IMAGE_PAGES_TOO_LARGE
+
     def test_plugin_error_code_attribute_is_wrapped(self):
         class VisionError(Exception):
             error_code = "VISION_LLM_REQUIRED"
@@ -209,7 +292,7 @@ class TestUnsupportedOperationGuard:
                     operation="Single-pass extraction",
                     adapter_instance_id="uuid-1",
                     shim=MagicMock(),
-                    execution_id="e1",
+                    scope_id="e1",
                 )
         assert excinfo.value.error_code == IMAGE_OUTPUT_UNSUPPORTED_OPERATION
 
@@ -222,7 +305,7 @@ class TestUnsupportedOperationGuard:
                 operation="Single-pass extraction",
                 adapter_instance_id="uuid-1",
                 shim=MagicMock(),
-                execution_id="e1",
+                scope_id="e1",
             )  # no raise
 
     def test_no_adapter_id_passes(self):

--- a/workers/executor/tests/test_vlm_image_answer_bridge.py
+++ b/workers/executor/tests/test_vlm_image_answer_bridge.py
@@ -1,10 +1,11 @@
 """Tests for the OSS vlm_image_answer bridge (detection + dispatch).
 
-The bridge must: detect image mode from the resolved x2text adapter
-config (never from payload metadata, which doesn't exist), raise a
+Detection must prefer the backend's per-prompt output-mode stamp (zero
+platform calls for text mode), fall back to run-scoped platform
+resolution, and never cache without a scope id. Dispatch must raise a
 structured plugin-absent error instead of falling through to the text
-path, map sdk1 loader errors to stable error codes, and return None for
-non-image adapters so the normal path continues untouched.
+path, key the pages directory on the never-rewritten extract path, and
+map sdk1 loader errors to stable error codes.
 """
 
 import sys
@@ -23,6 +24,7 @@ from executor.executors.vlm_image_answer import (  # noqa: E402
     IMAGE_OUTPUT_UNSUPPORTED_OPERATION,
     IMAGE_PAGE_CAP_EXCEEDED,
     IMAGE_PAGES_TOO_LARGE,
+    detect_image_mode_config,
     raise_if_image_mode_unsupported,
     run_vlm_image_answer,
 )
@@ -54,24 +56,133 @@ def _clear_cache():
     _MODE_CACHE.clear()
 
 
-def _call(output=None, plugin=None, adapter_config=_IMAGE_CONFIG, **overrides):
-    output = output or {"x2text_adapter": "uuid-1", "name": "p1", "promptx": "q?"}
+def _detect(output=None, adapter_config=_IMAGE_CONFIG, usage_kwargs=None):
+    output = output or {"x2text_adapter": "uuid-1", "name": "p1"}
+    with patch(
+        "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+        return_value=adapter_config,
+    ) as resolve:
+        result = detect_image_mode_config(
+            output=output,
+            shim=MagicMock(),
+            usage_kwargs=usage_kwargs or {"execution_id": "e1"},
+        )
+    return result, resolve
+
+
+class TestDetection:
+    def test_image_mode_returns_config(self):
+        result, _ = _detect()
+        assert result == _IMAGE_CONFIG
+
+    def test_non_image_mode_returns_none(self):
+        result, _ = _detect(adapter_config=_TEXT_CONFIG)
+        assert result is None
+
+    def test_non_llmwhisperer_adapter_returns_none(self):
+        # Another adapter with a coincidental output_mode key is not gated.
+        result, _ = _detect(adapter_config=_OTHER_ADAPTER_CONFIG)
+        assert result is None
+
+    def test_missing_adapter_id_returns_none_without_platform_call(self):
+        result, resolve = _detect(output={"name": "p1"})
+        assert result is None
+        resolve.assert_not_called()
+
+
+class TestStampedDetection:
+    """The backend stamp is the fast path — zero platform calls."""
+
+    def test_stamped_image_mode_detected_without_platform_call(self):
+        result, resolve = _detect(
+            output={
+                "x2text_adapter": "uuid-1",
+                "name": "p1",
+                "x2text_output_mode": "image",
+            }
+        )
+        assert result == {}
+        resolve.assert_not_called()
+
+    @pytest.mark.parametrize("mode", ["layout_preserving", "text", None])
+    def test_stamped_non_image_mode_skips_platform_call(self, mode):
+        result, resolve = _detect(
+            output={
+                "x2text_adapter": "uuid-1",
+                "name": "p1",
+                "x2text_output_mode": mode,
+            }
+        )
+        assert result is None
+        resolve.assert_not_called()
+
+    def test_unstamped_payload_falls_back_to_platform(self):
+        result, resolve = _detect(output={"x2text_adapter": "uuid-1", "name": "p1"})
+        assert result == _IMAGE_CONFIG
+        resolve.assert_called_once()
+
+
+class TestResolutionCache:
+    def test_resolution_cached_per_execution_and_adapter(self):
+        with patch(
+            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+            return_value=_IMAGE_CONFIG,
+        ) as resolve:
+            for _ in range(3):  # three prompts, same adapter + execution
+                detect_image_mode_config(
+                    output={"x2text_adapter": "uuid-1", "name": "p"},
+                    shim=MagicMock(),
+                    usage_kwargs={"execution_id": "e1"},
+                )
+        assert resolve.call_count == 1
+
+    def test_run_id_scopes_cache_when_execution_id_missing(self):
+        # IDE payloads carry no execution_id: two RUNS on the same adapter
+        # must each resolve fresh (an adapter edit between runs takes
+        # effect), while prompts within one run share the cached result.
+        with patch(
+            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+            return_value=_IMAGE_CONFIG,
+        ) as resolve:
+            for run in ("run-1", "run-2"):
+                for _ in range(2):  # two prompts per run
+                    detect_image_mode_config(
+                        output={"x2text_adapter": "uuid-1", "name": "p"},
+                        shim=MagicMock(),
+                        usage_kwargs={"run_id": run},
+                    )
+        assert resolve.call_count == 2  # once per run, not once total
+
+    def test_no_scope_id_never_caches(self):
+        # With neither execution_id nor run_id, a shared ("", adapter)
+        # entry would pin a stale mode forever — caching must be skipped.
+        with patch(
+            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
+            return_value=_IMAGE_CONFIG,
+        ) as resolve:
+            for _ in range(3):
+                detect_image_mode_config(
+                    output={"x2text_adapter": "uuid-1", "name": "p"},
+                    shim=MagicMock(),
+                    usage_kwargs={},
+                )
+        assert resolve.call_count == 3
+
+
+def _run(plugin=None, x2text_config=_IMAGE_CONFIG, metrics=None, **overrides):
     kwargs = {
-        "output": output,
+        "output": {"x2text_adapter": "uuid-1", "name": "p1", "promptx": "q?"},
         "shim": MagicMock(),
         "llm": MagicMock(),
-        "file_path": "/data/extract/doc.txt",
+        "extract_file_path": "/data/extract/doc.txt",
         "execution_source": "ide",
         "metadata": {"context": {}},
-        "metrics": {},
+        "metrics": metrics if metrics is not None else {},
+        "x2text_config": x2text_config,
         "usage_kwargs": {"run_id": "r1", "execution_id": "e1"},
     }
     kwargs.update(overrides)
     with (
-        patch(
-            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
-            return_value=adapter_config,
-        ),
         patch(
             "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
             return_value=plugin,
@@ -84,136 +195,10 @@ def _call(output=None, plugin=None, adapter_config=_IMAGE_CONFIG, **overrides):
         return run_vlm_image_answer(**kwargs)
 
 
-class TestDetection:
-    def test_non_image_mode_returns_none(self):
-        assert _call(adapter_config=_TEXT_CONFIG) is None
-
-    def test_non_llmwhisperer_adapter_returns_none(self):
-        # Another adapter with a coincidental output_mode key is not gated.
-        assert _call(adapter_config=_OTHER_ADAPTER_CONFIG) is None
-
-    def test_missing_adapter_id_returns_none_without_platform_call(self):
-        with patch(
-            "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config"
-        ) as resolve:
-            result = run_vlm_image_answer(
-                output={"name": "p1"},
-                shim=MagicMock(),
-                llm=MagicMock(),
-                file_path="/f.txt",
-                execution_source="ide",
-                metadata={},
-                metrics={},
-            )
-        assert result is None
-        resolve.assert_not_called()
-
-    def test_resolution_cached_per_execution_and_adapter(self):
-        plugin = MagicMock()
-        plugin.run_with_metrics.return_value = {"answer": "a"}
-        with (
-            patch(
-                "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
-                return_value=_IMAGE_CONFIG,
-            ) as resolve,
-            patch(
-                "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
-                return_value=plugin,
-            ),
-            patch(
-                "executor.executors.vlm_image_answer.FileUtils.get_fs_instance",
-                return_value=MagicMock(),
-            ),
-        ):
-            common = {
-                "shim": MagicMock(),
-                "llm": MagicMock(),
-                "file_path": "/data/extract/doc.txt",
-                "execution_source": "ide",
-                "metadata": {"context": {}},
-                "metrics": {},
-                "usage_kwargs": {"execution_id": "e1"},
-            }
-            for _ in range(3):  # three prompts, same adapter + execution
-                run_vlm_image_answer(
-                    output={"x2text_adapter": "uuid-1", "name": "p"}, **common
-                )
-        assert resolve.call_count == 1
-
-    def test_run_id_scopes_cache_when_execution_id_missing(self):
-        # IDE payloads carry no execution_id: two RUNS on the same adapter
-        # must each resolve fresh (an adapter edit between runs takes
-        # effect), while prompts within one run share the cached result.
-        plugin = MagicMock()
-        plugin.run_with_metrics.return_value = {"answer": "a"}
-        with (
-            patch(
-                "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
-                return_value=_IMAGE_CONFIG,
-            ) as resolve,
-            patch(
-                "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
-                return_value=plugin,
-            ),
-            patch(
-                "executor.executors.vlm_image_answer.FileUtils.get_fs_instance",
-                return_value=MagicMock(),
-            ),
-        ):
-            common = {
-                "shim": MagicMock(),
-                "llm": MagicMock(),
-                "file_path": "/data/extract/doc.txt",
-                "execution_source": "ide",
-                "metadata": {"context": {}},
-                "metrics": {},
-            }
-            for run in ("run-1", "run-2"):
-                for _ in range(2):  # two prompts per run
-                    run_vlm_image_answer(
-                        output={"x2text_adapter": "uuid-1", "name": "p"},
-                        usage_kwargs={"run_id": run},
-                        **common,
-                    )
-        assert resolve.call_count == 2  # once per run, not once total
-
-    def test_no_scope_id_never_caches(self):
-        # With neither execution_id nor run_id, a shared ("", adapter)
-        # entry would pin a stale mode forever — caching must be skipped.
-        plugin = MagicMock()
-        plugin.run_with_metrics.return_value = {"answer": "a"}
-        with (
-            patch(
-                "executor.executors.vlm_image_answer.PlatformHelper.get_adapter_config",
-                return_value=_IMAGE_CONFIG,
-            ) as resolve,
-            patch(
-                "executor.executors.vlm_image_answer.ExecutorPluginLoader.get",
-                return_value=plugin,
-            ),
-            patch(
-                "executor.executors.vlm_image_answer.FileUtils.get_fs_instance",
-                return_value=MagicMock(),
-            ),
-        ):
-            for _ in range(3):
-                run_vlm_image_answer(
-                    output={"x2text_adapter": "uuid-1", "name": "p"},
-                    shim=MagicMock(),
-                    llm=MagicMock(),
-                    file_path="/data/extract/doc.txt",
-                    execution_source="ide",
-                    metadata={"context": {}},
-                    metrics={},
-                    usage_kwargs={},
-                )
-        assert resolve.call_count == 3
-
-
 class TestPluginAbsent:
     def test_raises_structured_error_never_falls_through(self):
         with pytest.raises(VlmImageAnswerError) as excinfo:
-            _call(plugin=None)
+            _run(plugin=None)
         assert excinfo.value.error_code == IMAGE_OUTPUT_REQUIRES_CLOUD
         assert str(excinfo.value).startswith(IMAGE_OUTPUT_REQUIRES_CLOUD + ":")
         assert "Unstract Cloud" in str(excinfo.value)
@@ -224,7 +209,7 @@ class TestPluginDispatch:
         plugin = MagicMock()
         plugin.run_with_metrics.return_value = {"answer": "42", "llm_metrics": {"t": 1}}
         metrics = {}
-        answer = _call(plugin=plugin, metrics=metrics)
+        answer = _run(plugin=plugin, metrics=metrics)
         assert answer == "42"
         call_kwargs = plugin.run_with_metrics.call_args.kwargs
         # Deterministic path derived from the extract file path via the
@@ -233,13 +218,22 @@ class TestPluginDispatch:
         assert call_kwargs["x2text_config"] == _IMAGE_CONFIG
         assert metrics["p1"]["vlm_image_answer"] == {"t": 1}
 
+    def test_pages_dir_keys_on_extract_path_not_rewritten_file_path(self):
+        # Summarize-as-source / smart-table rewrite the payload FILE_PATH;
+        # the reader must key on the extract path regardless.
+        plugin = MagicMock()
+        plugin.run_with_metrics.return_value = {"answer": "a"}
+        _run(plugin=plugin, extract_file_path="/data/extract/report.txt")
+        call_kwargs = plugin.run_with_metrics.call_args.kwargs
+        assert call_kwargs["page_store_dir"] == "/data/extract/report/pages"
+
     def test_loader_not_found_maps_to_image_output_missing(self):
         plugin = MagicMock()
         plugin.run_with_metrics.side_effect = PageImagesNotFoundError(
             "no images", page_store_dir="/d/pages"
         )
         with pytest.raises(VlmImageAnswerError) as excinfo:
-            _call(plugin=plugin)
+            _run(plugin=plugin)
         assert excinfo.value.error_code == IMAGE_OUTPUT_MISSING
 
     def test_cap_error_maps_to_page_cap_code(self):
@@ -248,7 +242,7 @@ class TestPluginDispatch:
             "too big", page_store_dir="/d/pages", page_count=50, page_cap=20
         )
         with pytest.raises(VlmImageAnswerError) as excinfo:
-            _call(plugin=plugin)
+            _run(plugin=plugin)
         assert excinfo.value.error_code == IMAGE_PAGE_CAP_EXCEEDED
 
     def test_too_large_error_maps_to_pages_too_large_code(self):
@@ -260,7 +254,7 @@ class TestPluginDispatch:
             max_total_bytes=10,
         )
         with pytest.raises(VlmImageAnswerError) as excinfo:
-            _call(plugin=plugin)
+            _run(plugin=plugin)
         assert excinfo.value.error_code == IMAGE_PAGES_TOO_LARGE
 
     def test_plugin_error_code_attribute_is_wrapped(self):
@@ -270,7 +264,7 @@ class TestPluginDispatch:
         plugin = MagicMock()
         plugin.run_with_metrics.side_effect = VisionError("model X has no vision")
         with pytest.raises(VlmImageAnswerError) as excinfo:
-            _call(plugin=plugin)
+            _run(plugin=plugin)
         assert excinfo.value.error_code == "VISION_LLM_REQUIRED"
         assert "model X has no vision" in str(excinfo.value)
 
@@ -278,7 +272,7 @@ class TestPluginDispatch:
         plugin = MagicMock()
         plugin.run_with_metrics.side_effect = RuntimeError("boom")
         with pytest.raises(RuntimeError, match="boom"):
-            _call(plugin=plugin)
+            _run(plugin=plugin)
 
 
 class TestUnsupportedOperationGuard:

--- a/workers/file_processing/structure_tool_task.py
+++ b/workers/file_processing/structure_tool_task.py
@@ -397,6 +397,9 @@ def _execute_structure_tool_impl(params: dict) -> dict:
         _SK.FILE_HASH: file_hash,
         _SK.FILE_NAME: file_name,
         _SK.FILE_PATH: extracted_input_file,
+        # Never rewritten (unlike FILE_PATH, which summarize/smart-table
+        # overrides mutate) — the page-image reader keys on this.
+        "extract_file_path": extracted_input_file,
         _SK.EXECUTION_SOURCE: _SK.TOOL,
         _SK.CUSTOM_DATA: custom_data,
         "PLATFORM_SERVICE_API_KEY": platform_service_api_key,


### PR DESCRIPTION
## What

The complete **OSS half of the VLM image-answer feature** (the cloud-only consumer that answers prompts against LLMWhisperer image-output documents by sending the persisted page images to a vision LLM). Four commits, reviewable independently:

1. **Shared page-path contract** — promotes `build_page_store_dir` (`{extract_dir}/{stem}/pages`) and the page-naming constants (`PAGE_GLOB_PATTERN`, `PAGE_NUMBER_REGEX`) from the LLMWhisperer helper to the shared x2text surface; the adapter binds the shared function by identity. The tolerant ZIP-ingest pattern stays adapter-local as a named `ZIP_PAGE_MEMBER_REGEX` (service wire contract ≠ storage contract).
2. **sdk1 reader utilities** — a FileStorage-backed page-image loader (natural sort by integer page index, fail-fast page cap, base64 + `complete_vision` content blocks with "Page N" labels, typed empty/partial/over-cap errors with cache-bypass + re-billing remediation copy) and a vision-capability policy (LiteLLM local-registry classification: SUPPORTED / UNSUPPORTED / UNKNOWN; hard-block only definitive UNSUPPORTED, warn-and-allow unknown/self-hosted — never `get_model_info`, which can make network calls for Ollama).
3. **OSS bridge** (`vlm_image_answer`, mirroring the `lookup_enrichment` bridge with the opposite error policy): detects image mode in the `answer_prompt` flow by resolving the x2text adapter config via the platform service (payload carries only the instance id), dispatches to the cloud `vlm-image-answer` executor plugin, and raises structured code-prefixed errors (`IMAGE_OUTPUT_REQUIRES_CLOUD`, `IMAGE_OUTPUT_MISSING`, `IMAGE_PAGE_CAP_EXCEEDED`, `VISION_LLM_REQUIRED`) when it cannot serve — never a silent fallthrough to the text path. Single-pass extraction is rejected for image-mode profiles. Backend `vlm_utils` no-op bridge wires: profile `vision_warning`, deploy-time guard, and re-extraction invalidation.
4. **FE**: profile save surfaces a backend-computed `vision_warning` toast (field never present in OSS responses).

## Why

- Image mode produces per-page PNGs and no text; without a consumer the executor would answer prompts against the one-line extraction summary — the prohibited silent-wrong-answer mode. The bridge guarantees image-mode prompts either reach the vision path (cloud) or fail loudly with an actionable error (OSS).
- Writer (adapter) and reader (consumer) share one path derivation and one naming contract by identity, so they can never drift — this is what makes the no-transport/no-manifest design safe.
- The consumer itself is a paid cloud feature; OSS ships only neutral sdk1 utilities, the bridge, and gating (companion cloud PR: Zipstack/unstract-cloud — `feat/vlm-image-answer`).

## How

- Hook placement: inside `_execute_single_prompt`, the image-mode branch replaces **only** retrieval + completion; type conversion, lookup enrichment, webhooks, challenge, and output persistence run unchanged, so image-mode answers behave identically downstream.
- Detection cache: per `(execution_id, adapter_instance_id)`, bounded — one platform-service call per adapter per run, and adapter edits are picked up on the next execution.
- Error codes are prefixed onto messages because `ExecutionResult.error` is string-only; the code survives verbatim to the Prompt Studio socket events and deployment API responses.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- **No.** Text/layout-mode prompts take the `vlm_answer is None` branch and behave byte-identically (the bridge returns `None` without a platform call when no x2text adapter id is present, and after one cached resolution otherwise). The path-contract refactor is behavior-preserving — all 57 pre-existing sdk1 image tests pass unmodified. The backend hooks are no-ops without the cloud package. The FE change keys off a response field OSS never emits.

## Database Migrations

- None.

## Env Config

- None required. (`VLM_IMAGE_ANSWER_PAGE_CAP` is read by the cloud plugin, not OSS.)

## Relevant Docs

- LLMWhisperer output modes: https://docs.unstract.com/llmwhisperer/llm_whisperer/apis/llm_whisperer_text_extraction_api/#output-modes

## Related Issues or PRs

- Jira: **UN-2646** (VLM consumer phase — modules MUNS-206..212).
- **Stacked on #2210** (adapter image output mode) — retargets to `main` when #2210 merges.
- Companion cloud PR: `unstract-cloud` `feat/vlm-image-answer` (executor plugin + backend hooks; the two halves meet only at runtime via the `unstract.executor.plugins` entry point and the `plugins.vlm_image_answer` package presence).

## Dependencies Versions

- None added.

## Notes on Testing

### Unit suites

- **sdk1: 123 pass** (26 path-contract + 23 loader incl. stale-listing/TOCTOU regressions + 13 vision-capability + pre-existing image suite with 5 new PDF-sniffing cases, rest unmodified).
- **workers: 13 pass** (`executor/tests/test_vlm_image_answer_bridge.py` — detection, per-execution caching, plugin-absent structured error, error-code mapping, single-pass guard).
- **backend: 20 pass** (8 `vlm_utils` bridge + 12 image-output gating).
- All with pinned ruff v0.3.4 clean.

### Live end-to-end validation (merged-tree Docker stack, MinIO object storage)

Run against a local rig with the companion cloud plugin installed, then removed — every path below verified in the running product:

| Path | Result |
|---|---|
| Prompt Studio happy path (1-page invoice) | ✅ Correct VLM answer **with spatial reasoning** ("upper right corner of the invoice…") — conclusive proof the answer came from the page image, since image mode has no extracted text |
| Multi-page (11-page doc, stem with spaces) | ✅ Ordered "Page N" delivery; token cost linear (1,559/page vs 1,570 single-page) |
| **API deployment E2E** (7-page PDF via `POST /deployment/api/...`) | ✅ After fixing the extension-less input bug (below); pages persisted under the execution dir on MinIO, answered by the vision LLM |
| Missing images — empty `pages/` | ✅ `IMAGE_OUTPUT_MISSING` with cache-bypass + per-page re-billing remediation |
| Missing images — partial (2 of 11 purged) | ✅ Distinct copy with exact missing list `[6, 9]`; **zero VLM cost** on failure |
| Page cap (cap=2 vs 7-page doc) | ✅ `IMAGE_PAGE_CAP_EXCEEDED`; **zero image reads** (fail-fast before any bytes) |
| Vision gate — run time (Bedrock `nova-micro`, non-vision) | ✅ `VISION_LLM_REQUIRED` naming the model |
| Vision gate — config time (same model) | ✅ Non-blocking `vision_warning` toast on profile save |
| Single-pass rejection (with the cloud single-pass executor installed) | ✅ `IMAGE_OUTPUT_UNSUPPORTED_OPERATION` before the executor is invoked |
| Service-side failure (password-protected PDF) | ✅ Fail-closed poll surfaced the PDFium error verbatim on the first `error` status |
| Text/layout-mode regression | ✅ No behavior change |
| **Plugin-absent (pure OSS)** | ✅ `image` stripped from the served schema (enum + enumNames + conditional block); existing image-mode profile → `IMAGE_OUTPUT_REQUIRES_CLOUD` (never a silent answer from the summary); adapter save backstop → clean 400 |

### Bugs found and fixed by the live testing (each with regression tests)

1. **Stale object-store listings / TOCTOU** (`ff7a4774`): fsspec's directory cache in the long-lived worker served a stale page listing, so a purged page passed discovery and blew up at read time as a raw `FileNotFoundError`. Discovery now refreshes the backend listing cache, and a read-time miss maps to the typed `PageImageSetIncompleteError`.
2. **Extension-less deployment inputs** (`801ce759`): workflow executions store the source file as `SOURCE` (no extension), so the extension-only PDF guard false-rejected every API-deployment input. The guard now falls back to `%PDF-` magic-byte content sniffing (fail-closed; no extra read on `.pdf`-named paths).
3. **Gating 500 on adapter save** (`4d40c473`): the rejection was raised with a bare-string `ValidationError` from inside `to_internal_value`, which crashes DRF's error collection into a 500. Now a field-keyed dict detail → clean 400 with the "available only on Unstract Cloud" message.

### Known accepted edge

An adapter **saved in image mode on cloud** and later opened on a plugin-less deployment renders a misleading dropdown state (RJSF displays the schema default while `formData` still holds the removed `image` value); submit is correctly rejected with the clean 400, and actively re-picking any mode recovers. Cloud→OSS downgrade only; documented rather than fixed (a fix would mean mutating stored data on read or custom widget work for a rare corner).

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

