### PR TITLE
fix(docker): align standalone essentials network with full compose

### DIFF
--- a/docker/docker-compose-dev-essentials.yaml
+++ b/docker/docker-compose-dev-essentials.yaml
@@ -153,3 +153,7 @@ volumes:
   redis_data:
   prompt_studio_data:
   rabbitmq_data:
+
+networks:
+  default:
+    name: unstract-network


### PR DESCRIPTION
## Description

`docker-compose-dev-essentials.yaml` did not explicitly declare its default
network, causing standalone execution to create `docker_default`.

The full Compose configuration uses the explicitly named `unstract-network`,
and the essentials configuration already configures Traefik to use that network.

This change explicitly names the default network as `unstract-network` so the
standalone essentials configuration uses the same network as the full Compose
configuration.

## Relevant Docs

- `docker/docker-compose.yaml`
- `docker/docker-compose-dev-essentials.yaml`
- `docs/local-dev-setup-executor-migration.md`

## Related Issues or PRs

Fixes #2261

## Dependencies Versions

- Docker Compose 2.40.3
- Docker Engine: local development environment
- PostgreSQL image: `pgvector/pgvector:pg15`

## Notes on Testing

Before the change, running:

```bash
docker compose -f docker-compose-dev-essentials.yaml up -d db