### PR TITLE
UN-1184 [FIX] Show the docs link on all Add Connector/adapter screens

### DIFF
--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -75,6 +75,7 @@ class AdapterProcessor:
                     AdapterKeys.DESCRIPTION: each_adapter.get(AdapterKeys.DESCRIPTION),
                     AdapterKeys.ICON: each_adapter.get(AdapterKeys.ICON),
                     AdapterKeys.ADAPTER_TYPE: each_adapter.get(AdapterKeys.ADAPTER_TYPE),
+                    AdapterKeys.DOC_URL: each_adapter.get(AdapterKeys.DOC_URL, ""),
                 }
             )
         return supported_adapters

--- a/backend/adapter_processor_v2/constants.py
+++ b/backend/adapter_processor_v2/constants.py
@@ -13,6 +13,7 @@ class AdapterKeys:
     NAME = "name"
     DESCRIPTION = "description"
     ICON = "icon"
+    DOC_URL = "doc_url"
     ADAPTER_ID = "adapter_id"
     ADAPTER_METADATA = "adapter_metadata"
     ADAPTER_METADATA_B = "adapter_metadata_b"

--- a/unstract/connectors/src/unstract/connectors/databases/unstract_db.py
+++ b/unstract/connectors/src/unstract/connectors/databases/unstract_db.py
@@ -46,7 +46,7 @@ class UnstractDB(UnstractConnector, ABC):
 
     @staticmethod
     def get_doc_url() -> str:
-        # ponytail: connectors without a dedicated page fall back to the category index
+        # Connectors without a dedicated page fall back to the category index
         return "https://docs.unstract.com/unstract/unstract_platform/connectors/databases/index/"
 
     @staticmethod

--- a/unstract/connectors/src/unstract/connectors/databases/unstract_db.py
+++ b/unstract/connectors/src/unstract/connectors/databases/unstract_db.py
@@ -45,6 +45,11 @@ class UnstractDB(UnstractConnector, ABC):
         return ""
 
     @staticmethod
+    def get_doc_url() -> str:
+        # ponytail: connectors without a dedicated page fall back to the category index
+        return "https://docs.unstract.com/unstract/unstract_platform/connectors/databases/index/"
+
+    @staticmethod
     def get_json_schema() -> str:
         return ""
 

--- a/unstract/connectors/src/unstract/connectors/filesystems/sharepoint/sharepoint.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/sharepoint/sharepoint.py
@@ -456,6 +456,10 @@ class SharePointFS(UnstractFileSystem):
         return "/icons/connector-icons/SharePoint.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/connectors/filesystems/sharepoint_filesystem/"
+
+    @staticmethod
     def get_json_schema() -> str:
         schema_path = os.path.join(
             os.path.dirname(__file__),

--- a/unstract/connectors/src/unstract/connectors/filesystems/unstract_file_system.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/unstract_file_system.py
@@ -43,6 +43,11 @@ class UnstractFileSystem(UnstractConnector, ABC):
         return ""
 
     @staticmethod
+    def get_doc_url() -> str:
+        # ponytail: connectors without a dedicated page fall back to the category index
+        return "https://docs.unstract.com/unstract/unstract_platform/connectors/filesystems/index/"
+
+    @staticmethod
     def get_json_schema() -> str:
         return ""
 

--- a/unstract/connectors/src/unstract/connectors/filesystems/unstract_file_system.py
+++ b/unstract/connectors/src/unstract/connectors/filesystems/unstract_file_system.py
@@ -44,7 +44,7 @@ class UnstractFileSystem(UnstractConnector, ABC):
 
     @staticmethod
     def get_doc_url() -> str:
-        # ponytail: connectors without a dedicated page fall back to the category index
+        # Connectors without a dedicated page fall back to the category index
         return "https://docs.unstract.com/unstract/unstract_platform/connectors/filesystems/index/"
 
     @staticmethod

--- a/unstract/sdk1/src/unstract/sdk1/adapters/adapterkit.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/adapterkit.py
@@ -80,6 +80,7 @@ class Adapterkit:
                     "icon": icon,
                     "adapter_type": adapter_type,
                     "json_schema": json_schema,
+                    "doc_url": m.get_doc_url(),
                 }
             )
         return adapters

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 
+from unstract.sdk1.adapters.constants import AdapterDocs
 from unstract.sdk1.adapters.enums import AdapterTypes
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,10 @@ class Adapter(ABC):
     @abstractmethod
     def get_icon() -> str:
         return ""
+
+    @classmethod
+    def get_doc_url(cls) -> str:
+        return AdapterDocs.type_index_url(cls.get_adapter_type())
 
     @classmethod
     def get_json_schema(cls) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/base1.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
