### PR TITLE
UN-3991 [FIX] Show model names on Prompt Studio tiles for shared users

### DIFF
--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -20,7 +20,6 @@ from unstract.sdk1.adapters.adapterkit import Adapterkit
 from unstract.sdk1.adapters.base import Adapter
 from unstract.sdk1.adapters.x2text.constants import X2TextConstants
 from unstract.sdk1.constants import AdapterTypes
-from unstract.sdk1.constants import Common as common
 from unstract.sdk1.embedding import EmbeddingCompat
 from unstract.sdk1.exceptions import SdkError
 from unstract.sdk1.llm import LLM
@@ -113,29 +112,35 @@ class AdapterProcessor:
         return updated_adapters[0].get(key_value)
 
     @staticmethod
-    def get_display_info(adapter: AdapterInstance) -> tuple[str, str]:
-        """Icon and model label for an adapter, as (icon, model).
+    def get_icon(adapter: AdapterInstance) -> str:
+        """Registry icon for an adapter, or the warning icon if unresolvable."""
+        if not adapter.is_available:
+            return UNAVAILABLE_ADAPTER_ICON
+        try:
+            adapter_class = Adapterkit().get_adapter_class_by_adapter_id(
+                adapter.adapter_id
+            )
+        except Exception as e:
+            logger.warning(
+                "Adapter %s is not in the SDK registry: %s", adapter.adapter_id, e
+            )
+            return UNAVAILABLE_ADAPTER_ICON
+        return adapter_class.get_icon() or UNAVAILABLE_ADAPTER_ICON
 
-        Display data only, no credentials. Never raises - falls back to the
-        warning icon and the adapter id's provider prefix.
+    @staticmethod
+    def get_model_label(adapter: AdapterInstance) -> str:
+        """Model name from the adapter metadata.
+
+        Adapters without a model use the adapter id's provider prefix.
         """
-        icon = UNAVAILABLE_ADAPTER_ICON
-        if adapter.is_available:
-            try:
-                icon = (
-                    AdapterProcessor.get_adapter_data_with_key(
-                        adapter.adapter_id, common.ICON
-                    )
-                    or UNAVAILABLE_ADAPTER_ICON
-                )
-            except Exception as e:
-                logger.warning(f"No icon for adapter {adapter.adapter_id}: {e}")
         try:
             model = adapter.metadata.get("model")
         except Exception as e:
-            logger.warning(f"No metadata for adapter {adapter.adapter_id}: {e}")
+            logger.error(
+                "Could not read metadata for adapter %s: %s", adapter.adapter_id, e
+            )
             model = None
-        return icon, model or adapter.adapter_id.split("|")[0]
+        return model or adapter.adapter_id.split("|")[0]
 
     @staticmethod
     def test_adapter(adapter_id: str, adapter_metadata: dict[str, Any]) -> bool:

--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -122,8 +122,11 @@ class AdapterProcessor:
         icon = UNAVAILABLE_ADAPTER_ICON
         if adapter.is_available:
             try:
-                icon = AdapterProcessor.get_adapter_data_with_key(
-                    adapter.adapter_id, common.ICON
+                icon = (
+                    AdapterProcessor.get_adapter_data_with_key(
+                        adapter.adapter_id, common.ICON
+                    )
+                    or UNAVAILABLE_ADAPTER_ICON
                 )
             except Exception as e:
                 logger.warning(f"No icon for adapter {adapter.adapter_id}: {e}")

--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -20,6 +20,7 @@ from unstract.sdk1.adapters.adapterkit import Adapterkit
 from unstract.sdk1.adapters.base import Adapter
 from unstract.sdk1.adapters.x2text.constants import X2TextConstants
 from unstract.sdk1.constants import AdapterTypes
+from unstract.sdk1.constants import Common as common
 from unstract.sdk1.embedding import EmbeddingCompat
 from unstract.sdk1.exceptions import SdkError
 from unstract.sdk1.llm import LLM
@@ -27,6 +28,8 @@ from unstract.sdk1.llm import LLM
 from .models import AdapterInstance, UserDefaultAdapter
 
 logger = logging.getLogger(__name__)
+
+UNAVAILABLE_ADAPTER_ICON = "⚠️"
 
 try:
     from plugins.subscription.time_trials.subscription_adapter import add_unstract_key
@@ -108,6 +111,28 @@ class AdapterProcessor:
             )
             raise InValidAdapterId()
         return updated_adapters[0].get(key_value)
+
+    @staticmethod
+    def get_display_info(adapter: AdapterInstance) -> tuple[str, str]:
+        """Icon and model label for an adapter, as (icon, model).
+
+        Display data only, no credentials. Never raises - falls back to the
+        warning icon and the adapter id's provider prefix.
+        """
+        icon = UNAVAILABLE_ADAPTER_ICON
+        if adapter.is_available:
+            try:
+                icon = AdapterProcessor.get_adapter_data_with_key(
+                    adapter.adapter_id, common.ICON
+                )
+            except Exception as e:
+                logger.warning(f"No icon for adapter {adapter.adapter_id}: {e}")
+        try:
+            model = adapter.metadata.get("model")
+        except Exception as e:
+            logger.warning(f"No metadata for adapter {adapter.adapter_id}: {e}")
+            model = None
+        return icon, model or adapter.adapter_id.split("|")[0]
 
     @staticmethod
     def test_adapter(adapter_id: str, adapter_metadata: dict[str, Any]) -> bool:
@@ -213,27 +238,6 @@ class AdapterProcessor:
                 raise e
             else:
                 raise InternalServiceError()
-
-    @staticmethod
-    def get_adapter_instance_by_id(adapter_instance_id: str) -> Adapter:
-        """Get the adapter instance by its ID.
-
-        Parameters:
-        - adapter_instance_id (str): The ID of the adapter instance.
-
-        Returns:
-        - Adapter: The adapter instance with the specified ID.
-
-        Raises:
-        - Exception: If there is an error while fetching the adapter instance.
-        """
-        try:
-            adapter = AdapterInstance.objects.get(id=adapter_instance_id)
-        except Exception as e:
-            logger.error(f"Unable to fetch adapter: {e}")
-        if not adapter:
-            logger.error("Unable to fetch adapter")
-        return adapter.adapter_name
 
     @staticmethod
     def get_adapters_by_type(

--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -28,8 +28,6 @@ from .models import AdapterInstance, UserDefaultAdapter
 
 logger = logging.getLogger(__name__)
 
-UNAVAILABLE_ADAPTER_ICON = "⚠️"
-
 try:
     from plugins.subscription.time_trials.subscription_adapter import add_unstract_key
 except ImportError:
@@ -115,7 +113,7 @@ class AdapterProcessor:
     def get_icon(adapter: AdapterInstance) -> str:
         """Registry icon for an adapter, or the warning icon if unresolvable."""
         if not adapter.is_available:
-            return UNAVAILABLE_ADAPTER_ICON
+            return AdapterKeys.UNAVAILABLE_ICON
         try:
             adapter_class = Adapterkit().get_adapter_class_by_adapter_id(
                 adapter.adapter_id
@@ -124,8 +122,8 @@ class AdapterProcessor:
             logger.warning(
                 "Adapter %s is not in the SDK registry: %s", adapter.adapter_id, e
             )
-            return UNAVAILABLE_ADAPTER_ICON
-        return adapter_class.get_icon()
+            return AdapterKeys.UNAVAILABLE_ICON
+        return adapter_class.get_icon() or AdapterKeys.UNAVAILABLE_ICON
 
     @staticmethod
     def get_model_label(adapter: AdapterInstance) -> str:

--- a/backend/adapter_processor_v2/adapter_processor.py
+++ b/backend/adapter_processor_v2/adapter_processor.py
@@ -125,7 +125,7 @@ class AdapterProcessor:
                 "Adapter %s is not in the SDK registry: %s", adapter.adapter_id, e
             )
             return UNAVAILABLE_ADAPTER_ICON
-        return adapter_class.get_icon() or UNAVAILABLE_ADAPTER_ICON
+        return adapter_class.get_icon()
 
     @staticmethod
     def get_model_label(adapter: AdapterInstance) -> str:

--- a/backend/adapter_processor_v2/constants.py
+++ b/backend/adapter_processor_v2/constants.py
@@ -35,6 +35,7 @@ class AdapterKeys:
     IS_AVAILABLE = "is_available"
     DEPRECATION_METADATA = "deprecation_metadata"
     IS_DEPRECATED = "is_deprecated"
+    UNAVAILABLE_ICON = "⚠️"
 
 
 class AllowedDomains(Enum):

--- a/backend/adapter_processor_v2/serializers.py
+++ b/backend/adapter_processor_v2/serializers.py
@@ -184,24 +184,7 @@ class AdapterListSerializer(BaseAdapterSerializer):
         if not instance.is_available and instance.deprecation_metadata:
             rep[AdapterKeys.DEPRECATION_METADATA] = instance.deprecation_metadata
 
-        # Only call SDK for available adapters
-        if instance.is_available:
-            try:
-                rep[common.ICON] = AdapterProcessor.get_adapter_data_with_key(
-                    instance.adapter_id, common.ICON
-                )
-            except Exception as e:
-                # Log error but don't fail serialization
-                import logging
-
-                logger = logging.getLogger(__name__)
-                logger.warning(
-                    f"Failed to retrieve icon for adapter {instance.adapter_id}: {e}"
-                )
-                rep[common.ICON] = "⚠️"  # Fallback icon for SDK errors
-        else:
-            # Use generic warning icon for deprecated adapters
-            rep[common.ICON] = "⚠️"
+        rep[common.ICON] = AdapterProcessor.get_icon(instance)
 
         model = instance.metadata.get("model")
         if model:

--- a/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from adapter_processor_v2.adapter_processor import AdapterProcessor
 
@@ -9,7 +10,7 @@ from .models import ProfileManager
 
 logger = logging.getLogger(__name__)
 
-# Adapter FK -> label shown on the Prompt Studio output tiles.
+# Adapter FK -> "conf" response key read by the UI.
 ADAPTER_LABELS = (
     (ProfileManagerKeys.LLM, "LLM"),
     (ProfileManagerKeys.EMBEDDING_MODEL, "Embedding Model"),
@@ -22,7 +23,8 @@ class ProfileManagerSerializer(AuditSerializer):
     class Meta:
         model = ProfileManager
         fields = "__all__"
-        # Uniqueness is enforced by the view; the auto-validator 400s on re-save.
+        # Drop DRF's auto unique-together validator so a duplicate create
+        # surfaces the view's DuplicateData instead of DRF's generic message.
         validators = []
 
     def to_representation(self, instance):  # type: ignore
@@ -30,17 +32,16 @@ class ProfileManagerSerializer(AuditSerializer):
 
         Not filtered by adapter access - display data only, no credentials.
         """
