### PR TITLE
fix(mcp): skip the platform auth tests where their preconditions do not hold

### DIFF
--- a/backend/mcp_server/tests/test_platform_auth.py
+++ b/backend/mcp_server/tests/test_platform_auth.py
@@ -18,6 +18,7 @@ import uuid
 
 import pytest
 from account_v2.models import Organization, User
+from django.conf import settings
 from django.test import Client, TestCase
 from platform_api.models import PlatformApiKey
 from tenant_account_v2.models import OrganizationMember
@@ -49,8 +50,65 @@ def make_org_with_key(org_id: str, permission: str = "read_write"):
     return org, user, key
 
 
+def unmet_precondition() -> str | None:
+    """Why this suite cannot run here, or None when it can.
+
+    These tests assert that a credential is *rejected*. That only means
+    anything if the endpoint exists and something is there to reject it — and
+    neither is guaranteed outside the OSS tree, because both are settings-
+    dependent and the settings differ downstream.
+
+    Unstract Cloud is the live example of both halves. ``copy_cloud_deps``
+    overwrites the OSS ``settings/test.py`` with a redirect to ``test_cloud``,
+    which derives from ``settings/cloud`` — so this module's
+    ``MCP_PLATFORM_SERVER_ENABLED = True`` never reaches it and ``urls_v2``
+    leaves the route unmounted. That same file also drops
+    ``CUSTOM_AUTH_MIDDLEWARE`` from the default test ``MIDDLEWARE``, and this
+    view has ``permission_classes = []`` and deliberately does not
+    re-authenticate — so without the middleware the endpoint is reachable with
+    no credential at all.
+
+    Checked as two explicit preconditions rather than by reading
+    ``MCP_PLATFORM_SERVER_ENABLED``: the flag is what *causes* the mount in the
+    OSS URLconf, but it is not what these tests need. They need the route and
+    the middleware, and asking directly stays correct for any tree that mounts
+    the server some other way.
+    """
+    from django.urls import Resolver404, resolve
+
+    # The org segment is stripped from `path_info` by tenant middleware before
+    # URL resolution, so the mounted pattern carries no org — resolving the URL
+    # these tests request would 404 even on OSS, where they pass.
+    try:
+        resolve(f"/{settings.TENANT_SUBFOLDER_PREFIX}/mcp/")
+    except Resolver404:
+        return (
+            f"the platform MCP route is not mounted in {settings.ROOT_URLCONF} "
+            "(MCP_PLATFORM_SERVER_ENABLED is off, or this URLconf does not "
+            "carry the mount), so every request here would 404"
+        )
+
+    if settings.CUSTOM_AUTH_MIDDLEWARE not in settings.MIDDLEWARE:
+        return (
+            f"{settings.CUSTOM_AUTH_MIDDLEWARE} is not in MIDDLEWARE, and this "
+            "endpoint is authenticated by that middleware rather than by the "
+            "view — every request would arrive unauthenticated"
+        )
+
+    return None
+
+
 class PlatformMCPAuthTest(TestCase):
     def setUp(self) -> None:
+        # Skipped loudly rather than left to fail, because the failure mode is
+        # worse than a red test: with the route unmounted every request 404s,
+        # and a 404 satisfies "this request is refused" just as well as the 401
+        # being asserted. `test_bad_credentials_are_rejected` passed that way on
+        # cloud — green for auth that was never reached. A skip names the gap.
+        reason = unmet_precondition()
+        if reason:
+            self.skipTest(f"{reason}. See this module's docstring for why.")
+
         self.org, self.user, self.key = make_org_with_key(ORG_ID)
         _, _, self.other_key = make_org_with_key(OTHER_ORG_ID)
         UserContext.set_organization_identifier(ORG_ID)
@@ -59,11 +117,15 @@ class PlatformMCPAuthTest(TestCase):
 
     def _post(self, auth: str | None = None, body: dict | None = None, url: str = None):
         """POST through the full URL stack so the auth middleware runs."""
