### PR TITLE
[FIX] Stub the lookups seam in the profile-resolution tests

### DIFF
--- a/backend/prompt_studio/prompt_studio_core_v2/tests/test_profile_resolution_fallback.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/tests/test_profile_resolution_fallback.py
@@ -162,6 +162,10 @@ def _call(
             autospec=True,
             side_effect=lambda _doc, _prompt, _org, _user, _tool, output: output,
         ),
+        # Lookups no-op in OSS but hit the database in trees where the plugin is
+        # installed, which the mock prompt can't satisfy. Stubbed so both take
+        # the same path; the call itself is asserted below.
+        patch.object(psh, "get_lookup_config", autospec=True, return_value=None),
         patch.object(psh, "EnvHelper", MagicMock()),
         patch.object(psh, "PromptIdeBaseTool", MagicMock()),
         patch.object(psh, "IndexingUtils", MagicMock()),
@@ -194,7 +198,12 @@ def _call(
             kwargs["prompts"] = [prompt]
         else:
             kwargs["prompt"] = prompt
-        return getattr(helper, builder)(**kwargs)
+        result = getattr(helper, builder)(**kwargs)
+        # Stubbing the seam would otherwise let its call site be deleted
+        # silently. Only the single-prompt builder consults it.
+        if builder == "build_fetch_response_payload":
+            psh.get_lookup_config.assert_called_once_with(prompt)
+        return result
 
 
 @pytest.mark.parametrize("builder", FK_AWARE_BUILDERS)


### PR DESCRIPTION
## What

- Patch `get_lookup_config` in `test_profile_resolution_fallback.py`'s `_call` helper, alongside the collaborators it already stubs.
- Assert the seam was called with the prompt, for the single-prompt builder.

## Why

- `_call` patches every collaborator `build_fetch_response_payload` reaches except `get_lookup_config` (`prompt_studio_helper.py:903`).
- `prompt_studio/lookup_utils.py` no-ops when `pluggable_apps.lookups` is absent, so the suite is green in OSS. In trees where the lookups plugin is installed, the real `build_lookup_config_for_prompt` runs `PromptLookupAssignment.objects.filter(prompt=prompt)` against the `MagicMock` prompt and raises `django.core.exceptions.ValidationError: ['"[]" is not a valid UUID.']`.
- 4 tests fail there today — the three `TestProfileResolutionLadder` cases plus `TestResolvedProfileReachesCallback`, all on the `[build_fetch_response_payload]` param.

## How

- `patch.object(psh, "get_lookup_config", autospec=True, return_value=None)` added to the existing `patches` list, so both trees take the identical path.
- `psh.get_lookup_config.assert_called_once_with(prompt)` after the builder returns, so stubbing cannot silently mask a removed call site.
- Scoped to `build_fetch_response_payload`: `build_bulk_fetch_response_payload` has no lookup call site, which is why it was unaffected.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. Test-only change, confined to one file. No production code touched.

## Database Migrations

- None.

## Env Config

- None.

## Relevant Docs

- N/A

## Related Issues or PRs

- Follow-up to #2203, which introduced this test file.

## Dependencies Versions

- Unchanged.

## Notes on Testing

Run against a tree with the lookups plugin merged in, so the seam is live:

| Run | Result |
| --- | --- |
| Plugin present, without this change | 4 failed, 9 passed — reproduces the failure exactly |
| Plugin present, with this change | 13 passed |
| With this change + `get_lookup_config` call site deleted from the helper | 4 failed — the new assertion catches it |

`ruff check` clean on the file.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfGKCX7QYPc2P2iaSoskds