### PR TITLE
UN-3638 [MISC] Scope and gate critical-path regressions in the rig report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -670,6 +670,7 @@ backend/backend/settings/*
 !backend/backend/settings/base.py
 !backend/backend/settings/dev.py
 !backend/backend/settings/test.py
+!backend/backend/settings/test_base.py
 
 # Local Dependencies for docker testing
 unstract/unstract-sdk/

--- a/backend/backend/settings/test.py
+++ b/backend/backend/settings/test.py
@@ -1,16 +1,8 @@
+"""OSS test settings: the production base plus the shared test-only deltas.
+
+The deltas live in `test_base` rather than here because `copy_cloud_deps`
+replaces this file on a cloud build.
+"""
+
 from backend.settings.base import *  # noqa: F401, F403
-
-DEBUG = True
-
-# Django's default PBKDF2 hasher is deliberately slow; suites that seed several
-# users per test spend most of their time there. Test fixtures need speed, not
-# resistance to offline cracking.
-PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
-
-# The organization-scoped MCP server ships disabled (see
-# MCP_PLATFORM_SERVER_ENABLED in base.py), but its tests must still exercise
-# it: several drive requests through the full URL stack precisely so the auth
-# middleware runs, and an unmounted route would make them 404 — turning a suite
-# that checks a credential is *rejected* into one that passes because nothing
-# is there. Shipping-off and untested are different things.
-MCP_PLATFORM_SERVER_ENABLED = True
+from backend.settings.test_base import *  # noqa: F401, F403

--- a/backend/backend/settings/test_base.py
+++ b/backend/backend/settings/test_base.py
@@ -14,10 +14,6 @@ PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 
-# Env-driven, so unset under test: without it internal-API requests fail as
-# "not configured" rather than on their own merits.
-INTERNAL_SERVICE_API_KEY = "test-internal-service-key"
-
 # Ships disabled, but its tests drive the full URL stack to exercise the auth
 # middleware — an unmounted route would 404 and pass them vacuously.
 MCP_PLATFORM_SERVER_ENABLED = True

--- a/backend/backend/settings/test_base.py
+++ b/backend/backend/settings/test_base.py
@@ -1,0 +1,32 @@
+"""Test-only setting deltas, shared by the OSS and cloud test settings.
+
+This module imports nothing on purpose. `copy_cloud_deps` replaces the OSS
+`settings/test.py` on a cloud build, so a delta that lives only in that file is
+silently lost there; keeping the deltas here is what stops the two trees
+diverging. Star-importing a base settings module would re-export its names and
+clobber whatever the importer derived from `cloud`, so this file defines only
+what it overrides.
+"""
+
+DEBUG = True
+
+# Django's default PBKDF2 hasher is deliberately slow; suites that seed several
+# users per test spend most of their time there. Test fixtures need speed, not
+# resistance to offline cracking.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
+# Prod enforces HTTPS-only cookies; tests run over plain HTTP.
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+
+# Env-driven and unset under test, which would make any request to an internal
+# API fail as "not configured" rather than on its own merits.
+INTERNAL_SERVICE_API_KEY = "test-internal-service-key"
+
+# The organization-scoped MCP server ships disabled (see
+# MCP_PLATFORM_SERVER_ENABLED in base.py), but its tests must still exercise
+# it: several drive requests through the full URL stack precisely so the auth
+# middleware runs, and an unmounted route would make them 404 — turning a suite
+# that checks a credential is *rejected* into one that passes because nothing
+# is there. Shipping-off and untested are different things.
+MCP_PLATFORM_SERVER_ENABLED = True

--- a/backend/backend/settings/test_base.py
+++ b/backend/backend/settings/test_base.py
@@ -1,32 +1,23 @@
 """Test-only setting deltas, shared by the OSS and cloud test settings.
 
-This module imports nothing on purpose. `copy_cloud_deps` replaces the OSS
-`settings/test.py` on a cloud build, so a delta that lives only in that file is
-silently lost there; keeping the deltas here is what stops the two trees
-diverging. Star-importing a base settings module would re-export its names and
-clobber whatever the importer derived from `cloud`, so this file defines only
-what it overrides.
+Imports nothing on purpose: `copy_cloud_deps` replaces the OSS `settings/test.py`
+on a cloud build, so deltas kept only there are lost, and star-importing a base
+module here would re-export its names over whatever the importer derived.
 """
 
 DEBUG = True
 
-# Django's default PBKDF2 hasher is deliberately slow; suites that seed several
-# users per test spend most of their time there. Test fixtures need speed, not
-# resistance to offline cracking.
+# PBKDF2 is deliberately slow, and suites seeding users per test pay it repeatedly.
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 # Prod enforces HTTPS-only cookies; tests run over plain HTTP.
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 
-# Env-driven and unset under test, which would make any request to an internal
-# API fail as "not configured" rather than on its own merits.
+# Env-driven, so unset under test: without it internal-API requests fail as
+# "not configured" rather than on their own merits.
 INTERNAL_SERVICE_API_KEY = "test-internal-service-key"
 
-# The organization-scoped MCP server ships disabled (see
-# MCP_PLATFORM_SERVER_ENABLED in base.py), but its tests must still exercise
-# it: several drive requests through the full URL stack precisely so the auth
-# middleware runs, and an unmounted route would make them 404 — turning a suite
-# that checks a credential is *rejected* into one that passes because nothing
-# is there. Shipping-off and untested are different things.
+# Ships disabled, but its tests drive the full URL stack to exercise the auth
+# middleware — an unmounted route would 404 and pass them vacuously.
 MCP_PLATFORM_SERVER_ENABLED = True

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -374,7 +374,10 @@ def cmd_report(args: argparse.Namespace) -> int:
     # A skipped tier emits no junit, so scoping to the groups that reported keeps
     # its paths as gaps rather than regressions — nothing regressed, it never ran.
     # A group that ran and went red still reports, so real regressions survive.
-    scope_groups = [r.name for r in group_results]
+    # `optional` groups are excluded: they are documented as non-blocking, and
+    # leaving them in scope would let a red one gate the build through a
+    # regression instead.
+    scope_groups = [r.name for r in group_results if not manifest.get(r.name).optional]
     statuses = cp.evaluate(
         registry,
         groups_run_green=green,
@@ -399,11 +402,37 @@ def cmd_report(args: argparse.Namespace) -> int:
     # cmd_run gates on the regressions it can see, but only within its own tier.
     # This is the only cross-tier evaluation, so it is the only place a regression
     # spanning tiers can be gated on.
-    regressions = [s for s in statuses if s.state == "regression"]
-    if regressions:
-        ids = ", ".join(s.path.id for s in regressions)
+    # A covering group that ran green without attesting means its marked test
+    # was skipped or unmarked; a group that went red means the test failed. The
+    # remedies differ, so the two are reported apart rather than as one count.
+    unproven: list[cp.CriticalPathStatus] = []
+    uncovered: list[cp.CriticalPathStatus] = []
+    for s in statuses:
+        if s.state != "regression":
+            continue
+        target = unproven if any(g in green for g in s.path.covered_by) else uncovered
+        target.append(s)
+    regressions = unproven + uncovered
+    if uncovered:
+        ids = ", ".join(s.path.id for s in uncovered)
         print(
-            f"\n[rig] ❌ {len(regressions)} critical-path regression(s) detected: {ids}",
+            f"\n[rig] ❌ {len(uncovered)} critical-path regression(s) — no covering "
+            f"group ran green: {ids}",
+            file=sys.stderr,
+        )
+    if unproven:
+        ids = ", ".join(s.path.id for s in unproven)
+        print(
+            f"\n[rig] ❌ {len(unproven)} critical-path regression(s) — covering group "
+            f"ran green but no passing @pytest.mark.critical_path test attested "
+            f"them (skipped or unmarked?): {ids}",
+            file=sys.stderr,
+        )
+    if regressions:
+        print(
+            "[rig] to accept a deliberate removal, drop or re-point the path in "
+            "tests/critical_paths.yaml in the same PR — the baseline is keyed off "
+            "that registry.",
             file=sys.stderr,
         )
     if args.update_baseline:

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -398,9 +398,9 @@ def cmd_report(args: argparse.Namespace) -> int:
             f"(not in tests/critical_paths.yaml)",
             file=sys.stderr,
         )
-    # This is the only cross-tier evaluation, so it is also the only place a
-    # regression can be gated on. cmd_run deliberately doesn't: a single tier
-    # can't tell "another tier's path went red" from "another tier didn't run".
+    # cmd_run gates on the regressions it can see, but only within its own tier.
+    # This is the only cross-tier evaluation, so it is the only place a regression
+    # spanning tiers can be gated on.
     regressions = [s for s in statuses if s.state == "regression"]
     if regressions:
         ids = ", ".join(s.path.id for s in regressions)
@@ -424,7 +424,10 @@ def cmd_report(args: argparse.Namespace) -> int:
             return 1
         cp.merge_into_baseline(statuses, baseline_path)
         print(f"[rig] merged into baseline: {baseline_path}")
-    return 1 if unknown_marker_ids or regressions else 0
+    # A corrupt baseline empties previously_covered, so no path can reach
+    # "regression" and the gate above silently passes. Fail on it directly
+    # rather than leaving a required check green behind an advisory banner.
+    return 1 if unknown_marker_ids or regressions or baseline_corrupt else 0
 
 
 def cmd_run(args: argparse.Namespace) -> int:

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -371,8 +371,18 @@ def cmd_report(args: argparse.Namespace) -> int:
         print(f"[rig] {exc}", file=sys.stderr)
         baseline = None
         baseline_corrupt = True
+    # A tier the path filter skipped emits no junit, so its groups are absent
+    # here. Scoping to the groups that actually reported keeps their paths as
+    # gaps rather than regressions — nothing regressed, the tier never ran. A
+    # group that ran and went red still reports, so it stays in scope and a
+    # genuine regression is still caught.
+    scope_groups = [r.name for r in group_results]
     statuses = cp.evaluate(
-        registry, groups_run_green=green, baseline=baseline, marker_proven=proven
+        registry,
+        groups_run_green=green,
+        baseline=baseline,
+        scope_groups=scope_groups,
+        marker_proven=proven,
     )
     write_summary(
         reports_dir=reports_dir,
@@ -386,6 +396,16 @@ def cmd_report(args: argparse.Namespace) -> int:
             f"[rig] ❌ @pytest.mark.critical_path references unknown path "
             f"id(s): {', '.join(unknown_marker_ids)} "
             f"(not in tests/critical_paths.yaml)",
+            file=sys.stderr,
+        )
+    # This is the only cross-tier evaluation, so it is also the only place a
+    # regression can be gated on. cmd_run deliberately doesn't: a single tier
+    # can't tell "another tier's path went red" from "another tier didn't run".
+    regressions = [s for s in statuses if s.state == "regression"]
+    if regressions:
+        ids = ", ".join(s.path.id for s in regressions)
+        print(
+            f"\n[rig] ❌ {len(regressions)} critical-path regression(s) detected: {ids}",
             file=sys.stderr,
         )
     if args.update_baseline:
@@ -404,7 +424,7 @@ def cmd_report(args: argparse.Namespace) -> int:
             return 1
         cp.merge_into_baseline(statuses, baseline_path)
         print(f"[rig] merged into baseline: {baseline_path}")
-    return 1 if unknown_marker_ids else 0
+    return 1 if unknown_marker_ids or regressions else 0
 
 
 def cmd_run(args: argparse.Namespace) -> int:

--- a/tests/rig/cli.py
+++ b/tests/rig/cli.py
@@ -371,11 +371,9 @@ def cmd_report(args: argparse.Namespace) -> int:
         print(f"[rig] {exc}", file=sys.stderr)
         baseline = None
         baseline_corrupt = True
-    # A tier the path filter skipped emits no junit, so its groups are absent
-    # here. Scoping to the groups that actually reported keeps their paths as
-    # gaps rather than regressions — nothing regressed, the tier never ran. A
-    # group that ran and went red still reports, so it stays in scope and a
-    # genuine regression is still caught.
+    # A skipped tier emits no junit, so scoping to the groups that reported keeps
+    # its paths as gaps rather than regressions — nothing regressed, it never ran.
+    # A group that ran and went red still reports, so real regressions survive.
     scope_groups = [r.name for r in group_results]
     statuses = cp.evaluate(
         registry,
@@ -424,9 +422,8 @@ def cmd_report(args: argparse.Namespace) -> int:
             return 1
         cp.merge_into_baseline(statuses, baseline_path)
         print(f"[rig] merged into baseline: {baseline_path}")
-    # A corrupt baseline empties previously_covered, so no path can reach
-    # "regression" and the gate above silently passes. Fail on it directly
-    # rather than leaving a required check green behind an advisory banner.
+    # A corrupt baseline makes "regression" unreachable, so the gate above would
+    # pass vacuously; it has to fail on its own.
     return 1 if unknown_marker_ids or regressions or baseline_corrupt else 0
 
 

--- a/tests/rig/critical_paths.py
+++ b/tests/rig/critical_paths.py
@@ -234,9 +234,8 @@ def merge_into_baseline(statuses: list[CriticalPathStatus], destination: Path) -
     existing: set[str] = set()
     if destination.exists():
         try:
-            parsed = json.loads(destination.read_text())
-            existing = set(parsed.get("covered_paths") or [])
-        except (json.JSONDecodeError, OSError) as exc:
+            existing = set(_read_baseline(destination)["covered_paths"])
+        except (OSError, ValueError) as exc:
             raise BaselineCorruptError(
                 f"refusing to merge into corrupt baseline {destination}: {exc}. "
                 "Delete the cache entry and re-run."
@@ -248,18 +247,35 @@ def merge_into_baseline(statuses: list[CriticalPathStatus], destination: Path) -
     destination.write_text(json.dumps(payload, indent=2))
 
 
+def _read_baseline(source: Path) -> dict[str, Any]:
+    """Parse a baseline file and check its shape.
+
+    Well-formed JSON of the wrong shape is as unusable as a truncated file, and
+    would otherwise surface as an ``AttributeError``/``TypeError`` from whichever
+    caller touched it first. Raises ``OSError`` or ``ValueError``
+    (``JSONDecodeError`` is one) for callers to translate.
+    """
+    parsed = json.loads(source.read_text())
+    if not isinstance(parsed, dict):
+        raise ValueError(f"expected a JSON object, got {type(parsed).__name__}")
+    covered = parsed.get("covered_paths") or []
+    if not isinstance(covered, list) or not all(isinstance(p, str) for p in covered):
+        raise ValueError("'covered_paths' must be a list of strings")
+    return {**parsed, "covered_paths": covered}
+
+
 def load_baseline(source: Path) -> dict[str, Any] | None:
     """Load the cached baseline.
 
     Returns None if the file doesn't exist (first build / fresh cache).
-    Raises :class:`BaselineCorruptError` if the file exists but is unreadable
-    or unparseable — see :func:`merge_into_baseline` for the rationale.
+    Raises :class:`BaselineCorruptError` if the file exists but is unreadable,
+    unparseable, or misshapen — see :func:`merge_into_baseline` for the rationale.
     """
     if not source.exists():
         return None
     try:
-        return json.loads(source.read_text())
-    except (json.JSONDecodeError, OSError) as exc:
+        return _read_baseline(source)
+    except (OSError, ValueError) as exc:
         raise BaselineCorruptError(
             f"baseline at {source} is unreadable: {exc}. "
             "Delete the cache entry and re-run."

--- a/tests/rig/critical_paths.py
+++ b/tests/rig/critical_paths.py
@@ -226,6 +226,10 @@ def merge_into_baseline(statuses: list[CriticalPathStatus], destination: Path) -
     treated as empty: silently dropping previously-covered paths would erase
     the other tier's contribution and turn the next build into a regression
     festival. CI should delete the cache and retry on this exception.
+
+    Ids absent from the registry are pruned. The union alone never forgets, so a
+    deliberately retired path would otherwise sit in the cache forever; pruning
+    makes editing ``critical_paths.yaml`` the way to accept a removal.
     """
     existing: set[str] = set()
     if destination.exists():
@@ -238,7 +242,8 @@ def merge_into_baseline(statuses: list[CriticalPathStatus], destination: Path) -
                 "Delete the cache entry and re-run."
             ) from exc
     fresh = {s.path.id for s in statuses if s.state == "covered"}
-    payload = {"covered_paths": sorted(existing | fresh)}
+    known = {s.path.id for s in statuses}
+    payload = {"covered_paths": sorted((existing | fresh) & known)}
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_text(json.dumps(payload, indent=2))
 

--- a/tests/rig/reporting.py
+++ b/tests/rig/reporting.py
@@ -318,11 +318,15 @@ def _render_markdown(
 
     if critical_statuses:
         regressions = [s for s in critical_statuses if s.state == "regression"]
-        all_gaps = [s for s in critical_statuses if s.state == "gap"]
-        # A path whose covering groups exist but sat out this build is not
-        # "not yet covered" — reporting it as such reads as missing tests.
-        unexercised = [s for s in all_gaps if not s.in_scope and s.path.covered_by]
-        gaps = [s for s in all_gaps if s not in unexercised]
+        # A path whose covering groups exist but reported nothing is not "not yet
+        # covered" — listing it as such reads as missing tests.
+        unexercised: list[CriticalPathStatus] = []
+        gaps: list[CriticalPathStatus] = []
+        for s in critical_statuses:
+            if s.state != "gap":
+                continue
+            target = unexercised if not s.in_scope and s.path.covered_by else gaps
+            target.append(s)
         covered = [s for s in critical_statuses if s.state == "covered"]
 
         lines.append("## Critical paths")
@@ -353,7 +357,7 @@ def _render_markdown(
                 covers = ", ".join(s.path.covered_by)
                 lines.append(
                     f"- **{s.path.id}** — {s.path.description} "
-                    f"(covered by {covers}; that tier did not run here)"
+                    f"(covered by {covers}; no result reported in this build)"
                 )
             lines.append("")
             lines.append("</details>")

--- a/tests/rig/reporting.py
+++ b/tests/rig/reporting.py
@@ -318,7 +318,11 @@ def _render_markdown(
 
     if critical_statuses:
         regressions = [s for s in critical_statuses if s.state == "regression"]
-        gaps = [s for s in critical_statuses if s.state == "gap"]
+        all_gaps = [s for s in critical_statuses if s.state == "gap"]
+        # A path whose covering groups exist but sat out this build is not
+        # "not yet covered" — reporting it as such reads as missing tests.
+        unexercised = [s for s in all_gaps if not s.in_scope and s.path.covered_by]
+        gaps = [s for s in all_gaps if s not in unexercised]
         covered = [s for s in critical_statuses if s.state == "covered"]
 
         lines.append("## Critical paths")
@@ -338,6 +342,21 @@ def _render_markdown(
                     f"- **{s.path.id}** — {s.path.description} "
                     f"(declared coverage: {covers})"
                 )
+            lines.append("")
+        if unexercised:
+            lines.append(
+                "<details><summary>💤 Covered, but not exercised in this "
+                "build</summary>"
+            )
+            lines.append("")
+            for s in unexercised:
+                covers = ", ".join(s.path.covered_by)
+                lines.append(
+                    f"- **{s.path.id}** — {s.path.description} "
+                    f"(covered by {covers}; that tier did not run here)"
+                )
+            lines.append("")
+            lines.append("</details>")
             lines.append("")
         if covered:
             lines.append("<details><summary>✅ Covered critical paths</summary>")

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -963,6 +963,7 @@ def _drive_cmd_report(
     *,
     reporting_groups: dict[str, int],
     baseline_blob: str = '{"covered_paths": ["int-path"]}',
+    optional: bool = False,
 ) -> tuple[int, dict[str, str]]:
     """Drive ``cmd_report`` over one integration group covering ``int-path``.
 
@@ -982,6 +983,7 @@ def _drive_cmd_report(
         "    tier: integration\n"
         f"    workdir: {test_dir}\n"
         "    paths: [.]\n"
+        f"    optional: {str(optional).lower()}\n"
     )
     (tmp_path / "groups.yaml").write_text(manifest_yaml)
     (tmp_path / "critical_paths.yaml").write_text(
@@ -1075,6 +1077,24 @@ def test_cmd_report_gates_on_a_real_regression(tmp_path: Path, monkeypatch) -> N
     assert exit_code == 1, (
         "a regression must fail the report job, not just print into the comment"
     )
+
+
+def test_cmd_report_does_not_gate_on_an_optional_group(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``optional`` groups are documented as non-blocking, and ``cmd_run`` honours
+    that. A red optional group must not reach the gate here through a regression,
+    or the two commands disagree about the same result.
+    """
+    exit_code, states = _drive_cmd_report(
+        tmp_path, monkeypatch, reporting_groups={"int-g": 1}, optional=True
+    )
+
+    assert states["int-path"] == "gap", (
+        f"an optional group's red result must not read as a regression; "
+        f"got {states['int-path']}"
+    )
+    assert exit_code == 0
 
 
 def test_cmd_report_gates_on_a_corrupt_baseline(tmp_path: Path, monkeypatch) -> None:

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -962,13 +962,15 @@ def _drive_cmd_report(
     monkeypatch,
     *,
     reporting_groups: dict[str, int],
+    baseline_blob: str = '{"covered_paths": ["int-path"]}',
 ) -> tuple[int, dict[str, str]]:
     """Drive ``cmd_report`` over one integration group covering ``int-path``.
 
     ``reporting_groups`` maps group name -> failure count for the groups that
     emitted junit this build. A group absent from it emitted nothing, standing
-    in for a tier the CI path filter skipped. Returns the exit code and each
-    path's final state.
+    in for a tier the CI path filter skipped. ``baseline_blob`` is written as the
+    cached baseline verbatim, so a caller can hand over an unparseable one.
+    Returns the exit code and each path's final state.
     """
     from tests.rig.reporting import GroupResult
 
@@ -1030,9 +1032,7 @@ def _drive_cmd_report(
     reports_dir.mkdir()
     # Baseline says the path was green on main, which is what makes the
     # not-covered-now decision a regression-or-gap question at all.
-    (reports_dir / "previous-summary.json").write_text(
-        '{"covered_paths": ["int-path"]}'
-    )
+    (reports_dir / "previous-summary.json").write_text(baseline_blob)
 
     args = cli_mod._build_parser().parse_args(
         [
@@ -1077,3 +1077,23 @@ def test_cmd_report_gates_on_a_real_regression(tmp_path: Path, monkeypatch) -> N
     assert exit_code == 1, (
         "a regression must fail the report job, not just print into the comment"
     )
+
+
+def test_cmd_report_gates_on_a_corrupt_baseline(tmp_path: Path, monkeypatch) -> None:
+    """An unreadable baseline leaves ``previously_covered`` empty, so no path can
+    ever be classified as a regression and the gate above passes vacuously. The
+    corruption itself has to fail the job, or a required check stays green while
+    regression detection is off.
+    """
+    exit_code, states = _drive_cmd_report(
+        tmp_path,
+        monkeypatch,
+        reporting_groups={"int-g": 1},
+        baseline_blob='{"covered_paths": ["int-pat',
+    )
+
+    assert states["int-path"] == "gap", (
+        "without a baseline the regression classification is unreachable, which "
+        "is exactly why the corrupt flag must gate on its own"
+    )
+    assert exit_code == 1

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -955,3 +955,125 @@ def test_resolve_configfile_ignores_commented_section(tmp_path: Path) -> None:
     child.mkdir()
 
     assert cli._resolve_pytest_configfile(child) is None
+
+
+def _drive_cmd_report(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    reporting_groups: dict[str, int],
+) -> tuple[int, dict[str, str]]:
+    """Drive ``cmd_report`` over one integration group covering ``int-path``.
+
+    ``reporting_groups`` maps group name -> failure count for the groups that
+    emitted junit this build. A group absent from it emitted nothing, standing
+    in for a tier the CI path filter skipped. Returns the exit code and each
+    path's final state.
+    """
+    from tests.rig.reporting import GroupResult
+
+    test_dir = Path(__file__).parent
+    manifest_yaml = (
+        "version: 1\n"
+        "groups:\n"
+        "  int-g:\n"
+        "    tier: integration\n"
+        f"    workdir: {test_dir}\n"
+        "    paths: [.]\n"
+    )
+    (tmp_path / "groups.yaml").write_text(manifest_yaml)
+    (tmp_path / "critical_paths.yaml").write_text(
+        "version: 1\n"
+        "paths:\n"
+        "  - id: int-path\n"
+        "    description: covered only by the integration tier\n"
+        "    covered_by: [int-g]\n"
+    )
+
+    import tests.rig.cli as cli_mod
+    import tests.rig.critical_paths as cp_mod
+    import tests.rig.groups as groups_mod
+
+    monkeypatch.setattr(groups_mod, "DEFAULT_MANIFEST", tmp_path / "groups.yaml")
+    monkeypatch.setattr(cp_mod, "DEFAULT_REGISTRY", tmp_path / "critical_paths.yaml")
+    # Coverage combining needs real .coverage files and is not under test here.
+    monkeypatch.setattr(cli_mod, "combine_and_report", lambda reports_dir: None)
+
+    def fake_parse_junit(name, tier, reports_dir):
+        if name not in reporting_groups:
+            return None
+        failed = reporting_groups[name]
+        return GroupResult(
+            name=name,
+            tier=tier,
+            exit_code=1 if failed else 0,
+            passed=0 if failed else 1,
+            failed=failed,
+            errors=0,
+            skipped=0,
+            duration_seconds=0.01,
+        )
+
+    monkeypatch.setattr(cli_mod, "parse_junit", fake_parse_junit)
+
+    states: dict[str, str] = {}
+    real_evaluate = cp_mod.evaluate
+
+    def spy_evaluate(*args, **kwargs):
+        statuses = real_evaluate(*args, **kwargs)
+        states.update({s.path.id: s.state for s in statuses})
+        return statuses
+
+    monkeypatch.setattr(cli_mod.cp, "evaluate", spy_evaluate)
+
+    reports_dir = tmp_path / "reports"
+    reports_dir.mkdir()
+    # Baseline says the path was green on main, which is what makes the
+    # not-covered-now decision a regression-or-gap question at all.
+    (reports_dir / "previous-summary.json").write_text(
+        '{"covered_paths": ["int-path"]}'
+    )
+
+    args = cli_mod._build_parser().parse_args(
+        [
+            "report",
+            "combine",
+            "--reports-dir",
+            str(reports_dir),
+            "--baseline",
+            str(reports_dir / "previous-summary.json"),
+        ]
+    )
+    return cli_mod.cmd_report(args), states
+
+
+def test_cmd_report_skipped_tier_is_a_gap_not_a_regression(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A frontend-only PR skips the integration tier, so its groups emit no
+    junit. Those paths must degrade to ``gap`` — nothing regressed, the tier
+    never ran. Without ``scope_groups`` every baseline path in a skipped tier
+    is reported as regressed on every such PR.
+    """
+    exit_code, states = _drive_cmd_report(tmp_path, monkeypatch, reporting_groups={})
+
+    assert states["int-path"] == "gap", (
+        "a path whose tier did not run must not be called a regression; "
+        f"got {states['int-path']}"
+    )
+    assert exit_code == 0
+
+
+def test_cmd_report_gates_on_a_real_regression(tmp_path: Path, monkeypatch) -> None:
+    """The covering group ran and went red, so the path really did regress.
+    ``cmd_report`` is the only cross-tier evaluation, so it must gate on this —
+    it previously reported regressions in the PR comment while exiting 0.
+    """
+    exit_code, states = _drive_cmd_report(
+        tmp_path, monkeypatch, reporting_groups={"int-g": 1}
+    )
+
+    assert states["int-path"] == "regression"
+    assert exit_code == 1, (
+        "a regression must fail the report job, not just print into the comment"
+    )

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -1050,10 +1050,8 @@ def _drive_cmd_report(
 def test_cmd_report_skipped_tier_is_a_gap_not_a_regression(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """A frontend-only PR skips the integration tier, so its groups emit no
-    junit. Those paths must degrade to ``gap`` — nothing regressed, the tier
-    never ran. Without ``scope_groups`` every baseline path in a skipped tier
-    is reported as regressed on every such PR.
+    """A path filter can skip a whole tier, whose groups then emit no junit. Its
+    paths must degrade to ``gap``: nothing regressed, the tier never ran.
     """
     exit_code, states = _drive_cmd_report(tmp_path, monkeypatch, reporting_groups={})
 
@@ -1066,8 +1064,8 @@ def test_cmd_report_skipped_tier_is_a_gap_not_a_regression(
 
 def test_cmd_report_gates_on_a_real_regression(tmp_path: Path, monkeypatch) -> None:
     """The covering group ran and went red, so the path really did regress.
-    ``cmd_report`` is the only cross-tier evaluation, so it must gate on this —
-    it previously reported regressions in the PR comment while exiting 0.
+    Being the only cross-tier evaluation, ``cmd_report`` has to gate on it rather
+    than just render it into the comment.
     """
     exit_code, states = _drive_cmd_report(
         tmp_path, monkeypatch, reporting_groups={"int-g": 1}
@@ -1080,10 +1078,9 @@ def test_cmd_report_gates_on_a_real_regression(tmp_path: Path, monkeypatch) -> N
 
 
 def test_cmd_report_gates_on_a_corrupt_baseline(tmp_path: Path, monkeypatch) -> None:
-    """An unreadable baseline leaves ``previously_covered`` empty, so no path can
-    ever be classified as a regression and the gate above passes vacuously. The
-    corruption itself has to fail the job, or a required check stays green while
-    regression detection is off.
+    """An unreadable baseline leaves ``previously_covered`` empty, making the
+    regression state unreachable. Without gating on the corruption itself, the
+    job goes green with regression detection silently off.
     """
     exit_code, states = _drive_cmd_report(
         tmp_path,
@@ -1093,7 +1090,7 @@ def test_cmd_report_gates_on_a_corrupt_baseline(tmp_path: Path, monkeypatch) -> 
     )
 
     assert states["int-path"] == "gap", (
-        "without a baseline the regression classification is unreachable, which "
-        "is exactly why the corrupt flag must gate on its own"
+        "with no usable baseline the regression state is unreachable, which is "
+        "why the corrupt flag must gate on its own"
     )
     assert exit_code == 1

--- a/tests/rig/tests/test_critical_paths.py
+++ b/tests/rig/tests/test_critical_paths.py
@@ -59,22 +59,48 @@ def test_regression_when_baseline_covered_but_now_not() -> None:
 
 
 def test_baseline_merge_unions_with_existing(tmp_path: Path) -> None:
-    """Two tier runs in sequence must both contribute to the baseline."""
+    """Two tier runs in sequence must both contribute to the baseline.
+
+    Every invocation reads the same registry and differs only in which groups
+    ran, so each one sees the other tier's paths as uncovered — the union is
+    what stops the second run erasing the first.
+    """
     baseline = tmp_path / "previous-summary.json"
-    registry_a = _registry(("p1", ("g1",)))
-    statuses_a = evaluate(
-        registry_a, groups_run_green={"g1"}, baseline=None
-    )
+    registry = _registry(("p1", ("g1",)), ("p2", ("g2",)))
+
+    statuses_a = evaluate(registry, groups_run_green={"g1"}, baseline=None)
     merge_into_baseline(statuses_a, baseline)
 
-    registry_b = _registry(("p2", ("g2",)))
     statuses_b = evaluate(
-        registry_b, groups_run_green={"g2"}, baseline=load_baseline(baseline)
+        registry, groups_run_green={"g2"}, baseline=load_baseline(baseline)
     )
     merge_into_baseline(statuses_b, baseline)
 
     final = load_baseline(baseline) or {}
     assert sorted(final["covered_paths"]) == ["p1", "p2"]
+
+
+def test_baseline_merge_prunes_paths_dropped_from_the_registry(tmp_path: Path) -> None:
+    """Retiring a path must be able to clear it from the baseline.
+
+    The union never forgets on its own, so without pruning a deliberately
+    removed path stays cached forever and there is no in-repo way to accept the
+    removal.
+    """
+    baseline = tmp_path / "previous-summary.json"
+    before = _registry(("p1", ("g1",)), ("p2", ("g2",)))
+    merge_into_baseline(
+        evaluate(before, groups_run_green={"g1", "g2"}, baseline=None), baseline
+    )
+    assert sorted((load_baseline(baseline) or {})["covered_paths"]) == ["p1", "p2"]
+
+    after = _registry(("p1", ("g1",)))
+    merge_into_baseline(
+        evaluate(after, groups_run_green={"g1"}, baseline=load_baseline(baseline)),
+        baseline,
+    )
+
+    assert (load_baseline(baseline) or {})["covered_paths"] == ["p1"]
 
 
 def test_by_id_lookup_caches() -> None:

--- a/tests/rig/tests/test_critical_paths.py
+++ b/tests/rig/tests/test_critical_paths.py
@@ -143,6 +143,27 @@ def test_load_baseline_raises_on_corrupt_file(tmp_path: Path) -> None:
         load_baseline(baseline)
 
 
+@pytest.mark.parametrize(
+    "blob", ["[]", '{"covered_paths": 1}', '{"covered_paths": ["ok", 2]}']
+)
+def test_baseline_of_the_wrong_shape_is_corrupt(tmp_path: Path, blob: str) -> None:
+    """Parseable JSON of the wrong shape is as unusable as a truncated file.
+
+    Left unchecked it surfaces as an ``AttributeError``/``TypeError`` from
+    whichever caller touched it first, rather than the handled corrupt path.
+    """
+    baseline = tmp_path / "previous-summary.json"
+    baseline.write_text(blob)
+    registry = _registry(("p1", ("g1",)))
+
+    with pytest.raises(BaselineCorruptError):
+        load_baseline(baseline)
+    with pytest.raises(BaselineCorruptError):
+        merge_into_baseline(
+            evaluate(registry, groups_run_green={"g1"}, baseline=None), baseline
+        )
+
+
 def test_merge_raises_on_corrupt_existing_baseline(tmp_path: Path) -> None:
     """merge_into_baseline must not silently overwrite a corrupt file — that
     would erase the other tier's previously-covered paths.


### PR DESCRIPTION
## What

- Pass `scope_groups` to `evaluate()` in `cmd_report`, derived from the groups that actually emitted junit.
- Gate the report job on surviving regressions instead of returning 0 regardless.
- Split the report's gap section so a path covered by a tier that did not run is no longer listed under "not yet covered".

## Why

Spotted on #2230, a frontend-only PR. Its report comment listed nine critical paths under **❌ Regressions (must be zero)** — `adapter-register-llm`, `workflow-author`, `api-deployment-provision`, `api-deployment-auth`, `mcp-server-auth`, `mcp-platform-auth`, `prompt-studio-author`, `connector-register-test`, `usage-aggregate-read` — while every check on the PR was green.

Two independent defects, which masked each other.

**1. False positives.** All nine paths are covered solely by `integration-backend`. The `changes` filter marks `frontend/**` as not `relevant`, so the `test` job (unit + integration) skips and emits no junit. `cmd_report` called `evaluate()` without `scope_groups`, which the docstring documents as "no scoping is applied (back-compat)", making `in_scope` unconditionally true. Every one of those paths was in main's baseline and not covered in this build, so:

```python
elif path.id in previously_covered and in_scope:
    state = "regression"
```

`cmd_run` already passes `scope_groups` and degrades out-of-tier paths to `gap`. `cmd_report` never got the same treatment, even though the workflow comment names it "the sole regression authority".

**2. No gate.** `cmd_report`'s only exit path was `return 1 if unknown_marker_ids else 0` — it rendered "must be zero" into the comment and exited 0 regardless. The `report` job's fail step only inspects `needs.*.result`, and a path-filtered skip counts as a pass, so nothing failed.

Fixing either alone is wrong: gate-only turns every frontend PR red, scope-only leaves genuine regressions unenforced.

The practical cost today is a comment that cries wolf under a heading reading "must be zero", which trains reviewers to scroll past the section that is supposed to stop a merge.

## How

- `scope_groups = [r.name for r in group_results]` — a skipped tier contributes no groups, so its paths fall to `gap`. A group that ran and went red still reports, stays in scope, and is still classified as a regression.
- Collect `regressions` from the evaluated statuses, print the ids to stderr, and fold them into the return code.
- `reporting.py` splits out-of-scope gaps that have declared covering groups into a collapsed "💤 Covered, but not exercised in this build" section. Paths with no declared groups (e.g. `workflow-execution-fan-out`) stay under "not yet covered", where they belong.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

It changes when a required check fails, so it is worth reviewing on that basis rather than as a no-op.

- **On a full run the scoping is a no-op.** Every group reports, so `scope_groups` covers all of them and `in_scope` matches the previous unconditional `True`. Only builds with a skipped tier change classification. `main` always runs both tiers.
- **The gate is new behaviour by design.** Any genuine regression now fails `report`, where it previously only printed. If main's baseline is currently out of step with reality, the first build after this merges will surface it — that is the intended effect, but it is the reason to land this deliberately rather than fold it into an unrelated PR.
- **One edge case worth naming:** a non-optional group that runs green but collects zero tests does not attest coverage (`_coverage_attesting_groups` excludes `empty`), yet it does report, so it stays in scope. Its baseline-covered paths will now be regressions and will fail the job. That is the correct reading of a group that silently stopped collecting, and `cmd_run` already fails empty non-optional groups, but it is a new failure mode for the report job.
- **A corrupt baseline now fails the report job too.** Raised in review: a truncated `previous-summary.json` empties `previously_covered`, which makes the `regression` state unreachable and would have let the new gate pass vacuously. `cmd_report` now flips its exit code on `baseline_corrupt`, matching `cmd_run`. A *missing* baseline still exits 0, so first runs and post-eviction runs are unaffected — only a file that exists and is unreadable fails.
- **A skipped marked test now fails the report job, with a green tier.** Only *passing* `@pytest.mark.critical_path` tests attest, so an env-dependent `skipTest` leaves its group green and in scope while attesting nothing — which reads as a regression. Raised in review; kept as a failure (a silently-skipped critical-path test should shout), but the stderr line now distinguishes "covering group ran green but nothing attested" from "no covering group ran green", since the fixes differ.
- **`optional` groups are excluded from the gate's scope.** They are documented as non-blocking and `cmd_run` honours that; leaving them in scope let a red optional group gate the build through a regression instead. Latent today (no critical path names one), fixed before it isn't.
- **The baseline is now pruned to the registry on merge.** The union never forgot, so a deliberately retired path could not leave the cache. Editing `critical_paths.yaml` is what accepts a removal, and the failure message says so.
- Baseline writing is untouched: `--update-baseline` remains main-only and green-only, so no PR can poison it.

## Database Migrations

- None.

## Env Config

- None.

## Related Issues or PRs

- Found while reviewing CI output on #2230. No code dependency in either direction; that PR is frontend-only.

## Notes on Testing

- Two new tests in `tests/rig/tests/test_cli.py` drive `cmd_report` end to end: `test_cmd_report_skipped_tier_is_a_gap_not_a_regression` (covering group emits no junit → `gap`, exit 0) and `test_cmd_report_gates_on_a_real_regression` (covering group reports red → `regression`, exit 1).
- Both were confirmed to fail against the unmodified `cli.py` and pass with it, so they exercise the changed branch rather than passing vacuously.
- Full rig self-test suite: 106 passed, 1 skipped.
- Note that this PR cannot demonstrate the fix in its own CI run: touching `tests/rig/**` flips `relevant` to true, so the integration tier runs and those paths are attested normally. The live confirmation is #2230's next run once this lands — its nine paths should move out of the regression section.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).


