### PR TITLE
UN-3996 [FIX] Stop WebSockets exhausting the Gunicorn thread pool

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -30,17 +30,16 @@ if [ "$migrate" = true ]; then
 fi
 
 # Configure Gunicorn based on --dev flag.
-# Threads must exceed the number of concurrently connected browser tabs: the
-# Socket.IO WSGI app runs with async_mode="threading", so each open WebSocket
-# holds one gthread pool thread for that connection's lifetime, not just for a
-# request. The pool spawns threads lazily, so a high ceiling is free at idle.
+# Threads must exceed concurrent browser tabs — each open Socket.IO WebSocket
+# holds one thread for its lifetime. The pool spawns threads lazily, so a high
+# ceiling is free at idle.
 gunicorn_args=(
     --bind 0.0.0.0:8000
     --workers "${GUNICORN_WORKERS:-2}"
     --threads "${GUNICORN_THREADS:-512}"
     --worker-class gthread
     --worker-connections "${GUNICORN_WORKER_CONNECTIONS:-1000}"
-    --log-level "${DEFAULT_LOG_LEVEL:-INFO}"
+    --log-level debug
     --timeout 600
     --access-logfile -
 )

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -29,12 +29,18 @@ if [ "$migrate" = true ]; then
     .venv/bin/python manage.py migrate
 fi
 
