### PR TITLE
UN-4074 [FIX] Stub npx presence in the two rig node-command tests

### DIFF
--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -838,14 +838,24 @@ def test_failed_gate_blocks_dependents_and_cascades(tmp_path: Path, monkeypatch)
     assert (reports_dir / "e2e-leaf" / "junit.xml").exists()
 
 
-def test_node_command_vitest_points_reporter_at_group_junit(tmp_path: Path) -> None:
+def test_node_command_vitest_points_reporter_at_group_junit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The whole reason `vitest` is a first-class runner rather than a synthetic
     one-row wrapper: it writes real JUnit, so `parse_junit` reports per-test
     counts. That only holds if the reporter is aimed at the group's junit.xml.
+
+    `shutil.which` is stubbed PRESENT because this asserts command *construction*,
+    which must not depend on whether the host happens to have Node: without the
+    stub `_node_command` short-circuits to its `exit 5` sentinel and the assert
+    below compares against that instead. Mirrors
+    `test_node_command_without_npx_collects_nothing`, which stubs the same hook to
+    absent to cover the other branch.
     """
     import tests.rig.cli as cli_mod
     from tests.rig.groups import GroupDefinition
 
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npx")
     group = GroupDefinition(
         name="frontend", tier="unit", paths=("src",), runner="vitest",
         workdir="frontend",
@@ -859,13 +869,19 @@ def test_node_command_vitest_points_reporter_at_group_junit(tmp_path: Path) -> N
     assert cmd[-1] == "src"
 
 
-def test_node_command_playwright_takes_junit_from_env_not_flag(tmp_path: Path) -> None:
+def test_node_command_playwright_takes_junit_from_env_not_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Playwright reads its reporter path from config (PLAYWRIGHT_JUNIT_OUTPUT_NAME),
     not a CLI flag — passing --outputFile would make it fail to parse args.
+
+    `shutil.which` stubbed present for the same reason as the vitest case above:
+    the assertion is about argument shape, not about the host having Node.
     """
     import tests.rig.cli as cli_mod
     from tests.rig.groups import GroupDefinition
 
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npx")
     group = GroupDefinition(
         name="ui", tier="e2e", paths=("tests/ui",), runner="playwright",
         workdir="frontend",


### PR DESCRIPTION
## What

Stub `shutil.which` **present** in the two rig node-command tests, so they assert
command construction rather than whether the host happens to have Node installed.

## Why

`_node_command` deliberately degrades when Node is absent:

```python
if not shutil.which("npx"):
    # "so a machine without Node does not turn the whole run red"
    return ["sh", "-c", "exit 5"]
```

Both tests assert the real `npx` invocation, but neither required `npx` to be
present. On a machine without Node they compare against the sentinel and fail:

```
AssertionError: assert ['sh', '-c', 'exit 5'] == ['npx', '--no-install', 'vitest', 'run']
```

CI here is green because GitHub-hosted runners ship Node, so this is invisible
upstream. It surfaces downstream: the enterprise repo's test job runs on a
self-hosted runner with no Node, against a tree merged with this repo's `main`,
so every PR there currently goes red on these two tests. Because that merge pins
`main`, it cannot be fixed from any branch in either repo — it has to land here.

## How

Stub present, rather than `skipif`.

A `skipif` would stop these running on exactly the machine that reported the
problem. These assert argument *shape* — reporter flags, argv order, that
Playwright takes its JUnit path from env rather than a flag — none of which
depends on Node being installed.

This mirrors the existing `test_node_command_without_npx_collects_nothing`, which
stubs the same hook to *absent* to cover the other branch. Both branches are now
covered deterministically, and neither depends on the environment.

## Can this PR break any existing features?

No. Test-only, scoped to two functions in one file, and it adds determinism
rather than removing coverage — the Node-less branch keeps its own dedicated
test.

## Database Migrations

None.

## Env Config

None.

## Notes on Testing

Reproduced the downstream failure locally by running with `npx` removed from
`PATH`:

| Condition | Result |
|---|---|
| Without this fix, npx absent | **2 failed** — matches the CI failure |
| With this fix, npx absent | **3 passed** |
| Full `test_cli.py`, npx absent | 32 passed |
| Full `test_cli.py`, npx present | 32 passed |

The mutation check (reverting the stub and re-running with npx absent) reproduces
the original failure, so the change is load-bearing rather than incidental.

## Related Issues or PRs

UN-4074. Found while investigating two red checks on an unrelated enterprise
chart PR; the tests themselves came in with the frontend Ant Design removal work.

## Checklist

- [x] I have added an appropriate PR title and description
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
