### PR TITLE
UN-4021 [MISC] Let the Vite dev server run behind a TLS ingress

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -113,6 +113,18 @@ export default defineConfig(({ mode }) => {
     server: {
       host: "0.0.0.0",
       port: Number(env.PORT) || 3000,
+      // Vite refuses requests whose Host header is not localhost or an IP, as a
+      // DNS-rebinding guard. That is the right default locally, but when the dev
+      // server runs inside a cluster pod behind an ingress the browser sends the
+      // real domain and every request comes back "Blocked request". Opt in per
+      // environment with a comma-separated list, e.g. ".example.com".
+      // Empty list == Vite's default (localhost/IPs only), so local dev and the
+      // production build are unaffected.
+      allowedHosts: env.VITE_DEV_ALLOWED_HOSTS
+        ? env.VITE_DEV_ALLOWED_HOSTS.split(",")
+            .map((host) => host.trim())
+            .filter(Boolean)
+        : [],
       // Docker-specific: Enable polling for file watching
       watch: {
         usePolling: true,
@@ -124,6 +136,13 @@ export default defineConfig(({ mode }) => {
         clientPort: env.WDS_SOCKET_PORT
           ? Number(env.WDS_SOCKET_PORT)
           : Number(env.PORT) || 3000,
+        // Behind a TLS-terminating ingress the page is served over https, so the
+        // HMR socket has to be wss on the ingress port (443) rather than the
+        // port the dev server itself listens on. Left unset, Vite derives the
+        // protocol from its own (plain http) server and the socket never opens.
+        ...(env.VITE_DEV_HMR_PROTOCOL
+          ? { protocol: env.VITE_DEV_HMR_PROTOCOL }
+          : {}),
       },
       // Proxy configuration (similar to setupProxy.js in CRA)
       proxy:


### PR DESCRIPTION
## What

Lets the Vite dev server serve correctly when it runs behind a TLS-terminating ingress, instead of only on localhost. Two env-gated additions to `frontend/vite.config.js`:

- `server.allowedHosts`, from `VITE_DEV_ALLOWED_HOSTS` (comma-separated).
- `server.hmr.protocol`, from `VITE_DEV_HMR_PROTOCOL`.

Both default to off, so nothing changes unless the env vars are set.

## Why

Vite refuses any request whose `Host` header is not `localhost` or an IP — a DNS-rebinding guard. Running the dev server inside a Kubernetes pod behind an ingress means the browser sends the real domain, so every request returns `Blocked request. This host is not allowed.`

And because the ingress terminates TLS, the page is served over `https` while the dev server itself speaks plain http. Vite derives the HMR socket protocol from its own server, so it advertises `ws` to an `https` page and the socket never opens — you get full page reloads at best.

This is what unblocks an in-pod live-update loop, where source is streamed into a running pod and hot-reloads rather than requiring an image rebuild per change.

## How

`allowedHosts` parses the env var into a list, defaulting to `[]` — which is Vite's own default, i.e. localhost and IPs only. Setting it *scopes* the allowance to named domains rather than disabling the guard.

`hmr.protocol` is spread in conditionally so the key is absent unless the env var is set, preserving Vite's inference in every other case.

## Can this PR break any existing features. If yes, please list possible items. If no, please explain why.

No.

- Both options live under `server.*`, which Vite only reads when running the dev server. `vite build` ignores the whole block, so production output is byte-identical.
- Both default to the pre-existing behaviour: `allowedHosts: []` is Vite's own default, and `hmr.protocol` stays unset unless explicitly provided.
- The DNS-rebinding guard is still enforced — an unlisted host is still rejected (verified below).

## Database Migrations

None.

## Env Config

Two new optional dev-server-only variables, both unset by default:

| Variable | Example | Effect |
| --- | --- | --- |
| `VITE_DEV_ALLOWED_HOSTS` | `.example.com` | Extra hostnames the dev server will answer for |
| `VITE_DEV_HMR_PROTOCOL` | `wss` | Protocol the HMR client connects with |

`WDS_SOCKET_PORT` is already supported and is used alongside these to set the client port to 443.

## Relevant Docs

n/a

## Related Issues or PRs

- Jira: UN-4021
- Consumed by the corresponding change in the private deployment repo, which adds the image build, the chart overlay and the file-sync config.

## Dependencies Versions

None.

## Notes on Testing

Verified against a real deployment rather than only locally.

- `bun run build` succeeds; production output is unaffected.
- Ran the dev server behind a TLS ingress on a Kubernetes dev namespace:
  - request with the real domain in `Host` -> `200`, HTML includes the React Refresh runtime and `/@vite/client`
  - request with an unlisted host -> still `Blocked request. This host is not allowed.`
  - `/@vite/client` -> `200` over TLS
  - editing a source module -> `[vite] hmr update /src/...` for that exact module, and the transformed module served through the ingress reflected the change

## Screenshots

n/a

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).
