### PR TITLE
UN-4074 [FIX] Make the rig node-command tests independent of npx on PATH

### DIFF
--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -838,7 +838,9 @@ def test_failed_gate_blocks_dependents_and_cascades(tmp_path: Path, monkeypatch)
     assert (reports_dir / "e2e-leaf" / "junit.xml").exists()
 
 
-def test_node_command_vitest_points_reporter_at_group_junit(tmp_path: Path) -> None:
+def test_node_command_vitest_points_reporter_at_group_junit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The whole reason `vitest` is a first-class runner rather than a synthetic
     one-row wrapper: it writes real JUnit, so `parse_junit` reports per-test
     counts. That only holds if the reporter is aimed at the group's junit.xml.
@@ -846,6 +848,9 @@ def test_node_command_vitest_points_reporter_at_group_junit(tmp_path: Path) -> N
     import tests.rig.cli as cli_mod
     from tests.rig.groups import GroupDefinition
 
+    # This test is about the command's shape, not the host's PATH; the Node-less
+    # branch is `test_node_command_without_npx_collects_nothing`'s job.
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npx")
     group = GroupDefinition(
         name="frontend", tier="unit", paths=("src",), runner="vitest",
         workdir="frontend",
@@ -859,13 +864,18 @@ def test_node_command_vitest_points_reporter_at_group_junit(tmp_path: Path) -> N
     assert cmd[-1] == "src"
 
 
-def test_node_command_playwright_takes_junit_from_env_not_flag(tmp_path: Path) -> None:
+def test_node_command_playwright_takes_junit_from_env_not_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Playwright reads its reporter path from config (PLAYWRIGHT_JUNIT_OUTPUT_NAME),
     not a CLI flag — passing --outputFile would make it fail to parse args.
     """
     import tests.rig.cli as cli_mod
     from tests.rig.groups import GroupDefinition
 
+    # This test is about the command's shape, not the host's PATH; the Node-less
+    # branch is `test_node_command_without_npx_collects_nothing`'s job.
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npx")
     group = GroupDefinition(
         name="ui", tier="e2e", paths=("tests/ui",), runner="playwright",
         workdir="frontend",

--- a/tests/rig/tests/test_cli.py
+++ b/tests/rig/tests/test_cli.py
@@ -848,9 +848,14 @@ def test_node_command_vitest_points_reporter_at_group_junit(
     import tests.rig.cli as cli_mod
     from tests.rig.groups import GroupDefinition
 
-    # This test is about the command's shape, not the host's PATH; the Node-less
-    # branch is `test_node_command_without_npx_collects_nothing`'s job.
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npx")
+    # Without this stub the test fails wherever npx is absent, because
+    # `_node_command` returns the exit-5 skip before building anything. That
+    # branch is `test_node_command_without_npx_collects_nothing`'s job; this
+    # one is about the command's shape. `npx` specifically, so a change to
+    # which binary the guard probes fails here rather than passing silently.
+    monkeypatch.setattr(
+        cli_mod.shutil, "which", lambda name: "/usr/bin/npx" if name == "npx" else None
+    )
     group = GroupDefinition(
         name="frontend", tier="unit", paths=("src",), runner="vitest",
         workdir="frontend",
@@ -873,9 +878,14 @@ def test_node_command_playwright_takes_junit_from_env_not_flag(
     import tests.rig.cli as cli_mod
     from tests.rig.groups import GroupDefinition
 
-    # This test is about the command's shape, not the host's PATH; the Node-less
-    # branch is `test_node_command_without_npx_collects_nothing`'s job.
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _: "/usr/bin/npx")
+    # Without this stub the test fails wherever npx is absent, because
+    # `_node_command` returns the exit-5 skip before building anything. That
+    # branch is `test_node_command_without_npx_collects_nothing`'s job; this
+    # one is about the command's shape. `npx` specifically, so a change to
+    # which binary the guard probes fails here rather than passing silently.
+    monkeypatch.setattr(
+        cli_mod.shutil, "which", lambda name: "/usr/bin/npx" if name == "npx" else None
+    )
     group = GroupDefinition(
         name="ui", tier="e2e", paths=("tests/ui",), runner="playwright",
         workdir="frontend",


### PR DESCRIPTION
## What

- Make `test_node_command_vitest_points_reporter_at_group_junit` and
  `test_node_command_playwright_takes_junit_from_env_not_flag`
  (`tests/rig/tests/test_cli.py`) pass on any host, with or without Node.
- Both now `monkeypatch` `cli.shutil.which` to a truthy path. Assertions unchanged.

## Why

`_node_command` (`tests/rig/cli.py:1231`) deliberately degrades when Node is absent:

```python
if not shutil.which("npx"):
    print(f"[rig] npx not found; skipping {group.name} …", file=sys.stderr)
    return ["sh", "-c", "exit 5"]      # the rig's "nothing collected" convention
```

The two tests assert the real npx command without stubbing `shutil.which`, so they
only pass on a host that happens to have Node:

```
AssertionError: assert ['sh', '-c', 'exit 5'] == ['npx', '--no-install', 'vitest', 'run']
  Captured stderr: [rig] npx not found; skipping frontend (runner=vitest)
```

- **OSS CI** runs on `ubuntu-latest` → npx preinstalled → green, so the breakage is
  invisible here.
- **Cloud CI** runs on the self-hosted `unstract-test-suite-runner`, which installs
  neither node nor bun → the skip branch fires.

`Zipstack/unstract-cloud`'s *Run tests (unit + integration + e2e)* workflow resolves
OSS `main` at run time (`git ls-remote`), so cloud `main` has been red since
**2026-09-01 09:01 UTC** — the minute #2212 merged — with no cloud commit involved.
Latest instance: [run 33623880474](https://github.com/Zipstack/unstract-cloud/actions/runs/33623880474)
(`test (unit)`: 2 failed, 118 passed; `report` fails downstream). It cannot be fixed
from a cloud branch, because the merge pins OSS `main`.

## How

Add the `monkeypatch` fixture to both tests and pin `which` to `/usr/bin/npx`,
mirroring the sibling `test_node_command_without_npx_collects_nothing`, which already
stubs it to `None` to cover the Node-less branch. A one-line comment on each records
the pairing: the test is about the command's shape, not about the host.

`_node_command` itself is left alone — skipping rather than failing on a Node-less
machine is the documented convention, shared with `_hurl_command`'s empty-file case.

### Considered and rejected

Switching `npx` → `bunx` was investigated and validated (bunx supports `--no-install`,
emits identical JUnit, exits 1 on a missing binary just like npx) but is deliberately
**not** here: the cloud runner has no bun either, so `shutil.which("bunx")` would still
be `None` and both tests would still fail. It fixes nothing and widens the blast radius
of a CI-unblocking change.

### Recorded, not fixed (separate PR)

**The frontend vitest group runs nowhere in CI today.** Cloud skips it
(`[rig] npx not found; skipping frontend`); OSS *attempts* it and fails with
`npm error npx canceled due to missing packages … ["vitest@4.1.11"]` because no job
runs `bun install`, and the group's `optional: true` swallows that. Making those ~348
tests count needs a `bun install --frozen-lockfile` step in CI.

## Can this PR break any existing features? If yes, please list possible items. If no, please explain why.

No. The change is confined to two test functions in the rig's own test suite — no
production or rig source is touched, and the assertions are byte-identical. The only
behaviour that changes is which hosts the two tests can run on: previously
Node-having ones only, now all of them.

## Relevant Docs

- [UN-4074](https://zipstack.atlassian.net/browse/UN-4074)

## Related Issues or PRs

- Introduced by #2212 (`c49968e3`, Ant Design removal), which added both the
  `shutil.which("npx")` guard and these two tests together.

## Dependencies Versions / Env Variables

None.

## Notes on Testing

Reproduced the failure first, to prove the diagnosis rather than the symptom — a
Node-free PATH, which is what the cloud runner has:

```console
$ env PATH=~/.local/bin:/usr/bin:/bin uv run pytest tests/rig/tests/test_cli.py -k node_command -v
FAILED tests/rig/tests/test_cli.py::test_node_command_vitest_points_reporter_at_group_junit
FAILED tests/rig/tests/test_cli.py::test_node_command_playwright_takes_junit_from_env_not_flag
2 failed, 1 passed, 29 deselected
```

After the change, on the same set:

| | Node-free PATH | normal PATH |
|---|---|---|
| `-k node_command` | 3 passed | 3 passed |
| `tests/rig/tests/test_cli.py` | 32 passed | 32 passed |
| `tests/rig/tests/` | 100 passed, 1 skipped | 100 passed, 1 skipped |

(`tests/rig/tests/test_runtime.py` is excluded from the last row — it fails to
*collect* locally on `import requests`, an unrelated local venv gap; CI has it.)
Baseline for that same row on `origin/main` was 2 failed / 98 passed.

The real gate is cloud CI, the only environment with no npx. Once this merges to OSS
`main`, the next `unstract-cloud` `main` run picks it up via `oss_sha`; `test (unit)`
and `report` should both go green.

## Screenshots

n/a — test-only change.

## Checklist

I have read and understood the [Contribution Guidelines](https://zipstack.atlassian.net/wiki/spaces/ZMESH/pages/165085186/Contribution+Guidelines).


[UN-4074]: https://zipstack.atlassian.net/browse/UN-4074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