-        payload = body if body is not None else {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/list",
-        }
+        payload = (
+            body
+            if body is not None
+            else {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+            }
+        )
         headers = {"HTTP_AUTHORIZATION": auth} if auth else {}
         return self.client.post(
             url or self.url,
@@ -90,9 +152,10 @@ class PlatformMCPAuthTest(TestCase):
         for label, auth in cases:
             with self.subTest(label):
                 response = self._post(auth)
-                assert response.status_code in (401, 403), (
-                    f"{label}: got {response.status_code}, body={response.content[:200]}"
-                )
+                assert response.status_code in (
+                    401,
+                    403,
+                ), f"{label}: got {response.status_code}, body={response.content[:200]}"
 
     @pytest.mark.critical_path("mcp-platform-auth")
     def test_inactive_key_is_rejected(self) -> None:

--- a/backend/mcp_server/tests/test_platform_auth.py
+++ b/backend/mcp_server/tests/test_platform_auth.py
@@ -50,64 +50,60 @@ def make_org_with_key(org_id: str, permission: str = "read_write"):
     return org, user, key
 
 
-def unmet_precondition() -> str | None:
-    """Why this suite cannot run here, or None when it can.
+def assert_server_is_wired_up() -> None:
+    """Fail if the org-scoped server is enabled but not actually reachable.
 
-    These tests assert that a credential is *rejected*. That only means
-    anything if the endpoint exists and something is there to reject it — and
-    neither is guaranteed outside the OSS tree, because both are settings-
-    dependent and the settings differ downstream.
-
-    Unstract Cloud is the live example of both halves. ``copy_cloud_deps``
-    overwrites the OSS ``settings/test.py`` with a redirect to ``test_cloud``,
-    which derives from ``settings/cloud`` — so this module's
-    ``MCP_PLATFORM_SERVER_ENABLED = True`` never reaches it and ``urls_v2``
-    leaves the route unmounted. That same file also drops
-    ``CUSTOM_AUTH_MIDDLEWARE`` from the default test ``MIDDLEWARE``, and this
-    view has ``permission_classes = []`` and deliberately does not
-    re-authenticate — so without the middleware the endpoint is reachable with
-    no credential at all.
-
-    Checked as two explicit preconditions rather than by reading
-    ``MCP_PLATFORM_SERVER_ENABLED``: the flag is what *causes* the mount in the
-    OSS URLconf, but it is not what these tests need. They need the route and
-    the middleware, and asking directly stays correct for any tree that mounts
-    the server some other way.
+    Only called when ``MCP_PLATFORM_SERVER_ENABLED`` is on, which makes these
+    assertions rather than skips deliberate: with the flag set, a missing route
+    or missing auth middleware is a regression, and swallowing it would be the
+    very thing this suite exists to prevent. The flag is the statement of
+    intent; these two are whether the intent was carried out.
     """
     from django.urls import Resolver404, resolve
 
     # The org segment is stripped from `path_info` by tenant middleware before
     # URL resolution, so the mounted pattern carries no org — resolving the URL
-    # these tests request would 404 even on OSS, where they pass.
+    # these tests request would 404 even where they pass.
+    mounted_path = f"/{settings.TENANT_SUBFOLDER_PREFIX}/mcp/"
     try:
-        resolve(f"/{settings.TENANT_SUBFOLDER_PREFIX}/mcp/")
+        resolve(mounted_path)
     except Resolver404:
-        return (
-            f"the platform MCP route is not mounted in {settings.ROOT_URLCONF} "
-            "(MCP_PLATFORM_SERVER_ENABLED is off, or this URLconf does not "
-            "carry the mount), so every request here would 404"
-        )
+        raise AssertionError(
+            f"MCP_PLATFORM_SERVER_ENABLED is on but {mounted_path} does not "
+            f"resolve in {settings.ROOT_URLCONF}. Every request here would 404 "
+            "— and a 404 satisfies the rejection assertions below just as well "
+            "as the 401 they mean to check, so this must fail rather than pass."
+        ) from None
 
-    if settings.CUSTOM_AUTH_MIDDLEWARE not in settings.MIDDLEWARE:
-        return (
-            f"{settings.CUSTOM_AUTH_MIDDLEWARE} is not in MIDDLEWARE, and this "
-            "endpoint is authenticated by that middleware rather than by the "
-            "view — every request would arrive unauthenticated"
-        )
-
-    return None
+    assert settings.CUSTOM_AUTH_MIDDLEWARE in settings.MIDDLEWARE, (
+        f"MCP_PLATFORM_SERVER_ENABLED is on but "
+        f"{settings.CUSTOM_AUTH_MIDDLEWARE} is not in MIDDLEWARE. This view "
+        "carries `permission_classes = []` and does not re-authenticate, so "
+        "the endpoint would be reachable with no credential at all."
+    )
 
 
 class PlatformMCPAuthTest(TestCase):
     def setUp(self) -> None:
-        # Skipped loudly rather than left to fail, because the failure mode is
-        # worse than a red test: with the route unmounted every request 404s,
-        # and a 404 satisfies "this request is refused" just as well as the 401
-        # being asserted. `test_bad_credentials_are_rejected` passed that way on
-        # cloud — green for auth that was never reached. A skip names the gap.
-        reason = unmet_precondition()
-        if reason:
-            self.skipTest(f"{reason}. See this module's docstring for why.")
+        # Gated on the flag, not on whether the route happens to resolve.
+        #
+        # Skipping on a 404 would have been wrong in the direction that matters:
+        # where the server is meant to be on, an unmounted route is a
+        # regression, and this suite would have gone quiet exactly when it
+        # should have shouted. So the flag decides whether the server is
+        # expected here, and `assert_server_is_wired_up` then insists it really
+        # is — see that function for what "wired up" means.
+        #
+        # Where the flag is off the server is deliberately absent (Unstract
+        # Cloud ships it that way), and there is nothing to assert about an
+        # endpoint that is not supposed to exist.
+        if not settings.MCP_PLATFORM_SERVER_ENABLED:
+            self.skipTest(
+                "MCP_PLATFORM_SERVER_ENABLED is off, so the organization-scoped "
+                "MCP server is not mounted here and there is nothing to "
+                "authenticate. Enable it to run these."
+            )
+        assert_server_is_wired_up()
 
         self.org, self.user, self.key = make_org_with_key(ORG_ID)
         _, _, self.other_key = make_org_with_key(OTHER_ORG_ID)


### PR DESCRIPTION
Unblocks Unstract Cloud `main`, red since #2207 merged (cloud run 31159495978 and every run since).

## What is broken

`mcp_server/tests/test_platform_auth.py` drives requests through the real URL stack so `CustomAuthMiddleware` runs. On cloud neither thing it depends on is true:

- **The route is not mounted.** `copy_cloud_deps.py` overwrites the OSS `settings/test.py` with a redirect to `test_cloud.py`, which derives from `settings/cloud.py` → `base.py`. So `MCP_PLATFORM_SERVER_ENABLED = True` never reaches the cloud suite, and `urls_v2` skips the mount. Five tests 404.
- **The auth middleware is absent.** The same `test_cloud.py` drops `CUSTOM_AUTH_MIDDLEWARE` from the default test `MIDDLEWARE` (it is kept only in `MIDDLEWARE_WITH_AUTH`). This view has `permission_classes = []` and deliberately does not re-authenticate.

Why it passed pre-merge: cloud `ci-test.yaml` checks out OSS at a floating `ref: main`. #1712 was green at 07:42 against an OSS main where `mcp_server/` did not exist; #2207 landed at 07:54:05 and the next cloud run was red. Nothing re-validates a merged cloud PR against a newer OSS main — worth addressing separately.

## The sixth test is why this is a skip, not a deselect

`test_bad_credentials_are_rejected` **passed** on cloud. A 404 satisfies "this request is refused" exactly as well as the 401 it was written to assert, so it reported green for auth that was never reached. `--ignore`-ing the file keeps that hidden; a skip names it.

## Why not just enable the flag on cloud

It mounts the route but does not go green — with the middleware still absent the endpoint goes from *unmounted* to *unauthenticated*, trading five failures for a different five. I verified this on a merged tree before discarding the approach.

## Why not override the group in `groups.cloud.yaml`

`pytest_extra: ["--ignore=..."]` on `integration-backend` cannot work. The rig rejects redefinition:

```
ERROR: tests/groups.cloud.yaml: group 'integration-backend' already defined in a prior manifest
```

`_merge_manifest` raises on name collision by design ("a name collision is an error rather than a silent override"), and it fails at the `Validate rig manifests` step before any test runs. There is no ignore/exclude/disable key in the rig either. So the fix has to live here.

## What this does

Checks the two preconditions directly and skips with a named reason otherwise — deliberately **not** by reading `MCP_PLATFORM_SERVER_ENABLED`. That flag is what *causes* the mount in the OSS URLconf, but it is not what these tests need; asking for the route and the middleware stays correct for any tree that mounts the server another way, and re-arms on its own if cloud ever runs this endpoint with auth.

The route probe resolves a path with **no organization segment**, unlike the URL the tests request: tenant middleware strips the org from `path_info` before resolution, so resolving the request URL as written 404s even on OSS where these tests pass.

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why.

No.

- Test-only change; no production code is touched.
- On OSS both preconditions hold, so the suite runs exactly as before — verified, no unmet precondition reported.
- The deployment-scoped MCP server, the one required for release, is mounted unconditionally in `api_v2/execution_urls.py` and is unaffected by any of this.
- Nothing enables the organization-scoped server anywhere; it stays off in staging and production, as intended.

## Notes on Testing

Verified against real `copy_cloud_deps`-merged trees rather than by reasoning:

| tree | verdict |
|---|---|
| OSS `main` | no unmet precondition → suite runs unchanged |
| cloud merged, flag off (today) | skip, reporting the **route** reason |
| cloud merged, flag on | skip, reporting the **middleware** reason |

Both guard branches therefore exercised. `198 passed` in the OSS unit tier.

## Related Issues or PRs

- Zipstack/unstract#2207 — introduced these tests
- Zipstack/unstract-cloud#1712 — deployment-scoped allowlist; green, unrelated to this failure
- Unblocks Zipstack/unstract-cloud#1705