### PR TITLE
[MISC] Wait for minio-bootstrap to complete instead of racing it

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -26,14 +26,24 @@ services:
     env_file:
       - ../backend/.env
     depends_on:
-      - db
-      - redis
-      - rabbitmq
-      - reverse-proxy
-      - minio
-      - minio-bootstrap
-      - platform-service
-      - x2text-service
+      db:
+        condition: service_started
+      redis:
+        condition: service_started
+      rabbitmq:
+        condition: service_started
+      reverse-proxy:
+        condition: service_started
+      minio:
+        condition: service_started
+      # One-shot bucket setup. Waiting for completion keeps `up --wait` from
+      # treating its exit as a stack failure.
+      minio-bootstrap:
+        condition: service_completed_successfully
+      platform-service:
+        condition: service_started
+      x2text-service:
+        condition: service_started
     volumes:
       - prompt_studio_data:/app/prompt-studio-data
       - ./workflow_data:/data


### PR DESCRIPTION
## What

`backend`'s `depends_on: minio-bootstrap` becomes `condition: service_completed_successfully`. That required converting the whole `depends_on` block to the long syntax — the other seven entries keep their existing `service_started` semantics.

## Why

The e2e tier boots the stack with `docker compose up -d --wait`. `--wait` fails the entire command when a container exits while it is still waiting, **whatever the exit code**. `minio-bootstrap` is the only one-shot service in the compose files:

```yaml
  minio-bootstrap:
    image: minio/mc
    entrypoint: >
      /bin/sh -c "
      sleep 5;
      mc alias set minio http://unstract-minio:9000 minio minio123;
      mc mb minio/unstract;
      mc mirror /app/prompt-studio-data minio/unstract/prompt-studio-data;
      exit 0;
      "
```

So the tier passes or fails on whether compose reaches its wait phase inside that `sleep 5`. It usually does, which is why this reads as an unrelated flake when it doesn't. From [run 32133874152](https://github.com/Zipstack/unstract/actions/runs/32133874152/job/95700738911), where the run pulled images inline and was 6s late:

```
container unstract-test-minio-bootstrap-1 exited (0)
RuntimeError: command failed (exit 1): docker compose -p unstract-test \
  -f docker/docker-compose.yaml -f tests/compose/docker-compose.test.yaml up -d --wait
```

Every container had already reported `Healthy`. Green runs reach the wait phase ~2s after starting the container and mark it `Healthy` mid-`sleep`; that run reached it at 6s.

`service_completed_successfully` takes the service out of the set `--wait` watches, and is also the more accurate statement of what the backend needs — it can't use a bucket that doesn't exist yet.

## Verification

Minimal repro on compose v5.0.2, one-shot exiting before the wait phase:

| depends_on shape | result |
| --- | --- |
| `- boot` (today) | `container boot-1 exited (0)` → exit **1** |
| `condition: service_completed_successfully` | `boot-1 Exited`, `app-1 Healthy` → exit **0** |

`docker compose -f docker-compose.yaml -f tests/compose/docker-compose.test.yaml config` resolves to the expected `depends_on` map across all 25 services.

## Notes

- No dev impact: `compose.override.yaml` replaces the backend's `depends_on` wholesale (`!override`) and never listed `minio-bootstrap`.
- Safe against a failing bootstrap: the entrypoint ends in an explicit `exit 0` under a `sh -c` without `set -e`, so `mc mb` on an existing bucket still exits 0 and can't wedge the backend.
- `minio-bootstrap` is the only affected service — every other service in both compose files is a long-running daemon with `restart: unless-stopped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVoa8BMCNnhdkATd7A9U4J