-from unstract.sdk1.adapters.constants import Common
+from unstract.sdk1.adapters.constants import AdapterDocs, Common
 from unstract.sdk1.adapters.enums import AdapterTypes
 
 logger = logging.getLogger(__name__)
@@ -240,6 +240,10 @@ class BaseAdapter(ABC):
     @abstractmethod
     def get_icon() -> str:
         pass
+
+    @classmethod
+    def get_doc_url(cls) -> str:
+        return AdapterDocs.type_index_url(cls.get_adapter_type())
 
     @classmethod
     def get_json_schema(cls) -> str:

--- a/unstract/sdk1/src/unstract/sdk1/adapters/constants.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/constants.py
@@ -1,3 +1,24 @@
+from unstract.sdk1.adapters.enums import AdapterTypes
+
+
+class AdapterDocs:
+    """Documentation links surfaced on the adapter configuration screen."""
+
+    BASE_URL = "https://docs.unstract.com/unstract/unstract_platform/adapters"
+
+    _TYPE_INDEX = {
+        AdapterTypes.LLM: f"{BASE_URL}/llms/index/",
+        AdapterTypes.EMBEDDING: f"{BASE_URL}/embedding/index/",
+        AdapterTypes.VECTOR_DB: f"{BASE_URL}/vector_dbs/index/",
+        AdapterTypes.X2TEXT: f"{BASE_URL}/text_extractors/index/",
+    }
+
+    @classmethod
+    def type_index_url(cls, adapter_type: AdapterTypes) -> str:
+        """Category index used by adapters without a dedicated doc page."""
+        return cls._TYPE_INDEX.get(adapter_type, f"{cls.BASE_URL}/index/")
+
+
 class Common:
     METADATA = "metadata"
     MODULE = "module"

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/azure_openai.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/azure_openai.py
@@ -36,5 +36,9 @@ class AzureOpenAIEmbeddingAdapter(AzureOpenAIEmbeddingParameters, BaseAdapter):
         return "/icons/adapter-icons/AzureopenAI.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/embedding/azure_openai_embedding/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.EMBEDDING

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/bedrock.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/bedrock.py
@@ -36,5 +36,9 @@ class AWSBedrockEmbeddingAdapter(AWSBedrockEmbeddingParameters, BaseAdapter):
         return "/icons/adapter-icons/Bedrock.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/embedding/amazon_bedrock_embedding/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.EMBEDDING

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/gemini.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/gemini.py
@@ -36,5 +36,9 @@ class GeminiEmbeddingAdapter(GeminiEmbeddingParameters, BaseAdapter):
         return "/icons/adapter-icons/Gemini.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/embedding/gemini_embedding/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.EMBEDDING

--- a/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/openai.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/embedding1/openai.py
@@ -36,5 +36,9 @@ class OpenAIEmbeddingAdapter(OpenAIEmbeddingParameters, BaseAdapter):
         return "/icons/adapter-icons/OpenAI.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/embedding/openai_embedding/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.EMBEDDING

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/anthropic.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/anthropic.py
@@ -36,5 +36,9 @@ class AnthropicLLMAdapter(AnthropicLLMParameters, BaseAdapter):
         return "/icons/adapter-icons/Anthropic.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/anthropic_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/anyscale.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/anyscale.py
@@ -36,5 +36,9 @@ class AnyscaleLLMAdapter(AnyscaleLLMParameters, BaseAdapter):
         return "/icons/adapter-icons/anyscale.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/anyscale_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/azure_ai_foundry.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/azure_ai_foundry.py
@@ -36,5 +36,9 @@ class AzureAIFoundryLLMAdapter(AzureAIFoundryLLMParameters, BaseAdapter):
         return "/icons/adapter-icons/AzureAIFoundry.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/azure_ai_foundry_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/azure_openai.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/azure_openai.py
@@ -36,5 +36,9 @@ class AzureOpenAILLMAdapter(AzureOpenAILLMParameters, BaseAdapter):
         return "/icons/adapter-icons/AzureopenAI.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/azure_openai_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/bedrock.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/bedrock.py
@@ -36,5 +36,9 @@ class AWSBedrockLLMAdapter(AWSBedrockLLMParameters, BaseAdapter):
         return "/icons/adapter-icons/Bedrock.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/amazon_bedrock/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/gemini.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/gemini.py
@@ -36,5 +36,9 @@ class GeminiLLMAdapter(GeminiLLMParameters, BaseAdapter):
         return "/icons/adapter-icons/Gemini.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/gemini_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/mistral.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/mistral.py
