### PR TITLE
UN-3638 [TEST] Hermetic mock-auth0 sidecar for cloud e2e login

### DIFF
--- a/tests/compose/docker-compose.test.yaml
+++ b/tests/compose/docker-compose.test.yaml
@@ -10,6 +10,38 @@ services:
       # Workers ask the backend for this, so this is the value that normally
       # takes effect for fan-out.
       - MAX_PARALLEL_FILE_BATCHES=${MAX_PARALLEL_FILE_BATCHES:-3}
+      # Auth0 e2e (cloud image only): point the plugin at the mock sidecar over
+      # the compose network. The backend's /token call sets the id_token issuer,
+      # so ZIPSTACK_ID_DOMAIN just has to match how the backend reaches the mock
+      # (mock-auth0:8080). Defaults are the hermetic CI values, so this overlay
+      # + COMPOSE_PROFILES=auth0 logs in with no extra config. OSS ignores them.
+      - ZIPSTACK_ID_SCHEME=${ZIPSTACK_ID_SCHEME:-http}
+      - ALLOW_INSECURE_ZIPSTACK_ID_SCHEME=${ALLOW_INSECURE_ZIPSTACK_ID_SCHEME:-true}
+      - ZIPSTACK_ID_DOMAIN=${ZIPSTACK_ID_DOMAIN:-mock-auth0:8080}
+      - ZIPSTACK_ID_DEFAULT_DOMAIN=${ZIPSTACK_ID_DEFAULT_DOMAIN:-mock-auth0:8080}
+      - CI_ZIPSTACK_ID_DOMAIN=${CI_ZIPSTACK_ID_DOMAIN:-mock-auth0:8080}
+      - CI_ZIPSTACK_ID_CLIENT_ID=${CI_ZIPSTACK_ID_CLIENT_ID:-ci-client-id-abc123}
+      - CI_ZIPSTACK_ID_CLIENT_SECRET=${CI_ZIPSTACK_ID_CLIENT_SECRET:-ci-client-secret-xyz789}
+      # Mock validates M2M creds too, so the Management-API token client must
+      # be a pair it knows — reuse the CI pair.
+      - TOKEN_CLIENT_ID=${CI_ZIPSTACK_ID_CLIENT_ID:-ci-client-id-abc123}
+      - TOKEN_CLIENT_SECRET=${CI_ZIPSTACK_ID_CLIENT_SECRET:-ci-client-secret-xyz789}
+
+  # Hermetic Auth0 stand-in for cloud e2e login. Off unless COMPOSE_PROFILES
+  # includes `auth0`, so OSS e2e is untouched. HTTP-only by design (TLS is an
+  # external concern in-cluster). Port published so the host test process can
+  # play the browser leg (it rewrites the authorize URL to MOCK_AUTH0_URL).
+  mock-auth0:
+    profiles: [auth0]
+    image: us-central1-docker.pkg.dev/pandoras-tamer/zipstack-id/mock-auth0-http:${MOCK_AUTH0_TAG:-v1.1.1-rc1}
+    ports:
+      - "${MOCK_AUTH0_HOST_PORT:-18080}:8080"
+    environment:
+      - AUTH0_DOMAIN=mock-auth0
+      - AUTH0_CLIENT_ID=${MOCK_AUTH0_CLIENT_ID:-prod-client-unused}
+      - AUTH0_CLIENT_SECRET=${MOCK_AUTH0_CLIENT_SECRET:-prod-secret-unused}
+      - AUTH0_CI_CLIENT_ID=${CI_ZIPSTACK_ID_CLIENT_ID:-ci-client-id-abc123}
+      - AUTH0_CI_CLIENT_SECRET=${CI_ZIPSTACK_ID_CLIENT_SECRET:-ci-client-secret-xyz789}
 
   platform-service:
     image: unstract/platform-service:${UNSTRACT_TEST_VERSION:-latest}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,6 +12,7 @@ import os
 import time
 import uuid
 from dataclasses import dataclass
+from urllib.parse import quote, urlparse
 
 import pytest
 import requests
@@ -74,7 +75,13 @@ def authed_session(platform: PlatformEndpoints) -> requests.Session:
     with X-CSRFToken) so org-scoped endpoints are reachable. Session-scoped:
     logged in once, reused across tests. Tests that exercise login itself
     should build their own session instead.
