### PR TITLE
UN-4071 [FIX] Restore the Plan column on the LLM Whisperer API Keys page

### DIFF
--- a/frontend/src/components/data-table/DataTable.jsx
+++ b/frontend/src/components/data-table/DataTable.jsx
@@ -40,6 +40,24 @@ import { cn } from "@/lib/utils";
  */
 
 /**
+ * One cell's value, read the way antd reads it.
+ *
+ * `dataIndex` is either a key or a PATH: `["product", "name"]` is antd's
+ * documented nested form and means `record.product.name`. The flat lookup this
+ * replaces indexed the record with the array itself, and JavaScript stringifies
+ * that to the property name `"product,name"` — so the value was always
+ * undefined, and silently so, because a column with no `render` hands it
+ * straight to the cell. LLMWhisperer's API Keys table declares its Plan column
+ * exactly that way and lost the whole column to a blank strip.
+ */
+function cellValue(record, dataIndex) {
+  if (Array.isArray(dataIndex)) {
+    return dataIndex.reduce((v, k) => (v == null ? undefined : v[k]), record);
+  }
+  return record?.[dataIndex];
+}
+
+/**
  * One antd column → one TanStack column def.
  *
  * antd spells a banded header as a column that carries a `title` and a
@@ -76,7 +94,20 @@ function toColumn(c, path) {
 
   return {
     id,
-    accessorKey: c.dataIndex,
+    /*
+     * A path needs an accessor FUNCTION: TanStack's `accessorKey` is a single
+     * key (or a dotted string), so handing it the array would repeat the same
+     * stringified-`"product,name"` lookup one layer down. The string case keeps
+     * `accessorKey` deliberately — swapping it for `cellValue` too would drop
+     * TanStack's dotted-string deep access, a behaviour change beyond this fix.
+     *
+     * Nothing reads `row.getValue` today (the cell below resolves its own
+     * value, and `sortingFn` compares originals), so this is correctness for
+     * the value-based sorting or filtering a later change would reach for.
+     */
+    ...(Array.isArray(c.dataIndex)
+      ? { accessorFn: (row) => cellValue(row, c.dataIndex) }
+      : { accessorKey: c.dataIndex }),
     header: c.title,
     enableSorting: Boolean(c.sorter),
     /*
@@ -95,7 +126,9 @@ function toColumn(c, path) {
         : () => 0,
     meta,
     cell: ({ row }) => {
-      const value = c.dataIndex ? row.original?.[c.dataIndex] : undefined;
+      const value = c.dataIndex
+        ? cellValue(row.original, c.dataIndex)
+        : undefined;
       // antd's render(value, record, index) contract.
       return c.render ? c.render(value, row.original, row.index) : value;
     },

--- a/frontend/src/components/data-table/DataTable.jsx
+++ b/frontend/src/components/data-table/DataTable.jsx
@@ -71,6 +71,14 @@ function cellValue(record, dataIndex) {
  * version used would collide across levels.
  */
 function toColumn(c, path) {
+  /*
+   * Three places spell this identity, and they must agree: here, `columnKey`
+   * (ColumnFilter.jsx) and `toSorterInfo` below, which matches on it to answer
+   * antd's `onChange`. A PATH `dataIndex` with no `key` coerces to
+   * `"product,name"` in all three, so they still agree — which is why this is
+   * deliberately NOT normalised to `dataIndex.join(".")`. Tidying it here alone
+   * would silently stop sorting and filtering reporting for a nested column.
+   */
   const id = String(c.key ?? c.dataIndex ?? path);
   // `column` rides along so the header can render antd's filter affordance,
   // which is declared on the antd def and has no TanStack equivalent.
@@ -96,17 +104,28 @@ function toColumn(c, path) {
     id,
     /*
      * A path needs an accessor FUNCTION: TanStack's `accessorKey` is a single
-     * key (or a dotted string), so handing it the array would repeat the same
-     * stringified-`"product,name"` lookup one layer down. The string case keeps
-     * `accessorKey` deliberately — swapping it for `cellValue` too would drop
-     * TanStack's dotted-string deep access, a behaviour change beyond this fix.
+     * key, so handing it the array repeats the same stringified-`"product,name"`
+     * lookup one layer down.
      *
-     * Nothing reads `row.getValue` today (the cell below resolves its own
-     * value, and `sortingFn` compares originals), so this is correctness for
-     * the value-based sorting or filtering a later change would reach for.
+     * This is NOT inert. TanStack defaults every column to `sortUndefined: 1`,
+     * and `getSortedRowModel` reads `row.getValue()` to apply it BEFORE it ever
+     * consults `sortingFn` — so undefined-valued rows sort to the end even
+     * though `sortingFn` is `() => 0`. A nested column was accidentally exempt
+     * while every one of its values was undefined; with a real accessor it now
+     * behaves exactly as an equivalent string column already does (verified:
+     * both reorder identically on a sparse column). That quirk is pre-existing
+     * and cross-cutting, not introduced here, and no nested column declares a
+     * `sorter` today.
+     *
+     * The string case keeps `accessorKey` because it is unchanged, not because
+     * its behaviour is right: TanStack deep-reads a DOTTED string while the
+     * cell below reads it as a literal key, which is antd's own reading. Those
+     * two disagree for `dataIndex: "a.b"`. Pre-existing on both halves, no
+     * literal dotted `dataIndex` exists in either repo, and reconciling it is a
+     * behaviour change beyond this fix.
      */
     ...(Array.isArray(c.dataIndex)
-      ? { accessorFn: (row) => cellValue(row, c.dataIndex) }
+      ? { accessorFn: (record) => cellValue(record, c.dataIndex) }
       : { accessorKey: c.dataIndex }),
     header: c.title,
     enableSorting: Boolean(c.sorter),

--- a/frontend/src/components/data-table/DataTable.test.jsx
+++ b/frontend/src/components/data-table/DataTable.test.jsx
@@ -1521,3 +1521,77 @@ describe("DataTable controlled filters", () => {
     });
   });
 });
