### PR TITLE
UN-4073 [FIX] Make the organization list scrollable on the select-organization screen

### DIFF
--- a/frontend/src/components/set-org/SetOrg.css
+++ b/frontend/src/components/set-org/SetOrg.css
@@ -7,18 +7,27 @@
 }
 
 .card-list-container {
-  /* The scroll region. `.org-list` is a fixed-height (100vh) flex column, so
-   * without `min-height: 0` this box refuses to shrink below its content and
-   * the extra org cards spill past the viewport instead of scrolling. */
-  flex: 1 1 auto;
+  /* The scroll region. `.org-list` fills `.org-container`'s 100vh as a column
+   * flex container, so without `min-height: 0` this box refuses to shrink
+   * below its content: the extra org cards spill past the viewport and are
+   * clipped instead of scrolling. */
+  flex: 1;
   min-height: 0;
   overflow-y: auto;
+  /* Was `margin: 10%`. The horizontal half was redundant — `width: 80%` plus
+   * `align-items: center` on `.org-list` lands the cards at the same offset —
+   * so card geometry is unchanged. Note top/bottom percentages resolve
+   * against the containing block's WIDTH, as they did before. */
   margin: 5% 0;
   width: 80%;
-  /* Bottom room for the cards' 8px/24px box-shadow, which the scroll box
-   * clips. Deliberately no horizontal padding: it would narrow the cards and
-   * worsen the pre-existing title/Connect-button overlap on narrow viewports. */
-  padding-bottom: 24px;
+  /* Room below for `.org-card-container`'s box-shadow, which the scroll box
+   * clips. No horizontal padding: it would narrow the cards and worsen the
+   * overlap between a long org name and the Connect button that
+   * `.ant-card-meta-title` below causes by setting `text-overflow: ellipsis`
+   * with no `overflow: hidden`. Fix that rule and this constraint expires.
+   * The right-hand shadow stays clipped either way; at ~5% alpha it reads as
+   * nothing. */
+  padding-bottom: 32px;
 }
 .org-list {
   background: #ffffff;
@@ -95,7 +104,7 @@
   width: 200px;
   margin-top: 10%;
   /* Flex items default to `flex-shrink: 1`, so a long org list squashed the
-   * logo to zero height rather than scrolling the list. */
+   * logo instead of scrolling — measured at 0px height, not merely thin. */
   flex-shrink: 0;
 }
 

--- a/frontend/src/components/set-org/SetOrg.css
+++ b/frontend/src/components/set-org/SetOrg.css
@@ -7,8 +7,18 @@
 }
 
 .card-list-container {
-  margin: 10%;
+  /* The scroll region. `.org-list` is a fixed-height (100vh) flex column, so
+   * without `min-height: 0` this box refuses to shrink below its content and
+   * the extra org cards spill past the viewport instead of scrolling. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  margin: 5% 0;
   width: 80%;
+  /* Bottom room for the cards' 8px/24px box-shadow, which the scroll box
+   * clips. Deliberately no horizontal padding: it would narrow the cards and
+   * worsen the pre-existing title/Connect-button overlap on narrow viewports. */
+  padding-bottom: 24px;
 }
 .org-list {
   background: #ffffff;
@@ -84,6 +94,9 @@
 .select-org-unstract-logo {
   width: 200px;
   margin-top: 10%;
+  /* Flex items default to `flex-shrink: 1`, so a long org list squashed the
+   * logo to zero height rather than scrolling the list. */
+  flex-shrink: 0;
 }
 
 .select-org-button {


### PR DESCRIPTION
## What

Make the organization list on the "select an organization" screen (`/setOrg`) scrollable, so every org is reachable when a user belongs to more than ~5.

## Why

`.org-container` is `height: 100vh` and `.org-list` is `height: 100%` — a fixed-height flex column. Neither of its flex children (`.select-org-unstract-logo`, `.card-list-container`) set `min-height: 0` or any `overflow`, and both keep the default `flex-shrink: 1`.

So once the cards exceeded the panel height:

- the card list could not shrink below its content, and the extra cards spilled out of the viewport and were **clipped rather than scrolled** — with no scrollbar, those orgs were unreachable;
- the Unstract logo was squashed to **zero height** and disappeared.

Each row is ~104px tall (an 80px `.org-avatar` plus padding), so this triggered at roughly 5–6 organizations.

## How

CSS only, `frontend/src/components/set-org/SetOrg.css`:

- `.card-list-container` becomes the scroll region — `flex: 1 1 auto`, `min-height: 0`, `overflow-y: auto`. Its `margin: 10%` becomes `margin: 5% 0`; the horizontal part was redundant (`width: 80%` plus `align-items: center` on `.org-list` already centres it, and `80% + 2×10%` exactly filled the row).
- `padding-bottom: 24px` so the cards' `box-shadow: 8px 8px 24px` isn't clipped by the scroll box. Deliberately **no** horizontal padding — it narrowed the cards by 24px and worsened the pre-existing title/Connect-button overlap (see Notes).
- `.select-org-unstract-logo` gets `flex-shrink: 0` so it stays pinned.

No new scrollbar styling: `frontend/src/index.css` already defines the global thin 8px scrollbar that every other scroll region in the app uses.

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why.

No. The change is two rules in `SetOrg.css`, a stylesheet imported only by `components/set-org/SetOrg.jsx`, which renders only on the `/setOrg` route. No JS/JSX changes, no other selector touched, and none of these class names appear anywhere else in the codebase. Avatar size, card spacing, the right-hand panel and the gradient circles are unchanged.

Verified below that the short-list case (2 orgs) renders identically to `main` — no scrollbar, same spacing.

## Relevant Docs

-

## Related Issues or PRs

UN-4073 (parent epic UN-4047)

## Dependencies Versions / Env Variables

None.

## Notes on Testing

`npm run build` passes.

Verified in a browser against a live dev deployment (Vite HMR), driven through Chrome DevTools. `/setOrg` cannot be reached by URL — it renders `null` unless React Router `state` carries the org array — so the long-list case was produced by cloning the rendered `.org-card-container` nodes to 12 rows on the real page. **That is a DOM-level simulation of a many-org account, not a real multi-org login.** The two-org case below is real data.

Measured on the same live page, toggling the old rules back on via an injected stylesheet:

| | before | after |
|---|---|---|
| `scrollHeight > clientHeight` | `false` | `true` (499px box, 1476px content) |
| logo height | **0px** | 140px |
| last card, scrolled to end | bottom at 1609px in a 796px viewport — off-screen | fully visible |

Restoring the old rules reproduced the reported symptom exactly (missing logo, no scrollbar, cards running off the bottom). Checked at 1568×796 and 1280×700, and with the real 2-org list for regression.

**Pre-existing issue found but NOT fixed here** (out of scope for a scroller fix, happy to raise separately): long org names overlap the Connect button on narrow viewports, because `.ant-card-meta-title` sets `text-overflow: ellipsis` without `overflow: hidden` / `white-space: nowrap`, making it inert. Measured 51px of glyph overlap before this change and 60px after — the 9px delta is the scrollbar gutter, which is inherent to the list scrolling at all.

## Screenshots

_Attaching separately._

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).
