### PR TITLE
Unmerged review follow-ups from #2206: registry-tool authorization and API-key IDOR fixes

### DIFF
--- a/backend/api_v2/api_key_views.py
+++ b/backend/api_v2/api_key_views.py
@@ -3,7 +3,7 @@ from typing import Any
 from permissions.permission import IsOwnerOrSharedUser, IsParentDeploymentOwner
 from pipeline_v2.exceptions import PipelineNotFound
 from pipeline_v2.pipeline_processor import PipelineProcessor
-from rest_framework import serializers, viewsets
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -32,6 +32,33 @@ class APIKeyViewSet(viewsets.ModelViewSet):
         if self.action in ["api_keys"]:
             return APIKeyListSerializer
         return APIKeySerializer
+
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Create an API key, deriving the target from the URL.
+
+        `POST keys/api/<api_id>/` and `POST keys/pipeline/<pipeline_id>/`
+        already name the resource in the path, so callers should not have to
+        repeat it in the body. Fall back to whatever the body carries, keeping
+        the body-only routes (`keys/api/`, `keys/pipeline/`) working.
+        """
+        api_id = kwargs.get("api_id")
+        pipeline_id = kwargs.get("pipeline_id")
+
+        if api_id or pipeline_id:
+            request_data = request.data.copy()
+            if api_id:
+                request_data.setdefault("api", api_id)
+            if pipeline_id:
+                request_data.setdefault("pipeline", pipeline_id)
+            serializer = self.get_serializer(data=request_data)
+            serializer.is_valid(raise_exception=True)
+            self.perform_create(serializer)
+            headers = self.get_success_headers(serializer.data)
+            return Response(
+                serializer.data, status=status.HTTP_201_CREATED, headers=headers
+            )
+
+        return super().create(request, *args, **kwargs)
 
     @action(detail=True, methods=["get"])
     def api_keys(

--- a/backend/api_v2/api_key_views.py
+++ b/backend/api_v2/api_key_views.py
@@ -38,27 +38,57 @@ class APIKeyViewSet(viewsets.ModelViewSet):
 
         `POST keys/api/<api_id>/` and `POST keys/pipeline/<pipeline_id>/`
         already name the resource in the path, so callers should not have to
-        repeat it in the body. Fall back to whatever the body carries, keeping
-        the body-only routes (`keys/api/`, `keys/pipeline/`) working.
+        repeat it in the body. The body-only routes (`keys/api/`,
+        `keys/pipeline/`) fall through to the default implementation.
+
+        The path target is authoritative: a body naming the *other* target is
+        a contradiction, not an override, and is refused rather than silently
+        creating a key for whichever one wins. Ownership of the target is
+        checked here because `create` is collection-level -- DRF resolves
+        `IsParentDeploymentOwner` for it but never calls `get_object()`, so
+        `has_object_permission` would otherwise never run and any org member
+        could mint a live key for a deployment they do not own.
         """
         api_id = kwargs.get("api_id")
         pipeline_id = kwargs.get("pipeline_id")
 
-        if api_id or pipeline_id:
-            request_data = request.data.copy()
-            if api_id:
-                request_data.setdefault("api", api_id)
-            if pipeline_id:
-                request_data.setdefault("pipeline", pipeline_id)
-            serializer = self.get_serializer(data=request_data)
-            serializer.is_valid(raise_exception=True)
-            self.perform_create(serializer)
-            headers = self.get_success_headers(serializer.data)
-            return Response(
-                serializer.data, status=status.HTTP_201_CREATED, headers=headers
-            )
+        if not (api_id or pipeline_id):
+            return super().create(request, *args, **kwargs)
 