-        rep: dict[str, str] = super().to_representation(instance)
+        rep: dict[str, Any] = super().to_representation(instance)
         conf: dict[str, str] = {}
         for field, label in ADAPTER_LABELS:
-            adapter = getattr(instance, field, None)
+            adapter = getattr(instance, field)
             if not adapter:
                 continue
-            icon, model = AdapterProcessor.get_display_info(adapter)
             rep[field] = adapter.adapter_name
-            conf[label] = model
+            conf[label] = AdapterProcessor.get_model_label(adapter)
             if field == ProfileManagerKeys.LLM:
-                rep["icon"] = icon
+                rep["icon"] = AdapterProcessor.get_icon(adapter)
         if conf:
             conf["Profile Name"] = instance.profile_name
         rep["conf"] = conf

--- a/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
@@ -2,6 +2,8 @@ import logging
 from typing import Any
 
 from adapter_processor_v2.adapter_processor import AdapterProcessor
+from adapter_processor_v2.models import AdapterInstance
+from rest_framework.serializers import ValidationError
 
 from backend.serializers import AuditSerializer
 from prompt_studio.prompt_profile_manager_v2.constants import ProfileManagerKeys
@@ -25,6 +27,24 @@ class ProfileManagerSerializer(AuditSerializer):
         fields = "__all__"
         # Dropped so a duplicate create surfaces the view's DuplicateData.
         validators = []
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        """Reject a change to an adapter the requester cannot access.
+
+        An unchanged value passes, so a co-owner can still save a profile
+        that points at an adapter shared only with the owner.
+        """
+        request = self.context.get("request")
+        if not request:
+            return attrs
+        accessible = AdapterInstance.objects.for_user(request.user)
+        for field, _ in ADAPTER_LABELS:
+            adapter = attrs.get(field)
+            if not adapter or adapter == getattr(self.instance, field, None):
+                continue
+            if not accessible.filter(id=adapter.id).exists():
+                raise ValidationError({field: "No access to the selected adapter."})
+        return attrs
 
     def to_representation(self, instance):  # type: ignore
         """Resolve the adapter FKs to the name, model and icon the UI renders.

--- a/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
@@ -23,8 +23,7 @@ class ProfileManagerSerializer(AuditSerializer):
     class Meta:
         model = ProfileManager
         fields = "__all__"
-        # Drop DRF's auto unique-together validator so a duplicate create
-        # surfaces the view's DuplicateData instead of DRF's generic message.
+        # Dropped so a duplicate create surfaces the view's DuplicateData.
         validators = []
 
     def to_representation(self, instance):  # type: ignore
@@ -38,6 +37,8 @@ class ProfileManagerSerializer(AuditSerializer):
             adapter = getattr(instance, field)
             if not adapter:
                 continue
+            # Keep the id for adapters the viewer cannot access.
+            rep[f"{field}_id"] = str(rep[field])
             rep[field] = adapter.adapter_name
             conf[label] = AdapterProcessor.get_model_label(adapter)
             if field == ProfileManagerKeys.LLM:

--- a/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/serializers.py
@@ -9,33 +9,39 @@ from .models import ProfileManager
 
 logger = logging.getLogger(__name__)
 
+# Adapter FK -> label shown on the Prompt Studio output tiles.
+ADAPTER_LABELS = (
+    (ProfileManagerKeys.LLM, "LLM"),
+    (ProfileManagerKeys.EMBEDDING_MODEL, "Embedding Model"),
+    (ProfileManagerKeys.VECTOR_STORE, "Vector Store"),
+    (ProfileManagerKeys.X2TEXT, "Text Extractor"),
+)
+
 
 class ProfileManagerSerializer(AuditSerializer):
     class Meta:
         model = ProfileManager
         fields = "__all__"
-        # View owns uniqueness (IntegrityError->DuplicateData on create); drop
-        # the DRF auto-validator that 400s on re-save / PUT before the view runs.
+        # Uniqueness is enforced by the view; the auto-validator 400s on re-save.
         validators = []
 
     def to_representation(self, instance):  # type: ignore
+        """Resolve the adapter FKs to the name, model and icon the UI renders.
+
+        Not filtered by adapter access - display data only, no credentials.
+        """
         rep: dict[str, str] = super().to_representation(instance)
-        llm = rep[ProfileManagerKeys.LLM]
-        embedding = rep[ProfileManagerKeys.EMBEDDING_MODEL]
-        vector_db = rep[ProfileManagerKeys.VECTOR_STORE]
-        x2text = rep[ProfileManagerKeys.X2TEXT]
-        if llm:
-            rep[ProfileManagerKeys.LLM] = AdapterProcessor.get_adapter_instance_by_id(llm)
-        if embedding:
-            rep[ProfileManagerKeys.EMBEDDING_MODEL] = (
-                AdapterProcessor.get_adapter_instance_by_id(embedding)
-            )
-        if vector_db:
-            rep[ProfileManagerKeys.VECTOR_STORE] = (
-                AdapterProcessor.get_adapter_instance_by_id(vector_db)
-            )
-        if x2text:
-            rep[ProfileManagerKeys.X2TEXT] = AdapterProcessor.get_adapter_instance_by_id(
-                x2text
-            )
+        conf: dict[str, str] = {}
+        for field, label in ADAPTER_LABELS:
+            adapter = getattr(instance, field, None)
+            if not adapter:
+                continue
+            icon, model = AdapterProcessor.get_display_info(adapter)
+            rep[field] = adapter.adapter_name
+            conf[label] = model
+            if field == ProfileManagerKeys.LLM:
+                rep["icon"] = icon
+        if conf:
+            conf["Profile Name"] = instance.profile_name
+        rep["conf"] = conf
         return rep

--- a/backend/prompt_studio/prompt_profile_manager_v2/tests/test_profile_display_info.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/tests/test_profile_display_info.py
@@ -1,0 +1,93 @@
+"""Profile serializer resolves adapter FKs to display data without an access check.
+
+The DRF base is patched out so the assertions cover only that resolution.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from backend.serializers import AuditSerializer
+
+from prompt_studio.prompt_profile_manager_v2.serializers import ProfileManagerSerializer
+
+
+def _adapter(name: str, model: str) -> SimpleNamespace:
+    return SimpleNamespace(adapter_name=name, model=model)
+
+
+def _represent(instance: SimpleNamespace, base_rep: dict) -> dict:
+    with (
+        patch.object(AuditSerializer, "to_representation", return_value=base_rep),
+        patch(
+            "prompt_studio.prompt_profile_manager_v2.serializers."
+            "AdapterProcessor.get_display_info",
+            side_effect=lambda adapter: ("openai.png", adapter.model),
+        ),
+    ):
+        return ProfileManagerSerializer().to_representation(instance)
+
+
+class ProfileDisplayInfoTests(unittest.TestCase):
+    def test_display_info_resolved_without_adapter_access(self) -> None:
+        instance = SimpleNamespace(
+            profile_name="Prod",
+            llm=_adapter("Shared GPT", "gpt-4o"),
+            embedding_model=_adapter("Shared Embed", "text-embedding-3-small"),
+            vector_store=_adapter("Shared Qdrant", "qdrant"),
+            x2text=_adapter("Shared LLMW", "llmwhisperer"),
+        )
+        base_rep = {
+            field: "some-uuid"
+            for field in ("llm", "embedding_model", "vector_store", "x2text")
+        }
+
+        rep = _represent(instance, base_rep)
+
+        self.assertEqual(
+            rep["conf"],
+            {
+                "LLM": "gpt-4o",
+                "Embedding Model": "text-embedding-3-small",
+                "Vector Store": "qdrant",
+                "Text Extractor": "llmwhisperer",
+                "Profile Name": "Prod",
+            },
+        )
+        # Only the LLM contributes the tile icon.
+        self.assertEqual(rep["icon"], "openai.png")
+        # FK ids are replaced by the adapter names.
+        self.assertEqual(rep["llm"], "Shared GPT")
+
+    def test_unset_adapters_are_skipped(self) -> None:
+        instance = SimpleNamespace(
+            profile_name="Half configured",
+            llm=_adapter("Shared GPT", "gpt-4o"),
+            embedding_model=None,
+            vector_store=None,
+            x2text=None,
+        )
+
+        rep = _represent(instance, {"llm": "some-uuid", "embedding_model": None})
+
+        self.assertEqual(
+            rep["conf"], {"LLM": "gpt-4o", "Profile Name": "Half configured"}
+        )
+        self.assertIsNone(rep["embedding_model"])
+
+    def test_profile_with_no_adapters_has_empty_conf(self) -> None:
+        instance = SimpleNamespace(
+            profile_name="Empty",
+            llm=None,
+            embedding_model=None,
+            vector_store=None,
+            x2text=None,
+        )
+
+        rep = _represent(instance, {})
+
+        # No "Profile Name" either - the tile has nothing to show.
+        self.assertEqual(rep["conf"], {})
+        self.assertNotIn("icon", rep)