+
+/**
+ * antd's `dataIndex` is either a key or a PATH — `["product", "name"]` reads
+ * `record.product.name`. The flat lookup this guards indexed the record with
+ * the array itself, which JavaScript stringifies to the property name
+ * `"product,name"`, so the value was always undefined and — because a column
+ * with no `render` hands it straight to the cell — silently blank.
+ *
+ * LLMWhisperer's API Keys table declares its Plan column exactly this way and
+ * lost the whole column to an empty strip after the migration. It is the only
+ * nested `dataIndex` in either repo, which is why nothing else caught it.
+ */
+describe("DataTable nested dataIndex", () => {
+  const nested = [
+    { id: 1, product: { id: "free", name: "LLM Whisperer Free" } },
+  ];
+
+  it("resolves an array dataIndex as a path into the record", () => {
+    render(
+      <DataTable
+        columns={[
+          {
+            title: "Plan",
+            dataIndex: ["product", "name"],
+            key: "product_name",
+          },
+        ]}
+        dataSource={nested}
+        rowKey="id"
+      />,
+    );
+    expect(screen.getByText("LLM Whisperer Free")).toBeInTheDocument();
+  });
+
+  it("renders an empty cell rather than throwing on a missing segment", () => {
+    expect(() =>
+      render(
+        <DataTable
+          columns={[
+            {
+              title: "Plan",
+              dataIndex: ["product", "name"],
+              key: "product_name",
+            },
+          ]}
+          dataSource={[{ id: 1, product: null }, { id: 2 }]}
+          rowKey="id"
+        />,
+      ),
+    ).not.toThrow();
+    // Two rows, both with an empty Plan cell — not the empty state.
+    expect(document.querySelectorAll("tbody tr")).toHaveLength(2);
+  });
+
+  it("hands the resolved nested value to render, as antd does", () => {
+    const render_ = vi.fn((value) => `plan: ${value}`);
+    render(
+      <DataTable
+        columns={[
+          {
+            title: "Plan",
+            dataIndex: ["product", "name"],
+            key: "product_name",
+            render: render_,
+          },
+        ]}
+        dataSource={nested}
+        rowKey="id"
+      />,
+    );
+    expect(render_).toHaveBeenCalledWith("LLM Whisperer Free", nested[0], 0);
+    expect(screen.getByText("plan: LLM Whisperer Free")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/data-table/DataTable.test.jsx
+++ b/frontend/src/components/data-table/DataTable.test.jsx
@@ -1530,8 +1530,7 @@ describe("DataTable controlled filters", () => {
  * with no `render` hands it straight to the cell — silently blank.
  *
  * LLMWhisperer's API Keys table declares its Plan column exactly this way and
- * lost the whole column to an empty strip after the migration. It is the only
- * nested `dataIndex` in either repo, which is why nothing else caught it.
+ * lost the whole column to an empty strip after the migration.
  */
 describe("DataTable nested dataIndex", () => {
   const nested = [
@@ -1571,12 +1570,64 @@ describe("DataTable nested dataIndex", () => {
         />,
       ),
     ).not.toThrow();
-    // Two rows, both with an empty Plan cell — not the empty state.
-    expect(document.querySelectorAll("tbody tr")).toHaveLength(2);
+    // Two rows, both with an EMPTY Plan cell — not the empty state, and not a
+    // stand-in like "undefined" or "N/A" that a laxer resolver would print.
+    const cells = document.querySelectorAll("tbody td");
+    expect(cells).toHaveLength(2);
+    for (const cell of cells) {
+      expect(cell).toHaveTextContent("");
+    }
+  });
+
+  it("walks a path of any depth, including an array index", () => {
+    render(
+      <DataTable
+        columns={[
+          {
+            title: "Owner",
+            dataIndex: ["subscription", "owners", 0, "email"],
+            key: "owner",
+          },
+        ]}
+        dataSource={[
+          { id: 1, subscription: { owners: [{ email: "a@example.com" }] } },
+        ]}
+        rowKey="id"
+      />,
+    );
+    expect(screen.getByText("a@example.com")).toBeInTheDocument();
+  });
+
+  /*
+   * The identity a nested column reports back through antd's `onChange`.
+   *
+   * With no `key`, the column id and `toSorterInfo`'s lookup both coerce the
+   * array to `"product,name"` — agreeing only because NEITHER normalises it.
+   * Normalising the id alone (to `"product.name"`, say) is exactly the tidy-up
+   * a later reader would attempt, and it would silently stop a nested column
+   * reporting its sort, with every other test here still green.
+   */
+  it("reports a keyless nested column through onChange when sorted", async () => {
+    const onChange = vi.fn();
+    render(
+      <DataTable
+        columns={[
+          { title: "Plan", dataIndex: ["product", "name"], sorter: true },
+        ]}
+        dataSource={nested}
+        rowKey="id"
+        onChange={onChange}
+      />,
+    );
+    await userEvent.click(screen.getByText("Plan"));
+    expect(onChange).toHaveBeenCalled();
+    const sorter = onChange.mock.calls.at(-1)[2];
+    expect(sorter.field).toEqual(["product", "name"]);
+    expect(sorter.order).toBe("ascend");
   });
 
   it("hands the resolved nested value to render, as antd does", () => {
-    const render_ = vi.fn((value) => `plan: ${value}`);
+    const renderCell = vi.fn((value) => `plan: ${value}`);
     render(
       <DataTable
         columns={[
@@ -1584,14 +1635,14 @@ describe("DataTable nested dataIndex", () => {
             title: "Plan",
             dataIndex: ["product", "name"],
             key: "product_name",
-            render: render_,
+            render: renderCell,
           },
         ]}
         dataSource={nested}
         rowKey="id"
       />,
     );
-    expect(render_).toHaveBeenCalledWith("LLM Whisperer Free", nested[0], 0);
+    expect(renderCell).toHaveBeenCalledWith("LLM Whisperer Free", nested[0], 0);
     expect(screen.getByText("plan: LLM Whisperer Free")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

- Teach the shared shadcn `DataTable` adapter antd's **nested `dataIndex`** form (`["product", "name"]`), so it resolves as a path into the record rather than as a single key.
- Restores the **Plan** column on the LLM Whisperer **API Keys** page, which has rendered blank for every row since the Ant Design removal.

## Why

The cloud plugin's Plan column is unchanged by the migration — it is byte-identical before and after 
```js
{ title: "Plan", dataIndex: ["product", "name"], key: "product_name" }
```

An array `dataIndex` is antd's documented nested-path form, and real antd resolved it to `record.product.name`. `Table` now resolves to this `DataTable` (`antd-structure.tsx`), whose antd→TanStack adapter only did a flat, single-key lookup:

```js
const value = c.dataIndex ? row.original?.[c.dataIndex] : undefined;
```

With `c.dataIndex === ["product", "name"]`, JavaScript stringifies the array to the property name `"product,name"` → `undefined`. The column declares no `render`, so that `undefined` goes straight into the cell. Nothing throws — the column `id` comes from `c.key` (`"product_name"`) — so it fails **silently**: a header with an empty strip under it.

Backend is unaffected; `GET /api/v1/llmwhisperer/keys/` still returns `product: {id, name}` per key.

This is the **only** nested `dataIndex` in either repo (`grep -rn 'dataIndex:\s*\[' frontend/src` → one hit, in the cloud plugin), which is why neither the build nor the existing 74 `DataTable` tests caught it.

## How

`frontend/src/components/data-table/DataTable.jsx`:

- New `cellValue(record, dataIndex)` helper — walks an array `dataIndex` as a path, short-circuiting on a nullish segment; unchanged flat lookup for a string.
- The cell lookup uses it.
- The TanStack accessor splits: `accessorFn` for a path, `accessorKey` kept for a string (unchanged behaviour).

**Correction from self-review — the accessor half is NOT inert.** The first commit's comment claimed "nothing reads `row.getValue` today". That is wrong: TanStack defaults every column to `sortUndefined: 1`, and `getSortedRowModel` calls `rowA.getValue()` to apply it *before* it consults `sortingFn`. I probed what that actually costs: a nested column carrying a `sorter` now sorts undefined-valued rows to the end — **identically to how an equivalent string column already does** (probed both; same order in, same order out). So the quirk is pre-existing and cross-cutting rather than introduced here, and no nested column declares a `sorter` today. The comment now states this instead of denying it.

Worth flagging separately, **not fixed here**: that `sortUndefined` pre-pass means `sortingFn: () => 0` is not the complete guarantee against local reordering that the existing comment above it implies, for any `sorter: true` column with sparse values. Pre-existing and out of scope.
- The `id` derivation at `toColumn` is **deliberately untouched**. It stringifies an array to `"product,name"` — the same spelling `columnKey` (`ColumnFilter.jsx`) and `toSorterInfo` use. Normalising it in one place only would silently break sorter/filter matching for a nested column.

`frontend/src/components/data-table/DataTable.test.jsx`: new `describe("DataTable nested dataIndex")` — resolves the path; renders empty rather than throwing on a missing segment; hands the resolved value to `render(value, record, index)`.

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why.

Low risk, and scoped by construction:

- The **string** `dataIndex` path is byte-equivalent — `cellValue` falls through to the same `record?.[dataIndex]`, and those columns keep `accessorKey` exactly as before. Every column in both repos except one is a string.
- The **array** branch is new behaviour on input that previously always produced `undefined`, so there is nothing working today for it to regress. The one observable knock-on — `sortUndefined` ordering on a nested sortable column — is described above; no nested column declares a `sorter`.
- The `id` / `columnKey` / `toSorterInfo` spellings are unchanged, so sorting, filtering and `onChange` reporting are untouched.

Verified: all 596 frontend tests pass (35 files), including the 74 pre-existing `DataTable` tests; `vite build` succeeds; biome clean.

## Relevant Docs

- antd `Table` `dataIndex` nested-path form — https://ant.design/components/table#column

## Related Issues or PRs

- Regressed by #2212 (*[P0-P4] Remove Ant Design from the OSS frontend*) 

## Dependencies Versions / Env Variables

- None.

## Notes on Testing

The three new tests were written **first** and confirmed failing against the unpatched adapter — `render` received `undefined` where `"LLM Whisperer Free"` was expected — then passing after the change. Fixtures use the exact column definition from the cloud plugin and the exact payload shape the portal returns.

```
npx vitest run src/components/data-table/DataTable.test.jsx   # 79 passed
npx vitest run                                                # 598 passed, 35 files
npm run build                                                 # ✓ built
```

**Verified in the browser**, not just by the build. The fix was synced into a dev namespace over the DevSpace HMR loop (`OSS_FRONTEND_PATH` confirmed pointing at this branch's worktree, and the pod's `DataTable.jsx` confirmed to contain `cellValue`), then `/llm-whisperer/<org-id>/api-keys` was loaded. The same API key that rendered a blank Plan cell before the fix (`e68ce309-9794-4bf5-9a6e-30e0524736bb`) now renders **`LLM Whisperer Free`**. Read out of the live DOM:

```
headers:   ["API Key","Key ID","Plan","Generated At","State","Actions","Usage/Pages"]
planCells: ["LLM Whisperer Free"]
```

Also confirmed the page is genuinely the shadcn build and not a stale antd one (no antd stylesheet; wrapper is `ant-table-wrapper w-full` with shadcn table classes), so this exercises the fixed adapter rather than an antd fallback.

### Both new guards were mutation-checked

Each fails against exactly the mutant it describes, and no other:

| Mutant | Result |
|---|---|
| `id` normalised to `dataIndex.join(".")` in `toColumn` only | ✗ `reports a keyless nested column through onChange when sorted` |
| resolver handling only two segments | ✗ `walks a path of any depth, including an array index` |
| unmutated | 79/79 pass |

## Screenshots

Plan column rendering `LLM Whisperer Free` for key `e68ce309-…` on `/llm-whisperer/<org-id>/api-keys` — the same row that was blank before the fix. (Screenshot captured locally; happy to attach on request.)

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).