-        return super().create(request, *args, **kwargs)
+        # A JSON array (or scalar) body has no `.copy()` returning a mapping;
+        # reject it as a 400 rather than letting `AttributeError` become a 500.
+        if not isinstance(request.data, dict):
+            raise serializers.ValidationError("Request body must be a JSON object.")
+        request_data = request.data.copy()
+
+        if api_id:
+            if request_data.get("pipeline"):
+                raise serializers.ValidationError(
+                    "This endpoint creates a key for the API deployment named "
+                    "in the URL; remove `pipeline` from the body."
+                )
+            api = DeploymentHelper.get_api_by_id(api_id=api_id)
+            if not api:
+                raise APINotFound()
+            self.check_object_permissions(request, api)
+            request_data["api"] = api_id
+        else:
+            if request_data.get("api"):
+                raise serializers.ValidationError(
+                    "This endpoint creates a key for the pipeline named in the "
+                    "URL; remove `api` from the body."
+                )
+            pipeline = PipelineProcessor.get_active_pipeline(pipeline_id=pipeline_id)
+            if not pipeline:
+                raise PipelineNotFound()
+            self.check_object_permissions(request, pipeline)
+            request_data["pipeline"] = pipeline_id
+
+        serializer = self.get_serializer(data=request_data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     @action(detail=True, methods=["get"])
     def api_keys(

--- a/backend/api_v2/api_key_views.py
+++ b/backend/api_v2/api_key_views.py
@@ -51,7 +51,9 @@ class APIKeyViewSet(viewsets.ModelViewSet):
 
         The path target is authoritative: a body naming the *other* target is
         a contradiction, not an override, and is refused rather than silently
-        creating a key for whichever one wins.
+        creating a key for whichever one wins. A body repeating the *same*
+        target is accepted and overwritten -- it agrees with the path, so
+        there is nothing to refuse.
         """
         # A JSON array (or scalar) body has no `.copy()` returning a mapping;
         # reject it as a 400 rather than letting `AttributeError` become a 500.

--- a/backend/api_v2/api_key_views.py
+++ b/backend/api_v2/api_key_views.py
@@ -34,55 +34,73 @@ class APIKeyViewSet(viewsets.ModelViewSet):
         return APIKeySerializer
 
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        """Create an API key, deriving the target from the URL.
+        """Create an API key for the deployment or pipeline being targeted.
 
         `POST keys/api/<api_id>/` and `POST keys/pipeline/<pipeline_id>/`
-        already name the resource in the path, so callers should not have to
-        repeat it in the body. The body-only routes (`keys/api/`,
-        `keys/pipeline/`) fall through to the default implementation.
+        already name the resource in the path, so callers need not repeat it
+        in the body. The body-only routes (`keys/api/`, `keys/pipeline/`) name
+        it in `api` / `pipeline` instead.
+
+        Whichever route is used, the target is resolved and **ownership is
+        checked here**, because `create` is collection-level: DRF resolves
+        `IsParentDeploymentOwner` for it but never calls `get_object()`, so
+        `has_object_permission` never runs on its own. Without this, any org
+        member could mint a live key for a deployment they do not own. The
+        check must cover the body-only routes too — otherwise the same hole is
+        simply reachable by moving the identifier from the path into the body.
 
         The path target is authoritative: a body naming the *other* target is
         a contradiction, not an override, and is refused rather than silently
-        creating a key for whichever one wins. Ownership of the target is
-        checked here because `create` is collection-level -- DRF resolves
-        `IsParentDeploymentOwner` for it but never calls `get_object()`, so
-        `has_object_permission` would otherwise never run and any org member
-        could mint a live key for a deployment they do not own.
+        creating a key for whichever one wins.
         """
-        api_id = kwargs.get("api_id")
-        pipeline_id = kwargs.get("pipeline_id")
-
-        if not (api_id or pipeline_id):
-            return super().create(request, *args, **kwargs)
-
         # A JSON array (or scalar) body has no `.copy()` returning a mapping;
         # reject it as a 400 rather than letting `AttributeError` become a 500.
         if not isinstance(request.data, dict):
-            raise serializers.ValidationError("Request body must be a JSON object.")
+            raise serializers.ValidationError(
+                {"non_field_errors": "Request body must be a JSON object."}
+            )
         request_data = request.data.copy()
 
+        api_id = kwargs.get("api_id")
+        pipeline_id = kwargs.get("pipeline_id")
+
+        if api_id and request_data.get("pipeline"):
+            raise serializers.ValidationError(
+                {
+                    "pipeline": "This endpoint creates a key for the API "
+                    "deployment named in the URL; remove `pipeline` from the body."
+                }
+            )
+        if pipeline_id and request_data.get("api"):
+            raise serializers.ValidationError(
+                {
+                    "api": "This endpoint creates a key for the pipeline named "
+                    "in the URL; remove `api` from the body."
+                }
+            )
+
+        # The path wins where it names a target; otherwise fall back to the
+        # body, so the body-only routes resolve to the same guarded path.
+        api_id = api_id or request_data.get("api")
+        pipeline_id = pipeline_id or request_data.get("pipeline")
+
         if api_id:
-            if request_data.get("pipeline"):
-                raise serializers.ValidationError(
-                    "This endpoint creates a key for the API deployment named "
-                    "in the URL; remove `pipeline` from the body."
-                )
             api = DeploymentHelper.get_api_by_id(api_id=api_id)
             if not api:
                 raise APINotFound()
             self.check_object_permissions(request, api)
             request_data["api"] = api_id
-        else:
-            if request_data.get("api"):
-                raise serializers.ValidationError(
-                    "This endpoint creates a key for the pipeline named in the "
-                    "URL; remove `api` from the body."
-                )
-            pipeline = PipelineProcessor.get_active_pipeline(pipeline_id=pipeline_id)
+        elif pipeline_id:
+            # `check_active=False`: minting a key does not require a running
+            # pipeline, and `get_active_pipeline` would both 422 on a paused
+            # one and disclose its state before the ownership check below.
+            pipeline = PipelineProcessor.get_pipeline_by_id(pipeline_id=pipeline_id)
             if not pipeline:
                 raise PipelineNotFound()
             self.check_object_permissions(request, pipeline)
             request_data["pipeline"] = pipeline_id
+        # Neither named: let the serializer raise its "one of api/pipeline"
+        # error rather than inventing a second wording for the same condition.
 
         serializer = self.get_serializer(data=request_data)
         serializer.is_valid(raise_exception=True)

--- a/backend/api_v2/tests/test_api_key_create_target.py
+++ b/backend/api_v2/tests/test_api_key_create_target.py
@@ -1,0 +1,229 @@
+"""Guards on ``APIKeyViewSet.create`` for the path-derived target.
+
+``POST keys/api/<api_id>/`` and ``POST keys/pipeline/<pipeline_id>/`` name the
+target in the URL. Deriving it there removed the need to repeat it in the body,
+but ``create`` is a *collection*-level action: DRF resolves
+``IsParentDeploymentOwner`` for it and then never calls ``get_object()``, so
+``has_object_permission`` never ran. Any authenticated org member could mint a
+live key for a deployment they do not own. The view now performs the object
+check itself.
+
+Two things are pinned here, both cheap to break:
+
+1. **``IsParentDeploymentOwner`` accepts the parent itself.** The view hands it
+   an ``APIDeployment``/``Pipeline``, neither of which declares an ``api`` or
+   ``pipeline`` field. A plain ``obj.api`` raises ``AttributeError`` -> 500 on
+   every key creation; the lookups must be ``getattr`` guarded.
+
+2. **The path target is authoritative.** A body naming the *other* target is a
+   contradiction and must be refused, not silently resolved to whichever wins.
+
+These are unit tests over the real method bodies -- Django settings are not
+configured in the unit tier, so collaborators are stubbed and the source is
+extracted, mirroring
+``prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py``. The
+end-to-end request cycle needs a database and lives in the integration tier.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+PERMISSION_MODULE = BACKEND_DIR / "permissions" / "permission.py"
+
+START_MARKER = "class IsParentDeploymentOwner(permissions.BasePermission):"
+END_MARKER = "\nclass "
+
+
+class _User:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<User {self.name}>"
+
+
+class _Request:
+    def __init__(self, user: _User) -> None:
+        self.user = user
+
+
+class _APIDeployment:
+    """A deployment as the permission class actually receives it.
+
+    Deliberately declares neither ``api`` nor ``pipeline`` -- that is what the
+    real model looks like (``APIKey.api`` points *at* it with
+    ``related_name="api_keys"``), and it is the shape that made a bare
+    ``obj.api`` a 500.
+    """
+
+    def __init__(self, owner: _User) -> None:
+        self.owner = owner
+
+
+class _APIKey:
+    """A key row, whose ownership is inherited from its parent."""
+
+    def __init__(self, api: Any = None, pipeline: Any = None, owner: Any = None) -> None:
+        self.api = api
+        self.pipeline = pipeline
+        self.owner = owner
+
+
+def _build_permission(*, org_admins: set[str]) -> Any:
+    """Extract the real ``IsParentDeploymentOwner`` against stubbed collaborators."""
+    source = PERMISSION_MODULE.read_text()
+    if START_MARKER not in source:
+        pytest.fail(
+            f"Could not find {START_MARKER!r} in {PERMISSION_MODULE}. If it was "
+            "renamed, update this test rather than deleting it."
+        )
+    rest = source[source.index(START_MARKER) :]
+    next_class = rest.find(END_MARKER, len(START_MARKER))
+    body = textwrap.dedent(rest if next_class == -1 else rest[:next_class])
+
+    class _BasePermission:
+        pass
+
+    class _Permissions:
+        BasePermission = _BasePermission
+
+    def _is_resource_owner(user: _User, obj: Any) -> bool:
+        return getattr(obj, "owner", None) is user
+
+    def _is_service_account(request: _Request) -> bool:
+        return getattr(request.user, "is_service_account", False)
+
+    def _is_organization_admin(request: _Request) -> bool:
+        return request.user.name in org_admins
+
+    namespace: dict[str, Any] = {
+        "permissions": _Permissions,
+        "_is_resource_owner": _is_resource_owner,
+        "_is_service_account": _is_service_account,
+        "_is_organization_admin": _is_organization_admin,
+        "Request": object,
+        "APIView": object,
+        "Any": Any,
+    }
+    exec(compile(body, str(PERMISSION_MODULE), "exec"), namespace)
+    return namespace["IsParentDeploymentOwner"]()
+
+
+OWNER = _User("owner")
+STRANGER = _User("stranger")
+ADMIN = _User("admin")
+
+
+class TestParentDeploymentOwnerAcceptsTheParent:
+    """``create`` passes the parent directly; that must not 500 or over-admit."""
+
+    def test_deployment_owner_is_admitted(self) -> None:
+        permission = _build_permission(org_admins=set())
+        deployment = _APIDeployment(owner=OWNER)
+
+        assert permission.has_object_permission(_Request(OWNER), None, deployment) is True
+
+    def test_non_owner_is_refused(self) -> None:
+        """The IDOR this check closes: same-org, not the deployment's owner."""
+        permission = _build_permission(org_admins=set())
+        deployment = _APIDeployment(owner=OWNER)
+
+        allowed = permission.has_object_permission(_Request(STRANGER), None, deployment)
+
+        assert allowed is False, (
+            "A member who does not own the deployment must not be able to mint "
+            "an API key for it"
+        )
+
+    def test_org_admin_is_admitted(self) -> None:
+        permission = _build_permission(org_admins={"admin"})
+        deployment = _APIDeployment(owner=OWNER)
+
+        assert permission.has_object_permission(_Request(ADMIN), None, deployment) is True
+
+    def test_a_parent_without_api_or_pipeline_fields_does_not_raise(self) -> None:
+        """The regression that a bare ``obj.api`` would reintroduce.
+
+        ``APIDeployment``/``Pipeline`` declare no ``api`` or ``pipeline``
+        field, so an unguarded attribute access is an ``AttributeError`` --
+        surfacing as a 500 on every single key creation, which is worse than
+        the hole it was meant to close.
+        """
+        permission = _build_permission(org_admins=set())
+        deployment = _APIDeployment(owner=OWNER)
+
+        assert not hasattr(deployment, "api")
+        assert not hasattr(deployment, "pipeline")
+        # Must return a verdict rather than raising.
+        assert (
+            permission.has_object_permission(_Request(STRANGER), None, deployment)
+            is False
+        )
+
+    def test_key_rows_still_resolve_through_their_parent(self) -> None:
+        """The pre-existing detail-route behaviour must be unchanged."""
+        permission = _build_permission(org_admins=set())
+        key = _APIKey(api=_APIDeployment(owner=OWNER), owner=STRANGER)
+
+        assert permission.has_object_permission(_Request(OWNER), None, key) is True
+        assert permission.has_object_permission(_Request(STRANGER), None, key) is False
+
+    def test_parentless_key_falls_back_to_its_own_owner(self) -> None:
+        permission = _build_permission(org_admins=set())
+        key = _APIKey(api=None, pipeline=None, owner=OWNER)
+
+        assert permission.has_object_permission(_Request(OWNER), None, key) is True
+        assert permission.has_object_permission(_Request(STRANGER), None, key) is False
+
+
+VIEW_MODULE = BACKEND_DIR / "api_v2" / "api_key_views.py"
+
+
+class TestCreateContract:
+    """The wiring in ``create`` that no unit-level stub can stand in for."""
+
+    def test_create_checks_object_permissions_on_the_path_target(self) -> None:
+        """Without this call the permission class is dead code for ``create``."""
+        source = VIEW_MODULE.read_text()
+        body = source[source.index("    def create(") : source.index("@action")]
+
+        assert body.count("self.check_object_permissions(request,") == 2, (
+            "Both the api and pipeline branches must object-check their target; "
+            "`create` is collection-level, so DRF never does it for us"
+        )
+
+    def test_create_refuses_a_body_naming_the_other_target(self) -> None:
+        source = VIEW_MODULE.read_text()
+        body = source[source.index("    def create(") : source.index("@action")]
+
+        assert 'request_data.get("pipeline")' in body
+        assert 'request_data.get("api")' in body, (
+            "A body naming the other target must be refused; silently picking "
+            "one would create a key against a resource the URL does not name"
+        )
+
+    def test_create_rejects_a_non_mapping_body(self) -> None:
+        """A JSON array body must 400, not ``AttributeError`` into a 500."""
+        source = VIEW_MODULE.read_text()
+        body = source[source.index("    def create(") : source.index("@action")]
+
+        assert "isinstance(request.data, dict)" in body
+
+    def test_path_target_is_assigned_not_defaulted(self) -> None:
+        """``setdefault`` let ``{"api": ""}`` through as a present-but-empty key.
+
+        The path names the target, so it is assigned outright; the body cannot
+        blank it out into a confusing 400.
+        """
+        source = VIEW_MODULE.read_text()
+        body = source[source.index("    def create(") : source.index("@action")]
+
+        assert 'request_data["api"] = api_id' in body
+        assert 'request_data["pipeline"] = pipeline_id' in body
+        assert "setdefault" not in body

--- a/backend/api_v2/tests/test_api_key_create_target.py
+++ b/backend/api_v2/tests/test_api_key_create_target.py
@@ -43,9 +43,38 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from django.core.exceptions import ValidationError as DjangoValidationError
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 PERMISSION_MODULE = BACKEND_DIR / "permissions" / "permission.py"
+
+
+def _extract_defs(
+    module: Path, markers: tuple[str, ...], stops: tuple[str, ...]
+) -> list[str]:
+    """Slice each named definition out of ``module``'s source.
+
+    ``pytest.fail`` on a missing marker rather than skipping: a rename must
+    break loudly, since a silently-skipped guard test is worse than none.
+    """
+    source = module.read_text()
+    parts = []
+    for marker in markers:
+        if marker not in source:
+            pytest.fail(
+                f"Could not find {marker!r} in {module}. If it was renamed or "
+                "inlined, update this test rather than deleting it."
+            )
+        start = source.index(marker)
+        rest = source[start + len(marker) :]
+        end = len(rest)
+        for needle in stops:
+            found = rest.find(needle)
+            if found != -1:
+                end = min(end, found)
+        parts.append(marker + rest[:end])
+    return parts
+
 
 START_MARKER = "class IsParentDeploymentOwner(permissions.BasePermission):"
 END_MARKER = "\nclass "
@@ -505,51 +534,111 @@ class TestCreateBodyContract:
             view.create(_Req({}, OWNER), pipeline_id=MALFORMED_ID)
 
 
+class _DoesNotExist(Exception):
+    """Stand-in for ``Model.DoesNotExist``."""
+
+
+def _raising_manager(exc: BaseException) -> Any:
+    """A ``.objects`` whose ``get()`` raises ``exc``."""
+
+    class _Objects:
+        @staticmethod
+        def get(**_: Any) -> Any:
+            raise exc
+
+    return _Objects()
+
+
 class TestLookupHelpersTolerateMalformedIds:
     """The fix lives in the helpers, so pin the contract there.
 
     Both are reached with unvalidated caller input. Catching only
     ``DoesNotExist`` leaves ``ValidationError`` to escape as a 500.
+
+    The real ``django.core.exceptions.ValidationError`` is used -- Django is
+    installed in the unit tier even though *settings* are unconfigured, so the
+    exception class is importable and the ``except`` clause is exercised for
+    real rather than matched as source text.
     """
 
     @staticmethod
-    def _caught_exceptions(path: Path, marker: str) -> str:
-        """The ``except (...)`` line of the named function, docstring excluded.
-
-        Asserting on the whole body would match the *prose* explaining why
-        ``ValidationError`` is caught, so reverting the code while leaving the
-        comment would pass.
-        """
-        source = path.read_text()
-        if marker not in source:
-            pytest.fail(f"Could not find {marker!r} in {path}.")
-        body = source[source.index(marker) :]
-        body = body[: body.find("\n    @")] if "\n    @" in body else body
-        excepts = [
-            line for line in body.splitlines() if line.strip().startswith("except")
-        ]
-        if not excepts:
-            pytest.fail(f"No `except` clause found in {marker!r} ({path}).")
-        return "\n".join(excepts)
-
-    def test_get_api_by_id_treats_a_malformed_id_as_not_found(self) -> None:
-        caught = self._caught_exceptions(
-            BACKEND_DIR / "api_v2" / "utils.py",
-            "    def get_api_by_id(api_id: str) -> APIDeployment | None:",
+    def _build_get_api_by_id(raises: BaseException) -> Any:
+        marker = "    def get_api_by_id(api_id: str) -> APIDeployment | None:"
+        (body,) = _extract_defs(
+            BACKEND_DIR / "api_v2" / "utils.py", (marker,), ("\n    @",)
         )
 
-        assert "ValidationError" in caught, (
-            "A non-UUID id raises ValidationError, not DoesNotExist; without "
-            "catching it, malformed client input becomes a 500"
-        )
+        class _APIDeploymentModel:
+            objects = _raising_manager(raises)
+            DoesNotExist = _DoesNotExist
 
-    def test_get_pipeline_by_id_treats_a_malformed_id_as_not_found(self) -> None:
-        caught = self._caught_exceptions(
+        namespace: dict[str, Any] = {
+            "APIDeployment": _APIDeploymentModel,
+            "ValidationError": DjangoValidationError,
+            "Any": Any,
+        }
+        exec(compile(textwrap.dedent(body), "utils.py", "exec"), namespace)
+        return namespace["get_api_by_id"]
+
+    @staticmethod
+    def _build_get_pipeline_by_id(raises: BaseException) -> Any:
+        marker = "    def get_pipeline_by_id(cls, pipeline_id: str) -> Pipeline | None:"
+        (body,) = _extract_defs(
             BACKEND_DIR / "pipeline_v2" / "pipeline_processor.py",
-            "    def get_pipeline_by_id(cls, pipeline_id: str) -> Pipeline | None:",
+            (marker,),
+            ("\n    @",),
         )
 
-        assert "ValidationError" in caught, (
-            "A non-UUID id raises ValidationError, not DoesNotExist; without "
-            "catching it, malformed client input becomes a 500"
+        class _PipelineModel:
+            DoesNotExist = _DoesNotExist
+
+        class _Cls:
+            @staticmethod
+            def fetch_pipeline(pipeline_id: str, check_active: bool = True) -> Any:
+                raise raises
+
+        namespace: dict[str, Any] = {
+            "Pipeline": _PipelineModel,
+            "ValidationError": DjangoValidationError,
+            "Any": Any,
+        }
+        exec(compile(textwrap.dedent(body), "pipeline_processor.py", "exec"), namespace)
+        return lambda pipeline_id: namespace["get_pipeline_by_id"](_Cls, pipeline_id)
+
+    def test_get_api_by_id_returns_none_for_a_malformed_id(self) -> None:
+        """A non-UUID id raises ValidationError, not DoesNotExist.
+
+        Left uncaught it escapes the view as a 500 with a traceback, for what
+        is ordinary client garbage.
+        """
+        get_api_by_id = self._build_get_api_by_id(DjangoValidationError("bad uuid"))
+
+        assert get_api_by_id(MALFORMED_ID) is None
+
+    def test_get_api_by_id_still_returns_none_when_the_row_is_absent(self) -> None:
+        get_api_by_id = self._build_get_api_by_id(_DoesNotExist())
+
+        assert get_api_by_id("api-1") is None
+
+    def test_get_pipeline_by_id_returns_none_for_a_malformed_id(self) -> None:
+        get_pipeline_by_id = self._build_get_pipeline_by_id(
+            DjangoValidationError("bad uuid")
         )
+
+        assert get_pipeline_by_id(MALFORMED_ID) is None
+
+    def test_get_pipeline_by_id_still_returns_none_when_the_row_is_absent(self) -> None:
+        get_pipeline_by_id = self._build_get_pipeline_by_id(_DoesNotExist())
+
+        assert get_pipeline_by_id("pipe-1") is None
+
+    def test_an_unexpected_error_is_not_swallowed(self) -> None:
+        """The catch must stay narrow -- a real fault must still surface.
+
+        Broadening to a bare ``except Exception`` would turn database outages
+        into silent 404s.
+        """
+        get_api_by_id = self._build_get_api_by_id(RuntimeError("database is down"))
+
+        with pytest.raises(RuntimeError):
+            get_api_by_id("api-1")

--- a/backend/api_v2/tests/test_api_key_create_target.py
+++ b/backend/api_v2/tests/test_api_key_create_target.py
@@ -44,40 +44,12 @@ from typing import Any
 
 import pytest
 from django.core.exceptions import ValidationError as DjangoValidationError
+from tests_common.source_extraction import exec_def, extract_defs
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 PERMISSION_MODULE = BACKEND_DIR / "permissions" / "permission.py"
 
-
-def _extract_defs(
-    module: Path, markers: tuple[str, ...], stops: tuple[str, ...]
-) -> list[str]:
-    """Slice each named definition out of ``module``'s source.
-
-    ``pytest.fail`` on a missing marker rather than skipping: a rename must
-    break loudly, since a silently-skipped guard test is worse than none.
-    """
-    source = module.read_text()
-    parts = []
-    for marker in markers:
-        if marker not in source:
-            pytest.fail(
-                f"Could not find {marker!r} in {module}. If it was renamed or "
-                "inlined, update this test rather than deleting it."
-            )
-        start = source.index(marker)
-        rest = source[start + len(marker) :]
-        end = len(rest)
-        for needle in stops:
-            found = rest.find(needle)
-            if found != -1:
-                end = min(end, found)
-        parts.append(marker + rest[:end])
-    return parts
-
-
 START_MARKER = "class IsParentDeploymentOwner(permissions.BasePermission):"
-END_MARKER = "\nclass "
 
 
 class _User:
@@ -119,15 +91,7 @@ class _APIKey:
 
 def _build_permission(*, org_admins: set[str]) -> Any:
     """Extract the real ``IsParentDeploymentOwner`` against stubbed collaborators."""
-    source = PERMISSION_MODULE.read_text()
-    if START_MARKER not in source:
-        pytest.fail(
-            f"Could not find {START_MARKER!r} in {PERMISSION_MODULE}. If it was "
-            "renamed, update this test rather than deleting it."
-        )
-    rest = source[source.index(START_MARKER) :]
-    next_class = rest.find(END_MARKER, len(START_MARKER))
-    body = textwrap.dedent(rest if next_class == -1 else rest[:next_class])
+    (body,) = extract_defs(PERMISSION_MODULE, (START_MARKER,), ("\nclass ",))
 
     class _BasePermission:
         pass
@@ -256,9 +220,6 @@ CREATE_MARKER = (
     "    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:"
 )
 
-CREATED = object()
-"""Sentinel proving the key was actually minted."""
-
 
 class _ValidationError(Exception):
     """Stand-in for ``serializers.ValidationError`` (a 400)."""
@@ -311,20 +272,8 @@ def _build_create(
     inverted ``isinstance`` guard and against the wrong object being handed to
     ``check_object_permissions``.
     """
-    source = VIEW_MODULE.read_text()
-    if CREATE_MARKER not in source:
-        pytest.fail(
-            f"Could not find {CREATE_MARKER!r} in {VIEW_MODULE}. If the "
-            "signature changed, update this test rather than deleting it."
-        )
-    start = source.index(CREATE_MARKER)
-    rest = source[start + len(CREATE_MARKER) :]
-    end = len(rest)
-    for needle in ("\n    def ", "\n    @"):
-        found = rest.find(needle)
-        if found != -1:
-            end = min(end, found)
-    body = textwrap.dedent(CREATE_MARKER + rest[:end])
+    (body,) = extract_defs(VIEW_MODULE, (CREATE_MARKER,), ("\n    def ", "\n    @"))
+    body = textwrap.dedent(body)
 
     checked: list[Any] = []
 
@@ -563,32 +512,24 @@ class TestLookupHelpersTolerateMalformedIds:
 
     @staticmethod
     def _build_get_api_by_id(raises: BaseException) -> Any:
-        marker = "    def get_api_by_id(api_id: str) -> APIDeployment | None:"
-        (body,) = _extract_defs(
-            BACKEND_DIR / "api_v2" / "utils.py", (marker,), ("\n    @",)
-        )
-
         class _APIDeploymentModel:
             objects = _raising_manager(raises)
             DoesNotExist = _DoesNotExist
 
-        namespace: dict[str, Any] = {
-            "APIDeployment": _APIDeploymentModel,
-            "ValidationError": DjangoValidationError,
-            "Any": Any,
-        }
-        exec(compile(textwrap.dedent(body), "utils.py", "exec"), namespace)
+        namespace = exec_def(
+            BACKEND_DIR / "api_v2" / "utils.py",
+            "    def get_api_by_id(api_id: str) -> APIDeployment | None:",
+            ("\n    @",),
+            {
+                "APIDeployment": _APIDeploymentModel,
+                "ValidationError": DjangoValidationError,
+                "Any": Any,
+            },
+        )
         return namespace["get_api_by_id"]
 
     @staticmethod
     def _build_get_pipeline_by_id(raises: BaseException) -> Any:
-        marker = "    def get_pipeline_by_id(cls, pipeline_id: str) -> Pipeline | None:"
-        (body,) = _extract_defs(
-            BACKEND_DIR / "pipeline_v2" / "pipeline_processor.py",
-            (marker,),
-            ("\n    @",),
-        )
-
         class _PipelineModel:
             DoesNotExist = _DoesNotExist
 
@@ -597,12 +538,16 @@ class TestLookupHelpersTolerateMalformedIds:
             def fetch_pipeline(pipeline_id: str, check_active: bool = True) -> Any:
                 raise raises
 
-        namespace: dict[str, Any] = {
-            "Pipeline": _PipelineModel,
-            "ValidationError": DjangoValidationError,
-            "Any": Any,
-        }
-        exec(compile(textwrap.dedent(body), "pipeline_processor.py", "exec"), namespace)
+        namespace = exec_def(
+            BACKEND_DIR / "pipeline_v2" / "pipeline_processor.py",
+            "    def get_pipeline_by_id(cls, pipeline_id: str) -> Pipeline | None:",
+            ("\n    @",),
+            {
+                "Pipeline": _PipelineModel,
+                "ValidationError": DjangoValidationError,
+                "Any": Any,
+            },
+        )
         return lambda pipeline_id: namespace["get_pipeline_by_id"](_Cls, pipeline_id)
 
     def test_get_api_by_id_returns_none_for_a_malformed_id(self) -> None:

--- a/backend/api_v2/tests/test_api_key_create_target.py
+++ b/backend/api_v2/tests/test_api_key_create_target.py
@@ -8,21 +8,32 @@ but ``create`` is a *collection*-level action: DRF resolves
 live key for a deployment they do not own. The view now performs the object
 check itself.
 
-Two things are pinned here, both cheap to break:
+Three things are pinned here, all cheap to break:
 
-1. **``IsParentDeploymentOwner`` accepts the parent itself.** The view hands it
+1. **Every route authorizes.** The check must cover the body-only routes
+   (``keys/api/``, ``keys/pipeline/``) as well as the path ones -- guarding
+   only the path form leaves the identical hole reachable by moving the
+   identifier into the body.
+
+2. **``IsParentDeploymentOwner`` accepts the parent itself.** The view hands it
    an ``APIDeployment``/``Pipeline``, neither of which declares an ``api`` or
    ``pipeline`` field. A plain ``obj.api`` raises ``AttributeError`` -> 500 on
-   every key creation; the lookups must be ``getattr`` guarded.
+   every key creation; the lookups must be shape-guarded. An object matching
+   neither shape is denied, not admitted.
 
-2. **The path target is authoritative.** A body naming the *other* target is a
+3. **The path target is authoritative.** A body naming the *other* target is a
    contradiction and must be refused, not silently resolved to whichever wins.
 
 These are unit tests over the real method bodies -- Django settings are not
 configured in the unit tier, so collaborators are stubbed and the source is
 extracted, mirroring
-``prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py``. The
-end-to-end request cycle needs a database and lives in the integration tier.
+``prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py``.
+``create`` is *executed* rather than grepped: an earlier version asserted on
+source text and so passed against an inverted ``isinstance`` guard and against
+the wrong object being handed to ``check_object_permissions``.
+
+The end-to-end request cycle still needs a database and lives in the
+integration tier; what runs here is the method body, not the routing.
 """
 
 from __future__ import annotations
@@ -59,11 +70,13 @@ class _APIDeployment:
     Deliberately declares neither ``api`` nor ``pipeline`` -- that is what the
     real model looks like (``APIKey.api`` points *at* it with
     ``related_name="api_keys"``), and it is the shape that made a bare
-    ``obj.api`` a 500.
+    ``obj.api`` a 500. ``memberships`` is how the permission class recognises
+    a parent; both real models get it from ``HasMembersMixin``.
     """
 
     def __init__(self, owner: _User) -> None:
         self.owner = owner
+        self.memberships = ()
 
 
 class _APIKey:
@@ -102,11 +115,16 @@ def _build_permission(*, org_admins: set[str]) -> Any:
     def _is_organization_admin(request: _Request) -> bool:
         return request.user.name in org_admins
 
+    class _SilentLogger:
+        def warning(self, *_: Any, **__: Any) -> None:
+            pass
+
     namespace: dict[str, Any] = {
         "permissions": _Permissions,
         "_is_resource_owner": _is_resource_owner,
         "_is_service_account": _is_service_account,
         "_is_organization_admin": _is_organization_admin,
+        "logger": _SilentLogger(),
         "Request": object,
         "APIView": object,
         "Any": Any,
@@ -181,49 +199,271 @@ class TestParentDeploymentOwnerAcceptsTheParent:
         assert permission.has_object_permission(_Request(OWNER), None, key) is True
         assert permission.has_object_permission(_Request(STRANGER), None, key) is False
 
+    def test_an_unrecognised_object_is_denied(self) -> None:
+        """An authz gate that cannot identify its subject must fail closed.
+
+        A permissive fallthrough would admit any object that happens to expose
+        a matching owner, turning a wrong-type programming error into a silent
+        grant instead of a loud failure.
+        """
+
+        class _Unexpected:
+            def __init__(self, owner: _User) -> None:
+                self.owner = owner
+
+        permission = _build_permission(org_admins=set())
+
+        assert (
+            permission.has_object_permission(
+                _Request(OWNER), None, _Unexpected(owner=OWNER)
+            )
+            is False
+        )
+
 
 VIEW_MODULE = BACKEND_DIR / "api_v2" / "api_key_views.py"
 
+CREATE_MARKER = (
+    "    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:"
+)
 
-class TestCreateContract:
-    """The wiring in ``create`` that no unit-level stub can stand in for."""
+CREATED = object()
+"""Sentinel proving the key was actually minted."""
 
-    def test_create_checks_object_permissions_on_the_path_target(self) -> None:
-        """Without this call the permission class is dead code for ``create``."""
-        source = VIEW_MODULE.read_text()
-        body = source[source.index("    def create(") : source.index("@action")]
 
-        assert body.count("self.check_object_permissions(request,") == 2, (
-            "Both the api and pipeline branches must object-check their target; "
-            "`create` is collection-level, so DRF never does it for us"
+class _ValidationError(Exception):
+    """Stand-in for ``serializers.ValidationError`` (a 400)."""
+
+
+class _NotFound(Exception):
+    """Stand-in for ``APINotFound`` / ``PipelineNotFound`` (a 404)."""
+
+
+class _PermissionDenied(Exception):
+    """Raised by the stub ``check_object_permissions`` (a 403)."""
+
+
+class _Target:
+    """A resolvable APIDeployment/Pipeline row."""
+
+    def __init__(self, target_id: str, owner: _User) -> None:
+        self.id = target_id
+        self.owner = owner
+
+
+def _build_create(
+    *,
+    apis: dict[str, _Target] | None = None,
+    pipelines: dict[str, _Target] | None = None,
+    requester: _User = OWNER,
+) -> Any:
+    """Extract and execute the real ``create`` body against stubs.
+
+    Source extraction is used for the same reason as ``_build_permission``:
+    Django settings are unconfigured in the unit tier, so the module cannot be
+    imported. Executing the real body is what makes these behavioural -- the
+    previous version asserted on source *text*, and so passed against an
+    inverted ``isinstance`` guard and against the wrong object being handed to
+    ``check_object_permissions``.
+    """
+    source = VIEW_MODULE.read_text()
+    if CREATE_MARKER not in source:
+        pytest.fail(
+            f"Could not find {CREATE_MARKER!r} in {VIEW_MODULE}. If the "
+            "signature changed, update this test rather than deleting it."
         )
+    start = source.index(CREATE_MARKER)
+    rest = source[start + len(CREATE_MARKER) :]
+    end = len(rest)
+    for needle in ("\n    def ", "\n    @"):
+        found = rest.find(needle)
+        if found != -1:
+            end = min(end, found)
+    body = textwrap.dedent(CREATE_MARKER + rest[:end])
 
-    def test_create_refuses_a_body_naming_the_other_target(self) -> None:
-        source = VIEW_MODULE.read_text()
-        body = source[source.index("    def create(") : source.index("@action")]
+    checked: list[Any] = []
 
-        assert 'request_data.get("pipeline")' in body
-        assert 'request_data.get("api")' in body, (
-            "A body naming the other target must be refused; silently picking "
-            "one would create a key against a resource the URL does not name"
-        )
+    class _Serializers:
+        ValidationError = _ValidationError
 
-    def test_create_rejects_a_non_mapping_body(self) -> None:
-        """A JSON array body must 400, not ``AttributeError`` into a 500."""
-        source = VIEW_MODULE.read_text()
-        body = source[source.index("    def create(") : source.index("@action")]
+    class _DeploymentHelper:
+        @staticmethod
+        def get_api_by_id(api_id: str) -> _Target | None:
+            return (apis or {}).get(api_id)
 
-        assert "isinstance(request.data, dict)" in body
+    class _PipelineProcessor:
+        @staticmethod
+        def get_pipeline_by_id(pipeline_id: str) -> _Target | None:
+            return (pipelines or {}).get(pipeline_id)
 
-    def test_path_target_is_assigned_not_defaulted(self) -> None:
-        """``setdefault`` let ``{"api": ""}`` through as a present-but-empty key.
+    class _View:
+        """Minimal DRF-ish host for the extracted method."""
 
-        The path names the target, so it is assigned outright; the body cannot
-        blank it out into a confusing 400.
+        def check_object_permissions(self, request: Any, obj: Any) -> None:
+            checked.append(obj)
+            # Mirrors IsParentDeploymentOwner: only the owner passes.
+            if getattr(obj, "owner", None) is not request.user:
+                raise _PermissionDenied()
+
+        def get_serializer(self, data: Any) -> Any:
+            return _Serializer(data)
+
+        def perform_create(self, serializer: Any) -> None:
+            serializer.saved = True
+
+        def get_success_headers(self, data: Any) -> dict[str, str]:
+            return {}
+
+    class _Serializer:
+        def __init__(self, data: Any) -> None:
+            self.data = data
+            self.saved = False
+
+        def is_valid(self, raise_exception: bool = False) -> bool:
+            api = self.data.get("api")
+            pipeline = self.data.get("pipeline")
+            if api and pipeline:
+                raise _ValidationError("only one of api/pipeline")
+            if not api and not pipeline:
+                raise _ValidationError("at least one of api/pipeline")
+            return True
+
+    class _Response:
+        def __init__(self, data: Any, status: Any = None, headers: Any = None) -> None:
+            self.data = data
+            self.status = status
+
+    class _Status:
+        HTTP_201_CREATED = 201
+
+    namespace: dict[str, Any] = {
+        "serializers": _Serializers,
+        "DeploymentHelper": _DeploymentHelper,
+        "PipelineProcessor": _PipelineProcessor,
+        "APINotFound": _NotFound,
+        "PipelineNotFound": _NotFound,
+        "Response": _Response,
+        "status": _Status,
+        "Request": object,
+        "Any": Any,
+    }
+    exec(compile(body, str(VIEW_MODULE), "exec"), namespace)
+
+    view = _View()
+    view.create = namespace["create"].__get__(view, _View)
+    view.checked = checked
+    view.requester = requester
+    return view
+
+
+class _Req:
+    def __init__(self, data: Any, user: _User) -> None:
+        self.data = data
+        self.user = user
+
+
+class TestCreateAuthorizesEveryRoute:
+    """The IDOR fix, exercised rather than grepped.
+
+    The hole is reachable from four routes -- api/pipeline, each by path and
+    by body. Every one must resolve the target and object-check it.
+    """
+
+    def test_path_route_admits_the_owner(self) -> None:
+        target = _Target("api-1", OWNER)
+        view = _build_create(apis={"api-1": target})
+
+        response = view.create(_Req({}, OWNER), api_id="api-1")
+
+        assert response.status == 201
+        assert view.checked == [target], "the target must be object-checked"
+
+    def test_path_route_refuses_a_non_owner(self) -> None:
+        view = _build_create(apis={"api-1": _Target("api-1", OWNER)})
+
+        with pytest.raises(_PermissionDenied):
+            view.create(_Req({}, STRANGER), api_id="api-1")
+
+    def test_body_only_route_refuses_a_non_owner(self) -> None:
+        """The route the path-only fix left open.
+
+        Moving the identifier from the path into the body must not bypass the
+        ownership check -- otherwise the IDOR is simply relocated.
         """
-        source = VIEW_MODULE.read_text()
-        body = source[source.index("    def create(") : source.index("@action")]
+        view = _build_create(apis={"api-1": _Target("api-1", OWNER)})
 
-        assert 'request_data["api"] = api_id' in body
-        assert 'request_data["pipeline"] = pipeline_id' in body
-        assert "setdefault" not in body
+        with pytest.raises(_PermissionDenied):
+            view.create(_Req({"api": "api-1"}, STRANGER))
+
+    def test_body_only_route_admits_the_owner(self) -> None:
+        target = _Target("api-1", OWNER)
+        view = _build_create(apis={"api-1": target})
+
+        response = view.create(_Req({"api": "api-1"}, OWNER))
+
+        assert response.status == 201
+        assert view.checked == [target]
+
+    def test_body_only_pipeline_route_refuses_a_non_owner(self) -> None:
+        view = _build_create(pipelines={"pipe-1": _Target("pipe-1", OWNER)})
+
+        with pytest.raises(_PermissionDenied):
+            view.create(_Req({"pipeline": "pipe-1"}, STRANGER))
+
+    def test_pipeline_path_route_checks_the_pipeline_not_the_api(self) -> None:
+        """Guards against the wrong object reaching the permission check."""
+        target = _Target("pipe-1", OWNER)
+        view = _build_create(pipelines={"pipe-1": target})
+
+        view.create(_Req({}, OWNER), pipeline_id="pipe-1")
+
+        assert view.checked == [target]
+
+    def test_unknown_target_is_a_404(self) -> None:
+        view = _build_create(apis={})
+
+        with pytest.raises(_NotFound):
+            view.create(_Req({}, OWNER), api_id="missing")
+
+
+class TestCreateBodyContract:
+    def test_non_mapping_body_is_a_400(self) -> None:
+        """A JSON array body must 400, not ``AttributeError`` into a 500."""
+        view = _build_create(apis={"api-1": _Target("api-1", OWNER)})
+
+        with pytest.raises(_ValidationError):
+            view.create(_Req([{"api": "api-1"}], OWNER), api_id="api-1")
+
+    def test_body_naming_the_other_target_is_refused(self) -> None:
+        view = _build_create(
+            apis={"api-1": _Target("api-1", OWNER)},
+            pipelines={"pipe-1": _Target("pipe-1", OWNER)},
+        )
+
+        with pytest.raises(_ValidationError):
+            view.create(_Req({"pipeline": "pipe-1"}, OWNER), api_id="api-1")
+
+    def test_pipeline_path_with_api_body_is_refused(self) -> None:
+        view = _build_create(
+            apis={"api-1": _Target("api-1", OWNER)},
+            pipelines={"pipe-1": _Target("pipe-1", OWNER)},
+        )
+
+        with pytest.raises(_ValidationError):
+            view.create(_Req({"api": "api-1"}, OWNER), pipeline_id="pipe-1")
+
+    def test_empty_string_body_value_does_not_defeat_the_path(self) -> None:
+        """``setdefault`` used to let ``{"api": ""}`` through as a present key."""
+        target = _Target("api-1", OWNER)
+        view = _build_create(apis={"api-1": target})
+
+        response = view.create(_Req({"api": ""}, OWNER), api_id="api-1")
+
+        assert response.status == 201
+        assert view.checked == [target]
+
+    def test_no_target_anywhere_is_a_400(self) -> None:
+        view = _build_create()
+
+        with pytest.raises(_ValidationError):
+            view.create(_Req({}, OWNER))

--- a/backend/api_v2/tests/test_api_key_create_target.py
+++ b/backend/api_v2/tests/test_api_key_create_target.py
@@ -251,6 +251,22 @@ class _Target:
         self.owner = owner
 
 
+MALFORMED_ID = "not-a-uuid"
+
+
+def _lookup(rows: dict[str, _Target] | None, key: Any) -> _Target | None:
+    """Model the real ``get_api_by_id`` / ``get_pipeline_by_id`` contract.
+
+    ``pk`` is a UUID column, so the ORM raises ``ValidationError`` (not
+    ``DoesNotExist``) on a non-UUID string. Both helpers catch it and return
+    ``None``; a stub that quietly returned ``None`` for *every* unknown key
+    would hide a caller that reintroduces the 500.
+    """
+    if not isinstance(key, str) or key == MALFORMED_ID:
+        return None
+    return (rows or {}).get(key)
+
+
 def _build_create(
     *,
     apis: dict[str, _Target] | None = None,
@@ -289,12 +305,12 @@ def _build_create(
     class _DeploymentHelper:
         @staticmethod
         def get_api_by_id(api_id: str) -> _Target | None:
-            return (apis or {}).get(api_id)
+            return _lookup(apis, api_id)
 
     class _PipelineProcessor:
         @staticmethod
         def get_pipeline_by_id(pipeline_id: str) -> _Target | None:
-            return (pipelines or {}).get(pipeline_id)
+            return _lookup(pipelines, pipeline_id)
 
     class _View:
         """Minimal DRF-ish host for the extracted method."""
@@ -467,3 +483,73 @@ class TestCreateBodyContract:
 
         with pytest.raises(_ValidationError):
             view.create(_Req({}, OWNER))
+
+    def test_malformed_identifier_in_the_body_is_not_a_server_fault(self) -> None:
+        """A non-UUID body value must 404, not 500.
+
+        The body is read before the serializer runs, so the value goes
+        straight into ``objects.get(pk=...)``. ``pk`` is a UUID column, which
+        raises ``ValidationError`` rather than ``DoesNotExist`` -- unhandled,
+        that surfaces as a 500 with a traceback for ordinary client garbage.
+        """
+        view = _build_create(apis={"api-1": _Target("api-1", OWNER)})
+
+        with pytest.raises(_NotFound):
+            view.create(_Req({"api": MALFORMED_ID}, OWNER))
+
+    def test_malformed_identifier_in_the_path_is_not_a_server_fault(self) -> None:
+        """Path segments are ``<str:>``, so they are unvalidated too."""
+        view = _build_create(pipelines={"pipe-1": _Target("pipe-1", OWNER)})
+
+        with pytest.raises(_NotFound):
+            view.create(_Req({}, OWNER), pipeline_id=MALFORMED_ID)
+
+
+class TestLookupHelpersTolerateMalformedIds:
+    """The fix lives in the helpers, so pin the contract there.
+
+    Both are reached with unvalidated caller input. Catching only
+    ``DoesNotExist`` leaves ``ValidationError`` to escape as a 500.
+    """
+
+    @staticmethod
+    def _caught_exceptions(path: Path, marker: str) -> str:
+        """The ``except (...)`` line of the named function, docstring excluded.
+
+        Asserting on the whole body would match the *prose* explaining why
+        ``ValidationError`` is caught, so reverting the code while leaving the
+        comment would pass.
+        """
+        source = path.read_text()
+        if marker not in source:
+            pytest.fail(f"Could not find {marker!r} in {path}.")
+        body = source[source.index(marker) :]
+        body = body[: body.find("\n    @")] if "\n    @" in body else body
+        excepts = [
+            line for line in body.splitlines() if line.strip().startswith("except")
+        ]
+        if not excepts:
+            pytest.fail(f"No `except` clause found in {marker!r} ({path}).")
+        return "\n".join(excepts)
+
+    def test_get_api_by_id_treats_a_malformed_id_as_not_found(self) -> None:
+        caught = self._caught_exceptions(
+            BACKEND_DIR / "api_v2" / "utils.py",
+            "    def get_api_by_id(api_id: str) -> APIDeployment | None:",
+        )
+
+        assert "ValidationError" in caught, (
+            "A non-UUID id raises ValidationError, not DoesNotExist; without "
+            "catching it, malformed client input becomes a 500"
+        )
+
+    def test_get_pipeline_by_id_treats_a_malformed_id_as_not_found(self) -> None:
+        caught = self._caught_exceptions(
+            BACKEND_DIR / "pipeline_v2" / "pipeline_processor.py",
+            "    def get_pipeline_by_id(cls, pipeline_id: str) -> Pipeline | None:",
+        )
+
+        assert "ValidationError" in caught, (
+            "A non-UUID id raises ValidationError, not DoesNotExist; without "
+            "catching it, malformed client input becomes a 500"
+        )

--- a/backend/api_v2/utils.py
+++ b/backend/api_v2/utils.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from workflow_manager.workflow_v2.models.execution import WorkflowExecution
 
 from api_v2.models import APIDeployment
@@ -15,11 +16,18 @@ class APIDeploymentUtils:
         Returns:
             Optional[APIDeployment]: The APIDeployment instance if found,
                 otherwise None.
+
+        A malformed identifier is "not found", not a fault: ``pk`` is a UUID
+        column, so a non-UUID string raises ``ValidationError`` out of
+        ``to_python`` rather than ``DoesNotExist``. Callers reach this with
+        unvalidated caller input (path segments are ``<str:>``, and request
+        bodies are read before the serializer runs), so letting that escape
+        turns ordinary client garbage into a 500.
         """
         try:
             api_deployment: APIDeployment = APIDeployment.objects.get(pk=api_id)
             return api_deployment
-        except APIDeployment.DoesNotExist:
+        except (APIDeployment.DoesNotExist, ValidationError):
             return None
 
     @staticmethod

--- a/backend/permissions/permission.py
+++ b/backend/permissions/permission.py
@@ -166,12 +166,22 @@ class IsParentDeploymentOwner(permissions.BasePermission):
     one is set). Admits the parent's owner (creator + co-owners), org admin,
     or service account -- mirrors ``IsParentToolOwner`` (UN-2202). Falls back
     to the key's own ``created_by`` when both parents are null.
+
+    ``obj`` may also be the parent itself. ``create`` is a collection-level
+    action, so DRF never calls ``get_object()`` for it and there is no
+    ``APIKey`` yet to check — the view hands the target ``APIDeployment`` /
+    ``Pipeline`` straight to ``check_object_permissions``. Neither declares an
+    ``api`` or ``pipeline`` field, so the lookups are ``getattr`` guarded and
+    fall through to ``obj``; a plain attribute access would raise
+    ``AttributeError`` (500) on exactly that call.
     """
 
     def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
         if _is_service_account(request):
             return True
-        owner_resource = obj.api or obj.pipeline or obj
+        owner_resource = (
+            getattr(obj, "api", None) or getattr(obj, "pipeline", None) or obj
+        )
         if _is_resource_owner(request.user, owner_resource):
             return True
         return _is_organization_admin(request)

--- a/backend/permissions/permission.py
+++ b/backend/permissions/permission.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from adapter_processor_v2.models import AdapterInstance
@@ -6,6 +7,8 @@ from rest_framework.request import Request
 from rest_framework.views import APIView
 from tenant_account_v2.organization_member_service import OrganizationMemberService
 from utils.user_context import UserContext
+
+logger = logging.getLogger(__name__)
 
 _REQUEST_ADMIN_CACHE_ATTR = "_cached_is_organization_admin"
 
@@ -170,18 +173,35 @@ class IsParentDeploymentOwner(permissions.BasePermission):
     ``obj`` may also be the parent itself. ``create`` is a collection-level
     action, so DRF never calls ``get_object()`` for it and there is no
     ``APIKey`` yet to check — the view hands the target ``APIDeployment`` /
-    ``Pipeline`` straight to ``check_object_permissions``. Neither declares an
-    ``api`` or ``pipeline`` field, so the lookups are ``getattr`` guarded and
-    fall through to ``obj``; a plain attribute access would raise
-    ``AttributeError`` (500) on exactly that call.
+    ``Pipeline`` straight to ``check_object_permissions``.
+
+    An ``APIKey`` is recognised by declaring both parent FKs; a parent by
+    carrying ``memberships`` (both models use ``HasMembersMixin``). Anything
+    else is **denied** rather than guessed at — an authorization gate that
+    cannot identify its subject must fail closed. Note this cannot collapse to
+    ``obj.api or obj.pipeline or obj``: the parents declare no ``api``
+    attribute, so that raises ``AttributeError`` (500) on every ``create``.
     """
 
     def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
         if _is_service_account(request):
             return True
-        owner_resource = (
-            getattr(obj, "api", None) or getattr(obj, "pipeline", None) or obj
-        )
+
+        if hasattr(obj, "api") and hasattr(obj, "pipeline"):
+            # An APIKey: ownership is inherited from whichever parent is set,
+            # falling back to the key itself when both are null.
+            owner_resource = obj.api or obj.pipeline or obj
+        elif hasattr(obj, "memberships"):
+            # The parent deployment/pipeline, handed over by ``create``.
+            owner_resource = obj
+        else:
+            logger.warning(
+                "IsParentDeploymentOwner received an unsupported object type "
+                "%s; denying.",
+                type(obj).__name__,
+            )
+            return False
+
         if _is_resource_owner(request.user, owner_resource):
             return True
         return _is_organization_admin(request)

--- a/backend/pipeline_v2/pipeline_processor.py
+++ b/backend/pipeline_v2/pipeline_processor.py
@@ -50,6 +50,21 @@ class PipelineProcessor:
         except Pipeline.DoesNotExist:
             return None
 
+    @classmethod
+    def get_pipeline_by_id(cls, pipeline_id: str) -> Pipeline | None:
+        """Retrieve a pipeline regardless of whether it is currently active.
+
+        The active/inactive distinction matters to callers that are about to
+        *run* something. Callers that only need to identify the row -- to check
+        ownership, say -- must not be forced through ``get_active_pipeline``,
+        which raises ``InactivePipelineError`` (422) and logs at ERROR for what
+        is an ordinary request against a paused pipeline.
+        """
+        try:
+            return cls.fetch_pipeline(pipeline_id, check_active=False)
+        except Pipeline.DoesNotExist:
+            return None
+
     @staticmethod
     def _update_pipeline_status(
         pipeline: Pipeline,

--- a/backend/pipeline_v2/pipeline_processor.py
+++ b/backend/pipeline_v2/pipeline_processor.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from pipeline_v2.exceptions import InactivePipelineError
@@ -59,10 +60,17 @@ class PipelineProcessor:
         ownership, say -- must not be forced through ``get_active_pipeline``,
         which raises ``InactivePipelineError`` (422) and logs at ERROR for what
         is an ordinary request against a paused pipeline.
+
+        A malformed identifier is "not found", not a fault: ``pk`` is a UUID
+        column, so a non-UUID string raises ``ValidationError`` out of
+        ``to_python`` rather than ``DoesNotExist``. Callers reach this with
+        unvalidated caller input (path segments are ``<str:>``, and request
+        bodies are read before the serializer runs), so letting that escape
+        turns ordinary client garbage into a 500.
         """
         try:
             return cls.fetch_pipeline(pipeline_id, check_active=False)
-        except Pipeline.DoesNotExist:
+        except (Pipeline.DoesNotExist, ValidationError):
             return None
 
     @staticmethod

--- a/backend/prompt_studio/permission.py
+++ b/backend/prompt_studio/permission.py
@@ -31,3 +31,26 @@ class PromptAcesssToUser(permissions.BasePermission):
         if has_group_access(request.user, tool):
             return True
         return OrganizationMemberService.is_user_organization_admin(request.user)
+
+
+class IsRegistryToolOwner(permissions.BasePermission):
+    """Is unpublishing an exported tool allowed to user.
+
+    A ``PromptStudioRegistry`` row is not itself a membership resource, so
+    ownership is inherited from the linked ``CustomTool`` -- mirroring
+    ``IsParentToolOwner``, which does the same for ``ProfileManager``. Falls
+    back to the row's own owner for unlinked legacy rows (``custom_tool`` is
+    nullable).
+
+    Read access is deliberately broader (see
+    ``PromptStudioRegistry.objects.list_tools``); deleting is restricted to
+    owners and org admins.
+    """
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+        if getattr(request.user, "is_service_account", False):
+            return True
+        owner_resource = obj.custom_tool or obj
+        if _is_resource_owner(request.user, owner_resource):
+            return True
+        return OrganizationMemberService.is_user_organization_admin(request.user)

--- a/backend/prompt_studio/prompt_studio_core_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/views.py
@@ -228,13 +228,9 @@ class PromptStudioCoreView(
         instance.delete(organization_id)
 
     def _check_tool_usage_in_workflows(self, instance: CustomTool) -> tuple[bool, set]:
-        """Check if a tool is being used in any workflows.
+        """Whether ``instance``'s exported tool is in use, and by which workflows.
 
-        Args:
-            instance: The CustomTool instance to check
-
-        Returns:
-            Tuple of (is_used: bool, dependent_workflows: set)
+        An unexported project has no registry row and so no dependants.
         """
         registry = getattr(instance, "prompt_studio_registries", None)
         if not registry:
@@ -244,25 +240,11 @@ class PromptStudioCoreView(
         return bool(dependent_wfs), dependent_wfs
 
     def _get_deployment_types(self, workflow_ids: set) -> set:
-        """Get all deployment types where the tool is used.
-
-        Args:
-            workflow_ids: Set of workflow IDs to check
-
-        Returns:
-            Set of deployment type strings
-        """
+        """Deployment kinds reachable from ``workflow_ids``."""
         return deployment_types_for(workflow_ids)
 
     def _format_deployment_types_message(self, deployment_types: set) -> str:
-        """Format deployment types into human-readable message.
-
-        Args:
-            deployment_types: Set of deployment type strings
-
-        Returns:
-            Formatted message string or empty string if no types
-        """
+        """Render the "re-export needed" notice, or "" when nothing is deployed."""
         types_text = join_deployment_types(deployment_types)
         if not types_text:
             return ""

--- a/backend/prompt_studio/prompt_studio_core_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_core_v2/views.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import magic
 from account_v2.custom_exceptions import DuplicateData
-from api_v2.models import APIDeployment
 from celery import signature
 from celery.result import AsyncResult
 from django.db import IntegrityError
@@ -22,20 +21,17 @@ from permissions.permission import IsOwner, IsOwnerOrSharedUserOrSharedToOrg
 from permissions.resource_share_views import ResourceShareManagementMixin
 from permissions.roles import ResourceRole
 from pg_queue.flags import PG_QUEUE_FLAG_KEY
-from pipeline_v2.models import Pipeline
 from plugins import get_plugin
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.versioning import URLPathVersioning
-from tool_instance_v2.models import ToolInstance
 from utils.file_storage.helpers.prompt_studio_file_helper import PromptStudioFileHelper
 from utils.hubspot_notify import notify_hubspot_event
 from utils.pagination import OptionalPagination
 from utils.user_context import UserContext
 from utils.user_session import UserSessionUtils
-from workflow_manager.endpoint_v2.models import WorkflowEndpoint
 
 from backend.celery_service import app as celery_app
 from prompt_studio.lookup_utils import (
@@ -50,7 +46,6 @@ from prompt_studio.prompt_profile_manager_v2.constants import (
 from prompt_studio.prompt_profile_manager_v2.models import ProfileManager
 from prompt_studio.prompt_profile_manager_v2.serializers import ProfileManagerSerializer
 from prompt_studio.prompt_studio_core_v2.constants import (
-    DeploymentType,
     FileViewTypes,
     ToolStudioErrors,
     ToolStudioPromptKeys,
@@ -85,6 +80,11 @@ from prompt_studio.prompt_studio_registry_v2.serializers import (
 from prompt_studio.prompt_studio_v2.constants import ToolStudioPromptErrors
 from prompt_studio.prompt_studio_v2.models import ToolStudioPrompt
 from prompt_studio.prompt_studio_v2.serializers import ToolStudioPromptSerializer
+from prompt_studio.tool_usage import (
+    dependent_workflow_ids,
+    deployment_types_for,
+    join_deployment_types,
+)
 from unstract.core.data_models import PgTaskStatus
 from unstract.flags.feature_flag import check_feature_flag_status
 from unstract.sdk1.utils.common import Utils as CommonUtils
@@ -240,11 +240,7 @@ class PromptStudioCoreView(
         if not registry:
             return False, set()
 
-        dependent_wfs = set(
-            ToolInstance.objects.filter(tool_id=registry.pk)
-            .values_list("workflow_id", flat=True)
-            .distinct()
-        )
+        dependent_wfs = dependent_workflow_ids(registry.pk)
         return bool(dependent_wfs), dependent_wfs
 
     def _get_deployment_types(self, workflow_ids: set) -> set:
@@ -256,34 +252,7 @@ class PromptStudioCoreView(
         Returns:
             Set of deployment type strings
         """
-        deployment_types: set = set()
-
-        # Check API Deployments (include inactive to prevent drift)
-        if APIDeployment.objects.filter(workflow_id__in=workflow_ids).exists():
-            deployment_types.add(DeploymentType.API_DEPLOYMENT)
-
-        # Check Pipelines using mapping instead of if/elif
-        pipeline_type_mapping = {
-            Pipeline.PipelineType.ETL: DeploymentType.ETL_PIPELINE,
-            Pipeline.PipelineType.TASK: DeploymentType.TASK_PIPELINE,
-        }
-        pipelines = (
-            Pipeline.objects.filter(workflow_id__in=workflow_ids)
-            .values_list("pipeline_type", flat=True)
-            .distinct()
-        )
-        for pipeline_type in pipelines:
-            if pipeline_type in pipeline_type_mapping:
-                deployment_types.add(pipeline_type_mapping[pipeline_type])
-
-        # Check for Manual Review
-        if WorkflowEndpoint.objects.filter(
-            workflow_id__in=workflow_ids,
-            connection_type=WorkflowEndpoint.ConnectionType.MANUALREVIEW,
-        ).exists():
-            deployment_types.add(DeploymentType.HUMAN_QUALITY_REVIEW)
-
-        return deployment_types
+        return deployment_types_for(workflow_ids)
 
     def _format_deployment_types_message(self, deployment_types: set) -> str:
         """Format deployment types into human-readable message.
@@ -294,16 +263,9 @@ class PromptStudioCoreView(
         Returns:
             Formatted message string or empty string if no types
         """
-        if not deployment_types:
+        types_text = join_deployment_types(deployment_types)
+        if not types_text:
             return ""
-
-        types_list = sorted(deployment_types)
-        if len(types_list) == 1:
-            types_text = types_list[0]
-        elif len(types_list) == 2:
-            types_text = f"{types_list[0]} or {types_list[1]}"
-        else:
-            types_text = ", ".join(types_list[:-1]) + f", or {types_list[-1]}"
 
         return (
             f"You have made changes to this Prompt Studio project. "

--- a/backend/prompt_studio/prompt_studio_registry_v2/exceptions.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/exceptions.py
@@ -31,3 +31,11 @@ class InValidCustomToolError(APIException):
         "This prompt studio project cannot be exported. It probably "
         "has some empty or unexecuted prompts."
     )
+
+
+class RegistryToolInUseError(APIException):
+    status_code = 409
+    default_detail = (
+        "This exported tool is still used by one or more workflows. "
+        "Remove those usages before deleting it."
+    )

--- a/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
@@ -1,0 +1,214 @@
+"""Regression tests for the two guards on ``DELETE registry/<pk>/``.
+
+The route added in this PR is the first by-PK operation on
+``PromptStudioRegistryView``, which previously exposed only ``list``. Two
+things gate it, and both are load-bearing:
+
+1. **Authorization** (``IsRegistryToolOwner``). The viewset carries no
+   ``permission_classes`` and ``DEFAULT_PERMISSION_CLASSES`` is empty, so
+   without this every member of an organization could delete any other
+   member's exported tool by PK. ``OrganizationFilterBackend`` runs inside
+   ``get_object()`` and blocks *cross-org* access, but not intra-org.
+
+2. **In-use refusal** (409). An exported tool still attached to a workflow must
+   not be deletable, or those workflows break.
+
+``has_object_permission`` is pure logic over collaborators, so these tests stub
+the Django-coupled boundary (``permissions.permission``,
+``OrganizationMemberService``) and exercise the real method body. Django is not
+importable in a plain checkout, so the class body is extracted from source --
+mirroring ``prompt_studio_core_v2/tests/test_build_index_payload.py``. A rename
+fails these tests rather than silently skipping them.
+
+The in-use check is asserted against the same predicate the view applies
+(a non-empty set of dependent workflow IDs raises), without standing up the ORM.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[3]
+PERMISSION_MODULE = BACKEND_DIR / "prompt_studio" / "permission.py"
+
+START_MARKER = "class IsRegistryToolOwner(permissions.BasePermission):"
+
+
+class _User:
+    def __init__(self, name: str, is_service_account: bool = False) -> None:
+        self.name = name
+        self.is_service_account = is_service_account
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<User {self.name}>"
+
+
+class _CustomTool:
+    """Stand-in for the parent Prompt Studio project."""
+
+    def __init__(self, owner: _User) -> None:
+        self.owner = owner
+
+
+class _RegistryRow:
+    """Stand-in for a ``PromptStudioRegistry`` row.
+
+    ``custom_tool`` is nullable, so it may be ``None`` for legacy rows exported
+    before the link existed; those fall back to the row's own owner.
+    """
+
+    def __init__(self, custom_tool: _CustomTool | None, owner: _User) -> None:
+        self.custom_tool = custom_tool
+        self.owner = owner
+
+
+class _Request:
+    def __init__(self, user: _User) -> None:
+        self.user = user
+
+
+def _build_permission(*, org_admins: set[str]) -> Any:
+    """Extract the real ``IsRegistryToolOwner`` against stubbed collaborators."""
+    source = PERMISSION_MODULE.read_text()
+    if START_MARKER not in source:
+        pytest.fail(
+            f"Could not find {START_MARKER!r} in {PERMISSION_MODULE}. If it was "
+            "renamed, update this test rather than deleting it."
+        )
+    body = textwrap.dedent(source[source.index(START_MARKER) :])
+
+    class _BasePermission:
+        pass
+
+    class _Permissions:
+        BasePermission = _BasePermission
+
+    def _is_resource_owner(user: _User, obj: Any) -> bool:
+        return getattr(obj, "owner", None) is user
+
+    class _OrganizationMemberService:
+        @staticmethod
+        def is_user_organization_admin(user: _User) -> bool:
+            return user.name in org_admins
+
+    namespace: dict[str, Any] = {
+        "permissions": _Permissions,
+        "_is_resource_owner": _is_resource_owner,
+        "OrganizationMemberService": _OrganizationMemberService,
+        "Request": object,
+        "APIView": object,
+        "Any": Any,
+    }
+    exec(compile(body, str(PERMISSION_MODULE), "exec"), namespace)
+    return namespace["IsRegistryToolOwner"]()
+
+
+OWNER = _User("owner")
+STRANGER = _User("stranger")
+ADMIN = _User("admin")
+SERVICE = _User("service", is_service_account=True)
+
+
+def _linked_row(owner: _User = OWNER) -> _RegistryRow:
+    """A normal row whose parent project is owned by ``owner``."""
+    return _RegistryRow(custom_tool=_CustomTool(owner=owner), owner=_User("unused"))
+
+
+class TestRegistryToolDeleteAuthorization:
+    def test_project_owner_may_delete(self) -> None:
+        permission = _build_permission(org_admins=set())
+        assert (
+            permission.has_object_permission(_Request(OWNER), None, _linked_row()) is True
+        )
+
+    def test_other_org_member_may_not_delete(self) -> None:
+        """The IDOR this guard exists to close.
+
+        Org filtering already blocks cross-org access; this covers a member of
+        the *same* org who does not own the project.
+        """
+        permission = _build_permission(org_admins=set())
+
+        allowed = permission.has_object_permission(
+            _Request(STRANGER), None, _linked_row()
+        )
+
+        assert allowed is False, (
+            "A non-owner in the same organization must not be able to delete "
+            "another member's exported tool"
+        )
+
+    def test_org_admin_may_delete(self) -> None:
+        permission = _build_permission(org_admins={"admin"})
+        assert (
+            permission.has_object_permission(_Request(ADMIN), None, _linked_row()) is True
+        )
+
+    def test_service_account_may_delete(self) -> None:
+        permission = _build_permission(org_admins=set())
+        assert (
+            permission.has_object_permission(_Request(SERVICE), None, _linked_row())
+            is True
+        )
+
+    def test_ownership_follows_the_parent_project_not_the_row(self) -> None:
+        """Ownership is inherited from ``custom_tool``, mirroring IsParentToolOwner.
+
+        The row's own ``owner`` must be ignored while a parent exists, otherwise
+        a stale export-time owner could outrank the project's current owner.
+        """
+        row = _RegistryRow(custom_tool=_CustomTool(owner=OWNER), owner=STRANGER)
+        permission = _build_permission(org_admins=set())
+
+        assert permission.has_object_permission(_Request(STRANGER), None, row) is False
+        assert permission.has_object_permission(_Request(OWNER), None, row) is True
+
+    def test_unlinked_legacy_row_falls_back_to_its_own_owner(self) -> None:
+        """``custom_tool`` is nullable; those rows must stay deletable by their owner."""
+        row = _RegistryRow(custom_tool=None, owner=OWNER)
+        permission = _build_permission(org_admins=set())
+
+        assert permission.has_object_permission(_Request(OWNER), None, row) is True
+        assert permission.has_object_permission(_Request(STRANGER), None, row) is False
+
+
+class TestRegistryToolInUseRefusal:
+    """The 409 guard: a tool attached to a workflow must not be deleted.
+
+    Mirrors the predicate in ``PromptStudioRegistryView.destroy`` -- a non-empty
+    set of dependent workflow IDs refuses the delete.
+    """
+
+    @staticmethod
+    def _refuses(dependent_workflow_ids: set[str]) -> bool:
+        return bool(dependent_workflow_ids)
+
+    def test_tool_used_by_a_workflow_is_refused(self) -> None:
+        assert self._refuses({"workflow-1"}) is True
+
+    def test_unused_tool_is_deletable(self) -> None:
+        assert self._refuses(set()) is False
+
+    def test_in_use_error_is_a_409(self) -> None:
+        """Deleting an in-use tool is a conflict, not a server error.
+
+        The neighbouring ``ToolDeleteError`` is a 500; this must not be modelled
+        on it, since the condition is caller-correctable.
+        """
+        source = (
+            BACKEND_DIR / "prompt_studio" / "prompt_studio_registry_v2" / "exceptions.py"
+        ).read_text()
+
+        assert "class RegistryToolInUseError" in source, (
+            "RegistryToolInUseError is missing; the in-use guard has no way to "
+            "signal a conflict"
+        )
+        body = source[source.index("class RegistryToolInUseError") :]
+        assert "status_code = 409" in body.split("class ")[1], (
+            "RegistryToolInUseError must be a 409 so callers can distinguish a "
+            "correctable conflict from a server fault"
+        )

--- a/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
@@ -33,6 +33,7 @@ they run in the rig's integration tier rather than the per-PR unit tier.
 
 from __future__ import annotations
 
+import heapq
 import textwrap
 from pathlib import Path
 from typing import Any
@@ -346,6 +347,7 @@ def _build_guard(
         HUMAN_QUALITY_REVIEW = "Human in the Loop"
 
     namespace: dict[str, Any] = {
+        "heapq": heapq,
         "_BaseView": _BaseView,
         "ToolInstance": _Model(_queryset(workflow_ids, required_filters=("tool_id",))),
         "APIDeployment": _Model(_queryset([1] if api_deployments else [])),

--- a/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
@@ -34,11 +34,11 @@ they run in the rig's integration tier rather than the per-PR unit tier.
 from __future__ import annotations
 
 import heapq
-import textwrap
 from pathlib import Path
 from typing import Any
 
 import pytest
+from tests_common.source_extraction import extract_defs
 
 BACKEND_DIR = Path(__file__).resolve().parents[3]
 PERMISSION_MODULE = BACKEND_DIR / "prompt_studio" / "permission.py"
@@ -81,13 +81,7 @@ class _Request:
 
 def _build_permission(*, org_admins: set[str]) -> Any:
     """Extract the real ``IsRegistryToolOwner`` against stubbed collaborators."""
-    source = PERMISSION_MODULE.read_text()
-    if START_MARKER not in source:
-        pytest.fail(
-            f"Could not find {START_MARKER!r} in {PERMISSION_MODULE}. If it was "
-            "renamed, update this test rather than deleting it."
-        )
-    body = textwrap.dedent(source[source.index(START_MARKER) :])
+    (body,) = extract_defs(PERMISSION_MODULE, (START_MARKER,), ("\nclass ",))
 
     class _BasePermission:
         pass
@@ -228,12 +222,9 @@ def _queryset(rows: list[Any], *, required_filters: tuple[str, ...] = ()) -> Any
 
         def filter(self, **kwargs: Any) -> _QS:
             if required_filters and not all(k in kwargs for k in required_filters):
-                return _QS.__new__(_QS)._empty()
+                # `required_filters` is non-empty here, so this is unmatched.
+                return _QS()
             return _QS(matched=True)
-
-        def _empty(self) -> _QS:
-            self._matched = False
-            return self
 
         def values_list(self, *_: Any, **__: Any) -> _QS:
             return self
@@ -266,29 +257,21 @@ class _BaseView:
         return DELETED
 
 
-def _extract(module: Path, markers: tuple[str, ...], stops: tuple[str, ...]) -> list[str]:
-    """Slice each named definition out of ``module``'s source.
+def _logged_workflow_limit() -> int:
+    """Read the real cap rather than restating it."""
+    source = VIEWS_MODULE.read_text()
+    marker = "_LOGGED_WORKFLOW_LIMIT = "
+    if marker not in source:
+        pytest.fail(f"Could not find {marker!r} in {VIEWS_MODULE}.")
+    return int(source.split(marker)[1].split("\n")[0].strip())
 
-    ``pytest.fail`` on a missing marker rather than skipping: a rename must
-    break loudly, since a silently-skipped guard test is worse than none.
-    """
-    source = module.read_text()
-    parts = []
-    for marker in markers:
-        if marker not in source:
-            pytest.fail(
-                f"Could not find {marker!r} in {module}. If it was renamed or "
-                "inlined, update this test rather than deleting it."
-            )
-        start = source.index(marker)
-        rest = source[start + len(marker) :]
-        end = len(rest)
-        for needle in stops:
-            found = rest.find(needle)
-            if found != -1:
-                end = min(end, found)
-        parts.append(marker + rest[:end])
-    return parts
+
+class _SilentLogger:
+    def info(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def warning(self, *_: Any, **__: Any) -> None:
+        pass
 
 
 def _build_guard(
@@ -309,8 +292,8 @@ def _build_guard(
     wiring unpinned: dropping that one line made in-use tools deletable with
     the whole suite still green.
     """
-    view_parts = _extract(VIEWS_MODULE, GUARD_MARKERS, ("\n    def ", "\n    @"))
-    helper_parts = _extract(TOOL_USAGE_MODULE, HELPER_MARKERS, ("\ndef ",))
+    view_parts = extract_defs(VIEWS_MODULE, GUARD_MARKERS, ("\n    def ", "\n    @"))
+    helper_parts = extract_defs(TOOL_USAGE_MODULE, HELPER_MARKERS, ("\ndef ",))
 
     body = (
         "\n".join(helper_parts)
@@ -364,23 +347,6 @@ def _build_guard(
     }
     exec(compile(body, str(VIEWS_MODULE), "exec"), namespace)
     return namespace["_Guard"]()
-
-
-def _logged_workflow_limit() -> int:
-    """Read the real cap rather than restating it."""
-    source = VIEWS_MODULE.read_text()
-    marker = "_LOGGED_WORKFLOW_LIMIT = "
-    if marker not in source:
-        pytest.fail(f"Could not find {marker!r} in {VIEWS_MODULE}.")
-    return int(source.split(marker)[1].split("\n")[0].strip())
-
-
-class _SilentLogger:
-    def info(self, *_: Any, **__: Any) -> None:
-        pass
-
-    def warning(self, *_: Any, **__: Any) -> None:
-        pass
 
 
 class _Instance:

--- a/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
@@ -176,22 +176,195 @@ class TestRegistryToolDeleteAuthorization:
         assert permission.has_object_permission(_Request(STRANGER), None, row) is False
 
 
-class TestRegistryToolInUseRefusal:
-    """The 409 guard: a tool attached to a workflow must not be deleted.
+VIEWS_MODULE = BACKEND_DIR / "prompt_studio" / "prompt_studio_registry_v2" / "views.py"
 
-    Mirrors the predicate in ``PromptStudioRegistryView.destroy`` -- a non-empty
-    set of dependent workflow IDs refuses the delete.
+GUARD_MARKERS = (
+    "    def _get_deployment_types(self, workflow_ids: set) -> set:",
+    "    def _refuse_if_in_use(self, instance: PromptStudioRegistry) -> None:",
+    "    @staticmethod\n    def _in_use_detail(deployment_types: set) -> str:",
+)
+
+
+class _InUseError(Exception):
+    """Stand-in for ``RegistryToolInUseError``, whose 409 is asserted separately."""
+
+    status_code = 409
+
+    def __init__(self, detail: str = "") -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def _queryset(rows: list[Any]) -> Any:
+    """Minimal chainable stand-in for the ORM calls the guard makes."""
+
+    class _QS:
+        def filter(self, **_: Any) -> _QS:
+            return self
+
+        def values_list(self, *_: Any, **__: Any) -> _QS:
+            return self
+
+        def distinct(self) -> _QS:
+            return self
+
+        def exists(self) -> bool:
+            return bool(rows)
+
+        def __iter__(self) -> Any:
+            return iter(rows)
+
+    return _QS()
+
+
+def _build_guard(
+    *,
+    dependent_workflow_ids: list[str],
+    api_deployments: bool = False,
+    pipeline_types: list[str] | None = None,
+    manual_review: bool = False,
+) -> Any:
+    """Extract the real in-use guard against a stubbed ORM.
+
+    Same technique as ``_build_permission``: the method bodies come from
+    ``views.py``, so a change to the query, the raise, or the message wording
+    lands here rather than passing against a restated copy.
+    """
+    source = VIEWS_MODULE.read_text()
+    parts = []
+    for marker in GUARD_MARKERS:
+        if marker not in source:
+            pytest.fail(
+                f"Could not find {marker!r} in {VIEWS_MODULE}. If the guard was "
+                "renamed or inlined, update this test rather than deleting it."
+            )
+        start = source.index(marker)
+        rest = source[start + len(marker) :]
+        # Each method runs to the next top-level `    def ` / `    @` sibling.
+        end = len(rest)
+        for needle in ("\n    def ", "\n    @"):
+            found = rest.find(needle)
+            if found != -1:
+                end = min(end, found)
+        parts.append(marker + rest[:end])
+
+    body = "class _Guard:\n" + "\n".join(parts) + "\n"
+
+    class _Model:
+        def __init__(self, qs: Any) -> None:
+            self.objects = qs
+
+    class _PipelineType:
+        ETL = "ETL"
+        TASK = "TASK"
+
+    class _Pipeline:
+        objects = None
+        PipelineType = _PipelineType
+
+    _Pipeline.objects = _queryset(pipeline_types or [])
+
+    class _ConnectionType:
+        MANUALREVIEW = "MANUALREVIEW"
+
+    class _WorkflowEndpoint:
+        objects = _queryset([1] if manual_review else [])
+        ConnectionType = _ConnectionType
+
+    class _DeploymentType:
+        API_DEPLOYMENT = "API Deployment"
+        ETL_PIPELINE = "ETL Pipeline"
+        TASK_PIPELINE = "Task Pipeline"
+        HUMAN_QUALITY_REVIEW = "Human in the Loop"
+
+    namespace: dict[str, Any] = {
+        "ToolInstance": _Model(_queryset(dependent_workflow_ids)),
+        "APIDeployment": _Model(_queryset([1] if api_deployments else [])),
+        "Pipeline": _Pipeline,
+        "WorkflowEndpoint": _WorkflowEndpoint,
+        "DeploymentType": _DeploymentType,
+        "RegistryToolInUseError": _InUseError,
+        "PromptStudioRegistry": object,
+        "logger": _SilentLogger(),
+        "Any": Any,
+    }
+    exec(compile(body, str(VIEWS_MODULE), "exec"), namespace)
+    return namespace["_Guard"]()
+
+
+class _SilentLogger:
+    def info(self, *_: Any, **__: Any) -> None:
+        pass
+
+
+class _Instance:
+    def __init__(self) -> None:
+        self.pk = "tool-1"
+        self.prompt_registry_id = "tool-1"
+
+
+class TestRegistryToolInUseRefusal:
+    """The 409 guard, driven through the real method bodies from ``views.py``.
+
+    These exercise ``_refuse_if_in_use`` itself -- the workflow query, the
+    raise, and the message construction. The previous version restated the
+    predicate as ``bool(ids)``, which passed regardless of what the view did.
+
+    Route binding and permission wiring need a live request cycle (and so a
+    database); ``backend/conftest.py`` auto-marks such tests ``integration``,
+    which runs in the rig's integration tier rather than this PR's unit tier.
+    That boundary is why these stop at the guard.
     """
 
-    @staticmethod
-    def _refuses(dependent_workflow_ids: set[str]) -> bool:
-        return bool(dependent_workflow_ids)
-
     def test_tool_used_by_a_workflow_is_refused(self) -> None:
-        assert self._refuses({"workflow-1"}) is True
+        guard = _build_guard(dependent_workflow_ids=["wf-1"], api_deployments=True)
+
+        with pytest.raises(_InUseError) as excinfo:
+            guard._refuse_if_in_use(_Instance())
+
+        assert excinfo.value.status_code == 409, (
+            "An in-use tool is a caller-correctable conflict, not a server "
+            "fault; the neighbouring ToolDeleteError's 500 is the wrong model"
+        )
 
     def test_unused_tool_is_deletable(self) -> None:
-        assert self._refuses(set()) is False
+        """No dependants means the guard stands aside -- it is not a blanket ban."""
+        guard = _build_guard(dependent_workflow_ids=[])
+
+        assert guard._refuse_if_in_use(_Instance()) is None
+
+    def test_refusal_names_the_blocking_deployment(self) -> None:
+        """The 409 must say *where* the tool is used, or the caller cannot act."""
+        guard = _build_guard(dependent_workflow_ids=["wf-1"], api_deployments=True)
+
+        with pytest.raises(_InUseError) as excinfo:
+            guard._refuse_if_in_use(_Instance())
+
+        assert "API Deployment" in excinfo.value.detail
+
+    def test_refusal_names_every_distinct_blocker(self) -> None:
+        guard = _build_guard(
+            dependent_workflow_ids=["wf-1", "wf-2"],
+            api_deployments=True,
+            pipeline_types=["ETL"],
+            manual_review=True,
+        )
+
+        with pytest.raises(_InUseError) as excinfo:
+            guard._refuse_if_in_use(_Instance())
+
+        detail = excinfo.value.detail
+        for expected in ("API Deployment", "ETL Pipeline", "Human in the Loop"):
+            assert expected in detail
+
+    def test_refusal_falls_back_when_no_deployment_is_identifiable(self) -> None:
+        """A workflow need not be deployed anywhere; the refusal still stands."""
+        guard = _build_guard(dependent_workflow_ids=["wf-1"])
+
+        with pytest.raises(_InUseError) as excinfo:
+            guard._refuse_if_in_use(_Instance())
+
+        assert "one or more workflows" in excinfo.value.detail
 
     def test_in_use_error_is_a_409(self) -> None:
         """Deleting an in-use tool is a conflict, not a server error.

--- a/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/tests/test_registry_tool_delete_guards.py
@@ -20,8 +20,15 @@ importable in a plain checkout, so the class body is extracted from source --
 mirroring ``prompt_studio_core_v2/tests/test_build_index_payload.py``. A rename
 fails these tests rather than silently skipping them.
 
-The in-use check is asserted against the same predicate the view applies
-(a non-empty set of dependent workflow IDs raises), without standing up the ORM.
+The in-use check is driven the same way: ``destroy``, ``_refuse_if_in_use`` and
+the shared helpers in ``prompt_studio/tool_usage.py`` are all executed against a
+stubbed ORM. ``destroy`` is included deliberately -- covering only the guard
+left its *call site* unpinned, and deleting that one line made in-use tools
+deletable with the whole suite still green.
+
+What is *not* covered here: route binding and the live permission cycle need a
+database, and ``backend/conftest.py`` auto-marks such tests ``integration`` so
+they run in the rig's integration tier rather than the per-PR unit tier.
 """
 
 from __future__ import annotations
@@ -177,11 +184,21 @@ class TestRegistryToolDeleteAuthorization:
 
 
 VIEWS_MODULE = BACKEND_DIR / "prompt_studio" / "prompt_studio_registry_v2" / "views.py"
+TOOL_USAGE_MODULE = BACKEND_DIR / "prompt_studio" / "tool_usage.py"
 
 GUARD_MARKERS = (
-    "    def _get_deployment_types(self, workflow_ids: set) -> set:",
+    "    def destroy(",
     "    def _refuse_if_in_use(self, instance: PromptStudioRegistry) -> None:",
     "    @staticmethod\n    def _in_use_detail(deployment_types: set) -> str:",
+)
+
+# The shared helpers live in ``prompt_studio/tool_usage.py``; they are pulled
+# in the same way so the guard runs against the real query and the real
+# grammar rather than a restatement of either.
+HELPER_MARKERS = (
+    "def dependent_workflow_ids(registry_pk: str) -> set:",
+    "def deployment_types_for(workflow_ids: set) -> set:",
+    "def join_deployment_types(deployment_types: set) -> str:",
 )
 
 
@@ -195,11 +212,26 @@ class _InUseError(Exception):
         self.detail = detail
 
 
-def _queryset(rows: list[Any]) -> Any:
-    """Minimal chainable stand-in for the ORM calls the guard makes."""
+def _queryset(rows: list[Any], *, required_filters: tuple[str, ...] = ()) -> Any:
+    """Minimal chainable stand-in for the ORM calls the guard makes.
+
+    ``required_filters`` names the kwargs the real query must narrow on. A
+    query that stops filtering returns nothing rather than silently returning
+    every row -- otherwise dropping ``tool_id=`` would look identical to a
+    correct lookup and no test could tell the difference.
+    """
 
     class _QS:
-        def filter(self, **_: Any) -> _QS:
+        def __init__(self, matched: bool = False) -> None:
+            self._matched = matched or not required_filters
+
+        def filter(self, **kwargs: Any) -> _QS:
+            if required_filters and not all(k in kwargs for k in required_filters):
+                return _QS.__new__(_QS)._empty()
+            return _QS(matched=True)
+
+        def _empty(self) -> _QS:
+            self._matched = False
             return self
 
         def values_list(self, *_: Any, **__: Any) -> _QS:
@@ -209,46 +241,82 @@ def _queryset(rows: list[Any]) -> Any:
             return self
 
         def exists(self) -> bool:
-            return bool(rows)
+            return bool(rows) and self._matched
 
         def __iter__(self) -> Any:
-            return iter(rows)
+            return iter(rows if self._matched else [])
 
     return _QS()
 
 
+DELETED = object()
+"""Sentinel returned by the stub base ``destroy``, proving the delete ran."""
+
+
+class _BaseView:
+    """Stands in for ``viewsets.ModelViewSet`` under the extracted ``destroy``.
+
+    Recording the ``super().destroy()`` hand-off is what lets a test assert
+    that an unused tool actually reaches the delete, and — more importantly —
+    that an in-use one never does.
+    """
+
+    def destroy(self, request: Any, *args: Any, **kwargs: Any) -> Any:
+        return DELETED
+
+
+def _extract(module: Path, markers: tuple[str, ...], stops: tuple[str, ...]) -> list[str]:
+    """Slice each named definition out of ``module``'s source.
+
+    ``pytest.fail`` on a missing marker rather than skipping: a rename must
+    break loudly, since a silently-skipped guard test is worse than none.
+    """
+    source = module.read_text()
+    parts = []
+    for marker in markers:
+        if marker not in source:
+            pytest.fail(
+                f"Could not find {marker!r} in {module}. If it was renamed or "
+                "inlined, update this test rather than deleting it."
+            )
+        start = source.index(marker)
+        rest = source[start + len(marker) :]
+        end = len(rest)
+        for needle in stops:
+            found = rest.find(needle)
+            if found != -1:
+                end = min(end, found)
+        parts.append(marker + rest[:end])
+    return parts
+
+
 def _build_guard(
     *,
-    dependent_workflow_ids: list[str],
+    workflow_ids: list[str],
     api_deployments: bool = False,
     pipeline_types: list[str] | None = None,
     manual_review: bool = False,
 ) -> Any:
     """Extract the real in-use guard against a stubbed ORM.
 
-    Same technique as ``_build_permission``: the method bodies come from
-    ``views.py``, so a change to the query, the raise, or the message wording
-    lands here rather than passing against a restated copy.
-    """
-    source = VIEWS_MODULE.read_text()
-    parts = []
-    for marker in GUARD_MARKERS:
-        if marker not in source:
-            pytest.fail(
-                f"Could not find {marker!r} in {VIEWS_MODULE}. If the guard was "
-                "renamed or inlined, update this test rather than deleting it."
-            )
-        start = source.index(marker)
-        rest = source[start + len(marker) :]
-        # Each method runs to the next top-level `    def ` / `    @` sibling.
-        end = len(rest)
-        for needle in ("\n    def ", "\n    @"):
-            found = rest.find(needle)
-            if found != -1:
-                end = min(end, found)
-        parts.append(marker + rest[:end])
+    Same technique as ``_build_permission``: the bodies come from ``views.py``
+    and ``tool_usage.py``, so a change to the query, the raise, or the message
+    wording lands here rather than passing against a restated copy.
 
-    body = "class _Guard:\n" + "\n".join(parts) + "\n"
+    ``destroy`` is extracted alongside the guard so its *call* to
+    ``_refuse_if_in_use`` is covered too. Testing the guard alone left the
+    wiring unpinned: dropping that one line made in-use tools deletable with
+    the whole suite still green.
+    """
+    view_parts = _extract(VIEWS_MODULE, GUARD_MARKERS, ("\n    def ", "\n    @"))
+    helper_parts = _extract(TOOL_USAGE_MODULE, HELPER_MARKERS, ("\ndef ",))
+
+    body = (
+        "\n".join(helper_parts)
+        + "\n\nclass _Guard(_BaseView):\n"
+        + "\n".join(view_parts)
+        + "\n"
+    )
 
     class _Model:
         def __init__(self, qs: Any) -> None:
@@ -278,22 +346,38 @@ def _build_guard(
         HUMAN_QUALITY_REVIEW = "Human in the Loop"
 
     namespace: dict[str, Any] = {
-        "ToolInstance": _Model(_queryset(dependent_workflow_ids)),
+        "_BaseView": _BaseView,
+        "ToolInstance": _Model(_queryset(workflow_ids, required_filters=("tool_id",))),
         "APIDeployment": _Model(_queryset([1] if api_deployments else [])),
         "Pipeline": _Pipeline,
         "WorkflowEndpoint": _WorkflowEndpoint,
         "DeploymentType": _DeploymentType,
         "RegistryToolInUseError": _InUseError,
         "PromptStudioRegistry": object,
+        "_LOGGED_WORKFLOW_LIMIT": _logged_workflow_limit(),
         "logger": _SilentLogger(),
+        "Request": object,
+        "Response": object,
         "Any": Any,
     }
     exec(compile(body, str(VIEWS_MODULE), "exec"), namespace)
     return namespace["_Guard"]()
 
 
+def _logged_workflow_limit() -> int:
+    """Read the real cap rather than restating it."""
+    source = VIEWS_MODULE.read_text()
+    marker = "_LOGGED_WORKFLOW_LIMIT = "
+    if marker not in source:
+        pytest.fail(f"Could not find {marker!r} in {VIEWS_MODULE}.")
+    return int(source.split(marker)[1].split("\n")[0].strip())
+
+
 class _SilentLogger:
     def info(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def warning(self, *_: Any, **__: Any) -> None:
         pass
 
 
@@ -317,7 +401,7 @@ class TestRegistryToolInUseRefusal:
     """
 
     def test_tool_used_by_a_workflow_is_refused(self) -> None:
-        guard = _build_guard(dependent_workflow_ids=["wf-1"], api_deployments=True)
+        guard = _build_guard(workflow_ids=["wf-1"], api_deployments=True)
 
         with pytest.raises(_InUseError) as excinfo:
             guard._refuse_if_in_use(_Instance())
@@ -329,13 +413,13 @@ class TestRegistryToolInUseRefusal:
 
     def test_unused_tool_is_deletable(self) -> None:
         """No dependants means the guard stands aside -- it is not a blanket ban."""
-        guard = _build_guard(dependent_workflow_ids=[])
+        guard = _build_guard(workflow_ids=[])
 
         assert guard._refuse_if_in_use(_Instance()) is None
 
     def test_refusal_names_the_blocking_deployment(self) -> None:
         """The 409 must say *where* the tool is used, or the caller cannot act."""
-        guard = _build_guard(dependent_workflow_ids=["wf-1"], api_deployments=True)
+        guard = _build_guard(workflow_ids=["wf-1"], api_deployments=True)
 
         with pytest.raises(_InUseError) as excinfo:
             guard._refuse_if_in_use(_Instance())
@@ -344,7 +428,7 @@ class TestRegistryToolInUseRefusal:
 
     def test_refusal_names_every_distinct_blocker(self) -> None:
         guard = _build_guard(
-            dependent_workflow_ids=["wf-1", "wf-2"],
+            workflow_ids=["wf-1", "wf-2"],
             api_deployments=True,
             pipeline_types=["ETL"],
             manual_review=True,
@@ -357,9 +441,25 @@ class TestRegistryToolInUseRefusal:
         for expected in ("API Deployment", "ETL Pipeline", "Human in the Loop"):
             assert expected in detail
 
+    def test_two_blockers_are_joined_with_or(self) -> None:
+        """The 2-item branch has its own grammar; assert the whole sentence."""
+        guard = _build_guard(
+            workflow_ids=["wf-1"],
+            api_deployments=True,
+            pipeline_types=["ETL"],
+        )
+
+        with pytest.raises(_InUseError) as excinfo:
+            guard._refuse_if_in_use(_Instance())
+
+        assert excinfo.value.detail == (
+            "This exported tool is still used in API Deployment or ETL Pipeline. "
+            "Remove those usages before deleting it."
+        )
+
     def test_refusal_falls_back_when_no_deployment_is_identifiable(self) -> None:
         """A workflow need not be deployed anywhere; the refusal still stands."""
-        guard = _build_guard(dependent_workflow_ids=["wf-1"])
+        guard = _build_guard(workflow_ids=["wf-1"])
 
         with pytest.raises(_InUseError) as excinfo:
             guard._refuse_if_in_use(_Instance())
@@ -385,3 +485,38 @@ class TestRegistryToolInUseRefusal:
             "RegistryToolInUseError must be a 409 so callers can distinguish a "
             "correctable conflict from a server fault"
         )
+
+
+class TestDestroyIsWiredToTheGuard:
+    """``destroy`` must actually *call* the guard.
+
+    Testing ``_refuse_if_in_use`` in isolation left this unpinned: removing
+    the single call from ``destroy`` deleted in-use tools with the whole suite
+    still green. These drive the extracted ``destroy`` body, so the wiring —
+    not just the guard — is what fails when it breaks.
+    """
+
+    @staticmethod
+    def _view(guard: Any, instance: _Instance) -> Any:
+        guard.get_object = lambda: instance
+        return guard
+
+    def test_destroy_refuses_an_in_use_tool_before_deleting(self) -> None:
+        instance = _Instance()
+        guard = self._view(
+            _build_guard(workflow_ids=["wf-1"], api_deployments=True),
+            instance,
+        )
+
+        with pytest.raises(_InUseError) as excinfo:
+            guard.destroy(object())
+
+        assert excinfo.value.status_code == 409
+        assert "API Deployment" in excinfo.value.detail
+
+    def test_destroy_deletes_an_unused_tool(self) -> None:
+        """The guard must not become a blanket ban on deletion."""
+        instance = _Instance()
+        guard = self._view(_build_guard(workflow_ids=[]), instance)
+
+        assert guard.destroy(object()) is DELETED

--- a/backend/prompt_studio/prompt_studio_registry_v2/urls.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/urls.py
@@ -9,6 +9,11 @@ urlpatterns = [
         PromptStudioRegistryView.as_view({"get": "list"}),
         name="prompt_studio_registry_list",
     ),
+    path(
+        "registry/<uuid:pk>/",
+        PromptStudioRegistryView.as_view({"delete": "destroy"}),
+        name="prompt_studio_registry_detail",
+    ),
 ]
 
 # Optional: Apply format suffix patterns

--- a/backend/prompt_studio/prompt_studio_registry_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/views.py
@@ -9,6 +9,7 @@ from rest_framework.versioning import URLPathVersioning
 from tool_instance_v2.models import ToolInstance
 from utils.filtering import FilterHelper
 
+from prompt_studio.permission import IsRegistryToolOwner
 from prompt_studio.prompt_studio_registry_v2.constants import PromptStudioRegistryKeys
 from prompt_studio.prompt_studio_registry_v2.serializers import (
     PromptStudioRegistrySerializer,
@@ -27,6 +28,13 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
 
     versioning_class = URLPathVersioning
     serializer_class = PromptStudioRegistrySerializer
+
+    def get_permissions(self) -> list[Any]:
+        # `list` stays as it was - visibility is already derived by
+        # `list_tools`. Only the destructive detail route is gated.
+        if self.action == "destroy":
+            return [IsRegistryToolOwner()]
+        return super().get_permissions()
 
     def get_queryset(self) -> QuerySet | None:
         # Detail routes address a single row by PK; the list filters below are

--- a/backend/prompt_studio/prompt_studio_registry_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/views.py
@@ -1,8 +1,12 @@
 import logging
+from typing import Any
 
 from django.db.models import QuerySet
 from rest_framework import viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.versioning import URLPathVersioning
+from tool_instance_v2.models import ToolInstance
 from utils.filtering import FilterHelper
 
 from prompt_studio.prompt_studio_registry_v2.constants import PromptStudioRegistryKeys
@@ -10,6 +14,7 @@ from prompt_studio.prompt_studio_registry_v2.serializers import (
     PromptStudioRegistrySerializer,
 )
 
+from .exceptions import RegistryToolInUseError
 from .models import PromptStudioRegistry
 
 logger = logging.getLogger(__name__)
@@ -24,6 +29,13 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
     serializer_class = PromptStudioRegistrySerializer
 
     def get_queryset(self) -> QuerySet | None:
+        # Detail routes address a single row by PK; the list filters below are
+        # query-param driven and would resolve to None, breaking get_object().
+        # Keyed off the URL kwarg rather than `self.detail`, which DRF only
+        # populates for router-generated views (it is None under as_view()).
+        if self.kwargs.get("pk"):
+            return PromptStudioRegistry.objects.all()
+
         filterArgs = FilterHelper.build_filter_args(
             self.request,
             PromptStudioRegistryKeys.PROMPT_REGISTRY_ID,
@@ -34,3 +46,27 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
             queryset = PromptStudioRegistry.objects.filter(**filterArgs)
 
         return queryset
+
+    def destroy(
+        self, request: Request, *args: tuple[Any], **kwargs: dict[str, Any]
+    ) -> Response:
+        """Unpublish an exported tool without deleting its Prompt Studio project.
+
+        Deleting the project cascades to its registry entry, but that is a blunt
+        instrument - it gives no way to unpublish a tool while keeping the
+        project. Guarded by the same in-use check `prompt-studio delete`
+        performs, so a tool still attached to a workflow is refused.
+        """
+        instance: PromptStudioRegistry = self.get_object()
+        dependent_wfs = set(
+            ToolInstance.objects.filter(tool_id=instance.pk)
+            .values_list("workflow_id", flat=True)
+            .distinct()
+        )
+        if dependent_wfs:
+            logger.info(
+                f"Cannot delete exported tool {instance.prompt_registry_id}, "
+                f"depended by workflows {dependent_wfs}"
+            )
+            raise RegistryToolInUseError()
+        return super().destroy(request, *args, **kwargs)

--- a/backend/prompt_studio/prompt_studio_registry_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/views.py
@@ -1,28 +1,32 @@
 import logging
 from typing import Any
 
-from api_v2.models import APIDeployment
 from django.db.models import QuerySet
-from pipeline_v2.models import Pipeline
 from rest_framework import viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.versioning import URLPathVersioning
-from tool_instance_v2.models import ToolInstance
 from utils.filtering import FilterHelper
-from workflow_manager.endpoint_v2.models import WorkflowEndpoint
 
 from prompt_studio.permission import IsRegistryToolOwner
-from prompt_studio.prompt_studio_core_v2.constants import DeploymentType
 from prompt_studio.prompt_studio_registry_v2.constants import PromptStudioRegistryKeys
 from prompt_studio.prompt_studio_registry_v2.serializers import (
     PromptStudioRegistrySerializer,
+)
+from prompt_studio.tool_usage import (
+    dependent_workflow_ids,
+    deployment_types_for,
+    join_deployment_types,
 )
 
 from .exceptions import RegistryToolInUseError
 from .models import PromptStudioRegistry
 
 logger = logging.getLogger(__name__)
+
+# Blocking workflow IDs are logged so an operator can find the rows; capped so
+# a heavily-reused tool cannot emit an unbounded log line.
+_LOGGED_WORKFLOW_LIMIT = 20
 
 
 class PromptStudioRegistryView(viewsets.ModelViewSet):
@@ -59,41 +63,6 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
 
         return queryset
 
-    def _get_deployment_types(self, workflow_ids: set) -> set:
-        """Name the deployment kinds that reach ``workflow_ids``.
-
-        Mirrors ``PromptStudioCoreView._get_deployment_types``
-        (``prompt_studio_core_v2/views.py:249``) so the refusal can say *where*
-        the tool is still used rather than only that it is.
-        """
-        deployment_types: set = set()
-
-        # Inactive deployments are included: they still reference the tool and
-        # would break on re-activation.
-        if APIDeployment.objects.filter(workflow_id__in=workflow_ids).exists():
-            deployment_types.add(DeploymentType.API_DEPLOYMENT)
-
-        pipeline_type_mapping = {
-            Pipeline.PipelineType.ETL: DeploymentType.ETL_PIPELINE,
-            Pipeline.PipelineType.TASK: DeploymentType.TASK_PIPELINE,
-        }
-        pipeline_types = (
-            Pipeline.objects.filter(workflow_id__in=workflow_ids)
-            .values_list("pipeline_type", flat=True)
-            .distinct()
-        )
-        for pipeline_type in pipeline_types:
-            if pipeline_type in pipeline_type_mapping:
-                deployment_types.add(pipeline_type_mapping[pipeline_type])
-
-        if WorkflowEndpoint.objects.filter(
-            workflow_id__in=workflow_ids,
-            connection_type=WorkflowEndpoint.ConnectionType.MANUALREVIEW,
-        ).exists():
-            deployment_types.add(DeploymentType.HUMAN_QUALITY_REVIEW)
-
-        return deployment_types
-
     def destroy(
         self, request: Request, *args: tuple[Any], **kwargs: dict[str, Any]
     ) -> Response:
@@ -123,20 +92,31 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
         Split from ``destroy`` so the guard can be exercised without standing
         up DRF's delete machinery.
         """
-        dependent_wfs = set(
-            ToolInstance.objects.filter(tool_id=instance.pk)
-            .values_list("workflow_id", flat=True)
-            .distinct()
-        )
+        dependent_wfs = dependent_workflow_ids(instance.pk)
         if not dependent_wfs:
             return
-        logger.info(
-            f"Cannot delete exported tool {instance.prompt_registry_id}, "
-            f"depended by {len(dependent_wfs)} workflow(s)"
+
+        deployment_types = deployment_types_for(dependent_wfs)
+        # The IDs are what an operator needs to find the blocking rows; the
+        # slice bounds the line for a pathological fan-out.
+        blockers = sorted(str(wf) for wf in dependent_wfs)
+        logger.warning(
+            "Cannot delete exported tool %s, depended by %d workflow(s): %s",
+            instance.prompt_registry_id,
+            len(blockers),
+            blockers[:_LOGGED_WORKFLOW_LIMIT],
         )
-        raise RegistryToolInUseError(
-            self._in_use_detail(self._get_deployment_types(dependent_wfs))
-        )
+        if not deployment_types:
+            # Distinguishable from "genuinely undeployed": the deployment
+            # tables are org-scoped while ``ToolInstance`` is not, so an empty
+            # set here can also mean the dependants sit outside the active org.
+            logger.warning(
+                "No deployment type resolved for the %d workflow(s) blocking "
+                "tool %s; the 409 will carry only the generic wording.",
+                len(blockers),
+                instance.prompt_registry_id,
+            )
+        raise RegistryToolInUseError(self._in_use_detail(deployment_types))
 
     @staticmethod
     def _in_use_detail(deployment_types: set) -> str:
@@ -145,18 +125,12 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
         A tool can be attached to a workflow that is not deployed anywhere, so
         an empty set is normal and falls back to the generic wording.
         """
-        if not deployment_types:
+        types_text = join_deployment_types(deployment_types)
+        if not types_text:
             return (
                 "This exported tool is still used by one or more workflows. "
                 "Remove those usages before deleting it."
             )
-        types_list = sorted(deployment_types)
-        if len(types_list) == 1:
-            types_text = types_list[0]
-        elif len(types_list) == 2:
-            types_text = f"{types_list[0]} or {types_list[1]}"
-        else:
-            types_text = ", ".join(types_list[:-1]) + f", or {types_list[-1]}"
         return (
             f"This exported tool is still used in {types_text}. "
             "Remove those usages before deleting it."

--- a/backend/prompt_studio/prompt_studio_registry_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/views.py
@@ -1,15 +1,19 @@
 import logging
 from typing import Any
 
+from api_v2.models import APIDeployment
 from django.db.models import QuerySet
+from pipeline_v2.models import Pipeline
 from rest_framework import viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.versioning import URLPathVersioning
 from tool_instance_v2.models import ToolInstance
 from utils.filtering import FilterHelper
+from workflow_manager.endpoint_v2.models import WorkflowEndpoint
 
 from prompt_studio.permission import IsRegistryToolOwner
+from prompt_studio.prompt_studio_core_v2.constants import DeploymentType
 from prompt_studio.prompt_studio_registry_v2.constants import PromptStudioRegistryKeys
 from prompt_studio.prompt_studio_registry_v2.serializers import (
     PromptStudioRegistrySerializer,
@@ -55,6 +59,41 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
 
         return queryset
 
+    def _get_deployment_types(self, workflow_ids: set) -> set:
+        """Name the deployment kinds that reach ``workflow_ids``.
+
+        Mirrors ``PromptStudioCoreView._get_deployment_types``
+        (``prompt_studio_core_v2/views.py:249``) so the refusal can say *where*
+        the tool is still used rather than only that it is.
+        """
+        deployment_types: set = set()
+
+        # Inactive deployments are included: they still reference the tool and
+        # would break on re-activation.
+        if APIDeployment.objects.filter(workflow_id__in=workflow_ids).exists():
+            deployment_types.add(DeploymentType.API_DEPLOYMENT)
+
+        pipeline_type_mapping = {
+            Pipeline.PipelineType.ETL: DeploymentType.ETL_PIPELINE,
+            Pipeline.PipelineType.TASK: DeploymentType.TASK_PIPELINE,
+        }
+        pipeline_types = (
+            Pipeline.objects.filter(workflow_id__in=workflow_ids)
+            .values_list("pipeline_type", flat=True)
+            .distinct()
+        )
+        for pipeline_type in pipeline_types:
+            if pipeline_type in pipeline_type_mapping:
+                deployment_types.add(pipeline_type_mapping[pipeline_type])
+
+        if WorkflowEndpoint.objects.filter(
+            workflow_id__in=workflow_ids,
+            connection_type=WorkflowEndpoint.ConnectionType.MANUALREVIEW,
+        ).exists():
+            deployment_types.add(DeploymentType.HUMAN_QUALITY_REVIEW)
+
+        return deployment_types
+
     def destroy(
         self, request: Request, *args: tuple[Any], **kwargs: dict[str, Any]
     ) -> Response:
@@ -64,17 +103,61 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
         instrument - it gives no way to unpublish a tool while keeping the
         project. Guarded by the same in-use check `prompt-studio delete`
         performs, so a tool still attached to a workflow is refused.
+
+        Note that unpublishing is not reversible in place: re-exporting mints a
+        fresh `prompt_registry_id` and does not carry over `shared_to_org` /
+        `shared_users`, so anything holding the old UUID must be updated.
+
+        The dependent workflow IDs are materialised rather than reduced to an
+        `.exists()` -- they are what names the blocking deployments below, which
+        is the difference between an actionable 409 and one the caller cannot
+        act on.
         """
         instance: PromptStudioRegistry = self.get_object()
+        self._refuse_if_in_use(instance)
+        return super().destroy(request, *args, **kwargs)
+
+    def _refuse_if_in_use(self, instance: PromptStudioRegistry) -> None:
+        """Raise a 409 naming the blockers when workflows still use ``instance``.
+
+        Split from ``destroy`` so the guard can be exercised without standing
+        up DRF's delete machinery.
+        """
         dependent_wfs = set(
             ToolInstance.objects.filter(tool_id=instance.pk)
             .values_list("workflow_id", flat=True)
             .distinct()
         )
-        if dependent_wfs:
-            logger.info(
-                f"Cannot delete exported tool {instance.prompt_registry_id}, "
-                f"depended by workflows {dependent_wfs}"
+        if not dependent_wfs:
+            return
+        logger.info(
+            f"Cannot delete exported tool {instance.prompt_registry_id}, "
+            f"depended by {len(dependent_wfs)} workflow(s)"
+        )
+        raise RegistryToolInUseError(
+            self._in_use_detail(self._get_deployment_types(dependent_wfs))
+        )
+
+    @staticmethod
+    def _in_use_detail(deployment_types: set) -> str:
+        """Spell out which deployments block the delete, when any are known.
+
+        A tool can be attached to a workflow that is not deployed anywhere, so
+        an empty set is normal and falls back to the generic wording.
+        """
+        if not deployment_types:
+            return (
+                "This exported tool is still used by one or more workflows. "
+                "Remove those usages before deleting it."
             )
-            raise RegistryToolInUseError()
-        return super().destroy(request, *args, **kwargs)
+        types_list = sorted(deployment_types)
+        if len(types_list) == 1:
+            types_text = types_list[0]
+        elif len(types_list) == 2:
+            types_text = f"{types_list[0]} or {types_list[1]}"
+        else:
+            types_text = ", ".join(types_list[:-1]) + f", or {types_list[-1]}"
+        return (
+            f"This exported tool is still used in {types_text}. "
+            "Remove those usages before deleting it."
+        )

--- a/backend/prompt_studio/prompt_studio_registry_v2/views.py
+++ b/backend/prompt_studio/prompt_studio_registry_v2/views.py
@@ -1,3 +1,4 @@
+import heapq
 import logging
 from typing import Any
 
@@ -97,25 +98,23 @@ class PromptStudioRegistryView(viewsets.ModelViewSet):
             return
 
         deployment_types = deployment_types_for(dependent_wfs)
-        # The IDs are what an operator needs to find the blocking rows; the
-        # slice bounds the line for a pathological fan-out.
-        blockers = sorted(str(wf) for wf in dependent_wfs)
-        logger.warning(
-            "Cannot delete exported tool %s, depended by %d workflow(s): %s",
-            instance.prompt_registry_id,
-            len(blockers),
-            blockers[:_LOGGED_WORKFLOW_LIMIT],
+        # The IDs are what an operator needs to find the blocking rows;
+        # `nsmallest` bounds the work for a pathological fan-out rather than
+        # sorting the whole set just to slice it.
+        blockers = heapq.nsmallest(
+            _LOGGED_WORKFLOW_LIMIT, (str(wf) for wf in dependent_wfs)
         )
-        if not deployment_types:
-            # Distinguishable from "genuinely undeployed": the deployment
-            # tables are org-scoped while ``ToolInstance`` is not, so an empty
-            # set here can also mean the dependants sit outside the active org.
-            logger.warning(
-                "No deployment type resolved for the %d workflow(s) blocking "
-                "tool %s; the 409 will carry only the generic wording.",
-                len(blockers),
-                instance.prompt_registry_id,
-            )
+        # An unresolved deployment type is worth calling out: the deployment
+        # tables are org-scoped while ``ToolInstance`` is not, so an empty set
+        # can mean the dependants sit outside the active org rather than that
+        # the workflows are genuinely undeployed. One line either way.
+        logger.warning(
+            "Cannot delete exported tool %s, depended by %d workflow(s) %s: %s",
+            instance.prompt_registry_id,
+            len(dependent_wfs),
+            sorted(deployment_types) or "(no deployment type resolved)",
+            blockers,
+        )
         raise RegistryToolInUseError(self._in_use_detail(deployment_types))
 
     @staticmethod

--- a/backend/prompt_studio/tool_usage.py
+++ b/backend/prompt_studio/tool_usage.py
@@ -1,0 +1,83 @@
+"""Shared "is this exported tool still in use?" logic.
+
+Two delete paths need the same answer: deleting a Prompt Studio project
+(``prompt_studio_core_v2``) and unpublishing its exported tool
+(``prompt_studio_registry_v2``). Both refuse when a workflow still references
+the registry row, and both want to name *where* it is referenced.
+
+Keeping one copy matters because the set of deployment kinds is open — adding a
+fourth would otherwise leave one caller silently reporting a stale set, telling
+the user to clear usages in the wrong places.
+"""
+
+from api_v2.models import APIDeployment
+from pipeline_v2.models import Pipeline
+from tool_instance_v2.models import ToolInstance
+from workflow_manager.endpoint_v2.models import WorkflowEndpoint
+
+from prompt_studio.prompt_studio_core_v2.constants import DeploymentType
+
+
+def dependent_workflow_ids(registry_pk: str) -> set:
+    """Workflow IDs whose tool instances reference ``registry_pk``.
+
+    An exported tool's ``ToolInstance.tool_id`` is its ``prompt_registry_id``,
+    stored as a plain ``CharField`` rather than a foreign key -- which is why
+    the database cannot enforce this and callers must check explicitly.
+    """
+    return set(
+        ToolInstance.objects.filter(tool_id=registry_pk)
+        .values_list("workflow_id", flat=True)
+        .distinct()
+    )
+
+
+def deployment_types_for(workflow_ids: set) -> set:
+    """Name the deployment kinds reachable from ``workflow_ids``.
+
+    Inactive deployments count: they still reference the tool and would break
+    on re-activation.
+    """
+    deployment_types: set = set()
+    if not workflow_ids:
+        return deployment_types
+
+    if APIDeployment.objects.filter(workflow_id__in=workflow_ids).exists():
+        deployment_types.add(DeploymentType.API_DEPLOYMENT)
+
+    pipeline_type_mapping = {
+        Pipeline.PipelineType.ETL: DeploymentType.ETL_PIPELINE,
+        Pipeline.PipelineType.TASK: DeploymentType.TASK_PIPELINE,
+    }
+    pipeline_types = (
+        Pipeline.objects.filter(workflow_id__in=workflow_ids)
+        .values_list("pipeline_type", flat=True)
+        .distinct()
+    )
+    for pipeline_type in pipeline_types:
+        if pipeline_type in pipeline_type_mapping:
+            deployment_types.add(pipeline_type_mapping[pipeline_type])
+
+    if WorkflowEndpoint.objects.filter(
+        workflow_id__in=workflow_ids,
+        connection_type=WorkflowEndpoint.ConnectionType.MANUALREVIEW,
+    ).exists():
+        deployment_types.add(DeploymentType.HUMAN_QUALITY_REVIEW)
+
+    return deployment_types
+
+
+def join_deployment_types(deployment_types: set) -> str:
+    """Render deployment kinds as an English list ("A", "A or B", "A, B, or C").
+
+    Returns an empty string for an empty set so callers can choose their own
+    fallback wording.
+    """
+    if not deployment_types:
+        return ""
+    types_list = sorted(deployment_types)
+    if len(types_list) == 1:
+        return types_list[0]
+    if len(types_list) == 2:
+        return f"{types_list[0]} or {types_list[1]}"
+    return ", ".join(types_list[:-1]) + f", or {types_list[-1]}"

--- a/backend/tests_common/__init__.py
+++ b/backend/tests_common/__init__.py
@@ -1,0 +1,6 @@
+"""Helpers shared between test modules in different Django apps.
+
+Kept out of any one app because its consumers span several
+(``api_v2``, ``prompt_studio``); ``permissions/tests/base.py`` is the
+app-scoped equivalent for helpers with a single consumer.
+"""

--- a/backend/tests_common/source_extraction.py
+++ b/backend/tests_common/source_extraction.py
@@ -48,12 +48,23 @@ def extract_defs(
     return parts
 
 
+def _line_offset(source: str, marker: str) -> int:
+    """0-based line on which ``marker`` starts."""
+    return source.count("\n", 0, source.index(marker))
+
+
 def exec_def(module: Path, marker: str, stops: tuple[str, ...], namespace: Any) -> Any:
     """Extract one definition, ``exec`` it in ``namespace``, and hand it back.
 
     The body is dedented so a method can be executed at module level, which is
     what lets a view method be driven without standing up the class.
+
+    Blank lines are prepended so the snippet sits at its real line number.
+    ``compile`` is given the true path, so without the padding a traceback
+    would pair a genuine filename with a snippet-relative line -- pointing
+    whoever debugs a failure at whatever unrelated source sits there.
     """
     (body,) = extract_defs(module, (marker,), stops)
-    exec(compile(textwrap.dedent(body), str(module), "exec"), namespace)
+    padding = "\n" * _line_offset(module.read_text(), marker)
+    exec(compile(padding + textwrap.dedent(body), str(module), "exec"), namespace)
     return namespace

--- a/backend/tests_common/source_extraction.py
+++ b/backend/tests_common/source_extraction.py
@@ -1,0 +1,59 @@
+"""Run real method bodies in the unit tier, where Django settings are absent.
+
+Guard logic worth pinning (authorization, in-use refusal) lives in modules that
+import Django at module scope, so the unit tier cannot import them. Rather than
+restate the logic in a test -- which passes no matter what the real code does --
+these helpers slice the definition out of the source file and ``exec`` it
+against stubbed collaborators, so the assertions run against the shipped body.
+
+The end-to-end request cycle needs a database and belongs in the integration
+tier; ``backend/conftest.py`` auto-marks those.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def extract_defs(
+    module: Path, markers: tuple[str, ...], stops: tuple[str, ...]
+) -> list[str]:
+    """Slice each named definition out of ``module``'s source.
+
+    Each marker is the definition's opening line, verbatim; the slice runs to
+    the first ``stops`` needle after it. ``pytest.fail`` on a missing marker
+    rather than skipping: a rename must break loudly, since a silently-skipped
+    guard test is worse than none.
+    """
+    source = module.read_text()
+    parts = []
+    for marker in markers:
+        if marker not in source:
+            pytest.fail(
+                f"Could not find {marker!r} in {module}. If it was renamed or "
+                "inlined, update this test rather than deleting it."
+            )
+        start = source.index(marker)
+        rest = source[start + len(marker) :]
+        end = len(rest)
+        for needle in stops:
+            found = rest.find(needle)
+            if found != -1:
+                end = min(end, found)
+        parts.append(marker + rest[:end])
+    return parts
+
+
+def exec_def(module: Path, marker: str, stops: tuple[str, ...], namespace: Any) -> Any:
+    """Extract one definition, ``exec`` it in ``namespace``, and hand it back.
+
+    The body is dedented so a method can be executed at module level, which is
+    what lets a view method be driven without standing up the class.
+    """
+    (body,) = extract_defs(module, (marker,), stops)
+    exec(compile(textwrap.dedent(body), str(module), "exec"), namespace)
+    return namespace


### PR DESCRIPTION
Registry-tool authorization fixes, API-key IDOR fixes, and the tests covering them.

## Authorization and IDOR

| Commit | Change |
|---|---|
| `cae909946` | Restrict registry tool deletion to the project's owner |
| `bfde0813a` | Close the API-key **create** IDOR; make the registry 409 actionable |
| `4666d4b14` | Close the API-key IDOR on **every** route, not just the path-parameter one |
| `bad1ded67` | A malformed identifier returns 404, not 500 |

`4666d4b14` is the one to read first: the path-parameter route was guarded while the remaining
routes were not, so the check read as present while staying open.

## Tests and supporting refactor

| Commit | Change |
|---|---|
| `facf9c702` | Pin the authorization and in-use guards on registry tool deletion |
| `3b0604039` | Exercise the malformed-id catch instead of grepping for it |
| `00165fcae` | Share the test source-extraction helper |
| `9e255db8a` | Keep extracted-body tracebacks pointing at real lines |

`3b0604039` replaces an assertion on source text with one that exercises the code path — a
grep-based test passes whether or not the catch fires.

## Scope

14 files, **+1528 / −72**:

- `backend/prompt_studio/prompt_studio_registry_v2/` — views, urls, exceptions, and a 490-line
  guard test
- `backend/permissions/permission.py`, `backend/prompt_studio/permission.py`
- `backend/prompt_studio/tool_usage.py` (new)
- `backend/tests_common/` (new shared test helper)

## Before merging

The branch is based on `main` as of `88eed95b7`, which is now **36 commits behind**. It needs a
rebase or merge from `main` and a test run against current `main`. The authorization changes in
particular want a look against present-day routing, since the surrounding routes have moved.

Draft until that has been done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5SYUSp5fAwsejGVn1F57N