--- a/backend/prompt_studio/prompt_profile_manager_v2/tests/test_profile_display_info.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/tests/test_profile_display_info.py
@@ -23,8 +23,13 @@ def _represent(instance: SimpleNamespace, base_rep: dict) -> dict:
         patch.object(AuditSerializer, "to_representation", return_value=base_rep),
         patch(
             "prompt_studio.prompt_profile_manager_v2.serializers."
-            "AdapterProcessor.get_display_info",
-            side_effect=lambda adapter: ("openai.png", adapter.model),
+            "AdapterProcessor.get_model_label",
+            side_effect=lambda adapter: adapter.model,
+        ),
+        patch(
+            "prompt_studio.prompt_profile_manager_v2.serializers."
+            "AdapterProcessor.get_icon",
+            return_value="/icons/adapter-icons/OpenAI.png",
         ),
     ):
         return ProfileManagerSerializer().to_representation(instance)
@@ -57,7 +62,7 @@ class ProfileDisplayInfoTests(unittest.TestCase):
             },
         )
         # Only the LLM contributes the tile icon.
-        self.assertEqual(rep["icon"], "openai.png")
+        self.assertEqual(rep["icon"], "/icons/adapter-icons/OpenAI.png")
         # FK ids are replaced by the adapter names.
         self.assertEqual(rep["llm"], "Shared GPT")
 