-# Configure Gunicorn based on --dev flag
+# Configure Gunicorn based on --dev flag.
+# Threads must exceed the number of concurrently connected browser tabs: the
+# Socket.IO WSGI app runs with async_mode="threading", so each open WebSocket
+# holds one gthread pool thread for that connection's lifetime, not just for a
+# request. The pool spawns threads lazily, so a high ceiling is free at idle.
 gunicorn_args=(
     --bind 0.0.0.0:8000
-    --workers 2
-    --threads 2
-    --log-level debug
+    --workers "${GUNICORN_WORKERS:-2}"
+    --threads "${GUNICORN_THREADS:-512}"
+    --worker-class gthread
+    --worker-connections "${GUNICORN_WORKER_CONNECTIONS:-1000}"
+    --log-level "${DEFAULT_LOG_LEVEL:-INFO}"
     --timeout 600
     --access-logfile -
 )

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -38,7 +38,6 @@ gunicorn_args=(
     --workers "${GUNICORN_WORKERS:-2}"
     --threads "${GUNICORN_THREADS:-512}"
     --worker-class gthread
-    --worker-connections "${GUNICORN_WORKER_CONNECTIONS:-1000}"
     --log-level debug
     --timeout 600
     --access-logfile -

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -4,12 +4,11 @@ DJANGO_SETTINGS_MODULE='backend.settings.dev'
 SESSION_COOKIE_SECURE=False
 CSRF_COOKIE_SECURE=False
 
-# Default log level. Also drives Gunicorn's --log-level.
+# Default log level
 DEFAULT_LOG_LEVEL="INFO"
 
-# Gunicorn tuning. GUNICORN_THREADS must exceed the number of concurrently
-# connected browser tabs — each open Socket.IO WebSocket holds one thread for
-# its whole lifetime.
+# Gunicorn tuning. GUNICORN_THREADS must exceed concurrent browser tabs —
+# each open Socket.IO WebSocket holds one thread for its lifetime.
 # GUNICORN_WORKERS=2
 # GUNICORN_THREADS=512
 # GUNICORN_WORKER_CONNECTIONS=1000

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -9,9 +9,9 @@ DEFAULT_LOG_LEVEL="INFO"
 
 # Gunicorn tuning. GUNICORN_THREADS must exceed concurrent browser tabs —
 # each open Socket.IO WebSocket holds one thread for its lifetime.
-# GUNICORN_WORKERS=2
-# GUNICORN_THREADS=512
-# GUNICORN_WORKER_CONNECTIONS=1000
+GUNICORN_WORKERS=2
+GUNICORN_THREADS=512
+GUNICORN_WORKER_CONNECTIONS=1000
 
 # Common
 PATH_PREFIX="api/v1"

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -4,8 +4,15 @@ DJANGO_SETTINGS_MODULE='backend.settings.dev'
 SESSION_COOKIE_SECURE=False
 CSRF_COOKIE_SECURE=False
 
-# Default log level
+# Default log level. Also drives Gunicorn's --log-level.
 DEFAULT_LOG_LEVEL="INFO"
+
+# Gunicorn tuning. GUNICORN_THREADS must exceed the number of concurrently
+# connected browser tabs — each open Socket.IO WebSocket holds one thread for
+# its whole lifetime.
+# GUNICORN_WORKERS=2
+# GUNICORN_THREADS=512
+# GUNICORN_WORKER_CONNECTIONS=1000
 
 # Common
 PATH_PREFIX="api/v1"

--- a/backend/sample.env
+++ b/backend/sample.env
@@ -11,7 +11,6 @@ DEFAULT_LOG_LEVEL="INFO"
 # each open Socket.IO WebSocket holds one thread for its lifetime.
 GUNICORN_WORKERS=2
 GUNICORN_THREADS=512
-GUNICORN_WORKER_CONNECTIONS=1000
 
 # Common
 PATH_PREFIX="api/v1"


### PR DESCRIPTION
## What

- `backend/entrypoint.sh`: Gunicorn workers and threads are now env-driven, with the thread default raised from `2` to `512`.
- `backend/entrypoint.sh`: `--worker-class gthread` is stated explicitly.
- `backend/sample.env`: ships both variables set to their defaults, so the knob is visible in the file every deployment copies.

## Why

- The Socket.IO WSGI app runs with `async_mode="threading"`, so every open WebSocket holds one gthread pool thread for that connection's lifetime rather than for a single request.
- With `--threads 2`, two logged-in browser tabs landing on the same worker left it with zero threads for HTTP, and it kept accepting connections it could never read — so requests stalled silently instead of failing over.
- Reported as Workflows / Prompt Studio / Agentic Prompt Studio loading very slowly, and far worse with two concurrent logins.

## How

- Verified chain: `frontend/src/index.jsx:64` mounts one `SocketProvider` per tab → `backend/backend/wsgi.py:42` wraps Django in the Socket.IO app (`async_mode="threading"`, `utils/log_events.py:29-31`) → `engineio/socket.py:222` runs the socket loop inline on a pool thread sized by `--threads` (`gunicorn/workers/gthread.py:98`).
- `512` matches the value already running in the cloud chart and is free at idle, since `--threads` is a `ThreadPoolExecutor` ceiling and CPython only starts a thread on `submit()` when none is idle.
- `--worker-class gthread` was already in effect — `config.py:109-110` coerces `sync` to `gthread` whenever `threads > 1` — so stating it is a no-op that just removes the ambiguity.
- `worker-connections` is deliberately left alone. `1000` is already Gunicorn's default (`config.py:732`), so passing it explicitly would change nothing, and making it settable only adds a way to configure it below `GUNICORN_THREADS`, which drives `max_keepalived` negative (`gthread.py:73`) and force-closes every response (`gthread.py:330`).

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why. (PS: Admins do not merge the PR without this section filled)

No — the change is confined to Gunicorn CLI arguments, both variables fall back to the values already in use, and no application code is touched. The only behavioural change is that a worker can now serve more than two concurrent connections.

## Database Migrations

- None.

## Env Config

- `GUNICORN_WORKERS` (default `2`, unchanged from before).
- `GUNICORN_THREADS` (default `512`, was a hardcoded `2`) — must exceed concurrent browser tabs per worker.
- Both are set to these values in `backend/sample.env` and reach the container through the existing `env_file: ../backend/.env` on the backend service. The entrypoint keeps a `:-` fallback per variable, so an `.env` that predates this PR starts with the same values.

## Relevant Docs

- None.

## Related Issues or PRs

- Jira: [UN-3996](https://zipstack.atlassian.net/browse/UN-3996).
- Zipstack/unstract-cloud#1724 — closed. The cloud chart already runs `--threads 512`, so no cloud change is needed.
- #338 lowered this value from `4` to `2` as part of a local-memory cleanup. The line it changed carried a `# NOTE updated socket threads` comment, added in the same commit that introduced the Socket.IO threading mode.

## Dependencies Versions

- None.

## Notes on Testing

- `bash -n` passes; argument array expanded and inspected with no env set and with both variables overridden.
- Measured locally with `backend/.venv` (Python 3.12.9) — `--threads` is a ceiling, not an allocation, so a high default is free until the connections exist:

  | scenario | threads alive | RSS delta |
  |---|---|---|
  | ceiling 512, at construction | 0 | 0 |
  | 50 sequential tasks | 1 | — |
  | 20 concurrent blocking tasks | 20 | — |
  | all 512 forced live | 512 | +11.8 MB |

  CPU with 512 threads parked: 0.005% of one core over 3s. `VmSize` grows ~12.5 GB at 512 live threads (glibc reserves an 8 MB stack per thread from `RLIMIT_STACK`), but that is reserved address space rather than RSS.
- Repro for reviewers: with `--threads 2`, open two logged-in tabs and loop `GET /api/v1/health`; one worker stops responding while `ss -tanp | grep :8000` shows ESTABLISHED sockets with non-zero `Recv-Q` and an empty LISTEN backlog.

## Screenshots

N/A — no user-facing surface.

## Checklist

I have read and understood the [Contribution Guidelines](https://docs.unstract.com/unstract/contributing/unstract/).


[UN-3996]: https://zipstack.atlassian.net/browse/UN-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