### PR TITLE
UN-3770 [FEAT] ResourceTable: extraColumns + onRowClick (for lookups)

### DIFF
--- a/frontend/src/components/widgets/resource-table/ResourceTable.jsx
+++ b/frontend/src/components/widgets/resource-table/ResourceTable.jsx
@@ -134,10 +134,12 @@ function ResourceTable({
   ownerEmailsProp = "owner_emails",
   countProp,
   countLabel,
+  extraColumns = [],
   handleEdit,
   handleShare,
   handleDelete,
   handleCoOwner,
+  onRowClick,
   sessionDetails,
   showOwner = true,
   isClickable = true,
@@ -373,6 +375,9 @@ function ResourceTable({
         );
       },
     },
+    // Resource-specific columns (e.g. Files, Latest Version) sit between the
+    // shared date columns and Actions.
+    ...extraColumns,
     {
       title: <span className="resource-table-th static right">Actions</span>,
       key: "actions",
@@ -399,7 +404,12 @@ function ResourceTable({
       onChange={handleChange}
       rowClassName={isClickable ? "resource-table-row-clickable" : ""}
       onRow={(item) => ({
-        onClick: isClickable ? () => navigate(`${item?.[idProp]}`) : undefined,
+        // onRowClick lets callers override the default relative nav (e.g. an
+        // absolute org-scoped path with router state).
+        onClick: isClickable
+          ? () =>
+              onRowClick ? onRowClick(item) : navigate(`${item?.[idProp]}`)
+          : undefined,
       })}
       pagination={{
         current: pagination?.current,
@@ -433,10 +443,12 @@ ResourceTable.propTypes = {
   ownerEmailsProp: PropTypes.string,
   countProp: PropTypes.string,
   countLabel: PropTypes.string,
+  extraColumns: PropTypes.array,
   handleEdit: PropTypes.func,
   handleShare: PropTypes.func,
   handleDelete: PropTypes.func,
   handleCoOwner: PropTypes.func,
+  onRowClick: PropTypes.func,
   sessionDetails: PropTypes.object,
   showOwner: PropTypes.bool,
   isClickable: PropTypes.bool,


### PR DESCRIPTION
## What
Two small additions to the shared `ResourceTable` widget so the Prompt Studio **lookups** table can reuse it:

- `extraColumns` — resource-specific antd column defs, injected **before** the Actions column. Lookups uses this for its **Files** and **Latest Version** columns.
- `onRowClick(item)` — overrides the default relative row-click nav, so callers can navigate to an absolute, org-scoped path with router state (lookups needs this).

No behavior change for the existing 4 list pages (both props are optional).

## Stacking
Based on `feat/list-pagination-consistency` (#2208) — merge that first. The cloud consumer is Zipstack/unstract-cloud `feat/lookups-table-consistency`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HXYFVCZGi7YN9qjDGyJCQ