--- a/backend/prompt_studio/prompt_profile_manager_v2/views.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/views.py
@@ -36,7 +36,10 @@ class ProfileManagerView(viewsets.ModelViewSet):
         return [IsOwnerOrSharedUserOrSharedToOrg()]
 
     def get_queryset(self) -> QuerySet | None:
-        queryset = ProfileManager.objects.for_user(self.request.user)
+        # Serializer reads all four adapters per profile for the display info
+        queryset = ProfileManager.objects.for_user(self.request.user).select_related(
+            "llm", "embedding_model", "vector_store", "x2text"
+        )
         filter_args = FilterHelper.build_filter_args(
             self.request,
             ProfileManagerKeys.CREATED_BY,

--- a/backend/prompt_studio/prompt_profile_manager_v2/views.py
+++ b/backend/prompt_studio/prompt_profile_manager_v2/views.py
@@ -36,7 +36,7 @@ class ProfileManagerView(viewsets.ModelViewSet):
         return [IsOwnerOrSharedUserOrSharedToOrg()]
 
     def get_queryset(self) -> QuerySet | None:
-        # Serializer reads all four adapters per profile for the display info
+        # Serializer reads all four adapters for the display info
         queryset = ProfileManager.objects.for_user(self.request.user).select_related(
             "llm", "embedding_model", "vector_store", "x2text"
         )

--- a/backend/prompt_studio/prompt_studio_core_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/views.py
@@ -375,7 +375,7 @@ class PromptStudioCoreView(
 
         profile_manager_instances = ProfileManager.objects.filter(
             prompt_studio_tool=prompt_tool
-        )
+        ).select_related("llm", "embedding_model", "vector_store", "x2text")
 
         serialized_instances = ProfileManagerSerializer(
             profile_manager_instances, many=True

--- a/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
+++ b/frontend/src/components/custom-tools/add-llm-profile/AddLlmProfile.jsx
@@ -63,6 +63,21 @@ function AddLlmProfile({
   const { setPostHogCustomEvent } = usePostHogEvents();
   const { getStrategies } = useRetrievalStrategies();
 
+  const editedProfile = llmProfiles?.find(
+    (item) => item?.profile_id === editLlmProfileId,
+  );
+
+  const adapterOptions = (items, field) => {
+    const id = editedProfile?.[`${field}_id`];
+    if (!id || items?.some((item) => item?.value === id)) {
+      return items;
+    }
+    return [
+      ...items,
+      { value: id, label: editedProfile?.[field], disabled: true },
+    ];
+  };
+
   useEffect(() => {
     setAdaptorProfilesDropdown();
   }, []);
@@ -121,38 +136,18 @@ function AddLlmProfile({
 
     setModalTitle("Edit LLM Profile");
 
-    const llmProfileDetails = [...llmProfiles].find(
-      (item) => item?.profile_id === editLlmProfileId,
-    );
-
-    const llmItem = llmItems.find(
-      (item) => item?.label === llmProfileDetails?.llm,
-    );
-
-    const vectorDbItem = vectorDbItems.find(
-      (item) => item?.label === llmProfileDetails?.vector_store,
-    );
-
-    const embeddingItem = embeddingItems.find(
-      (item) => item?.label === llmProfileDetails?.embedding_model,
-    );
-
-    const x2TextItem = x2TextItems.find(
-      (item) => item?.label === llmProfileDetails?.x2text,
-    );
-
     setResetForm(true);
     setFormDetails({
-      profile_name: llmProfileDetails?.profile_name,
-      llm: llmItem?.value || null,
-      chunk_size: llmProfileDetails?.chunk_size,
-      vector_store: vectorDbItem?.value || null,
-      chunk_overlap: llmProfileDetails?.chunk_overlap,
-      embedding_model: embeddingItem?.value || null,
-      x2text: x2TextItem?.value || null,
-      retrieval_strategy: llmProfileDetails?.retrieval_strategy,
-      similarity_top_k: llmProfileDetails?.similarity_top_k,
-      section: llmProfileDetails?.section,
+      profile_name: editedProfile?.profile_name,
+      llm: editedProfile?.llm_id || null,
+      chunk_size: editedProfile?.chunk_size,
+      vector_store: editedProfile?.vector_store_id || null,
+      chunk_overlap: editedProfile?.chunk_overlap,
+      embedding_model: editedProfile?.embedding_model_id || null,
+      x2text: editedProfile?.x2text_id || null,
+      retrieval_strategy: editedProfile?.retrieval_strategy,
+      similarity_top_k: editedProfile?.similarity_top_k,
+      section: editedProfile?.section,
       prompt_studio_tool: details?.tool_id,
     });
     setActiveKey(true);
@@ -501,7 +496,7 @@ function AddLlmProfile({
                   help={getBackendErrorDetail("llm", backendErrors)}
                 >
                   <Select
-                    options={llmItems}
+                    options={adapterOptions(llmItems, "llm")}
                     onSelect={handleLlmChangeForTokens}
                   />
                 </Form.Item>
@@ -556,7 +551,9 @@ function AddLlmProfile({
                   }
                   help={getBackendErrorDetail("vector_store", backendErrors)}
                 >
-                  <Select options={vectorDbItems} />
+                  <Select
+                    options={adapterOptions(vectorDbItems, "vector_store")}
+                  />
                 </Form.Item>
               </Col>
               <Col span={1} />
@@ -598,7 +595,9 @@ function AddLlmProfile({
               }
               help={getBackendErrorDetail("embedding_model", backendErrors)}
             >
-              <Select options={embeddingItems} />
+              <Select
+                options={adapterOptions(embeddingItems, "embedding_model")}
+              />
             </Form.Item>
             <Form.Item
               label="Text Extractor"
@@ -615,7 +614,7 @@ function AddLlmProfile({
               }
               help={getBackendErrorDetail("x2text", backendErrors)}
             >
-              <Select options={x2TextItems} />
+              <Select options={adapterOptions(x2TextItems, "x2text")} />
             </Form.Item>
             <Collapse
               expandIcon={({ isActive }) => handleCaretIcon(isActive)}

--- a/frontend/src/components/custom-tools/combined-output/CombinedOutput.jsx
+++ b/frontend/src/components/custom-tools/combined-output/CombinedOutput.jsx
@@ -137,8 +137,7 @@ function CombinedOutput({ docId, setFilledFields, selectedPrompts }) {
       return;
     }
 
-    // Model names come off the profile payload; the viewer may not have
-    // access to the project's adapters.
+    // Model name comes from the profile payload, not the viewer's adapters.
     setAdapterData(
       (llmProfiles || []).map((profile) => ({
         profile_name: profile?.profile_name,

--- a/frontend/src/components/custom-tools/combined-output/CombinedOutput.jsx
+++ b/frontend/src/components/custom-tools/combined-output/CombinedOutput.jsx
@@ -9,10 +9,8 @@ import { useParams } from "react-router-dom";
 
 import {
   displayPromptResult,
-  getLLMModelNamesForProfiles,
   promptType,
 } from "../../../helpers/GetStaticData";
-import { fetchAllPages } from "../../../helpers/pagination";
 import { useAxiosPrivate } from "../../../hooks/useAxiosPrivate";
 import { useAlertStore } from "../../../store/alert-store";
 import { useCustomToolStore } from "../../../store/custom-tool-store";
@@ -35,14 +33,12 @@ try {
 }
 
 let publicOutputsApi;
-let publicAdapterApi;
 let publicDefaultOutputApi;
 try {
   const mod = await import(
     "../../../plugins/prompt-studio-public-share/helpers/PublicShareAPIs"
   );
   publicOutputsApi = mod.publicOutputsApi;
-  publicAdapterApi = mod.publicAdapterApi;
   publicDefaultOutputApi = mod.publicDefaultOutputApi;
 } catch {
   // The component will remain null if it is not available
@@ -141,22 +137,16 @@ function CombinedOutput({ docId, setFilledFields, selectedPrompts }) {
       return;
     }
 
-    const fetchAdapterInfo = async () => {
-      let url = `/api/v1/unstract/${sessionDetails?.orgId}/adapter/?adapter_type=LLM`;
-      if (isPublicSource) {
-        url = publicAdapterApi(id, "LLM");
-      }
-      try {
-        const adapterList = await fetchAllPages(axiosPrivate, { url });
-        setAdapterData(getLLMModelNamesForProfiles(llmProfiles, adapterList));
-      } catch (err) {
-        setAlertDetails(
-          handleException(err, "Failed to fetch adapter information"),
-        );
-      }
-    };
-    fetchAdapterInfo();
-  }, []);
+    // Model names come off the profile payload; the viewer may not have
+    // access to the project's adapters.
+    setAdapterData(
+      (llmProfiles || []).map((profile) => ({
+        profile_name: profile?.profile_name,
+        llm_model: profile?.conf?.LLM,
+        profile_id: profile?.profile_id,
+      })),
+    );
+  }, [llmProfiles, isSimplePromptStudio]);
 
   useEffect(() => {
     const key = singlePassExtractMode ? defaultLlmProfile : "0";

--- a/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
+++ b/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
@@ -89,8 +89,7 @@ function OutputForDocModal({
   ]);
 
   useEffect(() => {
-    // Model names come off the profile payload; the viewer may not have
-    // access to the project's adapters.
+    // Model name comes from the profile payload, not the viewer's adapters.
     setAdapterData(
       (llmProfiles || []).map((profile) => ({
         profile_name: profile?.profile_name,

--- a/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
+++ b/frontend/src/components/custom-tools/output-for-doc-modal/OutputForDocModal.jsx
@@ -15,7 +15,6 @@ import "./OutputForDocModal.css";
 import {
   displayPromptResult,
   getDocIdFromKey,
-  getLLMModelNamesForProfiles,
 } from "../../../helpers/GetStaticData";
 import { useExceptionHandler } from "../../../hooks/useExceptionHandler";
 import { useAlertStore } from "../../../store/alert-store";
@@ -24,13 +23,11 @@ import { SpinnerLoader } from "../../widgets/spinner-loader/SpinnerLoader";
 import { ProfileInfoBar } from "../profile-info-bar/ProfileInfoBar";
 
 let publicOutputsApi;
-let publicAdapterApi;
 try {
   const mod = await import(
     "../../../plugins/prompt-studio-public-share/helpers/PublicShareAPIs"
   );
   publicOutputsApi = mod.publicOutputsApi;
-  publicAdapterApi = mod.publicAdapterApi;
 } catch {
   // The component will remain null of it is not available
 }
@@ -84,13 +81,24 @@ function OutputForDocModal({
       return;
     }
     handleGetOutputForDocs(selectedProfile);
-    getAdapterInfo();
   }, [
     open,
     selectedProfile,
     singlePassExtractMode,
     isSinglePassExtractLoading,
   ]);
+
+  useEffect(() => {
+    // Model names come off the profile payload; the viewer may not have
+    // access to the project's adapters.
+    setAdapterData(
+      (llmProfiles || []).map((profile) => ({
+        profile_name: profile?.profile_name,
+        llm_model: profile?.conf?.LLM,
+        profile_id: profile?.profile_id,
+      })),
+    );
+  }, [llmProfiles]);
 
   useEffect(() => {
     setSelectedProfile(profileId);
@@ -174,17 +182,6 @@ function OutputForDocModal({
     promptOutputInstance["isLoading"] = docOutputs[key]?.isLoading || false;
 
     return promptOutputInstance;
-  };
-
-  const getAdapterInfo = () => {
-    let url = `/api/v1/unstract/${sessionDetails.orgId}/adapter/?adapter_type=LLM`;
-    if (isPublicSource) {
-      url = publicAdapterApi(id, "LLM");
-    }
-    axiosPrivate.get(url).then((res) => {
-      const adapterList = res.data;
-      setAdapterData(getLLMModelNamesForProfiles(llmProfiles, adapterList));
-    });
   };
 
   const handleGetOutputForDocs = (profile = profileManagerId) => {

--- a/frontend/src/components/custom-tools/prompt-card/ProfileIcon.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/ProfileIcon.jsx
@@ -1,0 +1,26 @@
+import { Image } from "antd";
+import PropTypes from "prop-types";
+
+import { isImageUrl } from "../../../helpers/GetStaticData";
+
+// Adapter icons are image paths; unresolved ones fall back to an emoji.
+function ProfileIcon({ icon }) {
+  if (!isImageUrl(icon)) {
+    return <span className="prompt-card-llm-icon">{icon || "⚠️"}</span>;
+  }
+  return (
+    <Image
+      src={icon}
+      width={15}
+      height={15}
+      preview={false}
+      className="prompt-card-llm-icon"
+    />
+  );
+}
+
+ProfileIcon.propTypes = {
+  icon: PropTypes.string,
+};
+
+export { ProfileIcon };

--- a/frontend/src/components/custom-tools/prompt-card/ProfileIcon.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/ProfileIcon.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 
 import { isImageUrl } from "../../../helpers/GetStaticData";
 
-// Adapter icons are image paths; unresolved ones fall back to an emoji.
 function ProfileIcon({ icon }) {
   if (!isImageUrl(icon)) {
     return <span className="prompt-card-llm-icon">{icon || "⚠️"}</span>;

--- a/frontend/src/components/custom-tools/prompt-card/ProfileIcon.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/ProfileIcon.jsx
@@ -5,7 +5,7 @@ import { isImageUrl } from "../../../helpers/GetStaticData";
 
 function ProfileIcon({ icon }) {
   if (!isImageUrl(icon)) {
-    return <span className="prompt-card-llm-icon">{icon || "⚠️"}</span>;
+    return <span className="prompt-card-llm-icon">{icon}</span>;
   }
   return (
     <Image

--- a/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
@@ -147,8 +147,7 @@ function PromptCardItems({
     if (isSimplePromptStudio) {
       return;
     }
-    // conf/icon come off the profile payload; the viewer may not have
-    // access to the project's adapters.
+    // conf and icon come from the profile payload, not the viewer's adapters.
     setLlmProfileDetails(
       (llmProfiles || [])
         .map((profile) => ({

--- a/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptCardItems.jsx
@@ -83,7 +83,6 @@ function PromptCardItems({
     indexDocs,
     isSimplePromptStudio,
     isPublicSource,
-    adapters,
     selectedHighlight,
     details,
     singlePassExtractMode,
@@ -114,32 +113,6 @@ function PromptCardItems({
     );
   }, [allTableSettings]);
 
-  const getModelOrAdapterId = (profile, adapters) => {
-    const result = { conf: {} };
-    const keys = [
-      { key: "llm", label: "LLM" },
-      { key: "embedding_model", label: "Embedding Model" },
-      { key: "vector_store", label: "Vector Store" },
-      { key: "x2text", label: "Text Extractor" },
-    ];
-
-    keys.forEach((key) => {
-      const adapterName = profile[key.key];
-      const adapter = adapters?.find(
-        (adapter) => adapter?.adapter_name === adapterName,
-      );
-      if (adapter) {
-        result.conf[key.label] =
-          adapter?.model || adapter?.adapter_id?.split("|")[0];
-        if (adapter?.adapter_type === "LLM") {
-          result.icon = adapter?.icon;
-        }
-        result.conf["Profile Name"] = profile?.profile_name;
-      }
-    });
-    return result;
-  };
-
   const getUpdatedCoverage = (promptId, singlePass, promptOutputs) => {
     let updatedCoverage = null;
     Object.keys(promptOutputs).forEach((key) => {
@@ -166,18 +139,18 @@ function PromptCardItems({
     getUpdatedCoverage(promptId, singlePassExtractMode, promptOutputs) ||
     coverageCountData;
 
-  const getAdapterInfo = async (adapterData) => {
-    // If simple prompt studio, return early
+  useEffect(() => {
+    setExpandCard(true);
+  }, [isSinglePassExtractLoading]);
+
+  useEffect(() => {
     if (isSimplePromptStudio) {
       return;
     }
-
-    // Update llmProfiles with additional fields
-    const updatedProfiles = llmProfiles?.map((profile) => {
-      return { ...getModelOrAdapterId(profile, adapterData), ...profile };
-    });
+    // conf/icon come off the profile payload; the viewer may not have
+    // access to the project's adapters.
     setLlmProfileDetails(
-      updatedProfiles
+      (llmProfiles || [])
         .map((profile) => ({
           ...profile,
           isDefault: profile?.profile_id === selectedLlmProfileId,
@@ -192,15 +165,7 @@ function PromptCardItems({
           return 0;
         }),
     );
-  };
-
-  useEffect(() => {
-    setExpandCard(true);
-  }, [isSinglePassExtractLoading]);
-
-  useEffect(() => {
-    getAdapterInfo(adapters);
-  }, [llmProfiles, selectedLlmProfileId]);
+  }, [llmProfiles, selectedLlmProfileId, isSimplePromptStudio]);
 
   return (
     <Card

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -4,16 +4,7 @@ import {
   PlayCircleFilled,
   PlayCircleOutlined,
 } from "@ant-design/icons";
-import {
-  Button,
-  Col,
-  Divider,
-  Image,
-  Radio,
-  Space,
-  Tooltip,
-  Typography,
-} from "antd";
+import { Button, Col, Divider, Radio, Space, Tooltip, Typography } from "antd";
 import { AnimatePresence, motion } from "framer-motion";
 import PropTypes from "prop-types";
 import { useState } from "react";
@@ -21,7 +12,6 @@ import { useState } from "react";
 import {
   displayPromptResult,
   generateApiRunStatusId,
-  isImageUrl,
   PROMPT_RUN_API_STATUSES,
   PROMPT_RUN_TYPES,
 } from "../../../helpers/GetStaticData";
@@ -33,6 +23,7 @@ import { TokenUsage } from "../token-usage/TokenUsage";
 import { CopyPromptOutputBtn } from "./CopyPromptOutputBtn";
 import { TABLE } from "./constants";
 import { DisplayPromptResult } from "./DisplayPromptResult";
+import { ProfileIcon } from "./ProfileIcon";
 import { PromptOutputExpandBtn } from "./PromptOutputExpandBtn";
 import { PromptRunCost } from "./PromptRunCost";
 import { PromptRunTimer } from "./PromptRunTimer";
@@ -131,7 +122,7 @@ function PromptOutput({
   const noHighlightEnforceType = !["table", "record"].includes(enforceType);
   const tooltipContent = (adapterConf) => (
     <div>
-      {Object.entries(adapterConf)?.map(([key, value]) => (
+      {Object.entries(adapterConf || {}).map(([key, value]) => (
         <div key={key}>
           <strong>{key}:</strong> {value}
         </div>
@@ -356,19 +347,7 @@ function PromptOutput({
                 >
                   <div className="llm-info">
                     <div className="llm-info-left">
-                      {isImageUrl(profile?.icon) ? (
-                        <Image
-                          src={profile?.icon}
-                          width={15}
-                          height={15}
-                          preview={false}
-                          className="prompt-card-llm-icon"
-                        />
-                      ) : (
-                        <span className="prompt-card-llm-icon">
-                          {profile?.icon}
-                        </span>
-                      )}
+                      <ProfileIcon icon={profile?.icon} />
                       <Typography.Text
                         className="prompt-card-llm-title"
                         ellipsis={{ tooltip: profile?.conf?.LLM }}

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutput.jsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 import {
   displayPromptResult,
   generateApiRunStatusId,
+  isImageUrl,
   PROMPT_RUN_API_STATUSES,
   PROMPT_RUN_TYPES,
 } from "../../../helpers/GetStaticData";
@@ -355,13 +356,19 @@ function PromptOutput({
                 >
                   <div className="llm-info">
                     <div className="llm-info-left">
-                      <Image
-                        src={profile?.icon}
-                        width={15}
-                        height={15}
-                        preview={false}
-                        className="prompt-card-llm-icon"
-                      />
+                      {isImageUrl(profile?.icon) ? (
+                        <Image
+                          src={profile?.icon}
+                          width={15}
+                          height={15}
+                          preview={false}
+                          className="prompt-card-llm-icon"
+                        />
+                      ) : (
+                        <span className="prompt-card-llm-icon">
+                          {profile?.icon}
+                        </span>
+                      )}
                       <Typography.Text
                         className="prompt-card-llm-title"
                         ellipsis={{ tooltip: profile?.conf?.LLM }}

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutputsModal.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutputsModal.jsx
@@ -1,5 +1,6 @@
 import { Col, Image, Modal, Row, Typography } from "antd";
 import PropTypes from "prop-types";
+import { isImageUrl } from "../../../helpers/GetStaticData";
 import usePromptOutput from "../../../hooks/usePromptOutput";
 import { useCustomToolStore } from "../../../store/custom-tool-store";
 import SpaceWrapper from "../../widgets/space-wrapper/SpaceWrapper";
@@ -68,13 +69,19 @@ function PromptOutputsModal({
                   <div>
                     {displayLlmProfile && (
                       <div className="prompt-output-llm-bg">
-                        <Image
-                          src={profile?.icon}
-                          width={15}
-                          height={15}
-                          preview={false}
-                          className="prompt-card-llm-icon"
-                        />
+                        {isImageUrl(profile?.icon) ? (
+                          <Image
+                            src={profile?.icon}
+                            width={15}
+                            height={15}
+                            preview={false}
+                            className="prompt-card-llm-icon"
+                          />
+                        ) : (
+                          <span className="prompt-card-llm-icon">
+                            {profile?.icon}
+                          </span>
+                        )}
                         <Typography.Text className="prompt-card-llm-title">
                           {profile?.conf?.LLM}
                         </Typography.Text>

--- a/frontend/src/components/custom-tools/prompt-card/PromptOutputsModal.jsx
+++ b/frontend/src/components/custom-tools/prompt-card/PromptOutputsModal.jsx
@@ -1,11 +1,11 @@
-import { Col, Image, Modal, Row, Typography } from "antd";
+import { Col, Modal, Row, Typography } from "antd";
 import PropTypes from "prop-types";
-import { isImageUrl } from "../../../helpers/GetStaticData";
 import usePromptOutput from "../../../hooks/usePromptOutput";
 import { useCustomToolStore } from "../../../store/custom-tool-store";
 import SpaceWrapper from "../../widgets/space-wrapper/SpaceWrapper";
 import { TABLE } from "./constants";
 import { DisplayPromptResult } from "./DisplayPromptResult";
+import { ProfileIcon } from "./ProfileIcon";
 
 let TableOutput;
 try {
@@ -69,19 +69,7 @@ function PromptOutputsModal({
                   <div>
                     {displayLlmProfile && (
                       <div className="prompt-output-llm-bg">
-                        {isImageUrl(profile?.icon) ? (
-                          <Image
-                            src={profile?.icon}
-                            width={15}
-                            height={15}
-                            preview={false}
-                            className="prompt-card-llm-icon"
-                          />
-                        ) : (
-                          <span className="prompt-card-llm-icon">
-                            {profile?.icon}
-                          </span>
-                        )}
+                        <ProfileIcon icon={profile?.icon} />
                         <Typography.Text className="prompt-card-llm-title">
                           {profile?.conf?.LLM}
                         </Typography.Text>

--- a/frontend/src/helpers/GetStaticData.js
+++ b/frontend/src/helpers/GetStaticData.js
@@ -476,9 +476,8 @@ const isNonNegativeNumber = (value) => {
   return typeof value === "number" && !isNaN(value) && value >= 0;
 };
 
-// Icons are image URLs, except the emoji fallback used when an adapter icon
-// cannot be resolved. Detect the URL rather than the emoji - compound (ZWJ)
-// emoji break length heuristics.
+// Icons are image URLs; an unresolved adapter falls back to an emoji.
+// Detect the URL - compound (ZWJ) emoji break length heuristics.
 const isImageUrl = (value) =>
   typeof value === "string" && /^(https?:\/\/|\/|data:image\/)/.test(value);
 

--- a/frontend/src/helpers/GetStaticData.js
+++ b/frontend/src/helpers/GetStaticData.js
@@ -476,9 +476,9 @@ const isNonNegativeNumber = (value) => {
   return typeof value === "number" && !isNaN(value) && value >= 0;
 };
 
-// Icons are image URLs, except the emoji fallbacks used for unavailable
-// adapters. Detect the URL rather than the emoji - compound (ZWJ) emoji break
-// length heuristics.
+// Icons are image URLs, except the emoji fallback used when an adapter icon
+// cannot be resolved. Detect the URL rather than the emoji - compound (ZWJ)
+// emoji break length heuristics.
 const isImageUrl = (value) =>
   typeof value === "string" && /^(https?:\/\/|\/|data:image\/)/.test(value);
 
@@ -495,23 +495,6 @@ const generateUUID = () => {
   const uuid = uuidv4();
   return uuid;
 };
-
-function getLLMModelNamesForProfiles(profiles, adapters) {
-  // Create a mapping of adapter_ids to model names
-  const adapterMap = adapters.reduce((map, adapter) => {
-    map[adapter?.adapter_name] = adapter?.model;
-    return map;
-  }, {});
-
-  // Map through profiles and find corresponding model names using the adapterMap
-  return profiles.map((profile) => {
-    return {
-      profile_name: profile?.profile_name,
-      llm_model: adapterMap[profile?.llm],
-      profile_id: profile?.profile_id,
-    };
-  });
-}
 
 function getFormattedTotalCost(tokenUsageDetails) {
   const value = tokenUsageDetails?.cost_in_dollars ?? 0;
@@ -795,7 +778,6 @@ export {
   getDateTimeString,
   getDocIdFromKey,
   getFormattedTotalCost,
-  getLLMModelNamesForProfiles,
   getMenuItem,
   getOrgNameFromPathname,
   getReadableDateAndTime,

--- a/frontend/src/helpers/GetStaticData.js
+++ b/frontend/src/helpers/GetStaticData.js
@@ -476,6 +476,12 @@ const isNonNegativeNumber = (value) => {
   return typeof value === "number" && !isNaN(value) && value >= 0;
 };
 
+// Icons are image URLs, except the emoji fallbacks used for unavailable
+// adapters. Detect the URL rather than the emoji - compound (ZWJ) emoji break
+// length heuristics.
+const isImageUrl = (value) =>
+  typeof value === "string" && /^(https?:\/\/|\/|data:image\/)/.test(value);
+
 // Default token usage object with all counts initialized to 0
 const defaultTokenUsage = {
   embedding_tokens: 0,
@@ -780,7 +786,6 @@ export {
   formatSecondsToHMS,
   formatTimeDisplay,
   formattedDateTime,
-  timeAgo,
   formattedDateTimeWithSeconds,
   generateApiRunStatusId,
   generateCoverageKey,
@@ -797,6 +802,7 @@ export {
   getSequenceNumber,
   getTimeForLogs,
   homePagePath,
+  isImageUrl,
   isJson,
   isNonNegativeNumber,
   isValidJsonKey,
@@ -817,6 +823,7 @@ export {
   sourceTypes,
   THEME,
   TRIAL_PLAN,
+  timeAgo,
   titleCase,
   toolIdeOutput,
   UNSTRACT_ADMIN,


### PR DESCRIPTION
## What

- Prompt Studio output tiles now show the model name and icon for anyone who can open the project, not just its owner.
- The backend sends those display details along with each LLM profile, so the UI no longer has to look them up on its own.

## Why

- A user the project was shared with — directly or through a group — saw a blank model name and no icon on the tiles.
- The UI built those labels from the list of adapters that user personally has access to, and a shared project's adapters are not in it.

## How

- The profile serializer resolves the four adapter FKs at render time and returns `conf` (per-adapter model label) and `icon` — display data only, no credentials.
- `get_queryset` adds `select_related` on those four FKs so the extra reads don't become N+1.
- `PromptCardItems.jsx` renders the payload as-is; the frontend adapter lookup is gone.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

- No. The payload only gains `conf`/`icon`; the adapter fields keep returning the adapter name as before. `AdapterInstance.objects.for_user` is untouched — this changes what is displayed, not what a user can reach or use.

## Database Migrations

- None

## Env Config

- None

## Relevant Docs

-

## Related Issues or PRs

- Zipstack/unstract-cloud#1722 — agentic Prompt Studio, same ticket

## Dependencies Versions

- None

## Notes on Testing

- `backend/prompt_studio/prompt_profile_manager_v2/tests/test_profile_display_info.py` — covers adapter FK resolution with no adapter access.
- Manual: share a Prompt Studio project that uses a private LLM (once directly, once via a group), open it as the invited user — the tiles show the model name.

## Screenshots
- 
<img width="3349" height="649" alt="11" src="https://github.com/user-attachments/assets/297c5342-d89a-47ec-b74d-426b0a0afb74" />

- 
<img width="1869" height="1090" alt="12" src="https://github.com/user-attachments/assets/7fafa551-9038-4d4e-aef1-5e4ddfc38e37" />

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).
