### PR TITLE
UN-3770 [MISC] Remove noisy tooltips from the resource list table

### DIFF
--- a/frontend/src/components/widgets/resource-table/ResourceTable.css
+++ b/frontend/src/components/widgets/resource-table/ResourceTable.css
@@ -160,6 +160,20 @@
   color: #1890ff;
 }
 
+/* Names the action for screen readers without an aria-label, which would
+   replace the owner text the button's contents already announce. */
+.resource-table-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Actions column */
 .resource-table-actions {
   justify-content: flex-end;

--- a/frontend/src/components/widgets/resource-table/ResourceTable.jsx
+++ b/frontend/src/components/widgets/resource-table/ResourceTable.jsx
@@ -247,13 +247,13 @@ function ResourceTable({
       <button
         type="button"
         className="resource-table-owner-btn"
-        aria-label={`Manage co-owners for ${item?.[titleProp]}`}
         onClick={(event) => {
           event.stopPropagation();
           handleCoOwner(event, item);
         }}
       >
         {cell}
+        <span className="resource-table-sr-only">Manage co-owners</span>
       </button>
     );
   };

--- a/frontend/src/components/widgets/resource-table/ResourceTable.jsx
+++ b/frontend/src/components/widgets/resource-table/ResourceTable.jsx
@@ -253,7 +253,9 @@ function ResourceTable({
         }}
       >
         {cell}
-        <span className="resource-table-sr-only">Manage co-owners</span>
+        <span className="resource-table-sr-only">
+          Manage co-owners{item?.[titleProp] ? ` for ${item[titleProp]}` : ""}
+        </span>
       </button>
     );
   };

--- a/frontend/src/components/widgets/resource-table/ResourceTable.jsx
+++ b/frontend/src/components/widgets/resource-table/ResourceTable.jsx
@@ -209,12 +209,6 @@ function ResourceTable({
       item?.co_owners_count > 1 ? ` +${item.co_owners_count - 1}` : "";
     const initials = (email || name).slice(0, 2).toUpperCase();
     const swatch = colorForSeed(email || name);
-    // With co-owners, name only the primary inline (+N); the tooltip lists all
-    // owners so search hitting a hidden co-owner is still explainable.
-    const ownerTooltip =
-      Array.isArray(ownerEmails) && ownerEmails.length > 1
-        ? ownerEmails.join(", ")
-        : `${name}${extra}`;
 
     const cell = (
       <Space size={10} className="resource-table-owner">
@@ -228,7 +222,7 @@ function ResourceTable({
         <div className="resource-table-owner-text">
           <Typography.Text
             className="resource-table-owner-name"
-            ellipsis={{ tooltip: ownerTooltip }}
+            ellipsis={{ tooltip: `${name}${extra}` }}
           >
             {name}
             {extra}
@@ -250,18 +244,17 @@ function ResourceTable({
       return cell;
     }
     return (
-      <Tooltip title="Manage Co-Owners">
-        <button
-          type="button"
-          className="resource-table-owner-btn"
-          onClick={(event) => {
-            event.stopPropagation();
-            handleCoOwner(event, item);
-          }}
-        >
-          {cell}
-        </button>
-      </Tooltip>
+      <button
+        type="button"
+        className="resource-table-owner-btn"
+        aria-label="Manage co-owners"
+        onClick={(event) => {
+          event.stopPropagation();
+          handleCoOwner(event, item);
+        }}
+      >
+        {cell}
+      </button>
     );
   };
 

--- a/frontend/src/components/widgets/resource-table/ResourceTable.jsx
+++ b/frontend/src/components/widgets/resource-table/ResourceTable.jsx
@@ -247,7 +247,7 @@ function ResourceTable({
       <button
         type="button"
         className="resource-table-owner-btn"
-        aria-label="Manage co-owners"
+        aria-label={`Manage co-owners for ${item?.[titleProp]}`}
         onClick={(event) => {
           event.stopPropagation();
           handleCoOwner(event, item);


### PR DESCRIPTION
## What

- Remove the always-on `Manage Co-Owners` tooltip that wrapped the owner cell in `ResourceTable`.
- Narrow the owner-name tooltip to the text actually rendered (`Me`, `user +2`) instead of the joined list of every co-owner email.

## Why

Follow-up polish on #2208. On the resource list pages (LLMs, adapters, connectors, Prompt Studio, workflows) hovering anywhere in the Owned By cell fired the `Manage Co-Owners` tooltip on every row. When the owner's email was long enough to be truncated, antd's ellipsis tooltip fired at the same time, so two tooltips stacked on top of each other and covered the adjacent rows.

The name-level tooltip listing all co-owner emails added a third source of noise for a detail the co-owner modal already shows on click.

## How

- Dropped the `<Tooltip title="Manage Co-Owners">` wrapper; the owner cell is now a bare `<button>` carrying `aria-label="Manage co-owners"`, so the action is still announced to screen readers and the click behaviour is unchanged.
- Replaced the computed `ownerTooltip` (which joined `owner_emails`) with the displayed `` `${name}${extra}` `` string.

No change was needed for the Name, description or email tooltips: antd's `EllipsisTooltip` already forces `open={false}` when the text is not actually truncated, so those only surface on genuine overflow. The same gating now means the owner-name tooltip effectively never appears for short names.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No. Presentation-only change scoped to one component:

- The co-owner click handler, its `stopPropagation`, and the row-click behaviour are untouched.
- `owner_emails` is still read for the primary-owner/`created_by_email` fallback — only its use as tooltip text was removed.
- Discoverability of the co-owner action is preserved via `aria-label` plus the existing hover affordance on the owner button.

## Database Migrations

- None.

## Env Config

- None.

## Related Issues or PRs

- Follow-up to #2208.

## Notes on Testing

- Built and deployed to the `chandru-unstract-dev` namespace ([run 31153963693](https://github.com/Zipstack/unstract-cloud/actions/runs/31153963693)); ArgoCD sync succeeded and the platform/runner/backend health probes are returning 200.
- Not yet manually verified in the browser. To check: open the LLMs settings list and hover an owner cell — the `Manage Co-Owners` popup should be gone, and the email tooltip should appear only on genuinely truncated addresses.
- Pod readiness and migration state were not checked on the dev namespace (bastion unavailable); this change ships no migrations.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