+
+    Cloud runs set UNSTRACT_AUTH_MODE=auth0 to drive the Auth0 plugin against
+    the hermetic mock sidecar instead of the OSS form login.
     """
+    if os.environ.get("UNSTRACT_AUTH_MODE") == "auth0":
+        return _auth0_login(platform)
+
     base = platform.backend_url.rstrip("/")
     session = CsrfSession()
 
@@ -105,6 +112,70 @@ def authed_session(platform: PlatformEndpoints) -> requests.Session:
         timeout=10,
     )
     resp.raise_for_status()
+    return session
+
+
+# Fixed CI email; the mock derives a stable sub/user from it, so the id_token
+# and the Management-API lookup on /callback stay mutually consistent.
+_AUTH0_CI_EMAIL = "ci-user@ci.unstract.io"
+_AUTH0_CI_HEADER = {"x-unstract-ci-run": "true"}
+
+
+def _auth0_login(platform: PlatformEndpoints) -> CsrfSession:
+    """Log in via the Auth0 plugin against the mock sidecar; return the session.
+
+    The backend legs are identical to prod (GET /login -> 302 to the mock's
+    /authorize, /callback runs the code exchange). Only the browser is faked:
+    appending login_hint makes the mock skip its credential screen straight to
+    a code.
+
+    Split-horizon note: the backend advertises the authorize redirect at its
+    internal ZIPSTACK_ID_DOMAIN (e.g. mock-auth0:8080), which the host test
+    process can't resolve. The id_token issuer is set by the *backend's* /token
+    call, not this browser leg, so we simply rewrite the authorize netloc to the
+    host-reachable MOCK_AUTH0_URL; the opaque code still validates on /callback.
+    """
+    base = platform.backend_url.rstrip("/")
+    mock_url = os.environ.get("MOCK_AUTH0_URL", "").rstrip("/")
+    session = CsrfSession()
+
+    # Leg 1: /login -> 302 to the mock's /authorize with the CI client.
+    resp = session.get(
+        f"{base}/api/v1/login",
+        headers=_AUTH0_CI_HEADER,
+        allow_redirects=False,
+        timeout=10,
+    )
+    assert resp.status_code == 302, f"login: expected 302, got {resp.status_code}"
+    authorize = resp.headers["Location"]
+    if mock_url:
+        authorize = urlparse(authorize)._replace(
+            scheme=urlparse(mock_url).scheme, netloc=urlparse(mock_url).netloc
+        ).geturl()
+
+    # Leg 2: play the browser — login_hint short-circuits to a code + state.
+    bounce = requests.get(
+        authorize + "&login_hint=" + quote(_AUTH0_CI_EMAIL),
+        allow_redirects=False,
+        timeout=10,
+    )
+    assert bounce.status_code == 302, bounce.text
+    callback = bounce.headers["Location"]
+    assert urlparse(callback).path.endswith("/callback"), callback
+
+    # Leg 3: hand the callback back to the backend to establish the session.
+    resp = session.get(
+        callback, headers=_AUTH0_CI_HEADER, allow_redirects=False, timeout=15
+    )
+    assert resp.status_code in (302, 200), f"callback: {resp.status_code} {resp.text}"
+
+    # Org handshake, same as the OSS fixture, so org-scoped endpoints work.
+    orgs = session.get(f"{base}/api/v1/organization", timeout=10)
+    orgs.raise_for_status()
+    org_id = orgs.json()["organizations"][0]["id"]
+    session.post(
+        f"{base}/api/v1/organization/{org_id}/set", timeout=10
+    ).raise_for_status()
     return session
 
 


### PR DESCRIPTION
## What

Adds a hermetic **mock-auth0 sidecar** to the e2e compose overlay so cloud e2e can log in through the Auth0 plugin without touching real Auth0 (no rate limits) or any deployed mock.

- `tests/compose/docker-compose.test.yaml`: new `mock-auth0` service gated behind the `auth0` compose **profile** — OSS e2e is completely untouched (service never starts unless `COMPOSE_PROFILES=auth0`). Backend env defaults to the hermetic CI values, so the overlay + profile is enough to log in. Port published so the host test process can play the browser leg.
- `tests/e2e/conftest.py`: `authed_session` branches on `UNSTRACT_AUTH_MODE=auth0` → drives the mock (GET `/login` → `/authorize`+`login_hint` → `/callback`). Every non-auth e2e test reuses this single seam unchanged.

## Why here (not cloud)

`ComposeRuntime` hardcodes its compose file list to `docker/docker-compose.yaml` + `tests/compose/docker-compose.test.yaml` (`tests/rig/runtime.py:33-34,137-140`) — there is no hook for the cloud repo to inject an extra overlay. So the sidecar physically has to live in this OSS overlay. The cloud side (Zipstack/unstract-cloud#1684) adds only the e2e *group* that flips `UNSTRACT_AUTH_MODE=auth0` + `MOCK_AUTH0_URL`.

## Split-horizon

The id_token `iss` is set by the **backend's** `/token` call (Host `mock-auth0:8080`), not the browser's `/authorize` leg — so the host test just rewrites the authorize netloc to the published `MOCK_AUTH0_URL`; the opaque code still validates on `/callback`.

## Scope of hermeticity

- **Integration** tier is already hermetic via the in-process stub (`test_login_mock_auth0.py`, cloud#1684) — no infra.
- **e2e** tier gets this sidecar.
- Deployed `mock-*-auth0-http` services stay reserved for **QA Playwright UI tests** per rc-build.

## Validation

`conftest.py` parses, compose YAML validates, mock service correctly profile-gated. Full green e2e run needs the cloud e2e group (cloud#1684) + a rig run with the image pullable from Artifact Registry — flagged for the follow-up CI wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDrwWF4VL97GBrcd8EKnXh