### PR TITLE
[FIX] Patch the lookups bridge in the profile-fallback tests (fixes cloud CI)

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/tests/test_profile_resolution_fallback.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/tests/test_profile_resolution_fallback.py
@@ -162,6 +162,11 @@ def _call(
             autospec=True,
             side_effect=lambda _doc, _prompt, _org, _user, _tool, output: output,
         ),
+        # The lookups bridge is a no-op in OSS, but cloud CI runs this suite
+        # against the merged tree where it resolves to the real lookups
+        # implementation — which then feeds this test's MagicMock prompt into
+        # an ORM query. Patch it out like every other collaborator.
+        patch.object(psh, "get_lookup_config", autospec=True, return_value=None),
         patch.object(psh, "EnvHelper", MagicMock()),
         patch.object(psh, "PromptIdeBaseTool", MagicMock()),
         patch.object(psh, "IndexingUtils", MagicMock()),
@@ -332,9 +337,7 @@ class TestSynchronousFetchResponse:
                 autospec=True,
                 side_effect=seen.append,
             ),
-            patch.object(
-                helper, "validate_profile_manager_owner_access", autospec=True
-            ),
+            patch.object(helper, "validate_profile_manager_owner_access", autospec=True),
             patch.object(
                 helper, "_resolve_llm_ids", autospec=True, return_value=("m", "c")
             ),


### PR DESCRIPTION
## What

Adds the missing `get_lookup_config` patch to the collaborator list in `test_profile_resolution_fallback.py` (added in #2203).

## Why

The suite calls the real `build_fetch_response_payload` and patches every collaborator — except the lookups bridge. In OSS that bridge is a no-op, so the suite is green here. But **cloud CI runs this same suite against the merged tree**, where `prompt_studio/lookup_utils.get_lookup_config` resolves to the real `pluggable_apps/lookups/execution.py` implementation — which feeds the test's `MagicMock` prompt into an ORM query. Since 892be3271 landed, **every cloud CI run fails** four of these tests with:

```
django.core.exceptions.ValidationError: ['“[]” is not a valid UUID.']
```

First failing cloud-main run: [31078494222](https://github.com/Zipstack/unstract-cloud/actions/runs/31078494222) (cloud main was green at 06:01, red at 06:47 — bracketing #2203's merge). The same failures currently block unrelated cloud PRs (e.g. Zipstack/unstract-cloud#1690).

## How

One line + comment: `patch.object(psh, "get_lookup_config", autospec=True, return_value=None)` — returning `None`, exactly what the OSS bridge returns, so the test pins profile resolution identically in both trees.

## Test

```
prompt_studio/prompt_studio_core_v2/tests/test_profile_resolution_fallback.py
13 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)