@@ -36,5 +36,9 @@ class MistralLLMAdapter(MistralLLMParameters, BaseAdapter):
         return "/icons/adapter-icons/Mistral%20AI.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/mistral_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/ollama.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/ollama.py
@@ -36,5 +36,9 @@ class OllamaLLMAdapter(OllamaLLMParameters, BaseAdapter):
         return "/icons/adapter-icons/ollama.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/ollama_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/llm1/openai.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/llm1/openai.py
@@ -36,5 +36,9 @@ class OpenAILLMAdapter(OpenAILLMParameters, BaseAdapter):
         return "/icons/adapter-icons/OpenAI.png"
 
     @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/llms/openai_llm/"
+
+    @staticmethod
     def get_adapter_type() -> AdapterTypes:
         return AdapterTypes.LLM

--- a/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/milvus/src/milvus.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/milvus/src/milvus.py
@@ -52,6 +52,10 @@ class Milvus(VectorDBAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/Milvus.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/vector_dbs/milvus_vectordb/"
+
     def get_vector_db_instance(self) -> VectorStore:
         return self._vector_db_instance
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/pinecone/src/pinecone.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/pinecone/src/pinecone.py
@@ -61,6 +61,10 @@ class Pinecone(VectorDBAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/pinecone.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/vector_dbs/pinecone_vectordb/"
+
     def get_vector_db_instance(self) -> BasePydanticVectorStore:
         return self._vector_db_instance
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/postgres/src/postgres.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/postgres/src/postgres.py
@@ -59,6 +59,10 @@ class Postgres(VectorDBAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/postgres.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/vector_dbs/postgres_vectordb/"
+
     def get_vector_db_instance(self) -> BasePydanticVectorStore:
         return self._vector_db_instance
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/qdrant/src/qdrant.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/qdrant/src/qdrant.py
@@ -50,6 +50,10 @@ class Qdrant(VectorDBAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/qdrant.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/vector_dbs/qdrant_vectordb/"
+
     def get_vector_db_instance(self) -> BasePydanticVectorStore:
         return self._vector_db_instance
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/weaviate/src/weaviate.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/vectordb/weaviate/src/weaviate.py
@@ -51,6 +51,10 @@ class Weaviate(VectorDBAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/Weaviate.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/vector_dbs/weaviate_vectordb/"
+
     def get_vector_db_instance(self) -> BasePydanticVectorStore:
         return self._vector_db_instance
 

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/llm_whisperer_v2.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/llm_whisperer_v2/src/llm_whisperer_v2.py
@@ -54,6 +54,10 @@ class LLMWhispererV2(X2TextAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/LLMWhispererV2.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/text_extractors/llm_whisperer_text_extractor_v2/"
+
     def test_connection(self) -> bool:
         LLMWhispererHelper.test_connection_request(
             config=self.config,

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/unstructured_community/src/unstructured_community.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/unstructured_community/src/unstructured_community.py
@@ -39,6 +39,10 @@ class UnstructuredCommunity(X2TextAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/UnstructuredIO.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/text_extractors/unstructured_io_community_text_extractor/"
+
     def process(
         self,
         input_file_path: str,

--- a/unstract/sdk1/src/unstract/sdk1/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
+++ b/unstract/sdk1/src/unstract/sdk1/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
@@ -39,6 +39,10 @@ class UnstructuredEnterprise(X2TextAdapter):
     def get_icon() -> str:
         return "/icons/adapter-icons/UnstructuredIO.png"
 
+    @staticmethod
+    def get_doc_url() -> str:
+        return "https://docs.unstract.com/unstract/unstract_platform/adapters/text_extractors/unstructured_io_enterprise_text_extractor/"
+
     def process(
         self,
         input_file_path: str,


### PR DESCRIPTION
## What

- Every Add Connector and Add LLM / Vector DB / Embedding / Text Extractor screen now shows the "Need help? See documentation." link.
- The link opens that item's own setup page, or its category page for the few items that don't have one yet.

## Why

- Users setting up a connector or model had to leave the product and search the docs site for the setup steps.
- The link already existed but appeared on only a handful of screens, so it read as broken and inconsistent.

## How

- Per-adapter/connector overrides return the dedicated docs page; anything without one inherits the category index from its base class, so the link is never empty.
- `Adapterkit.get_adapters_list()` now emits `doc_url`, and `get_all_supported_adapters()` passes it through to the UI.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. The change only adds a read-only string to two list responses; the frontend already guards on it and every URL was verified to return HTTP 200.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions

- None

## Notes on Testing

- Manual: open Add Connector and Add LLM / Vector DB / Embedding / Text Extractor, select any item, confirm the documentation link appears and opens the right page.

## Screenshots

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).